### PR TITLE
Fix missing member published-runs redirect

### DIFF
--- a/apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx
+++ b/apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx
@@ -1448,7 +1448,9 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
               loading={auditQuery.isFetching}
               onClick={() => {
                 runsQuery.refetch();
-                auditQuery.refetch();
+                if (auditCanLoad) {
+                  auditQuery.refetch();
+                }
               }}
             >
               {t("pages.runs.memberPublishedRuns.refresh", "Refresh")}

--- a/apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx
+++ b/apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx
@@ -36,6 +36,7 @@ import {
   buildTeamDetailHref,
   buildTeamMemberPublishedRunsHref,
   buildTeamMemberWorkflowStudioHref,
+  buildTeamsHref,
 } from "@/shared/navigation/teamRoutes";
 import GraphCanvas from "@/shared/graphs/GraphCanvas";
 import type {
@@ -509,6 +510,26 @@ const memberPublishedRunsReplayCss = `
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function isStudioMemberNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const record = error as {
+    readonly code?: unknown;
+    readonly message?: unknown;
+    readonly status?: unknown;
+  };
+  const code = typeof record.code === "string" ? record.code.trim().toUpperCase() : "";
+  if (code === "STUDIO_MEMBER_NOT_FOUND") {
+    return true;
+  }
+
+  const status = typeof record.status === "number" ? record.status : 0;
+  const message = typeof record.message === "string" ? record.message.toUpperCase() : "";
+  return status === 404 && message.includes("STUDIO_MEMBER_NOT_FOUND");
 }
 
 function normalizeRunStatus(status: string | null | undefined): string {
@@ -1060,9 +1081,17 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
     queryKey: ["runtime-member-published-runs", "member", scopeId, memberId],
     retry: false,
   });
+  const memberNotFound = isStudioMemberNotFoundError(memberQuery.error);
+  const memberReady = Boolean(scopeId && memberId && memberQuery.isSuccess && !memberNotFound);
+
+  React.useEffect(() => {
+    if (memberNotFound) {
+      history.replace(buildTeamsHref());
+    }
+  }, [memberNotFound]);
 
   const runsQuery = useQuery({
-    enabled: Boolean(scopeId && memberId),
+    enabled: memberReady,
     queryFn: () => scopeRuntimeApi.listMemberRuns(scopeId, memberId, { take: 200 }),
     queryKey: ["runtime-member-published-runs", scopeId, memberId],
     retry: false,
@@ -1080,6 +1109,14 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
   const selectedRunId = selectedCatalogRun?.runId ?? normalizedInitialRunId;
   const selectedRunActorId =
     selectedCatalogRun?.actorId || normalizedInitialActorId || "";
+  const selectedRunNeedsCatalogMatch = Boolean(
+    normalizedInitialRunId && !normalizedInitialActorId,
+  );
+  const auditCanLoad = Boolean(
+    memberReady &&
+      selectedRunId &&
+      (!selectedRunNeedsCatalogMatch || selectedCatalogRun),
+  );
 
   React.useEffect(() => {
     if (!selectedCatalogRun?.runId || normalizedInitialRunId) {
@@ -1098,7 +1135,7 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
   }, [memberId, normalizedInitialRunId, normalizedTeamId, scopeId, selectedCatalogRun]);
 
   const auditQuery = useQuery({
-    enabled: Boolean(scopeId && memberId && selectedRunId),
+    enabled: auditCanLoad,
     queryFn: () =>
       scopeRuntimeApi.getMemberRunAudit(scopeId, memberId, selectedRunId, {
         actorId: selectedRunActorId || undefined,
@@ -1127,8 +1164,12 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
   const audit = auditQuery.data?.audit ?? null;
   const displayRuns =
     runs.length || !selectedRun ? runs : [selectedRun];
+  const runsLoadError = memberNotFound ? null : memberQuery.error || runsQuery.error;
   const showReplaySkeleton = Boolean(
-    runsQuery.isLoading || (selectedRun && auditQuery.isLoading),
+    memberQuery.isLoading ||
+      memberNotFound ||
+      runsQuery.isLoading ||
+      (selectedRun && auditQuery.isLoading),
   );
   const graph = React.useMemo(
     () => buildExecutionGraph(audit, selectedStepId),
@@ -1302,9 +1343,9 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
           </div>
         </div>
         <div className="member-published-runs-replay__list">
-          {runsQuery.isLoading ? (
+          {memberQuery.isLoading || memberNotFound || runsQuery.isLoading ? (
             renderRunListSkeleton()
-          ) : runsQuery.error ? (
+          ) : runsLoadError ? (
             <Alert
               showIcon
               type="error"
@@ -1313,9 +1354,9 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
                 "Published runs are unavailable.",
               )}
               description={
-                runsQuery.error instanceof Error
-                  ? runsQuery.error.message
-                  : String(runsQuery.error)
+                runsLoadError instanceof Error
+                  ? runsLoadError.message
+                  : String(runsLoadError)
               }
             />
           ) : displayRuns.length ? (

--- a/apps/aevatar-console-web/src/pages/runtime-published-runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runtime-published-runs/index.test.tsx
@@ -246,6 +246,14 @@ describe("TeamMemberPublishedRunsPage", () => {
     expect(screen.getByTestId("member-published-runs-details-skeleton")).toBeTruthy();
     expect(screen.queryByText("No published runs yet.")).toBeNull();
 
+    await waitFor(() => {
+      expect(mockedScopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+        "scope-1",
+        "m-alpha",
+        { take: 200 },
+      );
+    });
+
     memberRuns.resolve({
       displayName: "Alpha Workflow",
       memberId: "m-alpha",
@@ -254,6 +262,27 @@ describe("TeamMemberPublishedRunsPage", () => {
       runs: [],
       scopeId: "scope-1",
     });
+    expect(await screen.findByText("No published runs yet.")).toBeTruthy();
+  });
+
+  it("redirects to the console home when the routed member does not exist", async () => {
+    const missingMemberError = Object.assign(
+      new Error("member 'm-missing' not found in scope 'scope-1'."),
+      {
+        code: "STUDIO_MEMBER_NOT_FOUND",
+        status: 404,
+      },
+    );
+    mockedStudioApi.getMember.mockRejectedValueOnce(missingMemberError);
+
+    renderWithQueryClient(React.createElement(TeamMemberPublishedRunsPage));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/scopes");
+    });
+    expect(window.location.search).toBe("");
+    expect(mockedScopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
+    expect(mockedScopeRuntimeApi.getMemberRunAudit).not.toHaveBeenCalled();
   });
 
   it("renders member published run history from the canonical Team member route", async () => {

--- a/apps/aevatar-console-web/src/pages/runtime-published-runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runtime-published-runs/index.test.tsx
@@ -285,6 +285,41 @@ describe("TeamMemberPublishedRunsPage", () => {
     expect(mockedScopeRuntimeApi.getMemberRunAudit).not.toHaveBeenCalled();
   });
 
+  it("does not refetch audit for a runId-only route when the catalog has no matching run", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/team-1/members/m-alpha/runs?runId=run-missing",
+    );
+    mockedScopeRuntimeApi.listMemberRuns.mockResolvedValueOnce({
+      displayName: "Alpha Workflow",
+      memberId: "m-alpha",
+      publishedServiceId: "svc-alpha",
+      publishedServiceKey: "scope-1:default:default:svc-alpha",
+      runs: [],
+      scopeId: "scope-1",
+    });
+
+    renderWithQueryClient(React.createElement(TeamMemberPublishedRunsPage));
+
+    expect(await screen.findByTestId("member-published-runs-replay")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockedScopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
+        "scope-1",
+        "m-alpha",
+        { take: 200 },
+      );
+    });
+    expect(mockedScopeRuntimeApi.getMemberRunAudit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Refresh" }).at(-1)!);
+
+    await waitFor(() => {
+      expect(mockedScopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(2);
+    });
+    expect(mockedScopeRuntimeApi.getMemberRunAudit).not.toHaveBeenCalled();
+  });
+
   it("renders member published run history from the canonical Team member route", async () => {
     const backendRunId = "scope-workflow:scope-1:wf-alpha:dep-alpha";
     window.history.replaceState(


### PR DESCRIPTION
## Problem

Published-runs member routes kept rendering the replay shell when the routed Team member no longer existed. The page then continued to request member runs and audit data, surfacing `STUDIO_MEMBER_NOT_FOUND` / unavailable error panels instead of leaving the stale member route.

Fixes #2630.

## Solution

- Treat `STUDIO_MEMBER_NOT_FOUND` from `studioApi.getMember` as a stale member route and replace navigation to `/scopes`.
- Gate member runs and audit loading behind a successful member lookup so missing members do not trigger follow-up runs/audit requests.
- Preserve deep-link behavior by only loading audit from a `runId`-only URL after the matching run is present in the runs catalog; URLs that include `actorId` can still load directly.
- Add a regression test for missing member redirect and tighten the loading test around the new member-first flow.

## Impact paths

- `apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx`
- `apps/aevatar-console-web/src/pages/runtime-published-runs/index.test.tsx`

## Verification

- `./node_modules/.bin/jest --selectProjects jsdom --runInBand --runTestsByPath src/pages/runtime-published-runs/index.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/max build`
- `git diff --check`

Note: direct `pnpm --dir apps/aevatar-console-web ...` initially stopped in this fresh worktree at pnpm's `ERR_PNPM_IGNORED_BUILDS` install gate. After dependencies were present, the same checks were run through local `node_modules/.bin`.

## Recurrence prevention

- Immediate symptom: missing Team member published-runs routes showed unavailable error panels.
- Root cause: runs/audit loaded before confirming the routed member existed.
- General failure pattern: child resource pages can leak child API failures when parent resource existence is not established first.
- Similar locations searched: `STUDIO_MEMBER_NOT_FOUND`, member routes, published runs, invoke/workflow studio member-loading call sites.
- Guard added: member lookup gates runs/audit queries; missing member routes replace to console home.
- Regression test added: missing member redirect test asserts `/scopes` and no runs/audit calls.
- Hard gate: targeted jsdom test, TypeScript, production build, and diff whitespace check.
- Remaining risks: no live browser session against the deployed backend in this PR.

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2630
- Worktree: /Users/xiezixin/Documents/work/aevatar-fix-missing-member-redirect
- Branch: fix/2026-07-08_missing-member-redirect
- Operator: AbigailDeng
- Freshness: Current user reproduction from July 8, 2026 on `origin/dev`.
