### PR TITLE
Fix Mission Wall first-run topology focus

### DIFF
--- a/apps/aevatar-console-web/src/pages/MissionWall/hooks/usePublishedRunWindow.test.ts
+++ b/apps/aevatar-console-web/src/pages/MissionWall/hooks/usePublishedRunWindow.test.ts
@@ -43,6 +43,7 @@ describe("Published Run Window state", () => {
 
     const model = reducePublishedRunWindowModel(
       {
+        manualSelection: false,
         runs: [first, second],
         selectedRunId: "run-second",
       },
@@ -63,6 +64,7 @@ describe("Published Run Window state", () => {
 
     const model = reducePublishedRunWindowModel(
       {
+        manualSelection: true,
         runs: [first, second],
         selectedRunId: "run-second",
       },
@@ -77,6 +79,29 @@ describe("Published Run Window state", () => {
     expect(model.selectedRunId).toBe("run-second");
   });
 
+  it("moves automatic focus to the preferred run when a new live run appears", () => {
+    const first = run("run-first");
+    const second = run("run-second");
+    const third = run("run-third");
+
+    const model = reducePublishedRunWindowModel(
+      {
+        manualSelection: false,
+        runs: [first, second],
+        selectedRunId: "run-second",
+      },
+      [third, first, second],
+      "run-third",
+    );
+
+    expect(model.runs.map((item) => item.runId)).toEqual([
+      "run-third",
+      "run-first",
+      "run-second",
+    ]);
+    expect(model.selectedRunId).toBe("run-third");
+  });
+
   it("selects a newly observed run after the current selection is done", () => {
     const first = run("run-first");
     const second = run("run-second", {
@@ -87,6 +112,7 @@ describe("Published Run Window state", () => {
 
     const model = reducePublishedRunWindowModel(
       {
+        manualSelection: false,
         runs: [first, second],
         selectedRunId: "run-second",
       },
@@ -115,6 +141,7 @@ describe("Published Run Window state", () => {
 
     const model = reducePublishedRunWindowModel(
       {
+        manualSelection: false,
         runs: [first, second],
         selectedRunId: "run-second",
       },

--- a/apps/aevatar-console-web/src/pages/MissionWall/hooks/usePublishedRunWindow.ts
+++ b/apps/aevatar-console-web/src/pages/MissionWall/hooks/usePublishedRunWindow.ts
@@ -9,6 +9,7 @@ export interface PublishedRunWindowState {
 }
 
 interface PublishedRunWindowModel {
+  readonly manualSelection: boolean;
   readonly runs: readonly MissionWallRun[];
   readonly selectedRunId?: string;
 }
@@ -64,6 +65,7 @@ export function mergePublishedRunWindowRuns(
 export function reducePublishedRunWindowModel(
   previousModel: PublishedRunWindowModel,
   nextRuns: readonly MissionWallRun[],
+  preferredRunId?: string,
 ): PublishedRunWindowModel {
   const previousRunIds = new Set(previousModel.runs.map((run) => run.runId));
   const nextWindowRuns = mergePublishedRunWindowRuns(
@@ -79,11 +81,19 @@ export function reducePublishedRunWindowModel(
   const selectedRun = previousModel.selectedRunId
     ? nextWindowRuns.find((run) => run.runId === previousModel.selectedRunId)
     : undefined;
+  const preferredRun = preferredRunId
+    ? nextWindowRuns.find((run) => run.runId === preferredRunId)
+    : undefined;
   const firstLiveRun = nextWindowRuns.find(isLiveRun);
+  const manualSelection =
+    previousModel.manualSelection && Boolean(selectedRunStillVisible);
 
   const nextModel = {
+    manualSelection,
     runs: nextWindowRuns,
     selectedRunId:
+      (manualSelection ? previousModel.selectedRunId : undefined) ??
+      preferredRun?.runId ??
       (selectedRunStillVisible && isLiveRun(selectedRun)
         ? previousModel.selectedRunId
         : undefined) ??
@@ -94,6 +104,7 @@ export function reducePublishedRunWindowModel(
   };
 
   if (
+    previousModel.manualSelection === nextModel.manualSelection &&
     previousModel.selectedRunId === nextModel.selectedRunId &&
     sameWindowRuns(previousModel.runs, nextModel.runs)
   ) {
@@ -108,15 +119,16 @@ export function usePublishedRunWindow(
   initialSelectedRunId?: string,
 ): PublishedRunWindowState {
   const [model, setModel] = React.useState<PublishedRunWindowModel>(() => ({
+    manualSelection: false,
     runs,
     selectedRunId: initialSelectedRunId ?? runs[0]?.runId,
   }));
 
   React.useEffect(() => {
     setModel((previousModel) =>
-      reducePublishedRunWindowModel(previousModel, runs),
+      reducePublishedRunWindowModel(previousModel, runs, initialSelectedRunId),
     );
-  }, [runs]);
+  }, [initialSelectedRunId, runs]);
 
   const selectedRun =
     model.runs.find((run) => run.runId === model.selectedRunId) ??
@@ -127,6 +139,7 @@ export function usePublishedRunWindow(
     selectRun: (runId) => {
       setModel((previousModel) => ({
         ...previousModel,
+        manualSelection: true,
         selectedRunId: runId,
       }));
     },

--- a/apps/aevatar-console-web/src/pages/MissionWall/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionWall/index.test.tsx
@@ -552,9 +552,9 @@ describe("MissionWallPage", () => {
     expect(cards[0]).toHaveTextContent("Fresh Workflow");
     expect(cards[0]).toHaveTextContent("0 / 15 steps");
     expect(
-      await screen.findByText(/Live Risk Workflow · Step Flow/),
+      await screen.findByText(/Fresh Workflow · Step Flow/),
     ).toBeInTheDocument();
-    expect(cards[0]).toHaveAttribute("aria-pressed", "false");
+    expect(cards[0]).toHaveAttribute("aria-pressed", "true");
     expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.getMemberRunAudit).not.toHaveBeenCalled();
 
@@ -565,6 +565,130 @@ describe("MissionWallPage", () => {
       await screen.findByText(/Fresh Workflow · Step Flow/),
     ).toBeInTheDocument();
     expect(cards[0]).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("auto-focuses a newly observed workflow run so its topology appears without a page reload", async () => {
+    const freshMember = workflowMember({
+      displayName: "Fresh workflow member",
+      memberId: "m-fresh",
+      publishedServiceId: "svc-fresh",
+      teamId: "team-alpha",
+      workflowId: "wf-fresh-draft",
+    });
+    let includeFreshMember = false;
+    (studioApi.getWorkflowBoardSnapshot as jest.Mock).mockImplementation(
+      async () =>
+        workflowBoardSnapshot([
+          workflowBoardMember({
+            actorId: "actor-risk-run",
+            completedSteps: 1,
+            currentNodeStatus: "waiting",
+            executionStatus: "running",
+            lastNodeUpdatedAt: "2026-06-30T04:59:20.000Z",
+            member: riskMember,
+            runId: "run-risk",
+            totalSteps: 3,
+            workflowName: "Live Risk Workflow",
+          }),
+          ...(includeFreshMember
+            ? [
+                workflowBoardMember({
+                  actorId: "actor-fresh-run",
+                  completedSteps: 0,
+                  currentNodeStatus: "running",
+                  executionStatus: "running",
+                  lastNodeUpdatedAt: "2026-06-30T04:59:58.000Z",
+                  member: freshMember,
+                  runId: "run-fresh",
+                  totalSteps: 4,
+                  workflowName: "Fresh Workflow",
+                }),
+              ]
+            : []),
+        ]),
+    );
+
+    const { queryClient } = renderWithQueryClient(
+      React.createElement(MissionWallPage),
+    );
+
+    expect(
+      await screen.findByText(/Live Risk Workflow · Step Flow/),
+    ).toBeInTheDocument();
+
+    includeFreshMember = true;
+    await queryClient.invalidateQueries({ queryKey: ["mission-wall"] });
+
+    expect(
+      await screen.findByText(/Fresh Workflow · Step Flow/),
+    ).toBeInTheDocument();
+
+    const list = screen.getByTestId("mission-wall-run-list");
+    const cards = within(list).getAllByRole("button");
+    expect(cards[0]).toHaveTextContent("Fresh Workflow");
+    expect(cards[0]).toHaveAttribute("aria-pressed", "true");
+    expect(await screen.findAllByText("Current")).not.toHaveLength(0);
+  });
+
+  it("keeps a manually selected run focused when another workflow run appears", async () => {
+    const freshMember = workflowMember({
+      displayName: "Fresh workflow member",
+      memberId: "m-fresh",
+      publishedServiceId: "svc-fresh",
+      teamId: "team-alpha",
+      workflowId: "wf-fresh-draft",
+    });
+    let includeFreshMember = false;
+    (studioApi.getWorkflowBoardSnapshot as jest.Mock).mockImplementation(
+      async () =>
+        workflowBoardSnapshot([
+          workflowBoardMember({
+            actorId: "actor-risk-run",
+            completedSteps: 1,
+            currentNodeStatus: "waiting",
+            executionStatus: "running",
+            lastNodeUpdatedAt: "2026-06-30T04:59:20.000Z",
+            member: riskMember,
+            runId: "run-risk",
+            totalSteps: 3,
+            workflowName: "Live Risk Workflow",
+          }),
+          ...(includeFreshMember
+            ? [
+                workflowBoardMember({
+                  actorId: "actor-fresh-run",
+                  completedSteps: 0,
+                  currentNodeStatus: "running",
+                  executionStatus: "running",
+                  lastNodeUpdatedAt: "2026-06-30T04:59:58.000Z",
+                  member: freshMember,
+                  runId: "run-fresh",
+                  totalSteps: 4,
+                  workflowName: "Fresh Workflow",
+                }),
+              ]
+            : []),
+        ]),
+    );
+
+    const { queryClient } = renderWithQueryClient(
+      React.createElement(MissionWallPage),
+    );
+
+    const riskCard = (await screen.findByText("Live Risk Workflow")).closest(
+      "button",
+    );
+    expect(riskCard).toBeTruthy();
+    fireEvent.click(riskCard as HTMLButtonElement);
+
+    includeFreshMember = true;
+    await queryClient.invalidateQueries({ queryKey: ["mission-wall"] });
+
+    expect(await screen.findByText("Fresh Workflow")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Live Risk Workflow · Step Flow/),
+    ).toBeInTheDocument();
+    expect(riskCard).toHaveAttribute("aria-pressed", "true");
   });
 
   it("shows the selected member snapshot nodes in the right workflow graph", async () => {


### PR DESCRIPTION
## Problem

Mission Wall can receive a newly created workflow first run in the left run window while the right-side topology remains on the previous automatically selected run. A full page refresh recomputes focus from the workflow-board snapshot and then shows the new workflow topology, which made the live incremental path inconsistent with page initialization.

Fixes #2638.

## Solution

- Track whether Mission Wall focus was chosen automatically or manually by the operator.
- On workflow-board refreshes, let automatic focus follow the current preferred run from the refreshed snapshot so newly observed first runs drive the right-side topology without a full reload.
- Preserve manual operator selection: if the user clicked a run, later refreshed/new runs are listed but do not steal the right panel.
- Add reducer and page-level regression coverage for both auto-focus and manual-selection behavior.

## Impact paths

- `apps/aevatar-console-web/src/pages/MissionWall/hooks/usePublishedRunWindow.ts`
- `apps/aevatar-console-web/src/pages/MissionWall/hooks/usePublishedRunWindow.test.ts`
- `apps/aevatar-console-web/src/pages/MissionWall/index.test.tsx`

## Validation

- `./node_modules/.bin/tsc --noEmit` passed.
- `./node_modules/.bin/jest --selectProjects jsdom --runInBand --watchman=false` passed: 112 suites, 925 tests.
- `./node_modules/.bin/max build` passed.

Note: `pnpm --dir apps/aevatar-console-web ...` attempted dependency install in the fresh worktree and was blocked by pnpm build-script approval policy (`ERR_PNPM_IGNORED_BUILDS`). After dependencies were present, validation used the equivalent local frontend binaries directly.

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2638
- Worktree: /Users/xiezixin/Documents/work/aevatar-fkst-2026-07-08-issue-2638-mission-wall-topology
- Branch: fix/2026-07-08_mission-wall-first-run-topology
- Operator: AbigailDeng
- Freshness: issue created on 2026-07-08 and selected by the user in the current turn