### PR TITLE
Fix FKST host policy CI gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,20 +145,17 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       (
-        vars.FKST_GITHUB_BOT_LOGIN != '' &&
         github.event_name == 'pull_request_review' &&
-        github.actor != vars.FKST_GITHUB_BOT_LOGIN
+        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
       ) ||
       (
-        vars.FKST_GITHUB_BOT_LOGIN != '' &&
         github.event_name == 'pull_request_review_comment' &&
-        github.actor != vars.FKST_GITHUB_BOT_LOGIN
+        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
       ) ||
       (
-        vars.FKST_GITHUB_BOT_LOGIN != '' &&
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        github.actor != vars.FKST_GITHUB_BOT_LOGIN
+        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/tools/ci/fkst_host_policy_guard.sh
+++ b/tools/ci/fkst_host_policy_guard.sh
@@ -34,8 +34,63 @@ resolve_diff_target() {
   printf 'HEAD\n'
 }
 
+resolve_pr_number() {
+  if [[ -n "${PR_NUMBER:-}" ]]; then
+    printf '%s\n' "${PR_NUMBER}"
+    return 0
+  fi
+
+  local event_path="${GITHUB_EVENT_PATH:-}"
+  if [[ -n "${event_path}" && -f "${event_path}" ]]; then
+    python3 - <<'PY' "${event_path}"
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+number = (
+    (payload.get("pull_request") or {}).get("number")
+    or (payload.get("issue") or {}).get("number")
+)
+if number:
+    print(number)
+PY
+  fi
+}
+
+resolve_diff_target_from_pr() {
+  local pr_number="$1"
+  [[ -n "${pr_number}" ]] || return 1
+  [[ -n "${GITHUB_REPOSITORY:-}" ]] || return 1
+
+  local pr_json
+  pr_json="$(gh pr view "${pr_number}" --repo "${GITHUB_REPOSITORY}" --json baseRefName,baseRefOid,headRefOid 2>/dev/null)" \
+    || return 1
+
+  local base_ref base_sha head_sha
+  base_ref="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("baseRefName") or "")' <<< "${pr_json}")"
+  base_sha="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("baseRefOid") or "")' <<< "${pr_json}")"
+  head_sha="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("headRefOid") or "")' <<< "${pr_json}")"
+
+  [[ -n "${base_sha}" && -n "${head_sha}" ]] || return 1
+
+  git fetch --no-tags origin \
+    "${base_sha}" \
+    "${head_sha}" \
+    "+refs/heads/${base_ref}:refs/remotes/origin/${base_ref}" \
+    2>/dev/null || true
+
+  resolve_diff_target_from_shas "${base_sha}" "${head_sha}"
+}
+
+RESOLVED_PR_NUMBER="$(resolve_pr_number || true)"
+export RESOLVED_PR_NUMBER
+
 if [[ -n "${GITHUB_BASE_SHA:-}" && -n "${GITHUB_HEAD_SHA:-}" ]]; then
   DIFF_TARGET="$(resolve_diff_target_from_shas "${GITHUB_BASE_SHA}" "${GITHUB_HEAD_SHA}")" \
+    || DIFF_TARGET="$(resolve_diff_target "${GITHUB_BASE_REF:-dev}")"
+elif [[ -n "${RESOLVED_PR_NUMBER}" ]]; then
+  DIFF_TARGET="$(resolve_diff_target_from_pr "${RESOLVED_PR_NUMBER}")" \
     || DIFF_TARGET="$(resolve_diff_target "${GITHUB_BASE_REF:-dev}")"
 elif [[ -n "${GITHUB_BASE_REF:-}" ]]; then
   DIFF_TARGET="$(resolve_diff_target "${GITHUB_BASE_REF}")"
@@ -48,29 +103,49 @@ fi
 echo "FKST host policy guard: comparing ${DIFF_TARGET}"
 
 CHANGED_PATHS="$(git diff --name-only "${DIFF_TARGET}" 2>/dev/null || true)"
-PRODUCT_PATHS=""
-while IFS= read -r changed_path; do
-  [[ -n "${changed_path}" ]] || continue
+BACKEND_IMPACT_PATHS=""
+
+is_backend_impact_path() {
+  local changed_path="$1"
+
   case "${changed_path}" in
-    LICENSE|CHANGELOG|README.md|.fkst/*|.github/*|docs/*|test/*|tests/*|tools/*|workflows/*|*.md|*.txt|*.yml|*.yaml|*.json|*.toml)
-      continue
+    src/*|agents/*|test/*|demos/*|scripts/*|tools/ci/*)
+      return 0
+      ;;
+    .github/workflows/ci.yml)
+      return 0
+      ;;
+    aevatar.slnx|aevatar.*.slnf|Directory.Build.props|Directory.Packages.props|global.json|buf.work.yaml)
+      return 0
+      ;;
+    docker-compose.yml|docker-compose.*.yml)
+      return 0
       ;;
   esac
-  PRODUCT_PATHS="${PRODUCT_PATHS}${changed_path}"$'\n'
-done <<< "${CHANGED_PATHS}"
-PRODUCT_PATHS="${PRODUCT_PATHS%$'\n'}"
 
-# Informational only: this classification is printed for reviewers; the guard itself
-# enforces nothing based on it. The only enforced gate below is the unresolved P1/P2
-# review-comment scan.
-if [[ -n "${PRODUCT_PATHS}" ]]; then
-  echo "Product/runtime-impact paths changed (informational):"
-  printf '%s\n' "${PRODUCT_PATHS}"
+  return 1
+}
+
+while IFS= read -r changed_path; do
+  [[ -n "${changed_path}" ]] || continue
+  if is_backend_impact_path "${changed_path}"; then
+    BACKEND_IMPACT_PATHS="${BACKEND_IMPACT_PATHS}${changed_path}"$'\n'
+  fi
+done <<< "${CHANGED_PATHS}"
+BACKEND_IMPACT_PATHS="${BACKEND_IMPACT_PATHS%$'\n'}"
+
+# The unresolved P1/P2 review-comment policy is a backend-host merge gate. Frontend-only
+# PRs still get their own console-web validation, but should not be blocked by backend
+# review policy threads.
+if [[ -n "${BACKEND_IMPACT_PATHS}" ]]; then
+  echo "Backend-impact paths changed:"
+  printf '%s\n' "${BACKEND_IMPACT_PATHS}"
 else
-  echo "No product/runtime-impact paths changed (informational)."
+  echo "No backend-impact paths changed; skipped unresolved P1/P2 review-comment gate."
+  exit 0
 fi
 
-if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" && -z "${PR_NUMBER:-}" ]]; then
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" && -z "${RESOLVED_PR_NUMBER}" ]]; then
   echo "Not a pull_request context; skipped GitHub review/comment gates."
   exit 0
 fi
@@ -89,7 +164,7 @@ if "/" not in repo:
     raise SystemExit(1)
 owner, name = repo.split("/", 1)
 
-pr_number = os.environ.get("PR_NUMBER")
+pr_number = os.environ.get("RESOLVED_PR_NUMBER") or os.environ.get("PR_NUMBER")
 if not pr_number:
     event_path = os.environ.get("GITHUB_EVENT_PATH")
     if event_path and Path(event_path).is_file():

--- a/tools/ci/test_stability_guards.sh
+++ b/tools/ci/test_stability_guards.sh
@@ -15,6 +15,7 @@ run_guard_meta_tests() {
   bash "${SCRIPT_DIR}/tests/test_projection_document_reader_list_async_guard.sh"
   bash "${SCRIPT_DIR}/tests/test_catch_exception_observability_guard.sh"
   bash "${SCRIPT_DIR}/tests/test_lark_agent_path_contract_guard.sh"
+  bash "${SCRIPT_DIR}/tests/test_fkst_host_policy_guard.sh"
 }
 
 if [[ ! -f "${allowlist_file}" ]]; then

--- a/tools/ci/tests/test_fkst_host_policy_guard.sh
+++ b/tools/ci/tests/test_fkst_host_policy_guard.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+SOURCE_GUARD="${REPO_ROOT}/tools/ci/fkst_host_policy_guard.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export GITHUB_REPOSITORY="aevatarAI/aevatar"
+export GITHUB_EVENT_NAME="pull_request"
+export PR_NUMBER="2631"
+
+run_guard() {
+  local worktree="$1"
+  local output="$2"
+
+  (
+    cd "${worktree}"
+    GITHUB_BASE_SHA="$(git rev-parse HEAD~1)" \
+      GITHUB_HEAD_SHA="$(git rev-parse HEAD)" \
+      PATH="${TMP_DIR}/bin:${PATH}" \
+      bash tools/ci/fkst_host_policy_guard.sh
+  ) > "${output}" 2>&1
+}
+
+create_worktree() {
+  local name="$1"
+  local path="${TMP_DIR}/${name}"
+
+  git init -q "${path}"
+  (
+    cd "${path}"
+    git config user.email "ci@example.invalid"
+    git config user.name "CI Test"
+    mkdir -p apps/aevatar-console-web/src src/Aevatar.Foundation.Core tools/ci
+    cp "${SOURCE_GUARD}" tools/ci/fkst_host_policy_guard.sh
+    printf 'initial\n' > README.md
+    git add README.md tools/ci/fkst_host_policy_guard.sh
+    git commit -q -m "initial"
+  )
+
+  printf '%s\n' "${path}"
+}
+
+install_mock_gh() {
+  mkdir -p "${TMP_DIR}/bin"
+  cat > "${TMP_DIR}/bin/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh was called\n' >> "${GH_CALL_LOG:?}"
+cat <<'JSON'
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": { "hasNextPage": false, "endCursor": null },
+          "nodes": []
+        },
+        "comments": {
+          "pageInfo": { "hasNextPage": false, "endCursor": null },
+          "nodes": []
+        }
+      }
+    }
+  }
+}
+JSON
+SH
+  chmod +x "${TMP_DIR}/bin/gh"
+}
+
+install_mock_gh
+
+frontend_worktree="$(create_worktree frontend-only)"
+(
+  cd "${frontend_worktree}"
+  printf 'frontend\n' > apps/aevatar-console-web/src/App.tsx
+  git add apps/aevatar-console-web/src/App.tsx
+  git commit -q -m "frontend"
+)
+frontend_output="${TMP_DIR}/frontend.out"
+frontend_gh_log="${TMP_DIR}/frontend-gh.log"
+export GH_CALL_LOG="${frontend_gh_log}"
+run_guard "${frontend_worktree}" "${frontend_output}"
+
+if ! grep -Fq "No backend-impact paths changed; skipped unresolved P1/P2 review-comment gate." "${frontend_output}"; then
+  echo "Expected frontend-only changes to skip FKST host policy review scan."
+  cat "${frontend_output}"
+  exit 1
+fi
+
+if [[ -s "${frontend_gh_log}" ]]; then
+  echo "Expected frontend-only changes not to query GitHub review threads."
+  cat "${frontend_output}"
+  cat "${frontend_gh_log}"
+  exit 1
+fi
+
+backend_worktree="$(create_worktree backend-change)"
+(
+  cd "${backend_worktree}"
+  printf 'backend\n' > src/Aevatar.Foundation.Core/Backend.cs
+  git add src/Aevatar.Foundation.Core/Backend.cs
+  git commit -q -m "backend"
+)
+backend_output="${TMP_DIR}/backend.out"
+backend_gh_log="${TMP_DIR}/backend-gh.log"
+export GH_CALL_LOG="${backend_gh_log}"
+run_guard "${backend_worktree}" "${backend_output}"
+
+if ! grep -Fq "Backend-impact paths changed:" "${backend_output}"; then
+  echo "Expected backend changes to enter FKST host policy review scan."
+  cat "${backend_output}"
+  exit 1
+fi
+
+if ! grep -Fq "No unresolved P1/P2 review comments found." "${backend_output}"; then
+  echo "Expected backend scan to complete when no P1/P2 blockers exist."
+  cat "${backend_output}"
+  exit 1
+fi
+
+if [[ ! -s "${backend_gh_log}" ]]; then
+  echo "Expected backend changes to query GitHub review threads."
+  cat "${backend_output}"
+  exit 1
+fi
+
+echo "fkst host policy guard tests passed"


### PR DESCRIPTION
## Problem

The FKST host policy guard was intended to enforce unresolved P1/P2 review comments for backend-impact PRs, but two CI details made it behave incorrectly:

- `pull_request_review` / `pull_request_review_comment` / PR `issue_comment` runs were gated on `vars.FKST_GITHUB_BOT_LOGIN != ''`, so repos without that variable skipped the rerun path entirely.
- `tools/ci/fkst_host_policy_guard.sh` only printed product/runtime changed paths as informational output. It still scanned unresolved P1/P2 comments for frontend-only PRs, so console-web review comments could block via a backend host policy job.

## Solution

- Let review/comment-triggered FKST host policy runs execute when the bot-login variable is unset, while still skipping the configured bot actor when present.
- Move the backend-impact path gate into `tools/ci/fkst_host_policy_guard.sh` so all event shapes share the same skip behavior.
- Resolve PR number and diff SHAs from the event payload or `gh pr view` when review/comment events do not provide normal pull-request SHA env vars.
- Add a regression shell test that proves frontend-only changes skip the GitHub review scan and backend changes still run it.

## Impact Paths

- `.github/workflows/ci.yml`
- `tools/ci/fkst_host_policy_guard.sh`
- `tools/ci/test_stability_guards.sh`
- `tools/ci/tests/test_fkst_host_policy_guard.sh`

## Verification

- `bash tools/ci/tests/test_fkst_host_policy_guard.sh`
- `bash tools/ci/test_stability_guards.sh`
- `GITHUB_REPOSITORY=aevatarAI/aevatar GITHUB_EVENT_NAME=pull_request_review_comment PR_NUMBER=2631 bash tools/ci/fkst_host_policy_guard.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci yaml ok"'`
- `git diff --check`

## Note

GitHub Actions has `pull_request_review_comment` activity types for comment create/edit/delete, but resolving a review thread by itself is not a review-comment event. This PR makes comment/review reruns work correctly; a resolve-only action may still need a manual rerun or a follow-up comment to trigger CI.
