### PR TITLE
Add Studio member workflow bind tool

### DIFF
--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Studio.Application.Provisioning;
+
+namespace Aevatar.AI.ToolProviders.StudioProvisioning;
+
+internal sealed class BindStudioMemberWorkflowTool : IAgentTool
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+    };
+
+    private readonly IStudioMemberWorkflowBindingPort _bindingPort;
+
+    public BindStudioMemberWorkflowTool(IStudioMemberWorkflowBindingPort bindingPort)
+    {
+        _bindingPort = bindingPort ?? throw new ArgumentNullException(nameof(bindingPort));
+    }
+
+    public string Name => "aevatar_bind_member_workflow";
+
+    public string Description =>
+        "Bind workflow YAML to an existing Studio member in the caller's current Aevatar scope. " +
+        "Use this after creating a team/member when the workflow should appear on that member's Studio workflow page. " +
+        "Supply member_id and workflow_yaml, plus optional workflow_id; do not provide scope_id because scope is taken from the session context.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "member_id": {
+              "type": "string",
+              "description": "Existing Studio member id to bind the workflow to. Required."
+            },
+            "workflow_yaml": {
+              "type": "string",
+              "description": "Complete workflow YAML to bind to the member. Required."
+            },
+            "workflow_id": {
+              "type": "string",
+              "description": "Optional stable workflow id. Omit to let the platform derive one."
+            }
+          },
+          "required": ["member_id", "workflow_yaml"]
+        }
+        """;
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalPolicies.CreateScopedResource;
+    public bool IsReadOnly => false;
+    public bool IsDestructive => false;
+    public string SideEffectKind => "studio.member.workflow.bind";
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var scopeId = Normalize(AgentToolRequestContext.ScopeId);
+        if (scopeId is null)
+        {
+            return ErrorJson(
+                "caller_scope_unavailable",
+                "scope_id is required in AgentToolRequestContext. The local Studio member workflow bind tool uses the caller scope from the tool execution context.");
+        }
+
+        BindStudioMemberWorkflowArguments? args;
+        try
+        {
+            var unknownArgument = FindUnknownArgument(argumentsJson);
+            if (unknownArgument is not null)
+                return ErrorJson("invalid_arguments", $"Unknown argument: {unknownArgument}");
+
+            args = JsonSerializer.Deserialize<BindStudioMemberWorkflowArguments>(argumentsJson, s_jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            return ErrorJson("invalid_arguments", $"Could not parse tool arguments: {ex.Message}");
+        }
+
+        if (args is null)
+            return ErrorJson("invalid_arguments", "Tool arguments are required.");
+
+        var memberId = Normalize(args.MemberId);
+        if (memberId is null)
+            return ErrorJson("invalid_arguments", "member_id is required.");
+
+        var workflowYaml = Normalize(args.WorkflowYaml);
+        if (workflowYaml is null)
+            return ErrorJson("invalid_arguments", "workflow_yaml is required.");
+
+        var request = new StudioMemberWorkflowBindingRequest(scopeId, memberId, workflowYaml)
+        {
+            WorkflowId = Normalize(args.WorkflowId),
+        };
+
+        try
+        {
+            var result = await _bindingPort.BindAsync(request, ct);
+            return JsonSerializer.Serialize(
+                new BindStudioMemberWorkflowResultJson(
+                    Success: result.Success,
+                    ScopeId: result.ScopeId,
+                    MemberId: result.MemberId,
+                    BindingRunId: result.BindingRunId,
+                    Status: result.Status,
+                    AckStage: result.AckStage,
+                    BindingRunRole: result.BindingRunRole,
+                    BindingRunUrl: $"/api/scopes/{Uri.EscapeDataString(result.ScopeId)}/members/{Uri.EscapeDataString(result.MemberId)}/binding-runs/{Uri.EscapeDataString(result.BindingRunId)}",
+                    MemberWorkflowUrl: $"/api/scopes/{Uri.EscapeDataString(result.ScopeId)}/members/{Uri.EscapeDataString(result.MemberId)}/binding"),
+                s_jsonOptions);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ErrorJson("invalid_arguments", ex.Message);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return ErrorJson("member_workflow_bind_failed", $"Studio member workflow bind failed: {ex.GetType().Name}");
+        }
+    }
+
+    private static string ErrorJson(string code, string message) =>
+        JsonSerializer.Serialize(new BindStudioMemberWorkflowErrorJson(
+            new BindStudioMemberWorkflowErrorBody(code, message)),
+            s_jsonOptions);
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? FindUnknownArgument(string argumentsJson)
+    {
+        using var document = JsonDocument.Parse(argumentsJson);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+            return null;
+
+        foreach (var property in document.RootElement.EnumerateObject())
+        {
+            if (property.Name is not "member_id" and not "workflow_yaml" and not "workflow_id")
+                return property.Name;
+        }
+
+        return null;
+    }
+
+    private sealed record BindStudioMemberWorkflowArguments(
+        [property: JsonPropertyName("member_id")] string? MemberId,
+        [property: JsonPropertyName("workflow_yaml")] string? WorkflowYaml,
+        [property: JsonPropertyName("workflow_id")] string? WorkflowId);
+
+    private sealed record BindStudioMemberWorkflowResultJson(
+        bool Success,
+        string ScopeId,
+        string MemberId,
+        string BindingRunId,
+        string Status,
+        string AckStage,
+        string BindingRunRole,
+        string BindingRunUrl,
+        string MemberWorkflowUrl);
+
+    private sealed record BindStudioMemberWorkflowErrorJson(BindStudioMemberWorkflowErrorBody Error);
+
+    private sealed record BindStudioMemberWorkflowErrorBody(string Code, string Message);
+}

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ProvisionWorkflowScheduleToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ProvisionWorkflowScheduleToolSource.cs
@@ -71,3 +71,22 @@ public sealed class CreateStudioMemberToolSource : IAgentToolSource
                 : [new CreateStudioMemberTool(_memberProvisioningPort)]);
     }
 }
+
+public sealed class BindStudioMemberWorkflowToolSource : IAgentToolSource
+{
+    private readonly IStudioMemberWorkflowBindingPort? _bindingPort;
+
+    public BindStudioMemberWorkflowToolSource(IStudioMemberWorkflowBindingPort? bindingPort = null)
+    {
+        _bindingPort = bindingPort;
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<IAgentTool>>(
+            _bindingPort is null
+                ? []
+                : [new BindStudioMemberWorkflowTool(_bindingPort)]);
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ServiceCollectionExtensions.cs
@@ -22,6 +22,8 @@ public static class ServiceCollectionExtensions
             ServiceDescriptor.Singleton<IAgentToolSource, CreateStudioTeamToolSource>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IAgentToolSource, CreateStudioMemberToolSource>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IAgentToolSource, BindStudioMemberWorkflowToolSource>());
         return services;
     }
 }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -321,6 +321,7 @@ public static class MainnetHostBuilderExtensions
                     CreateToolSource<ProvisionWorkflowScheduleToolSource>,
                     CreateToolSource<CreateStudioTeamToolSource>,
                     CreateToolSource<CreateStudioMemberToolSource>,
+                    CreateToolSource<BindStudioMemberWorkflowToolSource>,
                     CreateToolSource<ResponsesAevatarToolProvider>,
                     CreateToolSource<ChannelInteractiveReplyToolSource>,
                     CreateToolSource<ChannelRegistrationToolSource>,

--- a/src/Aevatar.Studio.Application.Abstractions/Provisioning/IStudioMemberWorkflowBindingPort.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Provisioning/IStudioMemberWorkflowBindingPort.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.Studio.Application.Provisioning;
+
+public interface IStudioMemberWorkflowBindingPort
+{
+    Task<StudioMemberWorkflowBindingResult> BindAsync(
+        StudioMemberWorkflowBindingRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowBindingContracts.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowBindingContracts.cs
@@ -1,0 +1,18 @@
+namespace Aevatar.Studio.Application.Provisioning;
+
+public sealed record StudioMemberWorkflowBindingRequest(
+    string ScopeId,
+    string MemberId,
+    string WorkflowYaml)
+{
+    public string? WorkflowId { get; init; }
+}
+
+public sealed record StudioMemberWorkflowBindingResult(
+    bool Success,
+    string ScopeId,
+    string MemberId,
+    string BindingRunId,
+    string Status,
+    string AckStage,
+    string BindingRunRole);

--- a/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IStudioTeamService, StudioTeamService>();
         services.TryAddSingleton<IStudioTeamProvisioningPort, StudioTeamProvisioningPort>();
         services.TryAddSingleton<IStudioMemberProvisioningPort, StudioMemberProvisioningPort>();
+        services.TryAddSingleton<IStudioMemberWorkflowBindingPort, StudioMemberWorkflowBindingPort>();
         services.TryAddSingleton<IStudioTeamGAgentStreamInvocationService, StudioTeamGAgentStreamInvocationService>();
         services.TryAddSingleton<IWorkflowBoardClock, SystemWorkflowBoardClock>();
         services.TryAddSingleton<IWorkflowBoardRosterQueryPort, StudioWorkflowBoardRosterQueryPort>();

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
@@ -3,16 +3,22 @@ using System.Text;
 using Aevatar.Studio.Application.Provisioning;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Studio.Application.Studio.Services;
 
 public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindingPort
 {
     private readonly IStudioMemberService _memberService;
+    private readonly IWorkflowDefinitionParser _workflowDefinitionParser;
 
-    public StudioMemberWorkflowBindingPort(IStudioMemberService memberService)
+    public StudioMemberWorkflowBindingPort(
+        IStudioMemberService memberService,
+        IWorkflowDefinitionParser workflowDefinitionParser)
     {
         _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
+        _workflowDefinitionParser = workflowDefinitionParser
+            ?? throw new ArgumentNullException(nameof(workflowDefinitionParser));
     }
 
     public async Task<StudioMemberWorkflowBindingResult> BindAsync(
@@ -20,6 +26,13 @@ public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindi
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+
+        var parseResult = await _workflowDefinitionParser.ParseWorkflowYamlAsync(request.WorkflowYaml, ct);
+        if (!parseResult.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"workflow_yaml is not a valid workflow definition: {parseResult.Error}");
+        }
 
         var receipt = await _memberService.BindAsync(
             request.ScopeId,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
@@ -1,0 +1,40 @@
+using Aevatar.Studio.Application.Provisioning;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Services;
+
+public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindingPort
+{
+    private readonly IStudioMemberService _memberService;
+
+    public StudioMemberWorkflowBindingPort(IStudioMemberService memberService)
+    {
+        _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
+    }
+
+    public async Task<StudioMemberWorkflowBindingResult> BindAsync(
+        StudioMemberWorkflowBindingRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var receipt = await _memberService.BindAsync(
+            request.ScopeId,
+            request.MemberId,
+            new UpdateStudioMemberBindingRequest(
+                Workflow: new StudioMemberWorkflowBindingSpec(
+                    request.WorkflowId ?? string.Empty,
+                    [request.WorkflowYaml])),
+            ct);
+
+        return new StudioMemberWorkflowBindingResult(
+            Success: true,
+            ScopeId: receipt.ScopeId,
+            MemberId: receipt.MemberId,
+            BindingRunId: receipt.BindingRunId,
+            Status: receipt.Status,
+            AckStage: receipt.AckStage,
+            BindingRunRole: receipt.BindingRunRole);
+    }
+}

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Aevatar.Studio.Application.Provisioning;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -24,7 +26,7 @@ public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindi
             request.MemberId,
             new UpdateStudioMemberBindingRequest(
                 Workflow: new StudioMemberWorkflowBindingSpec(
-                    request.WorkflowId ?? string.Empty,
+                    ResolveWorkflowId(request),
                     [request.WorkflowYaml])),
             ct);
 
@@ -36,5 +38,17 @@ public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindi
             Status: receipt.Status,
             AckStage: receipt.AckStage,
             BindingRunRole: receipt.BindingRunRole);
+    }
+
+    private static string ResolveWorkflowId(StudioMemberWorkflowBindingRequest request) =>
+        string.IsNullOrWhiteSpace(request.WorkflowId)
+            ? $"workflow-{BuildWorkflowKey(request.ScopeId, request.MemberId)}"
+            : request.WorkflowId.Trim();
+
+    private static string BuildWorkflowKey(string scopeId, string memberId)
+    {
+        var identity = Encoding.UTF8.GetBytes($"{scopeId}\n{memberId}");
+        var hash = SHA256.HashData(identity);
+        return Convert.ToHexString(hash.AsSpan(0, 16)).ToLowerInvariant();
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -79,8 +79,8 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
     /// <para>
     /// The role carries an <c>allowed_tools</c> allowlist (parsed by <c>WorkflowParser</c> →
     /// <c>RoleDefinition.AgentToolScope</c>, intersected with any step scope by the execution kernel →
-    /// <c>ToolVisibility</c>). It INCLUDES Studio team/member creation, <c>aevatar_provision_workflow_schedule</c>
-    /// + the observe tools and EXCLUDES both the Lark <c>scheduled_agent_creator</c> and the hanging loose-definition tools
+    /// <c>ToolVisibility</c>). It INCLUDES Studio team/member creation, member workflow binding,
+    /// <c>aevatar_provision_workflow_schedule</c> + the observe tools and EXCLUDES both the Lark <c>scheduled_agent_creator</c> and the hanging loose-definition tools
     /// (<c>workflow_create_def</c>/<c>update</c>/<c>read</c>/<c>list_defs</c>, <c>aevatar_start_workflow</c>);
     /// the allowlist is the lever that keeps those out of the studio surface entirely (prompt steering alone is
     /// unreliable while a tool is visible).
@@ -126,9 +126,13 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
                          target_role: analyst
                          parameters:
                            prompt_prefix: "Summarize:"
-              3. Persist and schedule workflows by calling `aevatar_provision_workflow_schedule` with `workflow_yaml`
-                 and a `display_name`. This creates the workflow as a persisted member whose runs land in
-                 /workflow/observatory — that persisted, observatory-delivered workflow is the deliverable.
+              3. If the user already has or just created a Studio member for the workflow, bind the YAML to that
+                 member by calling `aevatar_bind_member_workflow` with `member_id`, `workflow_yaml`, and optional
+                 `workflow_id`. This is what makes the workflow visible on the member's Studio workflow page.
+              4. If the user asks for a standalone scheduled/Observatory automation rather than a workflow on an
+                 existing Team/Member page, call `aevatar_provision_workflow_schedule` with `workflow_yaml`
+                 and a `display_name`. This creates its own persisted workflow member whose runs land in
+                 /workflow/observatory.
                  Scheduling rules:
                  - If the request is recurring — it says 每天, 每周, 每月, 每隔, 定时, daily, weekly, monthly, hourly,
                    "each", "every", "monitor", "keep watching" or any repeating cadence — you MUST pass BOTH
@@ -142,32 +146,37 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
                    state the cron + timezone you set so the user can confirm.
                  - `run_immediately` defaults true so a demo run fires shortly after the bind; a demo fire is fine
                    alongside the cron, but it does not replace the cron for a recurring request.
-              3. If `aevatar_provision_workflow_schedule` returns an error, fix the `workflow_yaml` per the
-                 error message and call it again with the SAME `display_name` — provisioning is idempotent
+              5. If `aevatar_bind_member_workflow` or `aevatar_provision_workflow_schedule` returns an error,
+                 fix the `workflow_yaml` per the error message and call the same tool again. For schedule
+                 provisioning, use the SAME `display_name` — provisioning is idempotent
                  per display name (retries re-use the same member and schedule; they do not create
                  duplicates), and a failed validation provisions nothing. The flip side: re-provisioning an
                  existing `display_name` REPLACES that workflow and re-enables its schedule, so only reuse a
                  name to retry or update the same automation — give a different automation a fresh, specific
                  `display_name`.
-              4. `aevatar_provision_workflow_schedule` returns `Accepted` (the bind + run are asynchronous) — do
-                 NOT claim the workflow "ran successfully" from that receipt. Use `aevatar_observe_run` (and
-                 `aevatar_read_workflow_run_artifact` for outputs) to watch the demo/scheduled run, and tell the
-                 user to open /workflow/observatory to see the runs. Report honestly: state that the workflow was
-                 accepted and provisioned, then report the observed run status — never optimistically assume success.
-              5. You may use `ornn_search_skills` and `use_skill` to discover and load skills for genuinely
+              6. `aevatar_bind_member_workflow` and `aevatar_provision_workflow_schedule` return Accepted receipts
+                 (binding/scheduling/run are asynchronous) — do NOT claim the workflow "ran successfully" from
+                 those receipts. Use `aevatar_observe_run` (and `aevatar_read_workflow_run_artifact` for outputs)
+                 to watch demo/scheduled runs, and tell the user to open /workflow/observatory to see runs. Report
+                 honestly: state that the workflow was accepted/bound or provisioned, then report any observed run
+                 status — never optimistically assume success.
+              7. You may use `ornn_search_skills` and `use_skill` to discover and load skills for genuinely
                  non-deterministic, language-driven subtasks inside the workflow — but the deliverable for an
                  automation request is a runnable workflow, not a separately published skill.
 
               Hard rules:
-              - The deliverable is a runnable workflow persisted as a member whose runs are visible in
-                /workflow/observatory. Do NOT publish a prose skill as the answer to "build/automate/schedule X".
-              - Scheduling goes exclusively through `aevatar_provision_workflow_schedule` (Observatory-delivered).
-                Never deliver results to Lark/Telegram or any chat/bot, and never schedule a bot delivery.
+              - The deliverable is a runnable workflow bound to the requested Studio member, or a standalone
+                provisioned workflow whose runs are visible in /workflow/observatory. Do NOT publish a prose skill
+                as the answer to "build/automate/schedule X".
+              - For an existing Team/Member workflow page, binding goes through `aevatar_bind_member_workflow`.
+                Scheduling goes through `aevatar_provision_workflow_schedule` only for standalone Observatory
+                automations. Never deliver results to Lark/Telegram or any chat/bot, and never schedule a bot delivery.
               - The owning scope and your credentials come from the session; do not ask the user for scope,
                 channel, owner, or tokens.
             allowed_tools:
               - aevatar_create_team
               - aevatar_create_member
+              - aevatar_bind_member_workflow
               - aevatar_provision_workflow_schedule
               - aevatar_observe_run
               - aevatar_read_workflow_run_artifact

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -13,6 +13,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
     private const string ScheduleToolName = "aevatar_provision_workflow_schedule";
     private const string CreateTeamToolName = "aevatar_create_team";
     private const string CreateMemberToolName = "aevatar_create_member";
+    private const string BindMemberWorkflowToolName = "aevatar_bind_member_workflow";
 
     [Fact]
     public async Task ToolSource_ShouldDiscoverProvisionWorkflowScheduleTool()
@@ -49,12 +50,13 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
-    public async Task AddStudioProvisioningTools_WhenPortsRegistered_ShouldExposeScheduleTeamAndMemberTools()
+    public async Task AddStudioProvisioningTools_WhenPortsRegistered_ShouldExposeScheduleTeamMemberAndBindingTools()
     {
         var services = new ServiceCollection();
         services.AddSingleton<IWorkflowScheduleProvisioningPort, RecordingProvisioningPort>();
         services.AddSingleton<IStudioTeamProvisioningPort, RecordingTeamProvisioningPort>();
         services.AddSingleton<IStudioMemberProvisioningPort, RecordingMemberProvisioningPort>();
+        services.AddSingleton<IStudioMemberWorkflowBindingPort, RecordingMemberWorkflowBindingPort>();
         services.AddStudioProvisioningTools();
 
         var provider = services.BuildServiceProvider();
@@ -69,6 +71,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
         toolNames.Should().Contain(ScheduleToolName);
         toolNames.Should().Contain(CreateTeamToolName);
         toolNames.Should().Contain(CreateMemberToolName);
+        toolNames.Should().Contain(BindMemberWorkflowToolName);
     }
 
     [Fact]
@@ -85,6 +88,27 @@ public sealed class ProvisionWorkflowScheduleToolTests
     public async Task ToolSource_WhenMemberPortMissing_ShouldNotDiscoverCreateMemberTool()
     {
         var source = new CreateStudioMemberToolSource();
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ToolSource_WhenBindingPortRegistered_ShouldDiscoverBindMemberWorkflowTool()
+    {
+        var source = new BindStudioMemberWorkflowToolSource(new RecordingMemberWorkflowBindingPort());
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().ContainSingle();
+        tools[0].Name.Should().Be(BindMemberWorkflowToolName);
+    }
+
+    [Fact]
+    public async Task ToolSource_WhenBindingPortMissing_ShouldNotDiscoverBindMemberWorkflowTool()
+    {
+        var source = new BindStudioMemberWorkflowToolSource();
 
         var tools = await source.DiscoverToolsAsync();
 
@@ -234,6 +258,79 @@ public sealed class ProvisionWorkflowScheduleToolTests
     public async Task CreateMember_ShouldUseSharedCreateScopedResourceApprovalPolicy()
     {
         var tool = await DiscoverCreateMemberToolAsync(new RecordingMemberProvisioningPort());
+
+        tool.ApprovalMode.Should().Be(ToolApprovalPolicies.CreateScopedResource);
+        tool.Should().NotBeAssignableTo<IAgentToolCapabilityDescriptor>();
+    }
+
+    [Fact]
+    public async Task BindMemberWorkflow_ShouldCallBindingPortWithCallerScope()
+    {
+        var bindingPort = new RecordingMemberWorkflowBindingPort();
+        var tool = await DiscoverBindMemberWorkflowToolAsync(bindingPort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "member-alpha",
+              "workflow_yaml": "name: team_workflow\nsteps: []\n",
+              "workflow_id": "workflow-alpha"
+            }
+            """);
+
+        bindingPort.LastRequest.Should().NotBeNull();
+        bindingPort.LastRequest!.ScopeId.Should().Be("scope-current");
+        bindingPort.LastRequest.MemberId.Should().Be("member-alpha");
+        bindingPort.LastRequest.WorkflowYaml.Should().Contain("name: team_workflow");
+        bindingPort.LastRequest.WorkflowId.Should().Be("workflow-alpha");
+
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("scope_id").GetString().Should().Be("scope-current");
+        root.GetProperty("member_id").GetString().Should().Be("member-alpha");
+        root.GetProperty("binding_run_id").GetString().Should().Be("binding-run-1");
+        root.GetProperty("member_workflow_url").GetString()
+            .Should().Be("/api/scopes/scope-current/members/member-alpha/binding");
+    }
+
+    [Fact]
+    public async Task BindMemberWorkflow_WhenScopeMissing_ShouldReturnStructuredErrorAndNotCallPort()
+    {
+        var bindingPort = new RecordingMemberWorkflowBindingPort();
+        var tool = await DiscoverBindMemberWorkflowToolAsync(bindingPort);
+
+        using var _ = PushContext(scopeId: null, ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""{"member_id":"member-alpha","workflow_yaml":"name: demo\n"}""");
+
+        ErrorCode(output).Should().Be("caller_scope_unavailable");
+        bindingPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BindMemberWorkflow_WhenModelSuppliesScope_ShouldRejectUnknownArgumentAndNotCallPort()
+    {
+        var bindingPort = new RecordingMemberWorkflowBindingPort();
+        var tool = await DiscoverBindMemberWorkflowToolAsync(bindingPort);
+
+        using var _ = PushContext(scopeId: "scope-context", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "scope_id": "scope-model",
+              "member_id": "member-alpha",
+              "workflow_yaml": "name: demo\n"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+        ErrorMessage(output).Should().Be("Unknown argument: scope_id");
+        bindingPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BindMemberWorkflow_ShouldUseSharedCreateScopedResourceApprovalPolicy()
+    {
+        var tool = await DiscoverBindMemberWorkflowToolAsync(new RecordingMemberWorkflowBindingPort());
 
         tool.ApprovalMode.Should().Be(ToolApprovalPolicies.CreateScopedResource);
         tool.Should().NotBeAssignableTo<IAgentToolCapabilityDescriptor>();
@@ -424,6 +521,13 @@ public sealed class ProvisionWorkflowScheduleToolTests
         return tools.Single(tool => tool.Name == CreateMemberToolName);
     }
 
+    private static async Task<IAgentTool> DiscoverBindMemberWorkflowToolAsync(IStudioMemberWorkflowBindingPort bindingPort)
+    {
+        var source = new BindStudioMemberWorkflowToolSource(bindingPort);
+        var tools = await source.DiscoverToolsAsync();
+        return tools.Single(tool => tool.Name == BindMemberWorkflowToolName);
+    }
+
     private static AgentToolContextScope PushContext(string? scopeId, string? ownerSubject, string? accessToken)
     {
         return AgentToolContextScope.Push(new AgentToolExecutionContext(
@@ -531,6 +635,26 @@ public sealed class ProvisionWorkflowScheduleToolTests
             {
                 TeamId = request.TeamId,
             });
+        }
+    }
+
+    private sealed class RecordingMemberWorkflowBindingPort : IStudioMemberWorkflowBindingPort
+    {
+        public StudioMemberWorkflowBindingRequest? LastRequest { get; private set; }
+
+        public Task<StudioMemberWorkflowBindingResult> BindAsync(
+            StudioMemberWorkflowBindingRequest request,
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new StudioMemberWorkflowBindingResult(
+                Success: true,
+                ScopeId: request.ScopeId,
+                MemberId: request.MemberId,
+                BindingRunId: "binding-run-1",
+                Status: "accepted",
+                AckStage: "dispatch_accepted",
+                BindingRunRole: "candidate"));
         }
     }
 }

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -276,6 +276,7 @@ public sealed class MainnetHostCompositionTests
         workspace.Sources.Should().Contain(source => source is ProvisionWorkflowScheduleToolSource);
         workspace.Sources.Should().Contain(source => source is CreateStudioTeamToolSource);
         workspace.Sources.Should().Contain(source => source is CreateStudioMemberToolSource);
+        workspace.Sources.Should().Contain(source => source is BindStudioMemberWorkflowToolSource);
         workspace.Sources.Should().Contain(source => source.GetType().Name == "ResponsesAevatarToolProvider");
         workspace.Sources.Should().Contain(source => source is ChannelInteractiveReplyToolSource);
         workspace.Sources.Should().Contain(source => source is ChannelRegistrationToolSource);

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
@@ -1,0 +1,157 @@
+using Aevatar.Studio.Application.Provisioning;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioMemberWorkflowBindingPortTests
+{
+    [Fact]
+    public async Task BindAsync_WhenWorkflowIdMissing_ShouldDeriveStableWorkflowId()
+    {
+        var memberService = new RecordingMemberService();
+        var port = new StudioMemberWorkflowBindingPort(memberService);
+
+        await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        memberService.LastScopeId.Should().Be("scope-1");
+        memberService.LastMemberId.Should().Be("member-1");
+        memberService.LastRequest.Should().NotBeNull();
+        memberService.LastRequest!.Workflow.Should().NotBeNull();
+        memberService.LastRequest.Workflow!.WorkflowId.Should().StartWith("workflow-");
+        memberService.LastRequest.Workflow.WorkflowId.Should().NotBe("workflow-member-1");
+        memberService.LastRequest.Workflow.WorkflowId.Should().HaveLength("workflow-".Length + 32);
+        memberService.LastRequest.Workflow.WorkflowYamls.Should().ContainSingle()
+            .Which.Should().Contain("name: demo");
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenWorkflowIdMissing_ShouldConvergePerScopeAndMember()
+    {
+        var first = await BindWithoutWorkflowIdAsync("scope-1", "member-1");
+        var second = await BindWithoutWorkflowIdAsync("scope-1", "member-1");
+        var differentScope = await BindWithoutWorkflowIdAsync("scope-2", "member-1");
+
+        first.Should().Be(second);
+        differentScope.Should().NotBe(first);
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenWorkflowIdProvided_ShouldUseTrimmedWorkflowId()
+    {
+        var memberService = new RecordingMemberService();
+        var port = new StudioMemberWorkflowBindingPort(memberService);
+
+        await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n")
+        {
+            WorkflowId = " workflow-explicit ",
+        });
+
+        memberService.LastRequest.Should().NotBeNull();
+        memberService.LastRequest!.Workflow.Should().NotBeNull();
+        memberService.LastRequest.Workflow!.WorkflowId.Should().Be("workflow-explicit");
+    }
+
+    private static async Task<string> BindWithoutWorkflowIdAsync(string scopeId, string memberId)
+    {
+        var memberService = new RecordingMemberService();
+        var port = new StudioMemberWorkflowBindingPort(memberService);
+
+        await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            scopeId,
+            memberId,
+            "name: demo\nsteps: []\n"));
+
+        return memberService.LastRequest!.Workflow!.WorkflowId;
+    }
+
+    private sealed class RecordingMemberService : IStudioMemberService
+    {
+        public string? LastScopeId { get; private set; }
+        public string? LastMemberId { get; private set; }
+        public UpdateStudioMemberBindingRequest? LastRequest { get; private set; }
+
+        public Task<StudioMemberBindingAcceptedResponse> BindAsync(
+            string scopeId,
+            string memberId,
+            UpdateStudioMemberBindingRequest request,
+            CancellationToken ct = default)
+        {
+            LastScopeId = scopeId;
+            LastMemberId = memberId;
+            LastRequest = request;
+            return Task.FromResult(new StudioMemberBindingAcceptedResponse(
+                Status: StudioMemberBindingRunStatusNames.Accepted,
+                BindingRunId: "bind-run-1",
+                ScopeId: scopeId,
+                MemberId: memberId));
+        }
+
+        public Task<StudioMemberSummaryResponse> CreateAsync(
+            string scopeId,
+            CreateStudioMemberRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberRosterResponse> ListAsync(
+            string scopeId,
+            StudioMemberRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberDetailResponse> GetAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingViewResponse> GetBindingAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingRunStatusResponse> GetBindingRunAsync(
+            string scopeId,
+            string memberId,
+            string bindingRunId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberEndpointContractResponse?> GetEndpointContractAsync(
+            string scopeId,
+            string memberId,
+            string endpointId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingActivationResponse> ActivateBindingRevisionAsync(
+            string scopeId,
+            string memberId,
+            string revisionId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingRevisionActionResponse> RetireBindingRevisionAsync(
+            string scopeId,
+            string memberId,
+            string revisionId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberCommandResponse> UpdateAsync(
+            string scopeId,
+            string memberId,
+            UpdateStudioMemberRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
@@ -2,6 +2,7 @@ using Aevatar.Studio.Application.Provisioning;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Application.Studio.Services;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 
 namespace Aevatar.Studio.Tests;
@@ -12,7 +13,8 @@ public sealed class StudioMemberWorkflowBindingPortTests
     public async Task BindAsync_WhenWorkflowIdMissing_ShouldDeriveStableWorkflowId()
     {
         var memberService = new RecordingMemberService();
-        var port = new StudioMemberWorkflowBindingPort(memberService);
+        var parser = new RecordingWorkflowDefinitionParser();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
 
         await port.BindAsync(new StudioMemberWorkflowBindingRequest(
             ScopeId: "scope-1",
@@ -45,7 +47,8 @@ public sealed class StudioMemberWorkflowBindingPortTests
     public async Task BindAsync_WhenWorkflowIdProvided_ShouldUseTrimmedWorkflowId()
     {
         var memberService = new RecordingMemberService();
-        var port = new StudioMemberWorkflowBindingPort(memberService);
+        var parser = new RecordingWorkflowDefinitionParser();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
 
         await port.BindAsync(new StudioMemberWorkflowBindingRequest(
             ScopeId: "scope-1",
@@ -60,10 +63,32 @@ public sealed class StudioMemberWorkflowBindingPortTests
         memberService.LastRequest.Workflow!.WorkflowId.Should().Be("workflow-explicit");
     }
 
+    [Fact]
+    public async Task BindAsync_WhenWorkflowYamlInvalid_ShouldRejectBeforeDispatchingBind()
+    {
+        var memberService = new RecordingMemberService();
+        var parser = new RecordingWorkflowDefinitionParser
+        {
+            Error = "missing workflow name",
+        };
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
+
+        var action = () => port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "steps: []\n"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("workflow_yaml is not a valid workflow definition: missing workflow name");
+        parser.LastYaml.Should().Be("steps: []\n");
+        memberService.LastRequest.Should().BeNull();
+    }
+
     private static async Task<string> BindWithoutWorkflowIdAsync(string scopeId, string memberId)
     {
         var memberService = new RecordingMemberService();
-        var port = new StudioMemberWorkflowBindingPort(memberService);
+        var parser = new RecordingWorkflowDefinitionParser();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
 
         await port.BindAsync(new StudioMemberWorkflowBindingRequest(
             scopeId,
@@ -71,6 +96,22 @@ public sealed class StudioMemberWorkflowBindingPortTests
             "name: demo\nsteps: []\n"));
 
         return memberService.LastRequest!.Workflow!.WorkflowId;
+    }
+
+    private sealed class RecordingWorkflowDefinitionParser : IWorkflowDefinitionParser
+    {
+        public string? Error { get; init; }
+        public string? LastYaml { get; private set; }
+
+        public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
+            string workflowYaml,
+            CancellationToken ct = default)
+        {
+            LastYaml = workflowYaml;
+            return Task.FromResult(Error is null
+                ? WorkflowYamlParseResult.Success("demo")
+                : WorkflowYamlParseResult.Invalid(Error));
+        }
     }
 
     private sealed class RecordingMemberService : IStudioMemberService

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -202,6 +202,7 @@ public class WorkflowDefinitionCatalogTests
         role.SystemPrompt.Should().Contain("Studio agent");
         role.SystemPrompt.Should().Contain("aevatar_create_team");
         role.SystemPrompt.Should().Contain("aevatar_create_member");
+        role.SystemPrompt.Should().Contain("aevatar_bind_member_workflow");
         role.SystemPrompt.Should().Contain("aevatar_provision_workflow_schedule");
         role.SystemPrompt.Should().Contain("/workflow/observatory");
         role.SystemPrompt.Should().Contain("Do NOT");
@@ -228,6 +229,7 @@ public class WorkflowDefinitionCatalogTests
         var allowed = role.AgentToolScope!.AllowedToolNames;
         allowed.Should().Contain("aevatar_create_team");
         allowed.Should().Contain("aevatar_create_member");
+        allowed.Should().Contain("aevatar_bind_member_workflow");
         allowed.Should().Contain("aevatar_provision_workflow_schedule");
         allowed.Should().Contain("aevatar_observe_run");
         allowed.Should().Contain("aevatar_read_workflow_run_artifact");


### PR DESCRIPTION
## Summary
- Add `aevatar_bind_member_workflow`, a scoped Studio tool that binds workflow YAML to an existing Studio member via the member-first binding service.
- Register the binding port/tool source in Studio provisioning DI and expose it in Mainnet `workspace.default` plus the built-in Studio workflow allowlist.
- Update Studio prompt guidance so existing Team/Member workflow pages use member binding, while `aevatar_provision_workflow_schedule` stays for standalone Observatory automations.

## Notes
- This intentionally does not expose raw `workflows:save-and-bind` as an AI tool; the new tool is a narrower Studio semantic action and uses caller scope from `AgentToolRequestContext`.
- Existing loose definition tools (`workflow_create_def`, etc.) remain excluded from Studio chat because they do not bind to the member workflow page.

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj --nologo -v minimal`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --no-restore --filter "BuiltInStudioYaml_ShouldParseAsMemberProvisionStudioRoleWithToolAllowlist" -v minimal`
- [x] `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo --no-restore --filter "AddAevatarMainnetHost_ShouldRegisterDefaultToolSets" -v minimal`
- [ ] `bash tools/ci/test_stability_guards.sh` (local environment failed after guard checks passed due Homebrew Python `pyexpat`/`libexpat` linkage error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)