### PR TITLE
Trim Team overview copy

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -359,6 +359,7 @@ const enUSMessages = {
   'teams.detail.overview.configuration.primaryService': 'Primary service entry',
   'teams.detail.overview.configuration.title': 'Configuration details',
   'teams.detail.overview.configuration.versionIdentity': 'Version identity',
+  'teams.detail.overview.configuration.versionStatus': 'Version status',
   'teams.detail.overview.configuration.workflow': 'Team workflow',
   'teams.detail.overview.entry.configuredCaption':
     'Calls to this team route to this member first.',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -345,6 +345,7 @@ const zhCNMessages = {
   'teams.detail.overview.configuration.primaryService': '主服务入口',
   'teams.detail.overview.configuration.title': '配置明细',
   'teams.detail.overview.configuration.versionIdentity': '版本标识',
+  'teams.detail.overview.configuration.versionStatus': '版本状态',
   'teams.detail.overview.configuration.workflow': '团队 Workflow',
   'teams.detail.overview.entry.configuredCaption':
     '调用这支团队时会先路由到这个成员。',

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1095,7 +1095,7 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("scope-1")).toBeNull();
     const currentPostureHeading = screen.getByText("当前态势");
     const compositionHeading = screen.getByText("团队构成");
-    const configurationHeading = screen.getByText("配置明细");
+    const configurationButton = screen.getByRole("button", { name: "配置明细" });
     expect(screen.getByRole("button", { name: "测试团队" })).toBeTruthy();
     expect(currentPostureHeading).toBeTruthy();
     expect(screen.queryByText("启动状态")).toBeNull();
@@ -1103,14 +1103,14 @@ describe("TeamDetailPage", () => {
     expect(await screen.findByText("版本 · 运行中")).toBeTruthy();
     expect(await screen.findByText("运行 · 等待处理")).toBeTruthy();
     expect(compositionHeading).toBeTruthy();
-    expect(configurationHeading).toBeTruthy();
+    expect(configurationButton).toBeTruthy();
     expect(screen.queryByLabelText("Team test prompt")).toBeNull();
     expect(
       currentPostureHeading.compareDocumentPosition(compositionHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      compositionHeading.compareDocumentPosition(configurationHeading) &
+      compositionHeading.compareDocumentPosition(configurationButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.queryByText("Team authority")).toBeNull();
@@ -1144,7 +1144,7 @@ describe("TeamDetailPage", () => {
 
     expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
-    expect(screen.getByText("配置明细")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "配置明细" })).toBeTruthy();
     expect(screen.queryByText("信任态势")).toBeNull();
     expect(screen.queryByText("No successful baseline is available yet.")).toBeNull();
     expect(screen.queryByText("等待基线")).toBeNull();
@@ -1279,9 +1279,9 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByText("配置明细");
+    fireEvent.click(await screen.findByRole("button", { name: "配置明细" }));
 
-    expect(await screen.findByText("配置明细")).toBeTruthy();
+    expect(await screen.findByText("版本状态")).toBeTruthy();
     expect(screen.queryByText("服务路由已配置。")).toBeNull();
     expect(screen.queryByText("revisionId: rev-20260414…716964f3")).toBeNull();
     expect(screen.queryByText(`revisionId: ${longRevisionId}`)).toBeNull();
@@ -1360,11 +1360,13 @@ describe("TeamDetailPage", () => {
   it("shows configuration details in the overview", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("配置明细")).toBeTruthy();
-    expect(screen.getAllByText("团队 Workflow").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("绑定方式").length).toBeGreaterThan(0);
+    fireEvent.click(await screen.findByRole("button", { name: "配置明细" }));
+
+    expect(await screen.findByText("团队 Workflow")).toBeTruthy();
     expect(screen.getAllByText("主服务入口").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("版本标识").length).toBeGreaterThan(0);
+    expect(screen.getByText("版本状态")).toBeTruthy();
+    expect(screen.queryByText("绑定方式")).toBeNull();
+    expect(screen.queryByText("版本标识")).toBeNull();
     expect(screen.queryByText("连接器引用")).toBeNull();
     expect(screen.queryByText("服务能力")).toBeNull();
   });
@@ -3117,7 +3119,7 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("来自团队更新时间")).toBeNull();
     expect(screen.getByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
-    expect(screen.getByText("配置明细")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "配置明细" })).toBeTruthy();
     expect(screen.queryByText("团队更新时间")).toBeNull();
     expect(screen.queryByText("生命周期")).toBeNull();
 
@@ -3301,7 +3303,7 @@ describe("TeamDetailPage", () => {
 
     expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(await screen.findByText("团队构成")).toBeTruthy();
-    expect(await screen.findByText("配置明细")).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "配置明细" })).toBeTruthy();
     expect(screen.queryByText("Team summary 暂不可用")).toBeNull();
     expect(
       screen.queryByText("当前仍会显示运行时视图；Team summary 暂时无法读取。"),

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1095,7 +1095,7 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("scope-1")).toBeNull();
     const currentPostureHeading = screen.getByText("当前态势");
     const compositionHeading = screen.getByText("团队构成");
-    const configurationButton = screen.getByRole("button", { name: "配置明细" });
+    const workflowConfigurationLabel = await screen.findByText("团队 Workflow");
     expect(screen.getByRole("button", { name: "测试团队" })).toBeTruthy();
     expect(currentPostureHeading).toBeTruthy();
     expect(screen.queryByText("启动状态")).toBeNull();
@@ -1103,14 +1103,18 @@ describe("TeamDetailPage", () => {
     expect(await screen.findByText("版本 · 运行中")).toBeTruthy();
     expect(await screen.findByText("运行 · 等待处理")).toBeTruthy();
     expect(compositionHeading).toBeTruthy();
-    expect(configurationButton).toBeTruthy();
+    expect(workflowConfigurationLabel).toBeTruthy();
+    expect(screen.getByText("主服务入口")).toBeTruthy();
+    expect(screen.getByText("版本状态")).toBeTruthy();
+    expect(screen.getByText("负责处理升级工单")).toBeTruthy();
+    expect(screen.queryByText("已绑定，可接收流量。")).toBeNull();
     expect(screen.queryByLabelText("Team test prompt")).toBeNull();
     expect(
       currentPostureHeading.compareDocumentPosition(compositionHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      compositionHeading.compareDocumentPosition(configurationButton) &
+      compositionHeading.compareDocumentPosition(workflowConfigurationLabel) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(screen.queryByText("Team authority")).toBeNull();
@@ -1144,7 +1148,7 @@ describe("TeamDetailPage", () => {
 
     expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "配置明细" })).toBeTruthy();
+    expect(screen.getByText("团队 Workflow")).toBeTruthy();
     expect(screen.queryByText("信任态势")).toBeNull();
     expect(screen.queryByText("No successful baseline is available yet.")).toBeNull();
     expect(screen.queryByText("等待基线")).toBeNull();
@@ -1279,8 +1283,6 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "配置明细" }));
-
     expect(await screen.findByText("版本状态")).toBeTruthy();
     expect(screen.queryByText("服务路由已配置。")).toBeNull();
     expect(screen.queryByText("revisionId: rev-20260414…716964f3")).toBeNull();
@@ -1359,8 +1361,6 @@ describe("TeamDetailPage", () => {
 
   it("shows configuration details in the overview", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    fireEvent.click(await screen.findByRole("button", { name: "配置明细" }));
 
     expect(await screen.findByText("团队 Workflow")).toBeTruthy();
     expect(screen.getAllByText("主服务入口").length).toBeGreaterThan(0);
@@ -3119,7 +3119,7 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("来自团队更新时间")).toBeNull();
     expect(screen.getByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "配置明细" })).toBeTruthy();
+    expect(screen.getByText("团队 Workflow")).toBeTruthy();
     expect(screen.queryByText("团队更新时间")).toBeNull();
     expect(screen.queryByText("生命周期")).toBeNull();
 
@@ -3303,7 +3303,7 @@ describe("TeamDetailPage", () => {
 
     expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(await screen.findByText("团队构成")).toBeTruthy();
-    expect(await screen.findByRole("button", { name: "配置明细" })).toBeTruthy();
+    expect(await screen.findByText("团队 Workflow")).toBeTruthy();
     expect(screen.queryByText("Team summary 暂不可用")).toBeNull();
     expect(
       screen.queryByText("当前仍会显示运行时视图；Team summary 暂时无法读取。"),

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1093,11 +1093,12 @@ describe("TeamDetailPage", () => {
     expect(screen.getByRole("button", { name: "返回团队列表" })).toBeTruthy();
     expect(screen.queryByText("工作区 ID")).toBeNull();
     expect(screen.queryByText("scope-1")).toBeNull();
-    const currentPostureHeading = screen.getByText("启动状态");
+    const currentPostureHeading = screen.getByText("当前态势");
     const compositionHeading = screen.getByText("团队构成");
     const configurationHeading = screen.getByText("配置明细");
     expect(screen.getByRole("button", { name: "测试团队" })).toBeTruthy();
     expect(currentPostureHeading).toBeTruthy();
+    expect(screen.queryByText("启动状态")).toBeNull();
     expect(await screen.findByText(/ReadModel ·/)).toBeTruthy();
     expect(await screen.findByText("版本 · 运行中")).toBeTruthy();
     expect(await screen.findByText("运行 · 等待处理")).toBeTruthy();
@@ -1141,7 +1142,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("启动状态")).toBeTruthy();
+    expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
     expect(screen.getByText("配置明细")).toBeTruthy();
     expect(screen.queryByText("信任态势")).toBeNull();
@@ -1280,7 +1281,8 @@ describe("TeamDetailPage", () => {
 
     await screen.findByText("配置明细");
 
-    expect(await screen.findByText("服务路由已配置。")).toBeTruthy();
+    expect(await screen.findByText("配置明细")).toBeTruthy();
+    expect(screen.queryByText("服务路由已配置。")).toBeNull();
     expect(screen.queryByText("revisionId: rev-20260414…716964f3")).toBeNull();
     expect(screen.queryByText(`revisionId: ${longRevisionId}`)).toBeNull();
   });
@@ -1335,7 +1337,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("启动状态")).toBeTruthy();
+    expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(screen.queryByText("当前任务事件流")).toBeNull();
 
     await waitFor(() => {
@@ -1584,7 +1586,7 @@ describe("TeamDetailPage", () => {
 
     expect(await screen.findByText("当前成员")).toBeTruthy();
     expect((await screen.findAllByText("Team Alpha Operator")).length).toBeGreaterThan(0);
-    expect(screen.getByText("当前从团队成员中选中。")).toBeTruthy();
+    expect(screen.queryByText("当前从团队成员中选中。")).toBeNull();
     expect(screen.queryByText("member-team-alpha")).toBeNull();
     expect(screen.queryByText("memberId · member-team-alpha")).toBeNull();
   });
@@ -1602,13 +1604,13 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("启动状态")).toBeTruthy();
+    expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(screen.getAllByText("等待首次测试").length).toBeGreaterThan(0);
     expect(screen.getByText("下一步 · 测试团队")).toBeTruthy();
     expect(
-      screen.getByText("团队入口已就绪，但还没有可见运行。点击“测试团队”生成第一条运行。"),
-    ).toBeTruthy();
-    expect(screen.getByText("测试团队后会在这里显示最新运行。")).toBeTruthy();
+      screen.queryByText("团队入口已就绪，但还没有可见运行。点击“测试团队”生成第一条运行。"),
+    ).toBeNull();
+    expect(screen.queryByText("测试团队后会在这里显示最新运行。")).toBeNull();
     expect(screen.queryByText("暂无可见运行")).toBeNull();
     expect(screen.queryByText("暂无近期可见运行")).toBeNull();
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
@@ -1737,7 +1739,7 @@ describe("TeamDetailPage", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Team Alpha Operator").length).toBeGreaterThan(0);
     });
-    expect(screen.getByText("调用这支团队时会先路由到这个成员。")).toBeTruthy();
+    expect(screen.queryByText("调用这支团队时会先路由到这个成员。")).toBeNull();
     expect(screen.getByRole("button", { name: "清除入口成员" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
@@ -3068,7 +3070,7 @@ describe("TeamDetailPage", () => {
     ).toBeTruthy();
     expect(await screen.findByText("暂无团队构成")).toBeTruthy();
     expect(screen.getByText("服务待配置")).toBeTruthy();
-    expect(screen.getAllByText("当前还没有匹配到主服务入口").length).toBeGreaterThan(0);
+    expect(screen.queryByText("当前还没有匹配到主服务入口")).toBeNull();
     expect(screen.queryByText("gagent-1")).toBeNull();
     expect(scopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
     expect(scopeRuntimeApi.listServiceRuns).not.toHaveBeenCalled();
@@ -3112,8 +3114,8 @@ describe("TeamDetailPage", () => {
     expect(screen.getByText("已启用")).toBeTruthy();
     expect((await screen.findAllByText("Team summary")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("3 个成员").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("来自团队更新时间").length).toBeGreaterThan(0);
-    expect(screen.getByText("启动状态")).toBeTruthy();
+    expect(screen.queryByText("来自团队更新时间")).toBeNull();
+    expect(screen.getByText("当前态势")).toBeTruthy();
     expect(screen.getByText("团队构成")).toBeTruthy();
     expect(screen.getByText("配置明细")).toBeTruthy();
     expect(screen.queryByText("团队更新时间")).toBeNull();
@@ -3297,7 +3299,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("启动状态")).toBeTruthy();
+    expect(await screen.findByText("当前态势")).toBeTruthy();
     expect(await screen.findByText("团队构成")).toBeTruthy();
     expect(await screen.findByText("配置明细")).toBeTruthy();
     expect(screen.queryByText("Team summary 暂不可用")).toBeNull();

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1062,11 +1062,8 @@ const TeamDetailPage: React.FC = () => {
     trimText(preferredMemberSummary?.displayName) ||
     teamRosterRows.find((row) => row.memberId === currentMemberId)?.name ||
     "--";
-  const currentMemberCardCaption = currentMemberId
-    ? t("teams.detail.overview.member.selectedCaption", "Selected from this team's members.")
-    : t("pages.teams.detail.copy.18", "No member selected yet");
   const currentMemberCardTooltip = currentMemberId
-    ? currentMemberCardCaption
+    ? t("teams.detail.overview.member.selectedCaption", "Selected from this team's members.")
     : t("pages.teams.detail.copy.19", "No member selected yet");
   const currentServiceFriendly =
     currentServiceDisplayName !== "--"
@@ -1105,27 +1102,14 @@ const TeamDetailPage: React.FC = () => {
   const currentRunPillText = hasVisibleRun
     ? t("pages.teams.detail.copy.25", "Run ·{value1}", { value1: currentRunFriendly })
     : t("pages.teams.detail.copy.26", "Next steps · Test team");
-  const currentServiceCardCaption = runtimeServiceId
+  const currentServiceCardTooltip = runtimeServiceId
     ? t("teams.detail.overview.service.boundCaption", "Traffic is routed through the bound service.")
     : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
       ? t("teams.detail.overview.service.configuredCaption", "Service routing is configured.")
       : t("pages.teams.detail.copy.27", "No service is visible yet.");
-  const currentServiceCardTooltip = runtimeServiceId
-    ? currentServiceCardCaption
-    : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
-      ? t("teams.detail.overview.service.configuredCaption", "Service routing is configured.")
-      : t("pages.teams.detail.copy.28", "No service is visible yet.");
-  const currentRunCardCaption = hasVisibleRun
+  const currentRunCardTooltip = hasVisibleRun
     ? t("teams.detail.overview.run.visibleCaption", "Latest run is available.")
     : t("pages.teams.detail.copy.29", "The latest runs will be displayed here after the testing team.");
-  const currentRunCardTooltip = hasVisibleRun
-    ? currentRunCardCaption
-    : t("pages.teams.detail.copy.30", "The latest runs will be displayed here after the testing team.");
-  const teamStartupGuidance = hasVisibleRun
-    ? t("pages.teams.detail.copy.31", "The recent runs are visible and you can continue to test the team or adjust the member configuration.")
-    : hasRunnableTeamEntry
-      ? t("pages.teams.detail.copy.32", "The team portal is ready, but not yet visibly running. Click \"Test Team\" to generate the first run.")
-      : t("pages.teams.detail.copy.33", "No entrance available yet. Configure entry members and services first, and then test the team.");
   const workflowNameValue =
     trimText(activeWorkflowSummary?.workflowName) ||
     trimText(lens.activeRevision?.workflowName) ||
@@ -1836,15 +1820,12 @@ const TeamDetailPage: React.FC = () => {
           background: token.colorFillQuaternary,
           color: token.colorTextSecondary,
         }}
-        currentMemberCardCaption={currentMemberCardCaption}
         currentMemberCardTooltip={currentMemberCardTooltip}
         currentMemberLabel={currentMemberLabel}
-        currentRunCardCaption={currentRunCardCaption}
         currentRunCardTooltip={currentRunCardTooltip}
         currentRunFriendly={currentRunFriendly}
         currentRunPillStyle={resolveStatusPillStyle(token, currentHeaderStatus)}
         currentRunPillText={currentRunPillText}
-        currentServiceCardCaption={currentServiceCardCaption}
         currentServiceCardTooltip={currentServiceCardTooltip}
         currentServiceFriendly={currentServiceFriendly}
         currentServicePillStyle={{
@@ -1866,7 +1847,6 @@ const TeamDetailPage: React.FC = () => {
         }
         onNavigate={(href) => history.push(href)}
         onOpenTeamTest={openTeamTestModal}
-        startupGuidance={teamStartupGuidance}
         teamRunDisabled={!canRunTeamFromOverview}
         teamRunDisabledReason={teamRunDisabledReason}
       />

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1117,29 +1117,21 @@ const TeamDetailPage: React.FC = () => {
   const configurationDetailRows = React.useMemo(
     () => [
       {
-        label: t("pages.teams.detail.copy.34", "team process"),
+        label: t("teams.detail.overview.configuration.workflow", "Team workflow"),
         note: activeWorkflowId
           ? t("teams.detail.overview.configuration.workflowLinked", "Workflow draft is linked.")
           : t("teams.detail.overview.configuration.workflowPending", "Workflow draft is not linked yet."),
         value: workflowNameValue !== "--" ? workflowNameValue : teamTitle,
       },
       {
-        label: t("pages.teams.detail.copy.35", "Binding method"),
-        note:
-          currentServiceFriendly !== "--"
-            ? t("pages.teams.detail.copy.36", "Currently routes to {value1}", { value1: currentServiceFriendly })
-            : t("pages.teams.detail.copy.37", "Currently, the main service entrance has not been matched."),
-        value: formatCompositionKind(lens.activeRevision?.implementationKind),
-      },
-      {
-        label: t("pages.teams.detail.copy.38", "Main service entrance"),
+        label: t("teams.detail.overview.configuration.primaryService", "Primary service entry"),
         note: runtimeServiceId || currentServiceKey !== "--"
           ? t("teams.detail.overview.service.configuredCaption", "Service routing is configured.")
           : t("pages.teams.detail.copy.37", "Currently, the main service entrance has not been matched."),
         value: currentServiceFriendly,
       },
       {
-        label: t("pages.teams.detail.copy.39", "Version ID"),
+        label: t("teams.detail.overview.configuration.versionStatus", "Version status"),
         note:
           currentRevisionId !== "--"
             ? t("teams.detail.overview.configuration.versionAvailable", "Current serving version is available.")
@@ -1153,7 +1145,6 @@ const TeamDetailPage: React.FC = () => {
       currentServiceFriendly,
       currentServiceKey,
       currentVersionFriendly,
-      lens.activeRevision?.implementationKind,
       runtimeServiceId,
       teamTitle,
       workflowNameValue,

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1240,11 +1240,7 @@ const TeamDetailPage: React.FC = () => {
             serviceLabel,
             statusLabel: row.lifecycleLabel,
             statusStyle: row.lifecycleStyle,
-            summary:
-              row.description ||
-              (row.isServiceBound
-                ? t("teams.detail.overview.composition.memberReady", "Bound and ready to receive traffic.")
-                : t("teams.detail.overview.composition.memberDraft", "Not bound yet.")),
+            summary: row.description,
           };
         });
       }

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -14,7 +14,6 @@ import {
   DetailPill,
   FactLine,
 } from "../components/TeamDetailPrimitives";
-import { t } from "@/shared/i18n/messages";
 
 type OverviewCompositionRow = {
   readonly canConfigure?: boolean;
@@ -67,15 +66,12 @@ type TeamOverviewTabProps = {
   readonly currentDeploymentPillText: string;
   readonly currentHeaderStatusFriendly: string;
   readonly currentHeaderStatusStyle: React.CSSProperties;
-  readonly currentMemberCardCaption: string;
   readonly currentMemberCardTooltip: string;
   readonly currentMemberLabel: string;
-  readonly currentRunCardCaption: string;
   readonly currentRunCardTooltip: string;
   readonly currentRunFriendly: string;
   readonly currentRunPillStyle: React.CSSProperties;
   readonly currentRunPillText: string;
-  readonly currentServiceCardCaption: string;
   readonly currentServiceCardTooltip: string;
   readonly currentServiceFriendly: string;
   readonly currentServicePillStyle: React.CSSProperties;
@@ -89,7 +85,6 @@ type TeamOverviewTabProps = {
   readonly onClearEntryMember?: () => void;
   readonly onNavigate?: (href: string) => void;
   readonly onOpenTeamTest?: () => void;
-  readonly startupGuidance: string;
   readonly teamRunDisabled?: boolean;
   readonly teamRunDisabledReason?: string;
 };
@@ -114,15 +109,12 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
   currentDeploymentPillText,
   currentHeaderStatusFriendly,
   currentHeaderStatusStyle,
-  currentMemberCardCaption,
   currentMemberCardTooltip,
   currentMemberLabel,
-  currentRunCardCaption,
   currentRunCardTooltip,
   currentRunFriendly,
   currentRunPillStyle,
   currentRunPillText,
-  currentServiceCardCaption,
   currentServiceCardTooltip,
   currentServiceFriendly,
   currentServicePillStyle,
@@ -136,7 +128,6 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
   onClearEntryMember,
   onNavigate,
   onOpenTeamTest,
-  startupGuidance,
   teamRunDisabled = false,
   teamRunDisabledReason,
 }) => {
@@ -163,7 +154,6 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
   });
   const summaryItems = [
     {
-      caption: currentMemberCardCaption,
       label: intl.formatMessage({
         defaultMessage: "Current member",
         id: "teams.detail.overview.cards.currentMember",
@@ -172,31 +162,29 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
       value: currentMemberLabel,
     },
     {
-      caption: currentServiceCardCaption,
       label: intl.formatMessage({ id: "teams.detail.overview.cards.currentService" }),
       tooltip: currentServiceCardTooltip,
       value: currentServiceFriendly,
     },
     {
-      caption: currentRunCardCaption,
       label: intl.formatMessage({ id: "teams.detail.overview.cards.currentRun" }),
       tooltip: currentRunCardTooltip,
       value: currentRunFriendly,
     },
     {
-      caption: latestVisibleUpdateNote,
       label: intl.formatMessage({ id: "teams.detail.overview.cards.latestUpdate" }),
+      tooltip: latestVisibleUpdateNote,
       value: latestVisibleUpdateLabel,
     },
     {
-      caption: hasEntryMember
+      label: intl.formatMessage({ id: "teams.detail.overview.cards.entryMember" }),
+      tooltip: hasEntryMember
         ? intl.formatMessage({
             id: "teams.detail.overview.entry.configuredCaption",
           })
         : intl.formatMessage({
             id: "teams.detail.overview.entry.unconfiguredCaption",
           }),
-      label: intl.formatMessage({ id: "teams.detail.overview.cards.entryMember" }),
       value: entryMemberValue,
     },
   ];
@@ -218,9 +206,6 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               <Typography.Text strong style={{ fontSize: 16 }}>
                 {intl.formatMessage({ id: "teams.detail.overview.status.title" })}
               </Typography.Text>
-              <Typography.Text type="secondary">
-                {t("pages.teams.tabs.teamoverviewtab.copy", "Startup status")}
-              </Typography.Text>
               <DetailPill
                 style={currentHeaderStatusStyle}
                 text={currentHeaderStatusFriendly}
@@ -237,9 +222,6 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               />
               <DetailPill compact style={currentRunPillStyle} text={currentRunPillText} />
             </Space>
-            <Typography.Text type="secondary">
-              {startupGuidance}
-            </Typography.Text>
           </div>
           <Tooltip title={teamRunDisabled ? teamRunDisabledReason : undefined}>
             <Button
@@ -280,15 +262,11 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               <Typography.Text style={{ fontSize: 12 }} type="secondary">
                 {item.label}
               </Typography.Text>
-              <Typography.Text strong ellipsis>
-                {item.value}
-              </Typography.Text>
-              <FactLine
-                rows={1}
-                secondary
-                text={item.caption}
-                tooltipText={item.tooltip}
-              />
+              <Tooltip title={item.tooltip}>
+                <Typography.Text strong ellipsis>
+                  {item.value}
+                </Typography.Text>
+              </Tooltip>
             </div>
           ))}
         </div>
@@ -396,7 +374,6 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                         <DetailPill compact style={row.statusStyle} text={row.statusLabel} />
                       ) : null}
                     </Space>
-                    <FactLine rows={2} secondary text={row.summary} />
                   </div>
                   <Space.Compact>
                     <Tooltip
@@ -482,13 +459,9 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                   <Typography.Text style={{ fontSize: 12 }} type="secondary">
                     {row.label}
                   </Typography.Text>
-                  <Typography.Text strong>{row.value}</Typography.Text>
-                  <FactLine
-                    rows={2}
-                    secondary
-                    text={row.note}
-                    tooltipText={row.noteTooltip}
-                  />
+                  <Tooltip title={row.noteTooltip || row.note}>
+                    <Typography.Text strong>{row.value}</Typography.Text>
+                  </Tooltip>
                 </div>
               ))}
             </div>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -4,10 +4,9 @@ import {
   HistoryOutlined,
   InfoCircleOutlined,
   PlayCircleOutlined,
-  SettingOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
-import { Button, Popover, Space, Tooltip, Typography, theme } from "antd";
+import { Button, Space, Tooltip, Typography, theme } from "antd";
 import { useIntl } from "@umijs/max";
 import React from "react";
 import { AevatarInspectorEmpty } from "@/shared/ui/aevatarPageShells";
@@ -311,39 +310,43 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               id: "teams.detail.overview.composition.title",
             })}
           </Typography.Title>
-          {configurationDetailRows.length > 0 ? (
-            <Popover
-              content={
-                <div style={{ display: "grid", gap: 10, minWidth: 260 }}>
-                  {configurationDetailRows.map((row) => (
-                    <div key={row.label} style={{ display: "grid", gap: 3 }}>
-                      <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                        {row.label}
-                      </Typography.Text>
-                      <Tooltip title={row.noteTooltip || row.note}>
-                        <Typography.Text strong>{row.value}</Typography.Text>
-                      </Tooltip>
-                    </div>
-                  ))}
-                </div>
-              }
-              placement="bottomRight"
-              title={intl.formatMessage({
-                id: "teams.detail.overview.configuration.title",
-              })}
-              trigger="click"
-            >
-              <Button
-                aria-label={intl.formatMessage({
-                  id: "teams.detail.overview.configuration.title",
-                })}
-                icon={<SettingOutlined />}
-                size="small"
-                type="text"
-              />
-            </Popover>
-          ) : null}
         </div>
+        {configurationDetailRows.length > 0 ? (
+          <div
+            style={{
+              background: token.colorFillQuaternary,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              borderRadius: 8,
+              display: "grid",
+              gap: 0,
+              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            }}
+          >
+            {configurationDetailRows.map((row, index) => (
+              <div
+                key={row.label}
+                style={{
+                  borderLeft:
+                    index === 0 ? "none" : `1px solid ${token.colorBorderSecondary}`,
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 4,
+                  minWidth: 0,
+                  padding: "10px 12px",
+                }}
+              >
+                <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                  {row.label}
+                </Typography.Text>
+                <Tooltip title={row.noteTooltip || row.note}>
+                  <Typography.Text strong ellipsis>
+                    {row.value}
+                  </Typography.Text>
+                </Tooltip>
+              </div>
+            ))}
+          </div>
+        ) : null}
         <div style={{ display: "grid", gap: 0 }}>
           {compositionRows.length > 0 ? (
             compositionRows.map((row, index) => (
@@ -386,9 +389,16 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                       />
                     ) : null}
                   </Space>
-                  <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                    {row.serviceLabel || row.summary}
-                  </Typography.Text>
+                  {row.serviceLabel ? (
+                    <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                      {row.serviceLabel}
+                    </Typography.Text>
+                  ) : null}
+                  {row.summary ? (
+                    <Typography.Text ellipsis style={{ fontSize: 12 }} type="secondary">
+                      {row.summary}
+                    </Typography.Text>
+                  ) : null}
                 </div>
                 <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
                   <Space size={6} wrap>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -4,9 +4,10 @@ import {
   HistoryOutlined,
   InfoCircleOutlined,
   PlayCircleOutlined,
+  SettingOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
-import { Button, Space, Tooltip, Typography, theme } from "antd";
+import { Button, Popover, Space, Tooltip, Typography, theme } from "antd";
 import { useIntl } from "@umijs/max";
 import React from "react";
 import { AevatarInspectorEmpty } from "@/shared/ui/aevatarPageShells";
@@ -297,175 +298,164 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
       </section>
 
       <section style={surfaceStyle(token)}>
-        <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+        <div
+          style={{
+            alignItems: "center",
+            display: "flex",
+            justifyContent: "space-between",
+            gap: 12,
+          }}
+        >
           <Typography.Title level={3} style={{ margin: 0 }}>
             {intl.formatMessage({
               id: "teams.detail.overview.composition.title",
             })}
           </Typography.Title>
           {configurationDetailRows.length > 0 ? (
-            <Typography.Text style={{ fontSize: 12 }} type="secondary">
-              {intl.formatMessage({
+            <Popover
+              content={
+                <div style={{ display: "grid", gap: 10, minWidth: 260 }}>
+                  {configurationDetailRows.map((row) => (
+                    <div key={row.label} style={{ display: "grid", gap: 3 }}>
+                      <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                        {row.label}
+                      </Typography.Text>
+                      <Tooltip title={row.noteTooltip || row.note}>
+                        <Typography.Text strong>{row.value}</Typography.Text>
+                      </Tooltip>
+                    </div>
+                  ))}
+                </div>
+              }
+              placement="bottomRight"
+              title={intl.formatMessage({
                 id: "teams.detail.overview.configuration.title",
               })}
-            </Typography.Text>
+              trigger="click"
+            >
+              <Button
+                aria-label={intl.formatMessage({
+                  id: "teams.detail.overview.configuration.title",
+                })}
+                icon={<SettingOutlined />}
+                size="small"
+                type="text"
+              />
+            </Popover>
           ) : null}
         </div>
-        <div
-          style={{
-            display: "grid",
-            gap: 18,
-            gridTemplateColumns:
-              configurationDetailRows.length > 0
-                ? "repeat(auto-fit, minmax(min(100%, 320px), 1fr))"
-                : "minmax(0, 1fr)",
-          }}
-        >
-          <div style={{ display: "grid", gap: 0 }}>
-            {compositionRows.length > 0 ? (
-              compositionRows.map((row, index) => (
-                <div
-                  key={row.key}
-                  style={{
-                    alignItems: "center",
-                    borderTop:
-                      index === 0 ? "none" : `1px solid ${token.colorBorderSecondary}`,
-                    display: "grid",
-                    gap: 12,
-                    gridTemplateColumns:
-                      "minmax(120px, 0.65fr) minmax(0, 1fr) max-content",
-                    padding: index === 0 ? "0 0 12px" : "12px 0",
-                  }}
-                >
-                  <div style={{ display: "flex", flexDirection: "column", gap: 4, minWidth: 0 }}>
-                    <Space size={6} wrap>
-                      <Typography.Text strong>{row.name}</Typography.Text>
-                      {row.entryLabel ? (
-                        <DetailPill
-                          compact
-                          style={{
-                            background: token.colorSuccessBg,
-                            border: `1px solid ${token.colorSuccessBorder}`,
-                            color: token.colorSuccess,
-                          }}
-                          text={row.entryLabel}
-                        />
-                      ) : null}
-                      {row.selectedLabel ? (
-                        <DetailPill
-                          compact
-                          style={{
-                            background: token.colorInfoBg,
-                            border: `1px solid ${token.colorInfoBorder}`,
-                            color: token.colorInfo,
-                          }}
-                          text={row.selectedLabel}
-                        />
-                      ) : null}
-                    </Space>
-                    <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                      {row.serviceLabel || row.summary}
-                    </Typography.Text>
-                  </div>
-                  <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
-                    <Space size={6} wrap>
-                      <DetailPill compact style={row.kindStyle} text={row.kindLabel} />
-                      {row.statusLabel && row.statusStyle ? (
-                        <DetailPill compact style={row.statusStyle} text={row.statusLabel} />
-                      ) : null}
-                    </Space>
-                  </div>
-                  <Space.Compact>
+        <div style={{ display: "grid", gap: 0 }}>
+          {compositionRows.length > 0 ? (
+            compositionRows.map((row, index) => (
+              <div
+                key={row.key}
+                style={{
+                  alignItems: "center",
+                  borderTop:
+                    index === 0 ? "none" : `1px solid ${token.colorBorderSecondary}`,
+                  display: "grid",
+                  gap: 12,
+                  gridTemplateColumns:
+                    "minmax(120px, 0.65fr) minmax(0, 1fr) max-content",
+                  padding: index === 0 ? "0 0 12px" : "12px 0",
+                }}
+              >
+                <div style={{ display: "flex", flexDirection: "column", gap: 4, minWidth: 0 }}>
+                  <Space size={6} wrap>
+                    <Typography.Text strong>{row.name}</Typography.Text>
+                    {row.entryLabel ? (
+                      <DetailPill
+                        compact
+                        style={{
+                          background: token.colorSuccessBg,
+                          border: `1px solid ${token.colorSuccessBorder}`,
+                          color: token.colorSuccess,
+                        }}
+                        text={row.entryLabel}
+                      />
+                    ) : null}
+                    {row.selectedLabel ? (
+                      <DetailPill
+                        compact
+                        style={{
+                          background: token.colorInfoBg,
+                          border: `1px solid ${token.colorInfoBorder}`,
+                          color: token.colorInfo,
+                        }}
+                        text={row.selectedLabel}
+                      />
+                    ) : null}
+                  </Space>
+                  <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                    {row.serviceLabel || row.summary}
+                  </Typography.Text>
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+                  <Space size={6} wrap>
+                    <DetailPill compact style={row.kindStyle} text={row.kindLabel} />
+                    {row.statusLabel && row.statusStyle ? (
+                      <DetailPill compact style={row.statusStyle} text={row.statusLabel} />
+                    ) : null}
+                  </Space>
+                </div>
+                <Space.Compact>
+                  <Tooltip
+                    title={
+                      row.canRun
+                        ? runMemberLabel
+                        : row.runDisabledReason || runMemberLabel
+                    }
+                  >
+                    <Button
+                      aria-label={runMemberLabel}
+                      href={row.canRun ? row.runHref : undefined}
+                      disabled={!row.canRun}
+                      icon={<PlayCircleOutlined />}
+                      onClick={
+                        row.canRun
+                          ? handleNavigate(row.runHref)
+                          : undefined
+                      }
+                      size="small"
+                      type={row.canRun ? "primary" : "default"}
+                    />
+                  </Tooltip>
+                  {row.configureLabel ? (
                     <Tooltip
                       title={
-                        row.canRun
-                          ? runMemberLabel
-                          : row.runDisabledReason || runMemberLabel
+                        row.canConfigure
+                          ? row.configureLabel
+                          : row.configureDisabledReason || row.configureLabel
                       }
                     >
                       <Button
-                        aria-label={runMemberLabel}
-                        href={row.canRun ? row.runHref : undefined}
-                        disabled={!row.canRun}
-                        icon={<PlayCircleOutlined />}
+                        aria-label={row.configureLabel}
+                        disabled={!row.canConfigure}
+                        href={row.canConfigure ? row.configureHref : undefined}
+                        icon={<ToolOutlined />}
                         onClick={
-                          row.canRun
-                            ? handleNavigate(row.runHref)
+                          row.canConfigure
+                            ? handleNavigate(row.configureHref)
                             : undefined
                         }
                         size="small"
-                        type={row.canRun ? "primary" : "default"}
+                        type={row.canConfigure ? "default" : "dashed"}
                       />
                     </Tooltip>
-                    {row.configureLabel ? (
-                      <Tooltip
-                        title={
-                          row.canConfigure
-                            ? row.configureLabel
-                            : row.configureDisabledReason || row.configureLabel
-                        }
-                      >
-                        <Button
-                          aria-label={row.configureLabel}
-                          disabled={!row.canConfigure}
-                          href={row.canConfigure ? row.configureHref : undefined}
-                          icon={<ToolOutlined />}
-                          onClick={
-                            row.canConfigure
-                              ? handleNavigate(row.configureHref)
-                              : undefined
-                          }
-                          size="small"
-                          type={row.canConfigure ? "default" : "dashed"}
-                        />
-                      </Tooltip>
-                    ) : null}
-                  </Space.Compact>
-                </div>
-              ))
-            ) : (
-              <AevatarInspectorEmpty
-                title={intl.formatMessage({
-                  id: "teams.detail.overview.composition.empty.title",
-                })}
-                description={intl.formatMessage({
-                  id: "teams.detail.overview.composition.empty.description",
-                })}
-              />
-            )}
-          </div>
-
-          {configurationDetailRows.length > 0 ? (
-            <div
-              style={{
-                background: token.colorFillQuaternary,
-                border: `1px solid ${token.colorBorderSecondary}`,
-                borderRadius: 8,
-                display: "grid",
-                gap: 0,
-              }}
-            >
-              {configurationDetailRows.map((row, index) => (
-                <div
-                  key={row.label}
-                  style={{
-                    borderTop:
-                      index === 0 ? "none" : `1px solid ${token.colorBorderSecondary}`,
-                    display: "grid",
-                    gap: 6,
-                    padding: "10px 12px",
-                  }}
-                >
-                  <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                    {row.label}
-                  </Typography.Text>
-                  <Tooltip title={row.noteTooltip || row.note}>
-                    <Typography.Text strong>{row.value}</Typography.Text>
-                  </Tooltip>
-                </div>
-              ))}
-            </div>
-          ) : null}
+                  ) : null}
+                </Space.Compact>
+              </div>
+            ))
+          ) : (
+            <AevatarInspectorEmpty
+              title={intl.formatMessage({
+                id: "teams.detail.overview.composition.empty.title",
+              })}
+              description={intl.formatMessage({
+                id: "teams.detail.overview.composition.empty.description",
+              })}
+            />
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Trimmed explanatory copy from the Team overview scan path.
- Kept status facts, summary values, actions, configuration facts, and recent runs visible.
- Preserved the removed explanatory context in hover tooltips where it is still useful.

## Testing
- pnpm --dir apps/aevatar-console-web tsc
- pnpm --dir apps/aevatar-console-web test:ui --runTestsByPath src/pages/teams/detail.test.tsx
- pnpm --dir apps/aevatar-console-web test:ui
- pnpm --dir apps/aevatar-console-web build
- bash tools/ci/test_stability_guards.sh

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2663
- Worktree: /Users/pottersun/Desktop/sbt_projects/aevatar
- Branch: fix/2026-07-08_trim-team-overview-copy
- Operator: potter-sun
- Freshness: current user screenshot/request on 2026-07-08

⟦AI:FKST⟧
