### PR TITLE
Add Studio member workflow schedule tool

### DIFF
--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ProvisionWorkflowScheduleToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ProvisionWorkflowScheduleToolSource.cs
@@ -90,3 +90,22 @@ public sealed class BindStudioMemberWorkflowToolSource : IAgentToolSource
                 : [new BindStudioMemberWorkflowTool(_bindingPort)]);
     }
 }
+
+public sealed class ScheduleStudioMemberWorkflowToolSource : IAgentToolSource
+{
+    private readonly IStudioMemberWorkflowSchedulePort? _schedulePort;
+
+    public ScheduleStudioMemberWorkflowToolSource(IStudioMemberWorkflowSchedulePort? schedulePort = null)
+    {
+        _schedulePort = schedulePort;
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult<IReadOnlyList<IAgentTool>>(
+            _schedulePort is null
+                ? []
+                : [new ScheduleStudioMemberWorkflowTool(_schedulePort)]);
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -5,7 +5,7 @@ using Aevatar.Studio.Application.Provisioning;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
+internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool, IAgentToolCapabilityDescriptor
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -61,6 +61,10 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
         """;
 
     public ToolApprovalMode ApprovalMode => ToolApprovalPolicies.CreateScopedResource;
+
+    public IReadOnlyCollection<string> Capabilities { get; } =
+        [AgentToolCapabilities.ExcludeFromDirectChannelChat];
+
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.workflow.schedule";

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Studio.Application.Provisioning;
+
+namespace Aevatar.AI.ToolProviders.StudioProvisioning;
+
+internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+    };
+
+    private readonly IStudioMemberWorkflowSchedulePort _schedulePort;
+
+    public ScheduleStudioMemberWorkflowTool(IStudioMemberWorkflowSchedulePort schedulePort)
+    {
+        _schedulePort = schedulePort ?? throw new ArgumentNullException(nameof(schedulePort));
+    }
+
+    public string Name => "aevatar_schedule_member_workflow";
+
+    public string Description =>
+        "Create or update a schedule for an existing Studio member's already-bound workflow in the caller's current Aevatar scope. " +
+        "Use this when the user already has or just created an m-... Studio member and asks to schedule that same member workflow. " +
+        "Supply member_id, schedule_cron, and schedule_timezone, plus optional prompt/display_name. " +
+        "This tool does not create standalone wf-... workflow members, does not accept workflow_yaml, and does not bind or rebind workflows. " +
+        "Do not provide scope_id, published_service_id, service_id, or tokens because scope, service identity, and caller subject are resolved from platform context.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "member_id": {
+              "type": "string",
+              "description": "Existing Studio member id whose already-bound workflow should be scheduled. Required."
+            },
+            "schedule_cron": {
+              "type": "string",
+              "description": "Standard 5-field cron expression (minute hour day-of-month month day-of-week), e.g. '0 9 * * *'. Required."
+            },
+            "schedule_timezone": {
+              "type": "string",
+              "description": "IANA timezone used to evaluate schedule_cron, e.g. 'Asia/Shanghai'. Required."
+            },
+            "prompt": {
+              "type": "string",
+              "description": "Optional prompt passed to the workflow chat endpoint when the schedule fires."
+            },
+            "display_name": {
+              "type": "string",
+              "description": "Optional display name for the schedule."
+            }
+          },
+          "required": ["member_id", "schedule_cron", "schedule_timezone"]
+        }
+        """;
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalPolicies.CreateScopedResource;
+    public bool IsReadOnly => false;
+    public bool IsDestructive => false;
+    public string SideEffectKind => "studio.member.workflow.schedule";
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var scopeId = Normalize(AgentToolRequestContext.ScopeId);
+        if (scopeId is null)
+        {
+            return ErrorJson(
+                "caller_scope_unavailable",
+                "scope_id is required in AgentToolRequestContext. The local Studio member workflow schedule tool uses the caller scope from the tool execution context.");
+        }
+
+        var ownerSubject = Normalize(AgentToolRequestContext.OwnerSubject);
+        if (ownerSubject is null)
+        {
+            return ErrorJson(
+                "caller_subject_unavailable",
+                "owner subject is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        ScheduleStudioMemberWorkflowArguments? args;
+        try
+        {
+            var unknownArgument = FindUnknownArgument(argumentsJson);
+            if (unknownArgument is not null)
+                return ErrorJson("invalid_arguments", $"Unknown argument: {unknownArgument}");
+
+            args = JsonSerializer.Deserialize<ScheduleStudioMemberWorkflowArguments>(argumentsJson, s_jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            return ErrorJson("invalid_arguments", $"Could not parse tool arguments: {ex.Message}");
+        }
+
+        if (args is null)
+            return ErrorJson("invalid_arguments", "Tool arguments are required.");
+
+        var memberId = Normalize(args.MemberId);
+        if (memberId is null)
+            return ErrorJson("invalid_arguments", "member_id is required.");
+
+        var scheduleCron = Normalize(args.ScheduleCron);
+        if (scheduleCron is null)
+            return ErrorJson("invalid_arguments", "schedule_cron is required.");
+
+        var scheduleTimezone = Normalize(args.ScheduleTimezone);
+        if (scheduleTimezone is null)
+            return ErrorJson("invalid_arguments", "schedule_timezone is required.");
+
+        var request = new StudioMemberWorkflowScheduleRequest(
+            ScopeId: scopeId,
+            MemberId: memberId,
+            ScheduleCron: scheduleCron,
+            ScheduleTimezone: scheduleTimezone,
+            CallerSubjectExternalUserId: ownerSubject)
+        {
+            Prompt = Normalize(args.Prompt),
+            DisplayName = Normalize(args.DisplayName),
+        };
+
+        try
+        {
+            var result = await _schedulePort.EnsureAsync(request, ct);
+            return JsonSerializer.Serialize(
+                new ScheduleStudioMemberWorkflowResultJson(
+                    Success: result.Success,
+                    Status: result.Status,
+                    ScopeId: result.ScopeId,
+                    MemberId: result.MemberId,
+                    ScheduleId: result.ScheduleId,
+                    PublishedServiceId: result.PublishedServiceId,
+                    ObservatoryUrl: result.ObservatoryUrl),
+                s_jsonOptions);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ErrorJson("invalid_arguments", ex.Message);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return ErrorJson("member_workflow_schedule_failed", $"Studio member workflow schedule failed: {ex.GetType().Name}");
+        }
+    }
+
+    private static string ErrorJson(string code, string message) =>
+        JsonSerializer.Serialize(new ScheduleStudioMemberWorkflowErrorJson(
+            new ScheduleStudioMemberWorkflowErrorBody(code, message)),
+            s_jsonOptions);
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? FindUnknownArgument(string argumentsJson)
+    {
+        using var document = JsonDocument.Parse(argumentsJson);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+            return null;
+
+        foreach (var property in document.RootElement.EnumerateObject())
+        {
+            if (property.Name is not "member_id" and not "schedule_cron" and not "schedule_timezone"
+                and not "prompt" and not "display_name")
+                return property.Name;
+        }
+
+        return null;
+    }
+
+    private sealed record ScheduleStudioMemberWorkflowArguments(
+        [property: JsonPropertyName("member_id")] string? MemberId,
+        [property: JsonPropertyName("schedule_cron")] string? ScheduleCron,
+        [property: JsonPropertyName("schedule_timezone")] string? ScheduleTimezone,
+        [property: JsonPropertyName("prompt")] string? Prompt,
+        [property: JsonPropertyName("display_name")] string? DisplayName);
+
+    private sealed record ScheduleStudioMemberWorkflowResultJson(
+        bool Success,
+        string Status,
+        string ScopeId,
+        string MemberId,
+        string ScheduleId,
+        string PublishedServiceId,
+        string ObservatoryUrl);
+
+    private sealed record ScheduleStudioMemberWorkflowErrorJson(ScheduleStudioMemberWorkflowErrorBody Error);
+
+    private sealed record ScheduleStudioMemberWorkflowErrorBody(string Code, string Message);
+}

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ServiceCollectionExtensions.cs
@@ -24,6 +24,8 @@ public static class ServiceCollectionExtensions
             ServiceDescriptor.Singleton<IAgentToolSource, CreateStudioMemberToolSource>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IAgentToolSource, BindStudioMemberWorkflowToolSource>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IAgentToolSource, ScheduleStudioMemberWorkflowToolSource>());
         return services;
     }
 }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -322,6 +322,7 @@ public static class MainnetHostBuilderExtensions
                     CreateToolSource<CreateStudioTeamToolSource>,
                     CreateToolSource<CreateStudioMemberToolSource>,
                     CreateToolSource<BindStudioMemberWorkflowToolSource>,
+                    CreateToolSource<ScheduleStudioMemberWorkflowToolSource>,
                     CreateToolSource<ResponsesAevatarToolProvider>,
                     CreateToolSource<ChannelInteractiveReplyToolSource>,
                     CreateToolSource<ChannelRegistrationToolSource>,

--- a/src/Aevatar.Studio.Application.Abstractions/Provisioning/IStudioMemberWorkflowSchedulePort.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Provisioning/IStudioMemberWorkflowSchedulePort.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.Studio.Application.Provisioning;
+
+public interface IStudioMemberWorkflowSchedulePort
+{
+    Task<StudioMemberWorkflowScheduleResult> EnsureAsync(
+        StudioMemberWorkflowScheduleRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowScheduleContracts.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowScheduleContracts.cs
@@ -1,0 +1,26 @@
+namespace Aevatar.Studio.Application.Provisioning;
+
+public sealed record StudioMemberWorkflowScheduleRequest(
+    string ScopeId,
+    string MemberId,
+    string ScheduleCron,
+    string ScheduleTimezone,
+    string CallerSubjectExternalUserId)
+{
+    public string? Prompt { get; init; }
+
+    public string? DisplayName { get; init; }
+
+    public string CallerSubjectPlatform { get; init; } = "nyxid";
+
+    public string? CallerSubjectTenant { get; init; }
+}
+
+public sealed record StudioMemberWorkflowScheduleResult(
+    bool Success,
+    string ScopeId,
+    string MemberId,
+    string ScheduleId,
+    string PublishedServiceId,
+    string ObservatoryUrl,
+    string Status);

--- a/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IStudioTeamProvisioningPort, StudioTeamProvisioningPort>();
         services.TryAddSingleton<IStudioMemberProvisioningPort, StudioMemberProvisioningPort>();
         services.TryAddSingleton<IStudioMemberWorkflowBindingPort, StudioMemberWorkflowBindingPort>();
+        services.TryAddSingleton<IStudioMemberWorkflowSchedulePort, StudioMemberWorkflowSchedulePort>();
         services.TryAddSingleton<IStudioTeamGAgentStreamInvocationService, StudioTeamGAgentStreamInvocationService>();
         services.TryAddSingleton<IWorkflowBoardClock, SystemWorkflowBoardClock>();
         services.TryAddSingleton<IWorkflowBoardRosterQueryPort, StudioWorkflowBoardRosterQueryPort>();

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
@@ -1,0 +1,159 @@
+using System.Security.Cryptography;
+using System.Text;
+using Aevatar.AI.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Schedules;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.Studio.Application.Provisioning;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Application.Studio.Services;
+
+public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSchedulePort
+{
+    private const string WorkflowInvokeEndpointId = "chat";
+    private const string ObservatoryPath = "/workflow/observatory";
+
+    private readonly IStudioMemberService _memberService;
+    private readonly IScheduledDispatchApplicationService _scheduleService;
+
+    public StudioMemberWorkflowSchedulePort(
+        IStudioMemberService memberService,
+        IScheduledDispatchApplicationService scheduleService)
+    {
+        _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
+        _scheduleService = scheduleService ?? throw new ArgumentNullException(nameof(scheduleService));
+    }
+
+    public async Task<StudioMemberWorkflowScheduleResult> EnsureAsync(
+        StudioMemberWorkflowScheduleRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var scopeId = NormalizeRequired(request.ScopeId, nameof(request.ScopeId));
+        var memberId = NormalizeRequired(request.MemberId, nameof(request.MemberId));
+        var scheduleCron = NormalizeRequired(request.ScheduleCron, nameof(request.ScheduleCron));
+        var scheduleTimezone = NormalizeRequired(request.ScheduleTimezone, nameof(request.ScheduleTimezone));
+        var callerSubjectExternalUserId = NormalizeRequired(
+            request.CallerSubjectExternalUserId,
+            nameof(request.CallerSubjectExternalUserId));
+
+        var member = await _memberService.GetAsync(scopeId, memberId, ct);
+        if (!string.Equals(member.Summary.ImplementationKind, MemberImplementationKindNames.Workflow, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"member_id '{memberId}' is not a workflow member and cannot be scheduled as a workflow.");
+        }
+
+        if (member.LastBinding is null)
+        {
+            throw new InvalidOperationException(
+                $"member_id '{memberId}' has no bound workflow. Bind workflow YAML before scheduling the member.");
+        }
+
+        var publishedServiceId = NormalizeRequired(
+            member.Summary.PublishedServiceId,
+            nameof(member.Summary.PublishedServiceId));
+        var boundPublishedServiceId = NormalizeRequired(
+            member.LastBinding.PublishedServiceId,
+            nameof(member.LastBinding.PublishedServiceId));
+        if (!string.Equals(publishedServiceId, boundPublishedServiceId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"member_id '{memberId}' binding service id does not match the published service id.");
+        }
+
+        var scheduleId = BuildScheduleId(scopeId, memberId);
+        var schedule = await _scheduleService.EnsureAsync(
+            BuildScheduleConfiguration(
+                scheduleId,
+                request.DisplayName,
+                scopeId,
+                memberId,
+                publishedServiceId,
+                NormalizeOptional(request.Prompt) ?? string.Empty,
+                BuildScheduleAuth(request, callerSubjectExternalUserId),
+                scheduleCron,
+                scheduleTimezone),
+            ct);
+
+        return new StudioMemberWorkflowScheduleResult(
+            Success: schedule.Accepted,
+            ScopeId: scopeId,
+            MemberId: memberId,
+            ScheduleId: NormalizeOptional(schedule.ScheduleId) ?? scheduleId,
+            PublishedServiceId: publishedServiceId,
+            ObservatoryUrl: ObservatoryPath,
+            Status: schedule.Accepted ? "accepted" : "rejected");
+    }
+
+    private static ScheduledDispatchConfiguration BuildScheduleConfiguration(
+        string scheduleId,
+        string? displayName,
+        string scopeId,
+        string memberId,
+        string publishedServiceId,
+        string prompt,
+        ScheduledServiceInvocationAuth auth,
+        string cronExpression,
+        string timezone) =>
+        new(
+            ScheduleId: scheduleId,
+            DisplayName: NormalizeOptional(displayName) ?? $"studio-member-workflow-{memberId}",
+            Target: new ScheduledDispatchTargetDescriptor(
+                ScheduledDispatchTargetKind.ServiceInvocation,
+                ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
+                    Identity: new ServiceIdentity
+                    {
+                        TenantId = scopeId,
+                        AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+                        Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
+                        ServiceId = publishedServiceId,
+                    },
+                    EndpointId: WorkflowInvokeEndpointId,
+                    Payload: Any.Pack(new ChatRequestEvent
+                    {
+                        Prompt = prompt,
+                        ScopeId = scopeId,
+                    }),
+                    Auth: auth)),
+            CronExpression: cronExpression,
+            Timezone: timezone,
+            Enabled: true,
+            Headers: new Dictionary<string, string>(StringComparer.Ordinal),
+            ScheduleKind: ScheduledDispatchScheduleKind.Workflow);
+
+    private static ScheduledServiceInvocationAuth BuildScheduleAuth(
+        StudioMemberWorkflowScheduleRequest request,
+        string callerSubjectExternalUserId) =>
+        new(SenderNyxId: new ScheduledServiceInvocationNyxIdCredentialSource(
+            new ScheduledServiceInvocationNyxIdSubjectRef(
+                Platform: NormalizeRequired(request.CallerSubjectPlatform, nameof(request.CallerSubjectPlatform)),
+                Tenant: NormalizeOptional(request.CallerSubjectTenant) ?? string.Empty,
+                ExternalUserId: callerSubjectExternalUserId),
+            Scope: ProvisionWorkflowCallerCredential.DefaultScope));
+
+    private static string BuildScheduleId(string scopeId, string memberId)
+    {
+        var identity = Encoding.UTF8.GetBytes($"{scopeId}\n{memberId}");
+        var hash = SHA256.HashData(identity);
+        return $"studio-member-workflow-{Convert.ToHexString(hash.AsSpan(0, 16)).ToLowerInvariant()}";
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+        return normalized;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        return normalized.Length == 0 ? null : normalized;
+    }
+}

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
@@ -15,6 +15,7 @@ public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSche
 {
     private const string WorkflowInvokeEndpointId = "chat";
     private const string ObservatoryPath = "/workflow/observatory";
+    private const int MaxScheduleGenerations = 50;
 
     private readonly IStudioMemberService _memberService;
     private readonly IScheduledDispatchApplicationService _scheduleService;
@@ -48,47 +49,108 @@ public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSche
                 $"member_id '{memberId}' is not a workflow member and cannot be scheduled as a workflow.");
         }
 
-        if (member.LastBinding is null)
-        {
-            throw new InvalidOperationException(
-                $"member_id '{memberId}' has no bound workflow. Bind workflow YAML before scheduling the member.");
-        }
-
         var publishedServiceId = NormalizeRequired(
             member.Summary.PublishedServiceId,
             nameof(member.Summary.PublishedServiceId));
-        var boundPublishedServiceId = NormalizeRequired(
-            member.LastBinding.PublishedServiceId,
-            nameof(member.LastBinding.PublishedServiceId));
-        if (!string.Equals(publishedServiceId, boundPublishedServiceId, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
-                $"member_id '{memberId}' binding service id does not match the published service id.");
-        }
+        EnsureWorkflowBindingCanBeScheduled(member, memberId, publishedServiceId);
 
-        var scheduleId = BuildScheduleId(scopeId, memberId);
-        var schedule = await _scheduleService.EnsureAsync(
-            BuildScheduleConfiguration(
-                scheduleId,
-                request.DisplayName,
-                scopeId,
-                memberId,
-                publishedServiceId,
-                NormalizeOptional(request.Prompt) ?? string.Empty,
-                BuildScheduleAuth(request, callerSubjectExternalUserId),
-                scheduleCron,
-                scheduleTimezone),
+        var schedule = await EnsureScheduleAsync(
+            BuildScheduleId(scopeId, memberId),
+            request.DisplayName,
+            scopeId,
+            memberId,
+            publishedServiceId,
+            NormalizeOptional(request.Prompt) ?? string.Empty,
+            BuildScheduleAuth(request, callerSubjectExternalUserId),
+            scheduleCron,
+            scheduleTimezone,
             ct);
 
         return new StudioMemberWorkflowScheduleResult(
             Success: schedule.Accepted,
             ScopeId: scopeId,
             MemberId: memberId,
-            ScheduleId: NormalizeOptional(schedule.ScheduleId) ?? scheduleId,
+            ScheduleId: NormalizeRequired(schedule.ScheduleId, nameof(schedule.ScheduleId)),
             PublishedServiceId: publishedServiceId,
             ObservatoryUrl: ObservatoryPath,
             Status: schedule.Accepted ? "accepted" : "rejected");
     }
+
+    private async Task<ScheduledDispatchMutationReceipt> EnsureScheduleAsync(
+        string baseScheduleId,
+        string? displayName,
+        string scopeId,
+        string memberId,
+        string publishedServiceId,
+        string prompt,
+        ScheduledServiceInvocationAuth auth,
+        string cronExpression,
+        string timezone,
+        CancellationToken ct)
+    {
+        for (var generation = 1; generation <= MaxScheduleGenerations; generation++)
+        {
+            var scheduleId = generation == 1 ? baseScheduleId : $"{baseScheduleId}.{generation}";
+            try
+            {
+                return await _scheduleService.EnsureAsync(
+                    BuildScheduleConfiguration(
+                        scheduleId,
+                        displayName,
+                        scopeId,
+                        memberId,
+                        publishedServiceId,
+                        prompt,
+                        auth,
+                        cronExpression,
+                        timezone),
+                    ct);
+            }
+            catch (ScheduledDispatchNotFoundException)
+            {
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Studio member workflow schedule for member '{memberId}' exhausted {MaxScheduleGenerations} deleted schedule generations.");
+    }
+
+    private static void EnsureWorkflowBindingCanBeScheduled(
+        StudioMemberDetailResponse member,
+        string memberId,
+        string publishedServiceId)
+    {
+        if (member.LastBinding is not null)
+        {
+            var boundPublishedServiceId = NormalizeRequired(
+                member.LastBinding.PublishedServiceId,
+                nameof(member.LastBinding.PublishedServiceId));
+            if (!string.Equals(publishedServiceId, boundPublishedServiceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"member_id '{memberId}' binding service id does not match the published service id.");
+            }
+
+            return;
+        }
+
+        if (member.CurrentBindingRun is null || !IsSchedulableCurrentBindingRun(member.CurrentBindingRun.Status))
+        {
+            throw new InvalidOperationException(
+                $"member_id '{memberId}' has no bound workflow. Bind workflow YAML before scheduling the member.");
+        }
+    }
+
+    private static bool IsSchedulableCurrentBindingRun(string? status) => status switch
+    {
+        StudioMemberBindingRunStatusNames.Accepted => true,
+        StudioMemberBindingRunStatusNames.AdmissionPending => true,
+        StudioMemberBindingRunStatusNames.Admitted => true,
+        StudioMemberBindingRunStatusNames.PlatformBindingPending => true,
+        StudioMemberBindingRunStatusNames.MemberNotificationPending => true,
+        StudioMemberBindingRunStatusNames.Succeeded => true,
+        _ => false,
+    };
 
     private static ScheduledDispatchConfiguration BuildScheduleConfiguration(
         string scheduleId,

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -129,7 +129,11 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
               3. If the user already has or just created a Studio member for the workflow, bind the YAML to that
                  member by calling `aevatar_bind_member_workflow` with `member_id`, `workflow_yaml`, and optional
                  `workflow_id`. This is what makes the workflow visible on the member's Studio workflow page.
-              4. If the user asks for a standalone scheduled/Observatory automation rather than a workflow on an
+              4. If the user asks to schedule an existing or just-bound Studio member workflow, call
+                 `aevatar_schedule_member_workflow` with the existing `member_id`, `schedule_cron`, and
+                 `schedule_timezone`. This schedules that same member's published workflow service; it does
+                 NOT create a separate `wf-...` member and does not bind YAML again.
+              5. If the user asks for a standalone scheduled/Observatory automation rather than a workflow on an
                  existing Team/Member page, call `aevatar_provision_workflow_schedule` with `workflow_yaml`
                  and a `display_name`. This creates its own persisted workflow member whose runs land in
                  /workflow/observatory.
@@ -146,7 +150,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
                    state the cron + timezone you set so the user can confirm.
                  - `run_immediately` defaults true so a demo run fires shortly after the bind; a demo fire is fine
                    alongside the cron, but it does not replace the cron for a recurring request.
-              5. If `aevatar_bind_member_workflow` or `aevatar_provision_workflow_schedule` returns an error,
+              6. If `aevatar_bind_member_workflow` or `aevatar_provision_workflow_schedule` returns an error,
                  fix the `workflow_yaml` per the error message and call the same tool again. For schedule
                  provisioning, use the SAME `display_name` — provisioning is idempotent
                  per display name (retries re-use the same member and schedule; they do not create
@@ -154,13 +158,13 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
                  existing `display_name` REPLACES that workflow and re-enables its schedule, so only reuse a
                  name to retry or update the same automation — give a different automation a fresh, specific
                  `display_name`.
-              6. `aevatar_bind_member_workflow` and `aevatar_provision_workflow_schedule` return Accepted receipts
+              7. `aevatar_bind_member_workflow`, `aevatar_schedule_member_workflow`, and `aevatar_provision_workflow_schedule` return Accepted receipts
                  (binding/scheduling/run are asynchronous) — do NOT claim the workflow "ran successfully" from
                  those receipts. Use `aevatar_observe_run` (and `aevatar_read_workflow_run_artifact` for outputs)
                  to watch demo/scheduled runs, and tell the user to open /workflow/observatory to see runs. Report
                  honestly: state that the workflow was accepted/bound or provisioned, then report any observed run
                  status — never optimistically assume success.
-              7. You may use `ornn_search_skills` and `use_skill` to discover and load skills for genuinely
+              8. You may use `ornn_search_skills` and `use_skill` to discover and load skills for genuinely
                  non-deterministic, language-driven subtasks inside the workflow — but the deliverable for an
                  automation request is a runnable workflow, not a separately published skill.
 
@@ -169,14 +173,16 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
                 provisioned workflow whose runs are visible in /workflow/observatory. Do NOT publish a prose skill
                 as the answer to "build/automate/schedule X".
               - For an existing Team/Member workflow page, binding goes through `aevatar_bind_member_workflow`.
-                Scheduling goes through `aevatar_provision_workflow_schedule` only for standalone Observatory
-                automations. Never deliver results to Lark/Telegram or any chat/bot, and never schedule a bot delivery.
+                Scheduling that existing member's workflow goes through `aevatar_schedule_member_workflow`.
+                `aevatar_provision_workflow_schedule` is only for standalone Observatory automations that create
+                their own `wf-...` member. Never deliver results to Lark/Telegram or any chat/bot, and never schedule a bot delivery.
               - The owning scope and your credentials come from the session; do not ask the user for scope,
                 channel, owner, or tokens.
             allowed_tools:
               - aevatar_create_team
               - aevatar_create_member
               - aevatar_bind_member_workflow
+              - aevatar_schedule_member_workflow
               - aevatar_provision_workflow_schedule
               - aevatar_observe_run
               - aevatar_read_workflow_run_artifact

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -14,6 +14,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
     private const string CreateTeamToolName = "aevatar_create_team";
     private const string CreateMemberToolName = "aevatar_create_member";
     private const string BindMemberWorkflowToolName = "aevatar_bind_member_workflow";
+    private const string ScheduleMemberWorkflowToolName = "aevatar_schedule_member_workflow";
 
     [Fact]
     public async Task ToolSource_ShouldDiscoverProvisionWorkflowScheduleTool()
@@ -57,6 +58,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
         services.AddSingleton<IStudioTeamProvisioningPort, RecordingTeamProvisioningPort>();
         services.AddSingleton<IStudioMemberProvisioningPort, RecordingMemberProvisioningPort>();
         services.AddSingleton<IStudioMemberWorkflowBindingPort, RecordingMemberWorkflowBindingPort>();
+        services.AddSingleton<IStudioMemberWorkflowSchedulePort, RecordingMemberWorkflowSchedulePort>();
         services.AddStudioProvisioningTools();
 
         var provider = services.BuildServiceProvider();
@@ -72,6 +74,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
         toolNames.Should().Contain(CreateTeamToolName);
         toolNames.Should().Contain(CreateMemberToolName);
         toolNames.Should().Contain(BindMemberWorkflowToolName);
+        toolNames.Should().Contain(ScheduleMemberWorkflowToolName);
     }
 
     [Fact]
@@ -264,6 +267,27 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
+    public async Task ToolSource_WhenScheduleMemberWorkflowPortRegistered_ShouldDiscoverScheduleMemberWorkflowTool()
+    {
+        var source = new ScheduleStudioMemberWorkflowToolSource(new RecordingMemberWorkflowSchedulePort());
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().ContainSingle();
+        tools[0].Name.Should().Be(ScheduleMemberWorkflowToolName);
+    }
+
+    [Fact]
+    public async Task ToolSource_WhenScheduleMemberWorkflowPortMissing_ShouldNotDiscoverScheduleMemberWorkflowTool()
+    {
+        var source = new ScheduleStudioMemberWorkflowToolSource();
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task BindMemberWorkflow_ShouldCallBindingPortWithCallerScope()
     {
         var bindingPort = new RecordingMemberWorkflowBindingPort();
@@ -331,6 +355,112 @@ public sealed class ProvisionWorkflowScheduleToolTests
     public async Task BindMemberWorkflow_ShouldUseSharedCreateScopedResourceApprovalPolicy()
     {
         var tool = await DiscoverBindMemberWorkflowToolAsync(new RecordingMemberWorkflowBindingPort());
+
+        tool.ApprovalMode.Should().Be(ToolApprovalPolicies.CreateScopedResource);
+        tool.Should().NotBeAssignableTo<IAgentToolCapabilityDescriptor>();
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_ShouldCallSchedulePortWithCallerScopeAndSubject()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "member-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai",
+              "prompt": "run digest",
+              "display_name": "Daily digest"
+            }
+            """);
+
+        schedulePort.LastRequest.Should().NotBeNull();
+        schedulePort.LastRequest!.ScopeId.Should().Be("scope-current");
+        schedulePort.LastRequest.MemberId.Should().Be("member-alpha");
+        schedulePort.LastRequest.ScheduleCron.Should().Be("0 9 * * *");
+        schedulePort.LastRequest.ScheduleTimezone.Should().Be("Asia/Shanghai");
+        schedulePort.LastRequest.Prompt.Should().Be("run digest");
+        schedulePort.LastRequest.DisplayName.Should().Be("Daily digest");
+        schedulePort.LastRequest.CallerSubjectExternalUserId.Should().Be("owner-1");
+
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        root.GetProperty("success").GetBoolean().Should().BeTrue();
+        root.GetProperty("scope_id").GetString().Should().Be("scope-current");
+        root.GetProperty("member_id").GetString().Should().Be("member-alpha");
+        root.GetProperty("schedule_id").GetString().Should().Be("schedule-member-1");
+        root.GetProperty("published_service_id").GetString().Should().Be("published-member-1");
+        root.GetProperty("observatory_url").GetString().Should().Be("/workflow/observatory");
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_WhenScopeMissing_ShouldReturnStructuredErrorAndNotCallPort()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(scopeId: null, ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""{"member_id":"member-alpha","schedule_cron":"0 9 * * *","schedule_timezone":"Asia/Shanghai"}""");
+
+        ErrorCode(output).Should().Be("caller_scope_unavailable");
+        schedulePort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_WhenOwnerSubjectMissing_ShouldReturnStructuredErrorAndNotCallPort()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: null, accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""{"member_id":"member-alpha","schedule_cron":"0 9 * * *","schedule_timezone":"Asia/Shanghai"}""");
+
+        ErrorCode(output).Should().Be("caller_subject_unavailable");
+        schedulePort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_WhenModelSuppliesScope_ShouldRejectUnknownArgumentAndNotCallPort()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(scopeId: "scope-context", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "scope_id": "scope-model",
+              "member_id": "member-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+        ErrorMessage(output).Should().Be("Unknown argument: scope_id");
+        schedulePort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_WhenRequiredArgumentsMissing_ShouldReturnInvalidArguments()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""{"member_id":"member-alpha","schedule_cron":"0 9 * * *"}""");
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+        ErrorMessage(output).Should().Be("schedule_timezone is required.");
+        schedulePort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_ShouldUseSharedCreateScopedResourceApprovalPolicy()
+    {
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(new RecordingMemberWorkflowSchedulePort());
 
         tool.ApprovalMode.Should().Be(ToolApprovalPolicies.CreateScopedResource);
         tool.Should().NotBeAssignableTo<IAgentToolCapabilityDescriptor>();
@@ -528,6 +658,14 @@ public sealed class ProvisionWorkflowScheduleToolTests
         return tools.Single(tool => tool.Name == BindMemberWorkflowToolName);
     }
 
+    private static async Task<IAgentTool> DiscoverScheduleMemberWorkflowToolAsync(
+        IStudioMemberWorkflowSchedulePort schedulePort)
+    {
+        var source = new ScheduleStudioMemberWorkflowToolSource(schedulePort);
+        var tools = await source.DiscoverToolsAsync();
+        return tools.Single(tool => tool.Name == ScheduleMemberWorkflowToolName);
+    }
+
     private static AgentToolContextScope PushContext(string? scopeId, string? ownerSubject, string? accessToken)
     {
         return AgentToolContextScope.Push(new AgentToolExecutionContext(
@@ -655,6 +793,26 @@ public sealed class ProvisionWorkflowScheduleToolTests
                 Status: "accepted",
                 AckStage: "dispatch_accepted",
                 BindingRunRole: "candidate"));
+        }
+    }
+
+    private sealed class RecordingMemberWorkflowSchedulePort : IStudioMemberWorkflowSchedulePort
+    {
+        public StudioMemberWorkflowScheduleRequest? LastRequest { get; private set; }
+
+        public Task<StudioMemberWorkflowScheduleResult> EnsureAsync(
+            StudioMemberWorkflowScheduleRequest request,
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new StudioMemberWorkflowScheduleResult(
+                Success: true,
+                ScopeId: request.ScopeId,
+                MemberId: request.MemberId,
+                ScheduleId: "schedule-member-1",
+                PublishedServiceId: "published-member-1",
+                ObservatoryUrl: "/workflow/observatory",
+                Status: "accepted"));
         }
     }
 }

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -463,7 +463,8 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(new RecordingMemberWorkflowSchedulePort());
 
         tool.ApprovalMode.Should().Be(ToolApprovalPolicies.CreateScopedResource);
-        tool.Should().NotBeAssignableTo<IAgentToolCapabilityDescriptor>();
+        var descriptor = tool.Should().BeAssignableTo<IAgentToolCapabilityDescriptor>().Subject;
+        descriptor.Capabilities.Should().Contain(AgentToolCapabilities.ExcludeFromDirectChannelChat);
     }
 
     [Fact]

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -277,6 +277,7 @@ public sealed class MainnetHostCompositionTests
         workspace.Sources.Should().Contain(source => source is CreateStudioTeamToolSource);
         workspace.Sources.Should().Contain(source => source is CreateStudioMemberToolSource);
         workspace.Sources.Should().Contain(source => source is BindStudioMemberWorkflowToolSource);
+        workspace.Sources.Should().Contain(source => source is ScheduleStudioMemberWorkflowToolSource);
         workspace.Sources.Should().Contain(source => source.GetType().Name == "ResponsesAevatarToolProvider");
         workspace.Sources.Should().Contain(source => source is ChannelInteractiveReplyToolSource);
         workspace.Sources.Should().Contain(source => source is ChannelRegistrationToolSource);

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowSchedulePortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowSchedulePortTests.cs
@@ -1,0 +1,311 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.GAgentService.Abstractions.Schedules;
+using Aevatar.Studio.Application.Provisioning;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioMemberWorkflowSchedulePortTests
+{
+    [Fact]
+    public async Task EnsureAsync_HappyPath_SchedulesExistingBoundWorkflowMember()
+    {
+        var memberService = new RecordingMemberService
+        {
+            Detail = CreateWorkflowMemberDetail(),
+        };
+        var scheduleService = new RecordingScheduleService();
+        var sut = new StudioMemberWorkflowSchedulePort(memberService, scheduleService);
+
+        var result = await sut.EnsureAsync(new StudioMemberWorkflowScheduleRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: "owner-1")
+        {
+            Prompt = "run digest",
+            DisplayName = "Daily digest",
+        });
+
+        result.Success.Should().BeTrue();
+        result.Status.Should().Be("accepted");
+        result.ScopeId.Should().Be("scope-1");
+        result.MemberId.Should().Be("member-1");
+        result.ScheduleId.Should().Be("schedule-accepted");
+        result.PublishedServiceId.Should().Be("published-member-1");
+        result.ObservatoryUrl.Should().Be("/workflow/observatory");
+
+        memberService.GetScopeId.Should().Be("scope-1");
+        memberService.GetMemberId.Should().Be("member-1");
+        memberService.CreateCallCount.Should().Be(0);
+        memberService.BindCallCount.Should().Be(0);
+
+        scheduleService.EnsureCallCount.Should().Be(1);
+        var configuration = scheduleService.Configuration!;
+        configuration.DisplayName.Should().Be("Daily digest");
+        configuration.CronExpression.Should().Be("0 9 * * *");
+        configuration.Timezone.Should().Be("Asia/Shanghai");
+        configuration.ScheduleKind.Should().Be(ScheduledDispatchScheduleKind.Workflow);
+        configuration.Enabled.Should().BeTrue();
+        configuration.Headers.Should().BeEmpty();
+
+        var invocation = configuration.Target.ServiceInvocation!;
+        invocation.Identity.TenantId.Should().Be("scope-1");
+        invocation.Identity.ServiceId.Should().Be("published-member-1");
+        invocation.EndpointId.Should().Be("chat");
+        var chat = invocation.Payload.Unpack<ChatRequestEvent>();
+        chat.Prompt.Should().Be("run digest");
+        chat.ScopeId.Should().Be("scope-1");
+    }
+
+    [Fact]
+    public async Task EnsureAsync_ThreadsCallerSubjectRefIntoDispatchAuth()
+    {
+        var scheduleService = new RecordingScheduleService();
+        var sut = new StudioMemberWorkflowSchedulePort(
+            new RecordingMemberService { Detail = CreateWorkflowMemberDetail() },
+            scheduleService);
+
+        await sut.EnsureAsync(new StudioMemberWorkflowScheduleRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: " owner-1 ")
+        {
+            CallerSubjectPlatform = " Lark ",
+            CallerSubjectTenant = " tenant-1 ",
+        });
+
+        var auth = scheduleService.Configuration!.Target.ServiceInvocation!.Auth;
+        auth.Should().NotBeNull();
+        auth!.SenderNyxId.Should().NotBeNull();
+        auth.SenderNyxId!.Subject.Platform.Should().Be("Lark");
+        auth.SenderNyxId.Subject.Tenant.Should().Be("tenant-1");
+        auth.SenderNyxId.Subject.ExternalUserId.Should().Be("owner-1");
+        auth.SenderNyxId.Scope.Should().Be(ProvisionWorkflowCallerCredential.DefaultScope);
+        auth.DurableSenderBearerToken.Should().BeNull();
+        auth.ScopeOwnerNyxId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task EnsureAsync_WhenWorkflowMemberUnbound_ShouldRejectBeforeScheduling()
+    {
+        var scheduleService = new RecordingScheduleService();
+        var sut = new StudioMemberWorkflowSchedulePort(
+            new RecordingMemberService { Detail = CreateWorkflowMemberDetail(hasBinding: false) },
+            scheduleService);
+
+        var action = () => sut.EnsureAsync(new StudioMemberWorkflowScheduleRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: "owner-1"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("member_id 'member-1' has no bound workflow*");
+        scheduleService.EnsureCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EnsureAsync_WhenMemberIsNotWorkflow_ShouldRejectBeforeScheduling()
+    {
+        var scheduleService = new RecordingScheduleService();
+        var sut = new StudioMemberWorkflowSchedulePort(
+            new RecordingMemberService { Detail = CreateWorkflowMemberDetail(implementationKind: MemberImplementationKindNames.Script) },
+            scheduleService);
+
+        var action = () => sut.EnsureAsync(new StudioMemberWorkflowScheduleRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: "owner-1"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("member_id 'member-1' is not a workflow member*");
+        scheduleService.EnsureCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EnsureAsync_ShouldUseDeterministicScheduleIdPerScopeAndMember()
+    {
+        var first = new RecordingScheduleService();
+        var second = new RecordingScheduleService();
+        var otherScope = new RecordingScheduleService();
+        var otherMember = new RecordingScheduleService();
+
+        await NewPort(first).EnsureAsync(Request("scope-1", "member-1"));
+        await NewPort(second).EnsureAsync(Request("scope-1", "member-1"));
+        await NewPort(otherScope).EnsureAsync(Request("scope-2", "member-1"));
+        await NewPort(otherMember).EnsureAsync(Request("scope-1", "member-2"));
+
+        var scheduleId = first.Configuration!.ScheduleId;
+        second.Configuration!.ScheduleId.Should().Be(scheduleId);
+        otherScope.Configuration!.ScheduleId.Should().NotBe(scheduleId);
+        otherMember.Configuration!.ScheduleId.Should().NotBe(scheduleId);
+        scheduleId.Should().StartWith("studio-member-workflow-");
+        scheduleId.Should().MatchRegex("^[A-Za-z0-9._-]+$");
+    }
+
+    private static StudioMemberWorkflowScheduleRequest Request(string scopeId, string memberId) =>
+        new(
+            ScopeId: scopeId,
+            MemberId: memberId,
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: "owner-1");
+
+    private static StudioMemberWorkflowSchedulePort NewPort(RecordingScheduleService schedule) =>
+        new(new RecordingMemberService { Detail = CreateWorkflowMemberDetail() }, schedule);
+
+    private static StudioMemberDetailResponse CreateWorkflowMemberDetail(
+        string implementationKind = MemberImplementationKindNames.Workflow,
+        bool hasBinding = true) =>
+        new(
+            Summary: new StudioMemberSummaryResponse(
+                MemberId: "member-1",
+                ScopeId: "scope-1",
+                DisplayName: "Member",
+                Description: string.Empty,
+                ImplementationKind: implementationKind,
+                LifecycleStage: MemberLifecycleStageNames.BindReady,
+                PublishedServiceId: "published-member-1",
+                LastBoundRevisionId: "rev-1",
+                CreatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+                UpdatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z")),
+            ImplementationRef: null,
+            LastBinding: hasBinding
+                ? new StudioMemberBindingContractResponse(
+                    PublishedServiceId: "published-member-1",
+                    RevisionId: "rev-1",
+                    ImplementationKind: MemberImplementationKindNames.Workflow,
+                    BoundAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"))
+                : null);
+
+    private sealed class RecordingMemberService : IStudioMemberService
+    {
+        public StudioMemberDetailResponse? Detail { get; init; }
+        public string? GetScopeId { get; private set; }
+        public string? GetMemberId { get; private set; }
+        public int CreateCallCount { get; private set; }
+        public int BindCallCount { get; private set; }
+
+        public Task<StudioMemberDetailResponse> GetAsync(
+            string scopeId, string memberId, CancellationToken ct = default)
+        {
+            GetScopeId = scopeId;
+            GetMemberId = memberId;
+            return Task.FromResult(Detail ?? throw new StudioMemberNotFoundException(scopeId, memberId));
+        }
+
+        public Task<StudioMemberSummaryResponse> CreateAsync(
+            string scopeId, CreateStudioMemberRequest request, CancellationToken ct = default)
+        {
+            CreateCallCount++;
+            throw new NotSupportedException();
+        }
+
+        public Task<StudioMemberBindingAcceptedResponse> BindAsync(
+            string scopeId, string memberId, UpdateStudioMemberBindingRequest request, CancellationToken ct = default)
+        {
+            BindCallCount++;
+            throw new NotSupportedException();
+        }
+
+        public Task<StudioMemberRosterResponse> ListAsync(
+            string scopeId, StudioMemberRosterPageRequest? page = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingViewResponse> GetBindingAsync(
+            string scopeId, string memberId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberEndpointContractResponse?> GetEndpointContractAsync(
+            string scopeId, string memberId, string endpointId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingRunStatusResponse> GetBindingRunAsync(
+            string scopeId, string memberId, string bindingRunId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingActivationResponse> ActivateBindingRevisionAsync(
+            string scopeId, string memberId, string revisionId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberBindingRevisionActionResponse> RetireBindingRevisionAsync(
+            string scopeId, string memberId, string revisionId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<StudioMemberCommandResponse> UpdateAsync(
+            string scopeId, string memberId, UpdateStudioMemberRequest request, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class RecordingScheduleService : IScheduledDispatchApplicationService
+    {
+        public int EnsureCallCount { get; private set; }
+        public ScheduledDispatchConfiguration? Configuration { get; private set; }
+
+        public Task<ScheduledDispatchMutationReceipt> EnsureAsync(
+            ScheduledDispatchConfiguration configuration, CancellationToken ct = default)
+        {
+            EnsureCallCount++;
+            Configuration = configuration;
+            return Task.FromResult(new ScheduledDispatchMutationReceipt(
+                "schedule-accepted",
+                "scheduled-dispatch:schedule-accepted",
+                Accepted: true,
+                CommandId: "cmd-1",
+                CorrelationId: "corr-1",
+                AckedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+                AckStage: "accepted"));
+        }
+
+        public Task<ScheduledDispatchMutationReceipt> CreateAsync(
+            ScheduledDispatchConfiguration configuration, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchMutationReceipt> UpdateAsync(
+            string scheduleId, ScheduledDispatchConfiguration configuration, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchMutationReceipt> EnableAsync(
+            string scheduleId, string reason, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchMutationReceipt> DisableAsync(
+            string scheduleId, string reason, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchMutationReceipt> DeleteAsync(
+            string scheduleId, string reason, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchDetail?> GetAsync(
+            string scheduleId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchListResult> ListAsync(
+            int take = 50, string? cursor = null, bool includeTotalCount = false, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchListResult> ListAsync(
+            ScheduledDispatchListQuery query, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchPreview> PreviewAsync(
+            string cronExpression, string? timezone, int count, DateTimeOffset? fromUtc = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScheduledDispatchRunNowReceipt> RunNowAsync(
+            string scheduleId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowSchedulePortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowSchedulePortTests.cs
@@ -36,7 +36,7 @@ public sealed class StudioMemberWorkflowSchedulePortTests
         result.Status.Should().Be("accepted");
         result.ScopeId.Should().Be("scope-1");
         result.MemberId.Should().Be("member-1");
-        result.ScheduleId.Should().Be("schedule-accepted");
+        result.ScheduleId.Should().Be(scheduleService.Configuration!.ScheduleId);
         result.PublishedServiceId.Should().Be("published-member-1");
         result.ObservatoryUrl.Should().Be("/workflow/observatory");
 
@@ -94,6 +94,56 @@ public sealed class StudioMemberWorkflowSchedulePortTests
     }
 
     [Fact]
+    public async Task EnsureAsync_WhenJustAcceptedBindingRun_ShouldScheduleBeforeLastBindingMaterializes()
+    {
+        var scheduleService = new RecordingScheduleService();
+        var sut = new StudioMemberWorkflowSchedulePort(
+            new RecordingMemberService
+            {
+                Detail = CreateWorkflowMemberDetail(
+                    hasBinding: false,
+                    currentBindingRunStatus: StudioMemberBindingRunStatusNames.Accepted),
+            },
+            scheduleService);
+
+        var result = await sut.EnsureAsync(new StudioMemberWorkflowScheduleRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: "owner-1"));
+
+        result.Success.Should().BeTrue();
+        scheduleService.EnsureCallCount.Should().Be(1);
+        scheduleService.Configuration!.Target.ServiceInvocation!.Identity.ServiceId.Should().Be("published-member-1");
+    }
+
+    [Fact]
+    public async Task EnsureAsync_WhenBindingRunFailedAndNoLastBinding_ShouldRejectBeforeScheduling()
+    {
+        var scheduleService = new RecordingScheduleService();
+        var sut = new StudioMemberWorkflowSchedulePort(
+            new RecordingMemberService
+            {
+                Detail = CreateWorkflowMemberDetail(
+                    hasBinding: false,
+                    currentBindingRunStatus: StudioMemberBindingRunStatusNames.Failed),
+            },
+            scheduleService);
+
+        var action = () => sut.EnsureAsync(new StudioMemberWorkflowScheduleRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            ScheduleCron: "0 9 * * *",
+            ScheduleTimezone: "Asia/Shanghai",
+            CallerSubjectExternalUserId: "owner-1"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("member_id 'member-1' has no bound workflow*");
+        scheduleService.EnsureCallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task EnsureAsync_WhenWorkflowMemberUnbound_ShouldRejectBeforeScheduling()
     {
         var scheduleService = new RecordingScheduleService();
@@ -134,6 +184,19 @@ public sealed class StudioMemberWorkflowSchedulePortTests
     }
 
     [Fact]
+    public async Task EnsureAsync_WhenBaseScheduleIdTombstoned_ShouldUseNextGeneration()
+    {
+        var scheduleService = new RecordingScheduleService { TombstonedAttempts = 1 };
+
+        var result = await NewPort(scheduleService).EnsureAsync(Request("scope-1", "member-1"));
+
+        scheduleService.EnsureCallCount.Should().Be(2);
+        var attemptedScheduleIds = scheduleService.Configurations.Select(static configuration => configuration.ScheduleId).ToArray();
+        attemptedScheduleIds[1].Should().Be($"{attemptedScheduleIds[0]}.2");
+        result.ScheduleId.Should().Be(attemptedScheduleIds[1]);
+    }
+
+    [Fact]
     public async Task EnsureAsync_ShouldUseDeterministicScheduleIdPerScopeAndMember()
     {
         var first = new RecordingScheduleService();
@@ -167,7 +230,8 @@ public sealed class StudioMemberWorkflowSchedulePortTests
 
     private static StudioMemberDetailResponse CreateWorkflowMemberDetail(
         string implementationKind = MemberImplementationKindNames.Workflow,
-        bool hasBinding = true) =>
+        bool hasBinding = true,
+        string? currentBindingRunStatus = null) =>
         new(
             Summary: new StudioMemberSummaryResponse(
                 MemberId: "member-1",
@@ -177,7 +241,7 @@ public sealed class StudioMemberWorkflowSchedulePortTests
                 ImplementationKind: implementationKind,
                 LifecycleStage: MemberLifecycleStageNames.BindReady,
                 PublishedServiceId: "published-member-1",
-                LastBoundRevisionId: "rev-1",
+                LastBoundRevisionId: hasBinding ? "rev-1" : null,
                 CreatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
                 UpdatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z")),
             ImplementationRef: null,
@@ -187,7 +251,18 @@ public sealed class StudioMemberWorkflowSchedulePortTests
                     RevisionId: "rev-1",
                     ImplementationKind: MemberImplementationKindNames.Workflow,
                     BoundAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"))
-                : null);
+                : null)
+        {
+            CurrentBindingRun = currentBindingRunStatus is null
+                ? null
+                : new StudioMemberBindingRunStatusResponse(
+                    BindingRunId: "bind-1",
+                    ScopeId: "scope-1",
+                    MemberId: "member-1",
+                    Status: currentBindingRunStatus,
+                    StateVersion: 1,
+                    UpdatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z")),
+        };
 
     private sealed class RecordingMemberService : IStudioMemberService
     {
@@ -251,16 +326,22 @@ public sealed class StudioMemberWorkflowSchedulePortTests
     private sealed class RecordingScheduleService : IScheduledDispatchApplicationService
     {
         public int EnsureCallCount { get; private set; }
+        public int TombstonedAttempts { get; init; }
         public ScheduledDispatchConfiguration? Configuration { get; private set; }
+        public List<ScheduledDispatchConfiguration> Configurations { get; } = [];
 
         public Task<ScheduledDispatchMutationReceipt> EnsureAsync(
             ScheduledDispatchConfiguration configuration, CancellationToken ct = default)
         {
             EnsureCallCount++;
             Configuration = configuration;
+            Configurations.Add(configuration);
+            if (EnsureCallCount <= TombstonedAttempts)
+                throw new ScheduledDispatchNotFoundException(configuration.ScheduleId);
+
             return Task.FromResult(new ScheduledDispatchMutationReceipt(
-                "schedule-accepted",
-                "scheduled-dispatch:schedule-accepted",
+                configuration.ScheduleId,
+                $"scheduled-dispatch:{configuration.ScheduleId}",
                 Accepted: true,
                 CommandId: "cmd-1",
                 CorrelationId: "corr-1",

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -203,7 +203,9 @@ public class WorkflowDefinitionCatalogTests
         role.SystemPrompt.Should().Contain("aevatar_create_team");
         role.SystemPrompt.Should().Contain("aevatar_create_member");
         role.SystemPrompt.Should().Contain("aevatar_bind_member_workflow");
+        role.SystemPrompt.Should().Contain("aevatar_schedule_member_workflow");
         role.SystemPrompt.Should().Contain("aevatar_provision_workflow_schedule");
+        role.SystemPrompt.Should().Contain("NOT create a separate `wf-...` member");
         role.SystemPrompt.Should().Contain("/workflow/observatory");
         role.SystemPrompt.Should().Contain("Do NOT");
         // Honesty: the receipt is Accepted (async), not a success claim.
@@ -230,6 +232,7 @@ public class WorkflowDefinitionCatalogTests
         allowed.Should().Contain("aevatar_create_team");
         allowed.Should().Contain("aevatar_create_member");
         allowed.Should().Contain("aevatar_bind_member_workflow");
+        allowed.Should().Contain("aevatar_schedule_member_workflow");
         allowed.Should().Contain("aevatar_provision_workflow_schedule");
         allowed.Should().Contain("aevatar_observe_run");
         allowed.Should().Contain("aevatar_read_workflow_run_artifact");


### PR DESCRIPTION
## Summary
- Add `aevatar_schedule_member_workflow` for scheduling an existing bound Studio member workflow without creating a standalone `wf-...` member.
- Resolve the member's published service from Studio state and schedule dispatch through the existing scheduled-dispatch service with caller subject auth.
- Expose the tool in workspace defaults and the built-in Studio workflow prompt/allowlist.

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj --nologo --filter "ScheduleMemberWorkflow|AddStudioProvisioningTools"`
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter "StudioMemberWorkflowSchedulePortTests"`
- [x] `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo --filter "MainnetHostCompositionTests"`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "WorkflowDefinitionCatalogTests"`
- [x] Local Mainnet Host startup with in-memory dependencies; `/api/status` returned 200.
- [x] Local `/api/chat` loaded the updated built-in Studio workflow and allowlist; full LLM tool-call path was blocked by upstream LLM 401 in local environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)