### PR TITLE
Sync member binding state after save-and-bind

### DIFF
--- a/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
+++ b/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
@@ -276,6 +276,34 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
         await SendTerminalAcknowledgementAsync(evt.BindingRunId, StudioMemberBindingRunStatus.Failed);
     }
 
+    [EventHandler(EndpointName = "recordPublishedBinding")]
+    public async Task HandlePublishedBindingRecorded(StudioMemberPublishedBindingRecordedEvent evt)
+    {
+        if (string.IsNullOrEmpty(State.MemberId))
+        {
+            throw new InvalidOperationException("member not yet created.");
+        }
+
+        if (!string.Equals(State.PublishedServiceId, evt.PublishedServiceId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"publishedServiceId '{evt.PublishedServiceId}' does not match member '{State.MemberId}' publishedServiceId '{State.PublishedServiceId}'.");
+        }
+
+        if (evt.ImplementationKind != State.ImplementationKind)
+        {
+            throw new InvalidOperationException(
+                $"binding record kind '{evt.ImplementationKind}' does not match member kind '{State.ImplementationKind}'.");
+        }
+
+        if (!HasResolvedImplementationRef(evt.ImplementationRef, evt.ImplementationKind))
+        {
+            throw new InvalidOperationException("published binding record must include a resolved implementation reference for its implementation kind.");
+        }
+
+        await PersistDomainEventAsync(evt);
+    }
+
     /// <summary>
     /// Mutates the member's team assignment (ADR-0017 Locked Rule 3).
     /// The single event shape covers assign / unassign / move; from/to are
@@ -419,6 +447,7 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
             .On<StudioMemberBindingPlatformPendingEvent>(ApplyBindingPlatformPending)
             .On<StudioMemberBindingCompletedEvent>(ApplyBindingCompleted)
             .On<StudioMemberBindingFailedEvent>(ApplyBindingFailed)
+            .On<StudioMemberPublishedBindingRecordedEvent>(ApplyPublishedBindingRecorded)
             .On<StudioMemberReassignedEvent>(ApplyReassigned)
             .OrCurrent();
     }
@@ -634,6 +663,37 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
         return next;
     }
 
+    private static StudioMemberState ApplyPublishedBindingRecorded(
+        StudioMemberState state,
+        StudioMemberPublishedBindingRecordedEvent evt)
+    {
+        if (string.IsNullOrEmpty(state.MemberId))
+            return state;
+
+        var recordedAt = evt.RecordedAtUtc ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var next = state.Clone();
+        next.LastBinding = new StudioMemberBindingContract
+        {
+            PublishedServiceId = evt.PublishedServiceId,
+            RevisionId = evt.RevisionId,
+            ImplementationKind = evt.ImplementationKind,
+            BoundAtUtc = recordedAt,
+            ExpectedActorId = evt.ExpectedActorId ?? string.Empty,
+        };
+        next.ImplementationRef = evt.ImplementationRef?.Clone();
+        next.Binding = new StudioMemberBindingAuthorityState
+        {
+            CurrentBindingRunId = string.Empty,
+            CurrentStatus = StudioMemberBindingRunStatus.Unspecified,
+            LastTerminalBindingRunId = state.Binding?.LastTerminalBindingRunId ?? string.Empty,
+            LastFailure = null,
+            UpdatedAtUtc = recordedAt,
+        };
+        next.LifecycleStage = StudioMemberLifecycleStage.BindReady;
+        next.UpdatedAtUtc = recordedAt;
+        return next;
+    }
+
     private static bool CanAcceptBindingRunProgress(StudioMemberState state, string bindingRunId)
     {
         var currentRun = state.Binding?.CurrentBindingRunId;
@@ -799,19 +859,29 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
         return trimmed;
     }
 
-    private static bool HasResolvedImplementationRef(StudioMemberImplementationRef? implRef)
+    private static bool HasResolvedImplementationRef(StudioMemberImplementationRef? implRef) =>
+        implRef != null &&
+        (HasResolvedImplementationRef(implRef, StudioMemberImplementationKind.Workflow) ||
+         HasResolvedImplementationRef(implRef, StudioMemberImplementationKind.Script) ||
+         HasResolvedImplementationRef(implRef, StudioMemberImplementationKind.Gagent));
+
+    private static bool HasResolvedImplementationRef(
+        StudioMemberImplementationRef? implRef,
+        StudioMemberImplementationKind implementationKind)
     {
         if (implRef == null)
             return false;
 
-        if (implRef.Workflow != null && !string.IsNullOrEmpty(implRef.Workflow.WorkflowId))
-            return true;
-        if (implRef.Script != null && !string.IsNullOrEmpty(implRef.Script.ScriptId))
-            return true;
-        if (implRef.Gagent != null && !string.IsNullOrEmpty(implRef.Gagent.ActorTypeName))
-            return true;
-
-        return false;
+        return implementationKind switch
+        {
+            StudioMemberImplementationKind.Workflow =>
+                implRef.Workflow != null && !string.IsNullOrEmpty(implRef.Workflow.WorkflowId),
+            StudioMemberImplementationKind.Script =>
+                implRef.Script != null && !string.IsNullOrEmpty(implRef.Script.ScriptId),
+            StudioMemberImplementationKind.Gagent =>
+                implRef.Gagent != null && !string.IsNullOrEmpty(implRef.Gagent.ActorTypeName),
+            _ => false,
+        };
     }
 
     private static StudioMemberImplementationKind GetRequestImplementationKind(StudioMemberBindingRequest request) =>

--- a/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
+++ b/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
@@ -259,6 +259,15 @@ message StudioMemberBindingCompletedEvent {
   string expected_actor_id = 7;
 }
 
+message StudioMemberPublishedBindingRecordedEvent {
+  string published_service_id = 1;
+  string revision_id = 2;
+  StudioMemberImplementationKind implementation_kind = 3;
+  StudioMemberImplementationRef implementation_ref = 4;
+  google.protobuf.Timestamp recorded_at_utc = 5;
+  string expected_actor_id = 6;
+}
+
 message StudioMemberBindingFailedEvent {
   string binding_run_id = 1;
   StudioMemberBindingFailure failure = 2;

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
@@ -103,12 +103,15 @@ internal sealed class BindStudioMemberWorkflowTool : IAgentTool
                     Success: result.Success,
                     ScopeId: result.ScopeId,
                     MemberId: result.MemberId,
-                    BindingRunId: result.BindingRunId,
+                    Operation: result.Operation,
                     Status: result.Status,
+                    BindingRunId: result.BindingRunId,
                     AckStage: result.AckStage,
                     BindingRunRole: result.BindingRunRole,
-                    BindingRunUrl: $"/api/scopes/{Uri.EscapeDataString(result.ScopeId)}/members/{Uri.EscapeDataString(result.MemberId)}/binding-runs/{Uri.EscapeDataString(result.BindingRunId)}",
-                    MemberWorkflowUrl: $"/api/scopes/{Uri.EscapeDataString(result.ScopeId)}/members/{Uri.EscapeDataString(result.MemberId)}/binding"),
+                    BindingRunUrl: BuildBindingRunUrl(result),
+                    MemberWorkflowUrl: $"/api/scopes/{Uri.EscapeDataString(result.ScopeId)}/members/{Uri.EscapeDataString(result.MemberId)}/binding",
+                    WorkflowId: result.WorkflowId,
+                    RevisionId: result.RevisionId),
                 s_jsonOptions);
         }
         catch (InvalidOperationException ex)
@@ -132,6 +135,11 @@ internal sealed class BindStudioMemberWorkflowTool : IAgentTool
 
     private static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? BuildBindingRunUrl(StudioMemberWorkflowBindingResult result) =>
+        string.IsNullOrWhiteSpace(result.BindingRunId)
+            ? null
+            : $"/api/scopes/{Uri.EscapeDataString(result.ScopeId)}/members/{Uri.EscapeDataString(result.MemberId)}/binding-runs/{Uri.EscapeDataString(result.BindingRunId)}";
 
     private static string? FindUnknownArgument(string argumentsJson)
     {
@@ -157,12 +165,15 @@ internal sealed class BindStudioMemberWorkflowTool : IAgentTool
         bool Success,
         string ScopeId,
         string MemberId,
-        string BindingRunId,
+        string Operation,
         string Status,
-        string AckStage,
-        string BindingRunRole,
-        string BindingRunUrl,
-        string MemberWorkflowUrl);
+        string? BindingRunId,
+        string? AckStage,
+        string? BindingRunRole,
+        string? BindingRunUrl,
+        string MemberWorkflowUrl,
+        string? WorkflowId,
+        string? RevisionId);
 
     private sealed record BindStudioMemberWorkflowErrorJson(BindStudioMemberWorkflowErrorBody Error);
 

--- a/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowBindingContracts.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowBindingContracts.cs
@@ -8,11 +8,20 @@ public sealed record StudioMemberWorkflowBindingRequest(
     public string? WorkflowId { get; init; }
 }
 
+public static class StudioMemberWorkflowBindingOperationNames
+{
+    public const string Bind = "bind";
+    public const string SaveAndBind = "save_and_bind";
+}
+
 public sealed record StudioMemberWorkflowBindingResult(
     bool Success,
     string ScopeId,
     string MemberId,
-    string BindingRunId,
+    string Operation,
     string Status,
-    string AckStage,
-    string BindingRunRole);
+    string? BindingRunId = null,
+    string? AckStage = null,
+    string? BindingRunRole = null,
+    string? WorkflowId = null,
+    string? RevisionId = null);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberCommandPort.cs
@@ -33,6 +33,16 @@ public interface IStudioMemberCommandPort
         CancellationToken ct = default);
 
     /// <summary>
+    /// Records that an already-published member service now points at a new
+    /// implementation revision without creating a binding run.
+    /// </summary>
+    Task RecordPublishedBindingAsync(
+        string scopeId,
+        string memberId,
+        StudioMemberPublishedBindingRecordRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Renames an existing member through the member actor's authoritative
     /// rename event. Identity fields and implementation references are left
     /// unchanged by the actor state transition.

--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -140,6 +140,13 @@ public sealed record StudioMemberBindingContractResponse(
     DateTimeOffset BoundAt,
     string? ExpectedActorId = null);
 
+public sealed record StudioMemberPublishedBindingRecordRequest(
+    string PublishedServiceId,
+    string RevisionId,
+    string ImplementationKind,
+    StudioMemberImplementationRefResponse ImplementationRef,
+    string? ExpectedActorId = null);
+
 /// <summary>
 /// Wrapper returned from <c>GET /members/{memberId}/binding</c> so the
 /// response is always a JSON object — distinguishes "exists but never

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
@@ -57,10 +57,17 @@ public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindi
                 $"workflow_yaml is not a valid workflow definition: {parseResult.Error}");
         }
 
-        var member = await _memberService.GetAsync(request.ScopeId, request.MemberId, ct);
-        return IsPublished(member)
-            ? await SaveAndBindPublishedMemberAsync(request, member, ct)
-            : await BindUnpublishedMemberAsync(request, ct);
+        try
+        {
+            var member = await _memberService.GetAsync(request.ScopeId, request.MemberId, ct);
+            return IsPublished(member)
+                ? await SaveAndBindPublishedMemberAsync(request, member, ct)
+                : await BindUnpublishedMemberAsync(request, ct);
+        }
+        catch (StudioMemberNotFoundException)
+        {
+            return await BindUnpublishedMemberAsync(request, ct);
+        }
     }
 
     private async Task<StudioMemberWorkflowBindingResult> BindUnpublishedMemberAsync(
@@ -96,6 +103,12 @@ public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindi
         StudioMemberDetailResponse member,
         CancellationToken ct)
     {
+        if (!string.Equals(member.Summary.ImplementationKind, MemberImplementationKindNames.Workflow, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Studio member '{request.MemberId}' implementation kind '{member.Summary.ImplementationKind}' cannot be bound with a workflow.");
+        }
+
         var publishedServiceId = member.Summary.PublishedServiceId;
         if (string.IsNullOrWhiteSpace(publishedServiceId))
         {

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowBindingPort.cs
@@ -1,5 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Application.Provisioning;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -9,16 +11,37 @@ namespace Aevatar.Studio.Application.Studio.Services;
 
 public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindingPort
 {
+    private static readonly TimeSpan BindingRunPollInterval = TimeSpan.FromSeconds(5);
+    private const int MaxBindingRunPollAttempts = 36;
+
     private readonly IStudioMemberService _memberService;
     private readonly IWorkflowDefinitionParser _workflowDefinitionParser;
+    private readonly IScopeWorkflowSaveAndBindPort _saveAndBindPort;
+    private readonly IStudioMemberCommandPort _memberCommandPort;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
 
     public StudioMemberWorkflowBindingPort(
         IStudioMemberService memberService,
-        IWorkflowDefinitionParser workflowDefinitionParser)
+        IWorkflowDefinitionParser workflowDefinitionParser,
+        IScopeWorkflowSaveAndBindPort saveAndBindPort,
+        IStudioMemberCommandPort memberCommandPort)
+        : this(memberService, workflowDefinitionParser, saveAndBindPort, memberCommandPort, Task.Delay)
+    {
+    }
+
+    internal StudioMemberWorkflowBindingPort(
+        IStudioMemberService memberService,
+        IWorkflowDefinitionParser workflowDefinitionParser,
+        IScopeWorkflowSaveAndBindPort saveAndBindPort,
+        IStudioMemberCommandPort memberCommandPort,
+        Func<TimeSpan, CancellationToken, Task> delayAsync)
     {
         _memberService = memberService ?? throw new ArgumentNullException(nameof(memberService));
         _workflowDefinitionParser = workflowDefinitionParser
             ?? throw new ArgumentNullException(nameof(workflowDefinitionParser));
+        _saveAndBindPort = saveAndBindPort ?? throw new ArgumentNullException(nameof(saveAndBindPort));
+        _memberCommandPort = memberCommandPort ?? throw new ArgumentNullException(nameof(memberCommandPort));
+        _delayAsync = delayAsync ?? throw new ArgumentNullException(nameof(delayAsync));
     }
 
     public async Task<StudioMemberWorkflowBindingResult> BindAsync(
@@ -34,23 +57,143 @@ public sealed class StudioMemberWorkflowBindingPort : IStudioMemberWorkflowBindi
                 $"workflow_yaml is not a valid workflow definition: {parseResult.Error}");
         }
 
+        var member = await _memberService.GetAsync(request.ScopeId, request.MemberId, ct);
+        return IsPublished(member)
+            ? await SaveAndBindPublishedMemberAsync(request, member, ct)
+            : await BindUnpublishedMemberAsync(request, ct);
+    }
+
+    private async Task<StudioMemberWorkflowBindingResult> BindUnpublishedMemberAsync(
+        StudioMemberWorkflowBindingRequest request,
+        CancellationToken ct)
+    {
+        var workflowId = ResolveWorkflowId(request);
         var receipt = await _memberService.BindAsync(
             request.ScopeId,
             request.MemberId,
             new UpdateStudioMemberBindingRequest(
                 Workflow: new StudioMemberWorkflowBindingSpec(
-                    ResolveWorkflowId(request),
+                    workflowId,
                     [request.WorkflowYaml])),
             ct);
 
+        var terminalRun = await WaitForTerminalBindingRunAsync(receipt, ct);
         return new StudioMemberWorkflowBindingResult(
             Success: true,
             ScopeId: receipt.ScopeId,
             MemberId: receipt.MemberId,
+            Operation: StudioMemberWorkflowBindingOperationNames.Bind,
+            Status: terminalRun.Status,
             BindingRunId: receipt.BindingRunId,
-            Status: receipt.Status,
             AckStage: receipt.AckStage,
-            BindingRunRole: receipt.BindingRunRole);
+            BindingRunRole: receipt.BindingRunRole,
+            WorkflowId: workflowId,
+            RevisionId: terminalRun.Result?.RevisionId);
+    }
+
+    private async Task<StudioMemberWorkflowBindingResult> SaveAndBindPublishedMemberAsync(
+        StudioMemberWorkflowBindingRequest request,
+        StudioMemberDetailResponse member,
+        CancellationToken ct)
+    {
+        var publishedServiceId = member.Summary.PublishedServiceId;
+        if (string.IsNullOrWhiteSpace(publishedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"Studio member '{request.MemberId}' is already published but has no published service id.");
+        }
+
+        var workflowId = ResolveWorkflowId(request);
+        var result = await _saveAndBindPort.SaveAndBindAsync(
+            new ScopeWorkflowSaveAndBindRequest(
+                request.ScopeId,
+                workflowId,
+                request.WorkflowYaml,
+                WorkflowName: workflowId,
+                DisplayName: member.Summary.DisplayName,
+                InlineWorkflowYamls: null,
+                AppId: "studio",
+                ServiceId: publishedServiceId,
+                ExposureDesired: true),
+            ct);
+
+        await _memberCommandPort.RecordPublishedBindingAsync(
+            request.ScopeId,
+            request.MemberId,
+            new StudioMemberPublishedBindingRecordRequest(
+                PublishedServiceId: publishedServiceId,
+                RevisionId: result.RevisionId,
+                ImplementationKind: MemberImplementationKindNames.Workflow,
+                ImplementationRef: new StudioMemberImplementationRefResponse(
+                    MemberImplementationKindNames.Workflow,
+                    WorkflowId: result.WorkflowId,
+                    WorkflowRevision: result.RevisionId),
+                ExpectedActorId: result.Binding.ExpectedActorId),
+            ct);
+
+        return new StudioMemberWorkflowBindingResult(
+            Success: true,
+            ScopeId: result.ScopeId,
+            MemberId: request.MemberId,
+            Operation: StudioMemberWorkflowBindingOperationNames.SaveAndBind,
+            Status: result.AcceptanceStage,
+            WorkflowId: result.WorkflowId,
+            RevisionId: result.RevisionId);
+    }
+
+    private static bool IsPublished(StudioMemberDetailResponse member) =>
+        member.LastBinding is not null || !string.IsNullOrWhiteSpace(member.Summary.LastBoundRevisionId);
+
+    private async Task<StudioMemberBindingRunStatusResponse> WaitForTerminalBindingRunAsync(
+        StudioMemberBindingAcceptedResponse receipt,
+        CancellationToken ct)
+    {
+        for (var attempt = 1; attempt <= MaxBindingRunPollAttempts; attempt++)
+        {
+            var run = await TryGetBindingRunAsync(receipt, ct);
+            if (run is null)
+            {
+                if (attempt < MaxBindingRunPollAttempts)
+                    await _delayAsync(BindingRunPollInterval, ct);
+                continue;
+            }
+
+            if (string.Equals(run.Status, StudioMemberBindingRunStatusNames.Succeeded, StringComparison.Ordinal))
+                return run;
+
+            if (string.Equals(run.Status, StudioMemberBindingRunStatusNames.Failed, StringComparison.Ordinal) ||
+                string.Equals(run.Status, StudioMemberBindingRunStatusNames.Rejected, StringComparison.Ordinal))
+            {
+                var message = run.Failure?.Message;
+                throw new InvalidOperationException(string.IsNullOrWhiteSpace(message)
+                    ? $"Studio member workflow binding ended with status '{run.Status}'."
+                    : $"Studio member workflow binding ended with status '{run.Status}': {message}");
+            }
+
+            if (attempt < MaxBindingRunPollAttempts)
+                await _delayAsync(BindingRunPollInterval, ct);
+        }
+
+        throw new InvalidOperationException(
+            $"Studio member workflow binding did not reach a terminal status after {MaxBindingRunPollAttempts} checks.");
+    }
+
+    private async Task<StudioMemberBindingRunStatusResponse?> TryGetBindingRunAsync(
+        StudioMemberBindingAcceptedResponse receipt,
+        CancellationToken ct)
+    {
+        try
+        {
+            return await _memberService.GetBindingRunAsync(
+                receipt.ScopeId,
+                receipt.MemberId,
+                receipt.BindingRunId,
+                ct);
+        }
+        catch (StudioMemberBindingRunNotFoundException)
+        {
+            return null;
+        }
     }
 
     private static string ResolveWorkflowId(StudioMemberWorkflowBindingRequest request) =>

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
@@ -195,6 +195,31 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
         await DispatchAsync(normalizedScopeId, normalizedMemberId, evt, ct);
     }
 
+    public async Task RecordPublishedBindingAsync(
+        string scopeId,
+        string memberId,
+        StudioMemberPublishedBindingRecordRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var normalizedScopeId = StudioMemberConventions.NormalizeScopeId(scopeId);
+        var normalizedMemberId = StudioMemberConventions.NormalizeMemberId(memberId);
+        var implementationKind = MemberImplementationKindMapper.Parse(request.ImplementationKind);
+
+        var evt = new StudioMemberPublishedBindingRecordedEvent
+        {
+            PublishedServiceId = request.PublishedServiceId ?? string.Empty,
+            RevisionId = request.RevisionId ?? string.Empty,
+            ImplementationKind = implementationKind,
+            ImplementationRef = BuildImplementationRefMessage(request.ImplementationRef),
+            RecordedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            ExpectedActorId = request.ExpectedActorId ?? string.Empty,
+        };
+
+        await DispatchAsync(normalizedScopeId, normalizedMemberId, evt, ct);
+    }
+
     public async Task RenameAsync(
         string scopeId,
         string memberId,

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -293,7 +293,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var bindingPort = new RecordingMemberWorkflowBindingPort();
         var tool = await DiscoverBindMemberWorkflowToolAsync(bindingPort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var context = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -313,9 +313,16 @@ public sealed class ProvisionWorkflowScheduleToolTests
         root.GetProperty("success").GetBoolean().Should().BeTrue();
         root.GetProperty("scope_id").GetString().Should().Be("scope-current");
         root.GetProperty("member_id").GetString().Should().Be("member-alpha");
+        root.GetProperty("operation").GetString().Should().Be(StudioMemberWorkflowBindingOperationNames.Bind);
+        root.GetProperty("status").GetString().Should().Be("succeeded");
         root.GetProperty("binding_run_id").GetString().Should().Be("binding-run-1");
+        root.GetProperty("binding_run_url").GetString()
+            .Should().Be("/api/scopes/scope-current/members/member-alpha/binding-runs/binding-run-1");
         root.GetProperty("member_workflow_url").GetString()
             .Should().Be("/api/scopes/scope-current/members/member-alpha/binding");
+        root.GetProperty("workflow_id").GetString().Should().Be("workflow-alpha");
+        root.GetProperty("revision_id").GetString().Should().Be("revision-1");
+        root.TryGetProperty("service_id", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -790,10 +797,13 @@ public sealed class ProvisionWorkflowScheduleToolTests
                 Success: true,
                 ScopeId: request.ScopeId,
                 MemberId: request.MemberId,
+                Operation: StudioMemberWorkflowBindingOperationNames.Bind,
+                Status: "succeeded",
                 BindingRunId: "binding-run-1",
-                Status: "accepted",
                 AckStage: "dispatch_accepted",
-                BindingRunRole: "candidate"));
+                BindingRunRole: "candidate",
+                WorkflowId: request.WorkflowId,
+                RevisionId: "revision-1"));
         }
     }
 

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberCommandServiceTests.cs
@@ -181,6 +181,43 @@ public sealed class ActorDispatchStudioMemberCommandServiceTests
     }
 
     [Fact]
+    public async Task RecordPublishedBindingAsync_ShouldDispatchPublishedBindingRecordedEvent()
+    {
+        var bootstrap = new RecordingBootstrap();
+        var dispatch = new RecordingDispatchPort();
+        var service = new ActorDispatchStudioMemberCommandService(bootstrap, CreateCommandDispatch(dispatch));
+
+        await service.RecordPublishedBindingAsync(
+            ScopeId,
+            "m-1",
+            new StudioMemberPublishedBindingRecordRequest(
+                PublishedServiceId: "member-m-1",
+                RevisionId: "rev-updated",
+                ImplementationKind: MemberImplementationKindNames.Workflow,
+                ImplementationRef: new StudioMemberImplementationRefResponse(
+                    MemberImplementationKindNames.Workflow,
+                    WorkflowId: "workflow-1",
+                    WorkflowRevision: "rev-updated"),
+                ExpectedActorId: "workflow-definition:workflow-1"),
+            CancellationToken.None);
+
+        bootstrap.EnsuredActorIds.Should().ContainSingle()
+            .Which.Should().Be("studio-member:scope-1:m-1");
+        dispatch.Dispatches.Should().ContainSingle();
+        var dispatched = dispatch.Dispatches[0];
+        dispatched.ActorId.Should().Be("studio-member:scope-1:m-1");
+        dispatched.Envelope.Payload.Is(StudioMemberPublishedBindingRecordedEvent.Descriptor).Should().BeTrue();
+        var evt = dispatched.Envelope.Payload.Unpack<StudioMemberPublishedBindingRecordedEvent>();
+        evt.PublishedServiceId.Should().Be("member-m-1");
+        evt.RevisionId.Should().Be("rev-updated");
+        evt.ImplementationKind.Should().Be(StudioMemberImplementationKind.Workflow);
+        evt.ImplementationRef.Workflow.WorkflowId.Should().Be("workflow-1");
+        evt.ImplementationRef.Workflow.WorkflowRevision.Should().Be("rev-updated");
+        evt.ExpectedActorId.Should().Be("workflow-definition:workflow-1");
+        evt.RecordedAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task RenameAsync_ShouldDispatchRenamedEventToCanonicalActor()
     {
         var bootstrap = new RecordingBootstrap();

--- a/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberBindingHostedConsistencyTests.cs
@@ -233,6 +233,13 @@ public sealed class StudioMemberBindingHostedConsistencyTests
             CancellationToken ct = default) =>
             throw new NotSupportedException("Implementation update is not exercised by this hosted consistency test.");
 
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException("Published binding record is not exercised by this hosted consistency test.");
+
         public Task RenameAsync(
             string scopeId,
             string memberId,

--- a/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberGAgentStateTests.cs
@@ -636,6 +636,143 @@ public sealed class StudioMemberGAgentStateTests
     }
 
     [Fact]
+    public void PublishedBindingRecorded_ShouldRefreshLastBindingAndClearStaleCurrentRun()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var created = _agent.Apply(new StudioMemberState(), new StudioMemberCreatedEvent
+        {
+            MemberId = "m-1",
+            ScopeId = "scope-1",
+            DisplayName = "Original",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            PublishedServiceId = "member-m-1",
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(now),
+        });
+        var pending = StartWorkflowBindingRun(created, "bind-first", now.AddSeconds(1));
+        var completed = _agent.Apply(pending, new StudioMemberBindingCompletedEvent
+        {
+            BindingRunId = "bind-first",
+            PublishedServiceId = "member-m-1",
+            RevisionId = "rev-first",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            CompletedAtUtc = Timestamp.FromDateTimeOffset(now.AddSeconds(4)),
+        });
+
+        var recorded = _agent.Apply(completed, new StudioMemberPublishedBindingRecordedEvent
+        {
+            PublishedServiceId = "member-m-1",
+            RevisionId = "rev-updated",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            ImplementationRef = new StudioMemberImplementationRef
+            {
+                Workflow = new StudioMemberWorkflowRef
+                {
+                    WorkflowId = "workflow-1",
+                    WorkflowRevision = "rev-updated",
+                },
+            },
+            RecordedAtUtc = Timestamp.FromDateTimeOffset(now.AddSeconds(10)),
+            ExpectedActorId = "workflow-definition:workflow-1",
+        });
+
+        recorded.LifecycleStage.Should().Be(StudioMemberLifecycleStage.BindReady);
+        recorded.LastBinding.Should().NotBeNull();
+        recorded.LastBinding.PublishedServiceId.Should().Be("member-m-1");
+        recorded.LastBinding.RevisionId.Should().Be("rev-updated");
+        recorded.LastBinding.ExpectedActorId.Should().Be("workflow-definition:workflow-1");
+        recorded.ImplementationRef.Workflow.WorkflowId.Should().Be("workflow-1");
+        recorded.ImplementationRef.Workflow.WorkflowRevision.Should().Be("rev-updated");
+        recorded.Binding.CurrentBindingRunId.Should().BeEmpty();
+        recorded.Binding.CurrentStatus.Should().Be(StudioMemberBindingRunStatus.Unspecified);
+        recorded.Binding.LastTerminalBindingRunId.Should().Be("bind-first");
+        recorded.Binding.LastFailure.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandlePublishedBindingRecorded_ShouldRejectMismatchedPublishedServiceId()
+    {
+        var current = NewCreatedWorkflowMember(DateTimeOffset.UtcNow);
+        var eventSourcing = new RecordingEventSourcing(current);
+        var agent = NewHandlerAgent(current, eventSourcing, new RecordingEventPublisher());
+
+        var act = () => agent.HandlePublishedBindingRecorded(new StudioMemberPublishedBindingRecordedEvent
+        {
+            PublishedServiceId = "different-service",
+            RevisionId = "rev-1",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            ImplementationRef = new StudioMemberImplementationRef
+            {
+                Workflow = new StudioMemberWorkflowRef
+                {
+                    WorkflowId = "workflow-1",
+                    WorkflowRevision = "rev-1",
+                },
+            },
+            RecordedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not match member 'm-1' publishedServiceId 'member-m-1'*");
+        eventSourcing.RaisedEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandlePublishedBindingRecorded_ShouldRejectMismatchedImplementationKind()
+    {
+        var current = NewCreatedWorkflowMember(DateTimeOffset.UtcNow);
+        var eventSourcing = new RecordingEventSourcing(current);
+        var agent = NewHandlerAgent(current, eventSourcing, new RecordingEventPublisher());
+
+        var act = () => agent.HandlePublishedBindingRecorded(new StudioMemberPublishedBindingRecordedEvent
+        {
+            PublishedServiceId = "member-m-1",
+            RevisionId = "rev-1",
+            ImplementationKind = StudioMemberImplementationKind.Script,
+            ImplementationRef = new StudioMemberImplementationRef
+            {
+                Script = new StudioMemberScriptRef
+                {
+                    ScriptId = "script-1",
+                    ScriptRevision = "rev-1",
+                },
+            },
+            RecordedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not match member kind 'Workflow'*");
+        eventSourcing.RaisedEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandlePublishedBindingRecorded_ShouldRejectImplementationRefForDifferentKind()
+    {
+        var current = NewCreatedWorkflowMember(DateTimeOffset.UtcNow);
+        var eventSourcing = new RecordingEventSourcing(current);
+        var agent = NewHandlerAgent(current, eventSourcing, new RecordingEventPublisher());
+
+        var act = () => agent.HandlePublishedBindingRecorded(new StudioMemberPublishedBindingRecordedEvent
+        {
+            PublishedServiceId = "member-m-1",
+            RevisionId = "rev-1",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
+            ImplementationRef = new StudioMemberImplementationRef
+            {
+                Script = new StudioMemberScriptRef
+                {
+                    ScriptId = "script-1",
+                    ScriptRevision = "rev-1",
+                },
+            },
+            RecordedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("published binding record must include a resolved implementation reference for its implementation kind.");
+        eventSourcing.RaisedEvents.Should().BeEmpty();
+    }
+
+    [Fact]
     public void BindingAdmissionRequested_ShouldRecordPendingRun()
     {
         var created = _agent.Apply(new StudioMemberState(), new StudioMemberCreatedEvent
@@ -1301,6 +1438,17 @@ public sealed class StudioMemberGAgentStateTests
             ScopeId = "scope-1",
             DisplayName = "Original",
             ImplementationKind = StudioMemberImplementationKind.Script,
+            PublishedServiceId = "member-m-1",
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(createdAt),
+        });
+
+    private StudioMemberState NewCreatedWorkflowMember(DateTimeOffset createdAt) =>
+        _agent.Apply(new StudioMemberState(), new StudioMemberCreatedEvent
+        {
+            MemberId = "m-1",
+            ScopeId = "scope-1",
+            DisplayName = "Original",
+            ImplementationKind = StudioMemberImplementationKind.Workflow,
             PublishedServiceId = "member-m-1",
             CreatedAtUtc = Timestamp.FromDateTimeOffset(createdAt),
         });

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceBindingTests.cs
@@ -422,6 +422,16 @@ public sealed class StudioMemberServiceBindingTests
             return Task.CompletedTask;
         }
 
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default)
+        {
+            OperationsInOrder.Add("RecordPublishedBinding");
+            return Task.CompletedTask;
+        }
+
         public Task RenameAsync(
             string scopeId,
             string memberId,

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceContractAndRevisionTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceContractAndRevisionTests.cs
@@ -495,6 +495,13 @@ public sealed class StudioMemberServiceContractAndRevisionTests
             StudioMemberImplementationRefResponse implementation, CancellationToken ct = default) =>
             throw new InvalidOperationException("contract/activate/retire flows must not update implementation refs.");
 
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("contract/activate/retire flows must not record published bindings.");
+
         public Task RenameAsync(
             string scopeId,
             string memberId,

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceCreateImplementationRefTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceCreateImplementationRefTests.cs
@@ -134,6 +134,13 @@ public sealed class StudioMemberServiceCreateImplementationRefTests
             CancellationToken ct = default) =>
             throw new InvalidOperationException("create must not dispatch implementation update.");
 
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("create must not record published bindings.");
+
         public Task StartBindingRunAsync(
             StudioMemberBindingRunStartRequest request,
             CancellationToken ct = default) =>

--- a/test/Aevatar.Studio.Tests/StudioMemberServicePatchTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServicePatchTests.cs
@@ -508,6 +508,13 @@ public sealed class StudioMemberServicePatchTests
             return Task.CompletedTask;
         }
 
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("member patch must not record published bindings.");
+
         public Task RenameAsync(
             string scopeId,
             string memberId,

--- a/test/Aevatar.Studio.Tests/StudioMemberServiceTeamTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberServiceTeamTests.cs
@@ -276,6 +276,13 @@ public sealed class StudioMemberServiceTeamTests
             StudioMemberImplementationRefResponse implementation, CancellationToken ct = default) =>
             Task.CompletedTask;
 
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
         public Task RenameAsync(
             string scopeId,
             string memberId,

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
@@ -1,3 +1,5 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Application.Provisioning;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -14,7 +16,9 @@ public sealed class StudioMemberWorkflowBindingPortTests
     {
         var memberService = new RecordingMemberService();
         var parser = new RecordingWorkflowDefinitionParser();
-        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
 
         await port.BindAsync(new StudioMemberWorkflowBindingRequest(
             ScopeId: "scope-1",
@@ -48,7 +52,9 @@ public sealed class StudioMemberWorkflowBindingPortTests
     {
         var memberService = new RecordingMemberService();
         var parser = new RecordingWorkflowDefinitionParser();
-        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
 
         await port.BindAsync(new StudioMemberWorkflowBindingRequest(
             ScopeId: "scope-1",
@@ -64,6 +70,155 @@ public sealed class StudioMemberWorkflowBindingPortTests
     }
 
     [Fact]
+    public async Task BindAsync_ShouldWaitForBindingRunSucceededBeforeReturning()
+    {
+        var memberService = new RecordingMemberService();
+        memberService.EnqueueBindingRun(StudioMemberBindingRunStatusNames.PlatformBindingPending);
+        memberService.EnqueueBindingRun(StudioMemberBindingRunStatusNames.Succeeded);
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort, (_, _) => Task.CompletedTask);
+
+        var result = await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        result.Success.Should().BeTrue();
+        result.Operation.Should().Be(StudioMemberWorkflowBindingOperationNames.Bind);
+        result.Status.Should().Be(StudioMemberBindingRunStatusNames.Succeeded);
+        memberService.GetBindingRunCallCount.Should().Be(2);
+        saveAndBindPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenBindingRunReadModelIsNotMaterializedYet_ShouldKeepPolling()
+    {
+        var memberService = new RecordingMemberService
+        {
+            MissingBindingRunReadCount = 1,
+        };
+        memberService.EnqueueBindingRun(StudioMemberBindingRunStatusNames.Succeeded);
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort, (_, _) => Task.CompletedTask);
+
+        var result = await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        result.Status.Should().Be(StudioMemberBindingRunStatusNames.Succeeded);
+        memberService.GetBindingRunCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenBindingRunFails_ShouldRejectInsteadOfReportingAcceptedAsSuccess()
+    {
+        var memberService = new RecordingMemberService();
+        memberService.EnqueueBindingRun(
+            StudioMemberBindingRunStatusNames.Failed,
+            new StudioMemberBindingFailureResponse(
+                Code: "STUDIO_MEMBER_PLATFORM_BINDING_FAILED",
+                Message: "workflow parse failed",
+                FailedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z")));
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort, (_, _) => Task.CompletedTask);
+
+        var action = () => port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Studio member workflow binding ended with status 'failed': workflow parse failed");
+        memberService.GetBindingRunCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenMemberAlreadyPublished_ShouldSaveAndBindPublishedService()
+    {
+        var memberService = new RecordingMemberService
+        {
+            Detail = BuildMemberDetail(
+                publishedServiceId: "published-service-1",
+                lastBoundRevisionId: "revision-existing",
+                lastBinding: new StudioMemberBindingContractResponse(
+                    PublishedServiceId: "published-service-1",
+                    RevisionId: "revision-existing",
+                    ImplementationKind: "workflow",
+                    BoundAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"))),
+        };
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
+
+        var result = await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n")
+        {
+            WorkflowId = " workflow-explicit ",
+        });
+
+        result.Success.Should().BeTrue();
+        result.Operation.Should().Be(StudioMemberWorkflowBindingOperationNames.SaveAndBind);
+        result.Status.Should().Be("accepted");
+        result.WorkflowId.Should().Be("workflow-explicit");
+        result.RevisionId.Should().Be("revision-new");
+        result.BindingRunId.Should().BeNull();
+        memberService.LastRequest.Should().BeNull();
+        memberService.GetBindingRunCallCount.Should().Be(0);
+        saveAndBindPort.LastRequest.Should().NotBeNull();
+        saveAndBindPort.LastRequest!.ScopeId.Should().Be("scope-1");
+        saveAndBindPort.LastRequest.ServiceId.Should().Be("published-service-1");
+        saveAndBindPort.LastRequest.AppId.Should().Be("studio");
+        saveAndBindPort.LastRequest.ExposureDesired.Should().BeTrue();
+        saveAndBindPort.LastRequest.DisplayName.Should().Be("Member One");
+        saveAndBindPort.LastRequest.WorkflowId.Should().Be("workflow-explicit");
+        memberCommandPort.LastRecordPublishedBinding.Should().NotBeNull();
+        memberCommandPort.LastScopeId.Should().Be("scope-1");
+        memberCommandPort.LastMemberId.Should().Be("member-1");
+        memberCommandPort.LastRecordPublishedBinding!.PublishedServiceId.Should().Be("published-service-1");
+        memberCommandPort.LastRecordPublishedBinding.RevisionId.Should().Be("revision-new");
+        memberCommandPort.LastRecordPublishedBinding.ImplementationKind.Should().Be(MemberImplementationKindNames.Workflow);
+        memberCommandPort.LastRecordPublishedBinding.ImplementationRef.WorkflowId.Should().Be("workflow-explicit");
+        memberCommandPort.LastRecordPublishedBinding.ImplementationRef.WorkflowRevision.Should().Be("revision-new");
+        memberCommandPort.LastRecordPublishedBinding.ExpectedActorId.Should().Be("workflow-definition:workflow-new");
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenPublishedMemberServiceIdMissing_ShouldRejectBeforeDispatch()
+    {
+        var memberService = new RecordingMemberService
+        {
+            Detail = BuildMemberDetail(
+                publishedServiceId: " ",
+                lastBoundRevisionId: "revision-existing"),
+        };
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
+
+        var action = () => port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Studio member 'member-1' is already published but has no published service id.");
+        memberService.LastRequest.Should().BeNull();
+        memberService.GetBindingRunCallCount.Should().Be(0);
+        saveAndBindPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task BindAsync_WhenWorkflowYamlInvalid_ShouldRejectBeforeDispatchingBind()
     {
         var memberService = new RecordingMemberService();
@@ -71,7 +226,9 @@ public sealed class StudioMemberWorkflowBindingPortTests
         {
             Error = "missing workflow name",
         };
-        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
 
         var action = () => port.BindAsync(new StudioMemberWorkflowBindingRequest(
             ScopeId: "scope-1",
@@ -82,13 +239,35 @@ public sealed class StudioMemberWorkflowBindingPortTests
             .WithMessage("workflow_yaml is not a valid workflow definition: missing workflow name");
         parser.LastYaml.Should().Be("steps: []\n");
         memberService.LastRequest.Should().BeNull();
+        saveAndBindPort.LastRequest.Should().BeNull();
     }
+
+    private static StudioMemberDetailResponse BuildMemberDetail(
+        string publishedServiceId = "published-service-1",
+        string? lastBoundRevisionId = null,
+        StudioMemberBindingContractResponse? lastBinding = null) =>
+        new(
+            new StudioMemberSummaryResponse(
+                MemberId: "member-1",
+                ScopeId: "scope-1",
+                DisplayName: "Member One",
+                Description: "Member description",
+                ImplementationKind: "workflow",
+                LifecycleStage: "active",
+                PublishedServiceId: publishedServiceId,
+                LastBoundRevisionId: lastBoundRevisionId,
+                CreatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+                UpdatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z")),
+            ImplementationRef: null,
+            LastBinding: lastBinding);
 
     private static async Task<string> BindWithoutWorkflowIdAsync(string scopeId, string memberId)
     {
         var memberService = new RecordingMemberService();
         var parser = new RecordingWorkflowDefinitionParser();
-        var port = new StudioMemberWorkflowBindingPort(memberService, parser);
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
 
         await port.BindAsync(new StudioMemberWorkflowBindingRequest(
             scopeId,
@@ -116,9 +295,25 @@ public sealed class StudioMemberWorkflowBindingPortTests
 
     private sealed class RecordingMemberService : IStudioMemberService
     {
+        private readonly Queue<StudioMemberBindingRunStatusResponse> _bindingRuns = new();
+
+        public StudioMemberDetailResponse Detail { get; init; } = BuildMemberDetail();
         public string? LastScopeId { get; private set; }
         public string? LastMemberId { get; private set; }
         public UpdateStudioMemberBindingRequest? LastRequest { get; private set; }
+        public int GetBindingRunCallCount { get; private set; }
+        public int MissingBindingRunReadCount { get; init; }
+        private int _missingBindingRunReads;
+
+        public void EnqueueBindingRun(string status, StudioMemberBindingFailureResponse? failure = null) =>
+            _bindingRuns.Enqueue(new StudioMemberBindingRunStatusResponse(
+                BindingRunId: "bind-run-1",
+                ScopeId: "scope-1",
+                MemberId: "member-1",
+                Status: status,
+                StateVersion: 1,
+                Failure: failure,
+                UpdatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z")));
 
         public Task<StudioMemberBindingAcceptedResponse> BindAsync(
             string scopeId,
@@ -152,7 +347,7 @@ public sealed class StudioMemberWorkflowBindingPortTests
             string scopeId,
             string memberId,
             CancellationToken ct = default) =>
-            throw new NotSupportedException();
+            Task.FromResult(Detail);
 
         public Task<StudioMemberBindingViewResponse> GetBindingAsync(
             string scopeId,
@@ -164,8 +359,24 @@ public sealed class StudioMemberWorkflowBindingPortTests
             string scopeId,
             string memberId,
             string bindingRunId,
-            CancellationToken ct = default) =>
-            throw new NotSupportedException();
+            CancellationToken ct = default)
+        {
+            GetBindingRunCallCount++;
+            if (_missingBindingRunReads++ < MissingBindingRunReadCount)
+            {
+                throw new StudioMemberBindingRunNotFoundException(scopeId, memberId, bindingRunId);
+            }
+
+            return Task.FromResult(_bindingRuns.Count == 0
+                ? new StudioMemberBindingRunStatusResponse(
+                    BindingRunId: bindingRunId,
+                    ScopeId: scopeId,
+                    MemberId: memberId,
+                    Status: StudioMemberBindingRunStatusNames.Succeeded,
+                    StateVersion: 1,
+                    UpdatedAt: DateTimeOffset.Parse("2026-07-01T00:00:00Z"))
+                : _bindingRuns.Dequeue());
+        }
 
         public Task<StudioMemberEndpointContractResponse?> GetEndpointContractAsync(
             string scopeId,
@@ -194,5 +405,91 @@ public sealed class StudioMemberWorkflowBindingPortTests
             UpdateStudioMemberRequest request,
             CancellationToken ct = default) =>
             throw new NotSupportedException();
+    }
+
+    private sealed class RecordingMemberCommandPort : IStudioMemberCommandPort
+    {
+        public string? LastScopeId { get; private set; }
+        public string? LastMemberId { get; private set; }
+        public StudioMemberPublishedBindingRecordRequest? LastRecordPublishedBinding { get; private set; }
+
+        public Task<StudioMemberSummaryResponse> CreateAsync(
+            string scopeId,
+            CreateStudioMemberRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UpdateImplementationAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberImplementationRefResponse implementation,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task RecordPublishedBindingAsync(
+            string scopeId,
+            string memberId,
+            StudioMemberPublishedBindingRecordRequest request,
+            CancellationToken ct = default)
+        {
+            LastScopeId = scopeId;
+            LastMemberId = memberId;
+            LastRecordPublishedBinding = request;
+            return Task.CompletedTask;
+        }
+
+        public Task RenameAsync(
+            string scopeId,
+            string memberId,
+            string displayName,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task StartBindingRunAsync(
+            StudioMemberBindingRunStartRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task PatchTeamAssignmentAsync(
+            string scopeId,
+            string memberId,
+            string? targetTeamId,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class RecordingSaveAndBindPort : IScopeWorkflowSaveAndBindPort
+    {
+        public ScopeWorkflowSaveAndBindRequest? LastRequest { get; private set; }
+
+        public Task<ScopeWorkflowSaveAndBindResult> SaveAndBindAsync(
+            ScopeWorkflowSaveAndBindRequest request,
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            var workflowId = request.WorkflowId ?? "workflow-new";
+            return Task.FromResult(new ScopeWorkflowSaveAndBindResult(
+                ScopeId: request.ScopeId,
+                WorkflowId: workflowId,
+                RevisionId: "revision-new",
+                Workflow: new ScopeWorkflowUpsertResult(
+                    ScopeId: request.ScopeId,
+                    WorkflowId: workflowId,
+                    ServiceKey: "service-key-1",
+                    RevisionId: "revision-new",
+                    DefinitionActorIdPrefix: "workflow-definition",
+                    ExpectedActorId: "workflow-definition:workflow-new",
+                    ExpectedDeploymentId: "deployment-new",
+                    AcceptedAtUtc: DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+                    CommandHandles: [],
+                    ReadModelUrl: "/api/scopes/scope-1/workflows/workflow-new"),
+                Binding: new ScopeBindingUpsertResult(
+                    ScopeId: request.ScopeId,
+                    ServiceId: request.ServiceId ?? "published-service-1",
+                    DisplayName: request.DisplayName ?? string.Empty,
+                    RevisionId: "revision-new",
+                    ImplementationKind: ScopeBindingImplementationKind.Workflow,
+                    ExpectedActorId: "workflow-definition:workflow-new")));
+        }
     }
 }

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowBindingPortTests.cs
@@ -140,6 +140,29 @@ public sealed class StudioMemberWorkflowBindingPortTests
     }
 
     [Fact]
+    public async Task BindAsync_WhenMemberReadModelNotMaterialized_ShouldStillDispatchBindingRun()
+    {
+        var memberService = new RecordingMemberService
+        {
+            ThrowMemberNotFoundOnGet = true,
+        };
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort, (_, _) => Task.CompletedTask);
+
+        var result = await port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        result.Operation.Should().Be(StudioMemberWorkflowBindingOperationNames.Bind);
+        result.Status.Should().Be(StudioMemberBindingRunStatusNames.Succeeded);
+        memberService.LastRequest.Should().NotBeNull();
+        saveAndBindPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task BindAsync_WhenMemberAlreadyPublished_ShouldSaveAndBindPublishedService()
     {
         var memberService = new RecordingMemberService
@@ -190,6 +213,32 @@ public sealed class StudioMemberWorkflowBindingPortTests
         memberCommandPort.LastRecordPublishedBinding.ImplementationRef.WorkflowId.Should().Be("workflow-explicit");
         memberCommandPort.LastRecordPublishedBinding.ImplementationRef.WorkflowRevision.Should().Be("revision-new");
         memberCommandPort.LastRecordPublishedBinding.ExpectedActorId.Should().Be("workflow-definition:workflow-new");
+    }
+
+    [Fact]
+    public async Task BindAsync_WhenPublishedMemberKindIsNotWorkflow_ShouldRejectBeforeSaveAndBind()
+    {
+        var memberService = new RecordingMemberService
+        {
+            Detail = BuildMemberDetail(
+                publishedServiceId: "published-service-1",
+                lastBoundRevisionId: "revision-existing",
+                implementationKind: MemberImplementationKindNames.Script),
+        };
+        var parser = new RecordingWorkflowDefinitionParser();
+        var saveAndBindPort = new RecordingSaveAndBindPort();
+        var memberCommandPort = new RecordingMemberCommandPort();
+        var port = new StudioMemberWorkflowBindingPort(memberService, parser, saveAndBindPort, memberCommandPort);
+
+        var action = () => port.BindAsync(new StudioMemberWorkflowBindingRequest(
+            ScopeId: "scope-1",
+            MemberId: "member-1",
+            WorkflowYaml: "name: demo\nsteps: []\n"));
+
+        await action.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Studio member 'member-1' implementation kind 'script' cannot be bound with a workflow.");
+        saveAndBindPort.LastRequest.Should().BeNull();
+        memberCommandPort.LastRecordPublishedBinding.Should().BeNull();
     }
 
     [Fact]
@@ -245,14 +294,15 @@ public sealed class StudioMemberWorkflowBindingPortTests
     private static StudioMemberDetailResponse BuildMemberDetail(
         string publishedServiceId = "published-service-1",
         string? lastBoundRevisionId = null,
-        StudioMemberBindingContractResponse? lastBinding = null) =>
+        StudioMemberBindingContractResponse? lastBinding = null,
+        string implementationKind = MemberImplementationKindNames.Workflow) =>
         new(
             new StudioMemberSummaryResponse(
                 MemberId: "member-1",
                 ScopeId: "scope-1",
                 DisplayName: "Member One",
                 Description: "Member description",
-                ImplementationKind: "workflow",
+                ImplementationKind: implementationKind,
                 LifecycleStage: "active",
                 PublishedServiceId: publishedServiceId,
                 LastBoundRevisionId: lastBoundRevisionId,
@@ -298,6 +348,7 @@ public sealed class StudioMemberWorkflowBindingPortTests
         private readonly Queue<StudioMemberBindingRunStatusResponse> _bindingRuns = new();
 
         public StudioMemberDetailResponse Detail { get; init; } = BuildMemberDetail();
+        public bool ThrowMemberNotFoundOnGet { get; init; }
         public string? LastScopeId { get; private set; }
         public string? LastMemberId { get; private set; }
         public UpdateStudioMemberBindingRequest? LastRequest { get; private set; }
@@ -347,7 +398,9 @@ public sealed class StudioMemberWorkflowBindingPortTests
             string scopeId,
             string memberId,
             CancellationToken ct = default) =>
-            Task.FromResult(Detail);
+            ThrowMemberNotFoundOnGet
+                ? throw new StudioMemberNotFoundException(scopeId, memberId)
+                : Task.FromResult(Detail);
 
         public Task<StudioMemberBindingViewResponse> GetBindingAsync(
             string scopeId,


### PR DESCRIPTION
## Summary
- Record already-published member save-and-bind results back into the StudioMember authority state.
- Return bind/save-and-bind operation, workflow id, and revision id from the member workflow binding tool without exposing service ids.
- Add actor, command-dispatch, binding-port, and tool-provider regression coverage for stale member detail after save-and-bind.

## Test plan
- [x] dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore -v:q --filter "StudioMemberGAgentStateTests|ActorDispatchStudioMemberCommandServiceTests|StudioMemberWorkflowBindingPortTests|StudioMemberCurrentStateProjectorTests|StudioMemberQueryPortTests"
- [x] dotnet test test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj --nologo --no-restore -v:q --filter ProvisionWorkflowScheduleToolTests
- [x] dotnet list src/Aevatar.AI.ToolProviders.StudioProvisioning/Aevatar.AI.ToolProviders.StudioProvisioning.csproj reference
- [x] git diff --check

Note: local end-to-end host smoke after this save-and-bind state-sync fix has not been rerun yet; earlier smoke is what exposed the stale member detail bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)