### PR TITLE
Fix unified loading animation

### DIFF
--- a/apps/aevatar-console-web/src/app.tsx
+++ b/apps/aevatar-console-web/src/app.tsx
@@ -1,7 +1,4 @@
-import {
-  PageLoading,
-  ProConfigProvider,
-} from "@ant-design/pro-components";
+import { ProConfigProvider } from "@ant-design/pro-components";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Badge, ConfigProvider } from "antd";
 import { getLocale, useIntl } from "@umijs/max";
@@ -46,6 +43,7 @@ import {
   resolveAntdLocale,
   resolveProIntl,
 } from "@/shared/i18n/localeProvider";
+import { AevatarPageLoading } from "@/shared/ui/AevatarLoading";
 
 const PUBLIC_ROUTES = new Set(["/login", "/auth/callback"]);
 const DEFAULT_PROTECTED_ROUTE = CONSOLE_HOME_ROUTE;
@@ -655,7 +653,7 @@ const AuthSessionBootstrap: React.FC<AuthSessionBootstrapProps> = ({
   }, [pathname]);
 
   if (!ready) {
-    return <PageLoading fullscreen />;
+    return <AevatarPageLoading fullscreen />;
   }
 
   return <>{children}</>;
@@ -783,7 +781,7 @@ export const layout = ({
           );
         })()
       ) : (
-        <PageLoading fullscreen />
+        <AevatarPageLoading fullscreen />
       ),
     ...initialState?.settings,
     title: "",

--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -468,7 +468,9 @@ body.aevatar-studio-host
   .aevatar-loading-dot,
   .aevatar-loading-pulse-dot,
   .aevatar-loading-cursor {
-    animation-duration: 2.4s;
+    animation: none;
+    opacity: 1;
+    transform: none;
   }
 }
 

--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -360,6 +360,118 @@ body.aevatar-studio-host
   pointer-events: none;
 }
 
+@keyframes aevatarLoadingPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@keyframes aevatarLoadingBlink {
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes aevatarLoadingBounce {
+  0%,
+  80%,
+  100% {
+    opacity: 0.7;
+    transform: translateY(0);
+  }
+
+  40% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+
+.aevatar-loading-dots {
+  align-items: center;
+  color: var(--aevatar-loading-color, currentColor);
+  display: inline-flex;
+  gap: var(--aevatar-loading-gap, 6px);
+  line-height: 1;
+  min-height: var(--aevatar-loading-dot-size, 6px);
+  vertical-align: middle;
+}
+
+.aevatar-loading-dot {
+  animation: aevatarLoadingBounce 1s ease-in-out infinite;
+  background: var(--aevatar-loading-color, currentColor);
+  border-radius: 999px;
+  display: block;
+  flex: 0 0 auto;
+  height: var(--aevatar-loading-dot-size, 6px);
+  width: var(--aevatar-loading-dot-size, 6px);
+}
+
+.aevatar-loading-pulse-dot {
+  animation: aevatarLoadingPulse 1.5s ease-in-out infinite;
+  background: var(--aevatar-loading-color, currentColor);
+  border-radius: 999px;
+  display: inline-block;
+  flex: 0 0 auto;
+  height: var(--aevatar-loading-dot-size, 6px);
+  width: var(--aevatar-loading-dot-size, 6px);
+}
+
+.aevatar-loading-cursor {
+  animation: aevatarLoadingBlink 1s step-end infinite;
+  background: var(--aevatar-loading-color, currentColor);
+  display: inline-block;
+  height: 18px;
+  margin-left: 4px;
+  vertical-align: text-bottom;
+  width: 2px;
+}
+
+.aevatar-loading-visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.aevatar-page-loading {
+  align-items: center;
+  color: #6b7280;
+  display: flex;
+  flex-direction: column;
+  font-size: 13px;
+  gap: 12px;
+  justify-content: center;
+  min-height: 220px;
+  padding: 24px;
+  text-align: center;
+}
+
+.aevatar-page-loading-fullscreen {
+  min-height: 100vh;
+}
+
+.aevatar-page-loading-tip {
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aevatar-loading-dot,
+  .aevatar-loading-pulse-dot,
+  .aevatar-loading-cursor {
+    animation-duration: 2.4s;
+  }
+}
+
 body.aevatar-studio-host
   .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
   .ant-pro-sider-collapsed-button:hover {

--- a/apps/aevatar-console-web/src/loading.tsx
+++ b/apps/aevatar-console-web/src/loading.tsx
@@ -1,7 +1,5 @@
-import { Skeleton } from 'antd';
+import { AevatarPageLoading } from '@/shared/ui/AevatarLoading';
 
-const Loading: React.FC = () => (
-  <Skeleton style={{ padding: '24px 40px', height: '60vh' }} active />
-);
+const Loading: React.FC = () => <AevatarPageLoading />;
 
 export default Loading;

--- a/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
@@ -1,10 +1,10 @@
-import { PageLoading } from '@ant-design/pro-components';
 import { Button, Result } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
 import { NyxIDAuthClient } from '@/shared/auth/client';
 import { getNyxIDRuntimeConfig } from '@/shared/auth/config';
 import { loadStoredAuthSession } from '@/shared/auth/session';
 import { CONSOLE_HOME_ROUTE } from '@/shared/navigation/consoleHome';
+import { AevatarPageLoading } from '@/shared/ui/AevatarLoading';
 import { describeError } from '@/shared/ui/errorText';
 import { t } from "@/shared/i18n/messages";
 
@@ -64,7 +64,7 @@ const CallbackPage: React.FC = () => {
     );
   }
 
-  return <PageLoading fullscreen tip="Completing NyxID sign-in..." />;
+  return <AevatarPageLoading fullscreen tip="Completing NyxID sign-in..." />;
 };
 
 export default CallbackPage;

--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
@@ -15,6 +15,11 @@ import { Empty } from "antd";
 import { RuntimeEventPreviewPanel } from "@/shared/agui/runtimeConversationPresentation";
 import { AevatarHeaderSelect } from "@/shared/ui/AevatarHeaderSelect";
 import {
+  AevatarLoadingDots,
+  AevatarLoadingPulseDot,
+  AevatarStreamingCursor,
+} from "@/shared/ui/AevatarLoading";
+import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
   AEVATAR_INTERACTIVE_CHIP_CLASS,
   joinInteractiveClassNames,
@@ -313,16 +318,7 @@ function StepIndicator({ step }: { step: StepInfo }): React.ReactElement {
         }}
       >
         {isRunning ? (
-          <span
-            style={{
-              animation: "pulse 1.5s ease-in-out infinite",
-              background: "#f59e0b",
-              borderRadius: 999,
-              display: "block",
-              height: 8,
-              width: 8,
-            }}
-          />
+          <AevatarLoadingPulseDot color="#f59e0b" size={8} />
         ) : isError ? (
           <span
             style={{
@@ -421,16 +417,7 @@ function ToolCallIndicator({ tool }: { tool: ToolCallInfo }): React.ReactElement
           }}
         >
           {tool.status === "running" ? (
-            <span
-              style={{
-                animation: "pulse 1.5s ease-in-out infinite",
-                background: "#60a5fa",
-                borderRadius: 999,
-                display: "block",
-                height: 6,
-                width: 6,
-              }}
-            />
+            <AevatarLoadingPulseDot color="#60a5fa" size={6} />
           ) : (
             <svg
               fill="none"
@@ -529,16 +516,7 @@ function ThinkingBlock({
         </svg>
         <span>{t("pages.chat.chatpresentation.thinking", "Thinking")}</span>
         {isStreaming ? (
-          <span
-            style={{
-              animation: "pulse 1.5s ease-in-out infinite",
-              background: "#a855f7",
-              borderRadius: 999,
-              display: "block",
-              height: 6,
-              width: 6,
-            }}
-          />
+          <AevatarLoadingPulseDot color="#a855f7" size={6} />
         ) : null}
       </button>
       {open ? (
@@ -1377,16 +1355,7 @@ export function ChatMessageBubble({
               </span>
               {message.steps?.some((step) => step.status === "running") ||
               message.toolCalls?.some((tool) => tool.status === "running") ? (
-                <span
-                  style={{
-                    animation: "pulse 1.5s ease-in-out infinite",
-                    background: "#f59e0b",
-                    borderRadius: 999,
-                    display: "block",
-                    height: 6,
-                    width: 6,
-                  }}
-                />
+                <AevatarLoadingPulseDot color="#f59e0b" size={6} />
               ) : null}
             </button>
             {actionsOpen ? (
@@ -1425,17 +1394,7 @@ export function ChatMessageBubble({
           <div style={{ wordBreak: "break-word" }}>
             {renderContent(message.content)}
             {message.status === "streaming" && message.content ? (
-              <span
-                style={{
-                  animation: "blink 1s step-end infinite",
-                  background: "#9ca3af",
-                  display: "inline-block",
-                  height: 18,
-                  marginLeft: 4,
-                  verticalAlign: "text-bottom",
-                  width: 2,
-                }}
-              />
+              <AevatarStreamingCursor color="#9ca3af" />
             ) : null}
           </div>
           {!message.content && message.status === "streaming" ? (
@@ -1447,20 +1406,11 @@ export function ChatMessageBubble({
                 padding: "10px 0",
               }}
             >
-              {[0, 1, 2].map((index) => (
-                <span
-                  key={index}
-                  style={{
-                    animation: "bounce 1s ease-in-out infinite",
-                    animationDelay: `${index * 160}ms`,
-                    background: "#d1d5db",
-                    borderRadius: 999,
-                    display: "block",
-                    height: 6,
-                    width: 6,
-                  }}
-                />
-              ))}
+              <AevatarLoadingDots
+                ariaLabel="Assistant is responding"
+                color="#d1d5db"
+                size={6}
+              />
             </div>
           ) : null}
         </div>

--- a/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
@@ -1168,21 +1168,6 @@ const ScopeInvokePage: React.FC = () => {
   return (
     <AevatarPageShell pageHeaderRender={false} title={t("pages.scopes.invoke.legacy.invoke.lab", "Legacy Invoke Lab")}>
       <div style={viewportShellStyle}>
-        <style>
-          {`
-            @keyframes pulse {
-              0%, 100% { opacity: 1; }
-              50% { opacity: 0.45; }
-            }
-            @keyframes blink {
-              50% { opacity: 0; }
-            }
-            @keyframes bounce {
-              0%, 80%, 100% { transform: translateY(0); opacity: 0.7; }
-              40% { transform: translateY(-3px); opacity: 1; }
-            }
-          `}
-        </style>
         <div style={pageHeaderStyle}>
           <AevatarPageTitleBlock
             backAriaLabel={t("pages.scopes.invoke.team.home", "Team Home")}

--- a/apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
+++ b/apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
@@ -5,6 +5,11 @@ import type {
   RuntimeStepInfo,
   RuntimeToolCallInfo,
 } from "./runtimeEventSemantics";
+import {
+  AevatarLoadingDots,
+  AevatarLoadingPulseDot,
+  AevatarStreamingCursor,
+} from "@/shared/ui/AevatarLoading";
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from "@/shared/ui/interactionStandards";
 import { t } from "@/shared/i18n/messages";
 import { sanitizeUserFacingText } from "@/shared/ui/userFacingIdentifiers";
@@ -162,16 +167,7 @@ function StepIndicator({
         }}
       >
         {isRunning ? (
-          <span
-            style={{
-              animation: "pulse 1.5s ease-in-out infinite",
-              background: "#f59e0b",
-              borderRadius: 999,
-              display: "block",
-              height: 8,
-              width: 8,
-            }}
-          />
+          <AevatarLoadingPulseDot color="#f59e0b" size={8} />
         ) : isError ? (
           <span
             style={{
@@ -275,16 +271,7 @@ function ToolCallIndicator({
           }}
         >
           {tool.status === "running" ? (
-            <span
-              style={{
-                animation: "pulse 1.5s ease-in-out infinite",
-                background: "#60a5fa",
-                borderRadius: 999,
-                display: "block",
-                height: 6,
-                width: 6,
-              }}
-            />
+            <AevatarLoadingPulseDot color="#60a5fa" size={6} />
           ) : (
             <svg
               fill="none"
@@ -383,16 +370,7 @@ function ThinkingBlock({
         </svg>
         <span>{t("shared.agui.runtimeconversationpresentation.thinking", "Thinking")}</span>
         {isStreaming ? (
-          <span
-            style={{
-              animation: "pulse 1.5s ease-in-out infinite",
-              background: "#a855f7",
-              borderRadius: 999,
-              display: "block",
-              height: 6,
-              width: 6,
-            }}
-          />
+          <AevatarLoadingPulseDot color="#a855f7" size={6} />
         ) : null}
       </button>
       {open ? (
@@ -529,16 +507,7 @@ export function RuntimeAssistantOutput({
                 </span>
                 {steps?.some((step) => step.status === "running") ||
                 toolCalls?.some((tool) => tool.status === "running") ? (
-                  <span
-                    style={{
-                      animation: "pulse 1.5s ease-in-out infinite",
-                      background: "#f59e0b",
-                      borderRadius: 999,
-                      display: "block",
-                      height: 6,
-                      width: 6,
-                    }}
-                  />
+                  <AevatarLoadingPulseDot color="#f59e0b" size={6} />
                 ) : null}
               </button>
               {actionsOpen ? (
@@ -577,17 +546,7 @@ export function RuntimeAssistantOutput({
             <div style={{ wordBreak: "break-word" }}>
               {renderContent(content)}
               {status === "streaming" && content ? (
-                <span
-                  style={{
-                    animation: "blink 1s step-end infinite",
-                    background: "#9ca3af",
-                    display: "inline-block",
-                    height: 18,
-                    marginLeft: 4,
-                    verticalAlign: "text-bottom",
-                    width: 2,
-                  }}
-                />
+                <AevatarStreamingCursor color="#9ca3af" />
               ) : null}
             </div>
             {!content && status === "streaming" ? (
@@ -599,20 +558,11 @@ export function RuntimeAssistantOutput({
                   padding: "10px 0",
                 }}
               >
-                {[0, 1, 2].map((index) => (
-                  <span
-                    key={index}
-                    style={{
-                      animation: "bounce 1s ease-in-out infinite",
-                      animationDelay: `${index * 160}ms`,
-                      background: "#d1d5db",
-                      borderRadius: 999,
-                      display: "block",
-                      height: 6,
-                      width: 6,
-                    }}
-                  />
-                ))}
+                <AevatarLoadingDots
+                  ariaLabel="Assistant is responding"
+                  color="#d1d5db"
+                  size={6}
+                />
               </div>
             ) : null}
           </div>

--- a/apps/aevatar-console-web/src/shared/auth/ProtectedRouteRedirectGate.tsx
+++ b/apps/aevatar-console-web/src/shared/auth/ProtectedRouteRedirectGate.tsx
@@ -1,8 +1,8 @@
-import { PageLoading } from "@ant-design/pro-components";
-import React from "react";
-import { CONSOLE_HOME_ROUTE } from "@/shared/navigation/consoleHome";
-import { history } from "@/shared/navigation/history";
-import { sanitizeReturnTo } from "./session";
+import React from 'react';
+import { CONSOLE_HOME_ROUTE } from '@/shared/navigation/consoleHome';
+import { history } from '@/shared/navigation/history';
+import { AevatarPageLoading } from '@/shared/ui/AevatarLoading';
+import { sanitizeReturnTo } from './session';
 
 type ProtectedRouteRedirectGateProps = {
   pathname: string;
@@ -16,7 +16,7 @@ function buildLoginRoute(returnTo: string): string {
 }
 
 function getCurrentReturnTo(pathname: string): string {
-  return pathname === "/"
+  return pathname === '/'
     ? CONSOLE_HOME_ROUTE
     : `${pathname}${window.location.search}${window.location.hash}`;
 }
@@ -28,5 +28,5 @@ export const ProtectedRouteRedirectGate: React.FC<
     history.replace(buildLoginRoute(getCurrentReturnTo(pathname)));
   }, [pathname]);
 
-  return <PageLoading fullscreen />;
+  return <AevatarPageLoading fullscreen />;
 };

--- a/apps/aevatar-console-web/src/shared/ui/AevatarLoading.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarLoading.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  AevatarLoadingDots,
+  AevatarLoadingPulseDot,
+  AevatarPageLoading,
+  AevatarStreamingCursor,
+} from './AevatarLoading';
+
+describe('AevatarLoading', () => {
+  it('renders animated dots with staggered delays', () => {
+    const { container } = render(
+      <AevatarLoadingDots
+        ariaLabel="Assistant is responding"
+        color="#d1d5db"
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Assistant is responding',
+    );
+    expect(container.querySelectorAll('.aevatar-loading-dot')).toHaveLength(3);
+    expect(container.querySelectorAll('.aevatar-loading-dot')[1]).toHaveStyle({
+      animationDelay: '160ms',
+    });
+  });
+
+  it('can render pulse dots as decorative status accents', () => {
+    const { container } = render(
+      <AevatarLoadingPulseDot color="#f59e0b" size={8} />,
+    );
+
+    expect(
+      container.querySelector('.aevatar-loading-pulse-dot'),
+    ).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('.aevatar-loading-pulse-dot')).toHaveStyle({
+      '--aevatar-loading-dot-size': '8px',
+    });
+  });
+
+  it('keeps streaming cursors hidden from assistive technologies', () => {
+    const { container } = render(<AevatarStreamingCursor color="#9ca3af" />);
+
+    expect(container.querySelector('.aevatar-loading-cursor')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+
+  it('uses the shared dots for page loading states', () => {
+    render(<AevatarPageLoading fullscreen tip="Loading console" />);
+
+    expect(screen.getByRole('status')).toHaveClass(
+      'aevatar-page-loading-fullscreen',
+    );
+    expect(screen.getByText('Loading console')).toBeInTheDocument();
+  });
+});

--- a/apps/aevatar-console-web/src/shared/ui/AevatarLoading.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarLoading.test.tsx
@@ -55,4 +55,13 @@ describe('AevatarLoading', () => {
     );
     expect(screen.getByText('Loading console')).toBeInTheDocument();
   });
+
+  it('announces a default page loading label without a visible tip', () => {
+    render(<AevatarPageLoading />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading');
+    expect(screen.getByText('Loading')).toHaveClass(
+      'aevatar-loading-visually-hidden',
+    );
+  });
 });

--- a/apps/aevatar-console-web/src/shared/ui/AevatarLoading.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarLoading.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+
+type LoadingSize = 'small' | 'medium' | 'large' | number;
+
+type LoadingStyle = React.CSSProperties & {
+  '--aevatar-loading-color'?: string;
+  '--aevatar-loading-dot-size'?: string;
+  '--aevatar-loading-gap'?: string;
+};
+
+const loadingSizeMap: Record<Exclude<LoadingSize, number>, number> = {
+  large: 8,
+  medium: 6,
+  small: 4,
+};
+const dotAnimationDelays = [0, 160, 320] as const;
+
+function joinClassNames(
+  ...classNames: Array<string | false | null | undefined>
+): string | undefined {
+  const value = classNames.filter(Boolean).join(' ');
+  return value || undefined;
+}
+
+function resolveLoadingSize(size: LoadingSize | undefined): string {
+  const resolved =
+    typeof size === 'number' ? size : loadingSizeMap[size ?? 'medium'];
+  return `${resolved}px`;
+}
+
+export type AevatarLoadingDotsProps = {
+  ariaLabel?: string;
+  className?: string;
+  color?: string;
+  decorative?: boolean;
+  gap?: number;
+  size?: LoadingSize;
+  style?: React.CSSProperties;
+};
+
+export function AevatarLoadingDots({
+  ariaLabel = 'Loading',
+  className,
+  color = 'currentColor',
+  decorative = false,
+  gap,
+  size = 'medium',
+  style,
+}: AevatarLoadingDotsProps): React.ReactElement {
+  const mergedStyle: LoadingStyle = {
+    '--aevatar-loading-color': color,
+    '--aevatar-loading-dot-size': resolveLoadingSize(size),
+    ...(gap === undefined
+      ? undefined
+      : { '--aevatar-loading-gap': `${gap}px` }),
+    ...style,
+  };
+
+  const dots = dotAnimationDelays.map((delay) => (
+    <span
+      aria-hidden="true"
+      className="aevatar-loading-dot"
+      key={delay}
+      style={{ animationDelay: `${delay}ms` }}
+    />
+  ));
+
+  if (decorative) {
+    return (
+      <span
+        aria-hidden="true"
+        className={joinClassNames('aevatar-loading-dots', className)}
+        style={mergedStyle}
+      >
+        {dots}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={joinClassNames('aevatar-loading-dots', className)}
+      role="status"
+      style={mergedStyle}
+    >
+      <span className="aevatar-loading-visually-hidden">{ariaLabel}</span>
+      {dots}
+    </span>
+  );
+}
+
+export type AevatarLoadingPulseDotProps = {
+  ariaLabel?: string;
+  className?: string;
+  color?: string;
+  decorative?: boolean;
+  size?: LoadingSize;
+  style?: React.CSSProperties;
+};
+
+export function AevatarLoadingPulseDot({
+  ariaLabel = 'Loading',
+  className,
+  color = 'currentColor',
+  decorative = true,
+  size = 'medium',
+  style,
+}: AevatarLoadingPulseDotProps): React.ReactElement {
+  const mergedStyle: LoadingStyle = {
+    '--aevatar-loading-color': color,
+    '--aevatar-loading-dot-size': resolveLoadingSize(size),
+    ...style,
+  };
+
+  if (decorative) {
+    return (
+      <span
+        aria-hidden="true"
+        className={joinClassNames('aevatar-loading-pulse-dot', className)}
+        style={mergedStyle}
+      />
+    );
+  }
+
+  return (
+    <span
+      className={joinClassNames('aevatar-loading-pulse-dot', className)}
+      role="status"
+      style={mergedStyle}
+    >
+      <span className="aevatar-loading-visually-hidden">{ariaLabel}</span>
+    </span>
+  );
+}
+
+export type AevatarStreamingCursorProps = {
+  className?: string;
+  color?: string;
+  style?: React.CSSProperties;
+};
+
+export function AevatarStreamingCursor({
+  className,
+  color = 'currentColor',
+  style,
+}: AevatarStreamingCursorProps): React.ReactElement {
+  const mergedStyle: LoadingStyle = {
+    '--aevatar-loading-color': color,
+    ...style,
+  };
+
+  return (
+    <span
+      aria-hidden="true"
+      className={joinClassNames('aevatar-loading-cursor', className)}
+      style={mergedStyle}
+    />
+  );
+}
+
+export type AevatarPageLoadingProps = {
+  className?: string;
+  fullscreen?: boolean;
+  style?: React.CSSProperties;
+  tip?: React.ReactNode;
+};
+
+export function AevatarPageLoading({
+  className,
+  fullscreen = false,
+  style,
+  tip,
+}: AevatarPageLoadingProps): React.ReactElement {
+  return (
+    <div
+      aria-busy="true"
+      className={joinClassNames(
+        'aevatar-page-loading',
+        fullscreen && 'aevatar-page-loading-fullscreen',
+        className,
+      )}
+      role="status"
+      style={style}
+    >
+      <AevatarLoadingDots color="#2563eb" decorative size="large" />
+      {tip ? <span className="aevatar-page-loading-tip">{tip}</span> : null}
+    </div>
+  );
+}

--- a/apps/aevatar-console-web/src/shared/ui/AevatarLoading.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarLoading.tsx
@@ -159,6 +159,7 @@ export function AevatarStreamingCursor({
 }
 
 export type AevatarPageLoadingProps = {
+  ariaLabel?: string;
   className?: string;
   fullscreen?: boolean;
   style?: React.CSSProperties;
@@ -166,6 +167,7 @@ export type AevatarPageLoadingProps = {
 };
 
 export function AevatarPageLoading({
+  ariaLabel = 'Loading',
   className,
   fullscreen = false,
   style,
@@ -183,7 +185,11 @@ export function AevatarPageLoading({
       style={style}
     >
       <AevatarLoadingDots color="#2563eb" decorative size="large" />
-      {tip ? <span className="aevatar-page-loading-tip">{tip}</span> : null}
+      {tip ? (
+        <span className="aevatar-page-loading-tip">{tip}</span>
+      ) : (
+        <span className="aevatar-loading-visually-hidden">{ariaLabel}</span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add a shared Aevatar loading component for dots, pulse dots, streaming cursor, and page loading states.
- Move loading keyframes into global namespaced styles so reused chat/runtime components animate outside page-local style blocks.
- Replace page-level loading and chat/AGUI streaming indicators with the shared component.

Closes #2695

## Impact paths

- apps/aevatar-console-web/src/shared/ui/AevatarLoading.tsx
- apps/aevatar-console-web/src/global.less
- apps/aevatar-console-web/src/pages/chat/*
- apps/aevatar-console-web/src/shared/agui/runtimeConversationPresentation.tsx
- apps/aevatar-console-web/src/app.tsx
- apps/aevatar-console-web/src/loading.tsx
- apps/aevatar-console-web/src/pages/auth/callback/index.tsx
- apps/aevatar-console-web/src/shared/auth/ProtectedRouteRedirectGate.tsx
- apps/aevatar-console-web/src/pages/scopes/invoke.tsx

## Validation

- `./node_modules/.bin/biome lint src/shared/ui/AevatarLoading.tsx src/shared/ui/AevatarLoading.test.tsx`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `./node_modules/.bin/jest --selectProjects jsdom --runTestsByPath src/shared/ui/AevatarLoading.test.tsx src/pages/chat/index.test.tsx --runInBand`
- `./node_modules/.bin/jest --selectProjects jsdom --runInBand`
- `./node_modules/.bin/max build`
- `bash tools/ci/test_stability_guards.sh`

Note: `pnpm --dir apps/aevatar-console-web install --frozen-lockfile` populated dependencies but exited with `ERR_PNPM_IGNORED_BUILDS`; validation above used the installed local binaries.

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2695
- Worktree: /Users/xiezixin/Documents/work/aevatar-pr-loading
- Branch: fix/2026-07-10_unified-loading-animation
- Operator: AbigailDeng
- Freshness: current user report on 2026-07-10