### PR TITLE
Fix review-triggered CI required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: ci
 
 on:
   pull_request:
-  pull_request_review:
-    types: [submitted, edited, dismissed]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
-  issue_comment:
-    types: [created, edited, deleted]
   push:
     branches:
       - main
@@ -142,25 +136,12 @@ jobs:
           fi
 
   fkst-host-policy:
-    if: |
-      github.event_name == 'pull_request' ||
-      (
-        github.event_name == 'pull_request_review' &&
-        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
-      )
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
+      issues: read
       pull-requests: read
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/fkst-review-policy.yml
+++ b/.github/workflows/fkst-review-policy.yml
@@ -1,0 +1,50 @@
+name: fkst-review-policy
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+
+concurrency:
+  group: fkst-review-policy-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  fkst-review-policy:
+    if: |
+      (
+        github.event_name == 'pull_request_review' &&
+        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        (vars.FKST_GITHUB_BOT_LOGIN == '' || github.actor != vars.FKST_GITHUB_BOT_LOGIN)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: FKST Review Policy Guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref || github.event.pull_request.base.ref || '' }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: bash tools/ci/fkst_host_policy_guard.sh

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -33,7 +33,7 @@ This directory keeps CI gate scripts and smoke tests.
   - Job `changes`
     - Uses path filters to detect whether projection-provider or Kafka-runtime integration jobs must run.
   - Job `fkst-host-policy`
-    - Runs the host FKST policy gate for PR updates; PR-side comment/review automation is handled by the `github-devloop-pr` package in FKST supervise.
+    - Runs the host FKST policy gate for PR updates.
   - Job `fast-gates`
     - Runs static architecture and test-stability guards.
   - Test authority
@@ -55,3 +55,5 @@ This directory keeps CI gate scripts and smoke tests.
     - Uploads the filtered `artifacts/coverage/**/report/Cobertura.xml` file to Codecov when `CODECOV_TOKEN` is available, using the same assembly/file filters as the local quality gate; upload failures are non-blocking because the local coverage guard is the authoritative quality gate.
     - Triggered on `main/dev` pushes, nightly schedule, or manual dispatch.
   - Job `distributed-3node-smoke` -> `tools/ci/distributed_3node_smoke.sh`
+- `.github/workflows/fkst-review-policy.yml`
+  - Handles `pull_request_review`, `pull_request_review_comment`, and PR `issue_comment` events with a dedicated `fkst-review-policy` check name, so review/comment automation cannot create or cancel the branch-protected `fast-gates`, `console-web`, or `coverage-quality` required checks.

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -68,6 +68,8 @@ if [ -d "src/Aevatar.Host.Api" ] || [ -d "src/Aevatar.Host.Gateway" ]; then
   exit 1
 fi
 
+bash "${SCRIPT_DIR}/required_ci_workflow_event_guard.sh"
+
 # Refactor (v1/issue1454-first):
 #   Old: 无中央 .NET 版本源,各项目自带或默认 1.0.0.0,无中央事实
 #   New: Directory.Build.props 中央 v0.1.0-beta + guard 防回归

--- a/tools/ci/fkst_host_policy_guard.sh
+++ b/tools/ci/fkst_host_policy_guard.sh
@@ -112,7 +112,7 @@ is_backend_impact_path() {
     src/*|agents/*|test/*|demos/*|scripts/*|tools/ci/*)
       return 0
       ;;
-    .github/workflows/ci.yml)
+    .github/workflows/ci.yml|.github/workflows/fkst-review-policy.yml)
       return 0
       ;;
     aevatar.slnx|aevatar.*.slnf|Directory.Build.props|Directory.Packages.props|global.json|buf.work.yaml)

--- a/tools/ci/required_ci_workflow_event_guard.sh
+++ b/tools/ci/required_ci_workflow_event_guard.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${AEVATAR_CI_WORKFLOW_GUARD_ROOT:-$(cd -- "${SCRIPT_DIR}/../.." && pwd)}"
+cd "${REPO_ROOT}"
+
+CI_WORKFLOW=".github/workflows/ci.yml"
+REVIEW_POLICY_WORKFLOW=".github/workflows/fkst-review-policy.yml"
+
+workflow_section_keys() {
+  local section="$1"
+  local path="$2"
+
+  if [[ ! -f "${path}" ]]; then
+    echo "${path} is required for CI workflow event guard." >&2
+    exit 1
+  fi
+
+  awk -v section="${section}" '
+    $0 ~ "^" section "[[:space:]]*:" {
+      value = $0
+      sub("^[^:]*:[[:space:]]*", "", value)
+      if (value != "") {
+        gsub(/[\[\],]/, " ", value)
+        split(value, parts, /[[:space:]]+/)
+        for (part_index in parts) {
+          if (parts[part_index] ~ /^[A-Za-z_][A-Za-z0-9_-]*$/) {
+            print parts[part_index]
+          }
+        }
+        exit
+      }
+      in_section = 1
+      next
+    }
+    in_section && /^[A-Za-z_][A-Za-z0-9_-]*[[:space:]]*:/ {
+      exit
+    }
+    in_section && /^  [A-Za-z_][A-Za-z0-9_-]*[[:space:]]*:/ {
+      key = $0
+      sub(/^  /, "", key)
+      sub(/[[:space:]]*:.*/, "", key)
+      print key
+    }
+  ' "${path}"
+}
+
+contains_line() {
+  local needle="$1"
+  grep -Fxq "${needle}"
+}
+
+join_by_comma() {
+  local IFS=", "
+  echo "$*"
+}
+
+CI_EVENTS="$(workflow_section_keys "on" "${CI_WORKFLOW}")"
+FORBIDDEN_MATCHES=()
+for event_name in pull_request_review pull_request_review_comment issue_comment; do
+  if printf '%s\n' "${CI_EVENTS}" | contains_line "${event_name}"; then
+    FORBIDDEN_MATCHES+=("${event_name}")
+  fi
+done
+
+if (( ${#FORBIDDEN_MATCHES[@]} > 0 )); then
+  echo "${CI_WORKFLOW} must not subscribe to $(join_by_comma "${FORBIDDEN_MATCHES[@]}"). Review/comment policy checks must stay in ${REVIEW_POLICY_WORKFLOW} so required ci jobs are not recreated for comment events." >&2
+  exit 1
+fi
+
+REVIEW_POLICY_EVENTS="$(workflow_section_keys "on" "${REVIEW_POLICY_WORKFLOW}")"
+MISSING_REVIEW_POLICY_EVENTS=()
+for event_name in pull_request_review pull_request_review_comment issue_comment; do
+  if ! printf '%s\n' "${REVIEW_POLICY_EVENTS}" | contains_line "${event_name}"; then
+    MISSING_REVIEW_POLICY_EVENTS+=("${event_name}")
+  fi
+done
+
+if (( ${#MISSING_REVIEW_POLICY_EVENTS[@]} > 0 )); then
+  echo "${REVIEW_POLICY_WORKFLOW} must handle $(join_by_comma "${MISSING_REVIEW_POLICY_EVENTS[@]}")." >&2
+  exit 1
+fi
+
+REVIEW_POLICY_JOBS="$(workflow_section_keys "jobs" "${REVIEW_POLICY_WORKFLOW}")"
+if ! printf '%s\n' "${REVIEW_POLICY_JOBS}" | contains_line "fkst-review-policy"; then
+  echo "${REVIEW_POLICY_WORKFLOW} must expose the fkst-review-policy job." >&2
+  exit 1
+fi
+
+REQUIRED_CHECK_CONFLICTS=()
+for job_name in fast-gates console-web coverage-quality; do
+  if printf '%s\n' "${REVIEW_POLICY_JOBS}" | contains_line "${job_name}"; then
+    REQUIRED_CHECK_CONFLICTS+=("${job_name}")
+  fi
+done
+
+if (( ${#REQUIRED_CHECK_CONFLICTS[@]} > 0 )); then
+  echo "${REVIEW_POLICY_WORKFLOW} must not reuse required check job names: $(join_by_comma "${REQUIRED_CHECK_CONFLICTS[@]}")." >&2
+  exit 1
+fi
+
+echo "required CI workflow event guard passed"

--- a/tools/ci/tests/test_required_ci_workflow_event_guard.sh
+++ b/tools/ci/tests/test_required_ci_workflow_event_guard.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
+GUARD="${REPO_ROOT}/tools/ci/required_ci_workflow_event_guard.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+write_valid_workflows() {
+  local root="$1"
+
+  mkdir -p "${root}/.github/workflows"
+  cat > "${root}/.github/workflows/ci.yml" <<'YAML'
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  fast-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo fast
+  console-web:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo console
+  coverage-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo coverage
+YAML
+
+  cat > "${root}/.github/workflows/fkst-review-policy.yml" <<'YAML'
+name: fkst-review-policy
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  fkst-review-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo review
+YAML
+}
+
+valid_root="${TMP_DIR}/valid"
+write_valid_workflows "${valid_root}"
+AEVATAR_CI_WORKFLOW_GUARD_ROOT="${valid_root}" bash "${GUARD}" > "${TMP_DIR}/valid.out"
+if ! rg -q "required CI workflow event guard passed" "${TMP_DIR}/valid.out"; then
+  echo "Expected valid workflow split to pass."
+  cat "${TMP_DIR}/valid.out"
+  exit 1
+fi
+
+forbidden_root="${TMP_DIR}/forbidden"
+write_valid_workflows "${forbidden_root}"
+perl -0pi -e 's/  push:\n/  issue_comment:\n    types: [created]\n  push:\n/' "${forbidden_root}/.github/workflows/ci.yml"
+
+if AEVATAR_CI_WORKFLOW_GUARD_ROOT="${forbidden_root}" bash "${GUARD}" > "${TMP_DIR}/forbidden.out" 2>&1; then
+  echo "Expected ci.yml review/comment trigger regression to fail."
+  cat "${TMP_DIR}/forbidden.out"
+  exit 1
+fi
+
+if ! rg -q "must not subscribe to issue_comment" "${TMP_DIR}/forbidden.out"; then
+  echo "Expected forbidden event failure to name issue_comment."
+  cat "${TMP_DIR}/forbidden.out"
+  exit 1
+fi
+
+conflict_root="${TMP_DIR}/conflict"
+write_valid_workflows "${conflict_root}"
+perl -0pi -e 's/  fkst-review-policy:\n/  fast-gates:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo conflict\n  fkst-review-policy:\n/' "${conflict_root}/.github/workflows/fkst-review-policy.yml"
+
+if AEVATAR_CI_WORKFLOW_GUARD_ROOT="${conflict_root}" bash "${GUARD}" > "${TMP_DIR}/conflict.out" 2>&1; then
+  echo "Expected review policy required-check job name conflict to fail."
+  cat "${TMP_DIR}/conflict.out"
+  exit 1
+fi
+
+if ! rg -q "must not reuse required check job names: fast-gates" "${TMP_DIR}/conflict.out"; then
+  echo "Expected required-check job name conflict failure."
+  cat "${TMP_DIR}/conflict.out"
+  exit 1
+fi
+
+echo "required CI workflow event guard tests passed"


### PR DESCRIPTION
## Problem

PRs could become unmergeable after review/comment activity even when the real pull-request CI run had passed. The `ci` workflow listened to `pull_request_review`, `pull_request_review_comment`, and PR `issue_comment` events while also defining branch-protected required jobs such as `fast-gates`, `console-web`, and `coverage-quality`. Those review/comment runs could create same-name skipped or cancelled check runs on the same commit, polluting the required-check rollup.

Blame check:
- Introduced by the FKST PR-side host policy series on 2026-07-01: `6b7ef8a6f`, `511704623`, `b9899ff5e` by `louis.li`.
- `880297134` by `AbigailDeng` later adjusted related gating, but did not originally wire review/comment events into the required CI workflow.

## Solution

- Keep `.github/workflows/ci.yml` scoped to `pull_request`, protected-branch `push`, scheduled, and manual CI events.
- Move review/comment FKST policy checks into `.github/workflows/fkst-review-policy.yml` with a dedicated `fkst-review-policy` job name.
- Keep `fkst-host-policy` in `ci.yml` for normal PR updates only.
- Add `tools/ci/required_ci_workflow_event_guard.sh` and wire it into `architecture_guards.sh` so `ci.yml` cannot re-subscribe to review/comment events, and the review policy workflow cannot reuse required check job names.

## Impact Paths

- `.github/workflows/ci.yml`
- `.github/workflows/fkst-review-policy.yml`
- `tools/ci/required_ci_workflow_event_guard.sh`
- `tools/ci/fkst_host_policy_guard.sh`
- `tools/ci/architecture_guards.sh`
- `tools/ci/tests/test_required_ci_workflow_event_guard.sh`
- `tools/ci/README.md`

## Validation

- `bash -n tools/ci/required_ci_workflow_event_guard.sh tools/ci/tests/test_required_ci_workflow_event_guard.sh tools/ci/fkst_host_policy_guard.sh`
- `bash tools/ci/required_ci_workflow_event_guard.sh`
- `bash tools/ci/tests/test_required_ci_workflow_event_guard.sh`
- `bash tools/ci/tests/test_fkst_host_policy_guard.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/fkst-review-policy.yml"); puts "workflow yaml parsed"'`
- `git diff --check`

`bash tools/ci/architecture_guards.sh` was also started locally and passed through the new guard plus earlier static guards, then stopped because this local machine does not have `buf` installed: `buf is required to lint proto contracts.` CI fast-gates installs `buf` via runner setup.

## Recurrence prevention

- Immediate symptom: PR mergeability could be blocked by skipped/cancelled same-name required checks from review/comment workflow runs.
- Root cause: branch-protected required jobs lived in a workflow that also listened to review/comment events.
- General failure pattern: optional automation reused the required CI workflow/check namespace.
- Similar locations searched: `.github/workflows/**`, `tools/ci/**`, branch protection required check names.
- Guard added: `required_ci_workflow_event_guard.sh` blocks review/comment events in `ci.yml` and required-check job-name reuse in `fkst-review-policy.yml`.
- Regression test added: `tools/ci/tests/test_required_ci_workflow_event_guard.sh` covers valid split, forbidden `issue_comment` regression, and required job-name conflicts.
- Hard gate: wired into `tools/ci/architecture_guards.sh`, which runs under `fast-gates`.
- Remaining risks: GitHub branch protection still depends on repository settings, but the workflow side no longer creates required check names for review/comment events.
