### PR TITLE
Frontend: make Chat workflow run state and next actions explicit

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -63,6 +63,38 @@ const enUSMessages = {
   'pages.chat.index.reviewPlan': 'Review the plan before creating resources.',
   'pages.chat.index.scopeValue': 'Scope {scopeId}',
   'pages.chat.index.status.completed': 'Completed',
+  'pages.chat.index.statusCenter.actionRequired': 'Action required',
+  'pages.chat.index.statusCenter.approvalTool': 'Tool: {toolName}',
+  'pages.chat.index.statusCenter.completed': 'Completed',
+  'pages.chat.index.statusCenter.completedDescription':
+    'The run completed. You can continue in chat.',
+  'pages.chat.index.statusCenter.completedTextDescription':
+    'The run completed. You can continue in chat.',
+  'pages.chat.index.statusCenter.completedTitle': 'Workflow created',
+  'pages.chat.index.statusCenter.completedWithTargetDescription':
+    'Open Studio to review the created workflow.',
+  'pages.chat.index.statusCenter.confirmDescription':
+    'No resources are created until you confirm.',
+  'pages.chat.index.statusCenter.creatingDescription':
+    'The current chat run is still working.',
+  'pages.chat.index.statusCenter.creatingTitle': 'Creating workflow',
+  'pages.chat.index.statusCenter.currentStep': 'Current step: {stepName}',
+  'pages.chat.index.statusCenter.error': 'Run stopped',
+  'pages.chat.index.statusCenter.errorDescription':
+    'This run stopped or failed. You can send a follow-up message to continue.',
+  'pages.chat.index.statusCenter.reviewAction': 'Review action',
+  'pages.chat.index.statusCenter.reviewBeforeCreate':
+    'Review before creating resources',
+  'pages.chat.index.statusCenter.runInterventionFallback':
+    'This run is waiting for an operator response.',
+  'pages.chat.index.statusCenter.runInterventionWaiting':
+    'Run input or approval is waiting below.',
+  'pages.chat.index.statusCenter.runningTool': 'Running tool: {toolName}',
+  'pages.chat.index.statusCenter.stopHelp':
+    'Stop only cancels the current chat run.',
+  'pages.chat.index.statusCenter.streamingTitle': 'Working on your request',
+  'pages.chat.index.statusCenter.toolApprovalWaiting':
+    'Tool approval is waiting below.',
   'pages.chat.index.status.creating': 'Creating',
   'pages.chat.index.status.draft': 'Draft',
   'pages.chat.index.status.error': 'Error',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -60,6 +60,38 @@ const zhCNMessages = {
   'pages.chat.index.reviewPlan': '创建资源前请先确认计划。',
   'pages.chat.index.scopeValue': 'Scope {scopeId}',
   'pages.chat.index.status.completed': '已完成',
+  'pages.chat.index.statusCenter.actionRequired': '需要处理操作',
+  'pages.chat.index.statusCenter.approvalTool': '工具：{toolName}',
+  'pages.chat.index.statusCenter.completed': '已完成',
+  'pages.chat.index.statusCenter.completedDescription':
+    '本次运行已完成，你可以继续在 Chat 中追问。',
+  'pages.chat.index.statusCenter.completedTextDescription':
+    '本次运行已完成，你可以继续在 Chat 中追问。',
+  'pages.chat.index.statusCenter.completedTitle': 'Workflow 已创建',
+  'pages.chat.index.statusCenter.completedWithTargetDescription':
+    '打开 Studio 查看刚创建的 workflow。',
+  'pages.chat.index.statusCenter.confirmDescription':
+    '在你确认之前，不会真正创建任何资源。',
+  'pages.chat.index.statusCenter.creatingDescription':
+    '当前 Chat run 仍在处理中。',
+  'pages.chat.index.statusCenter.creatingTitle': '正在创建 workflow',
+  'pages.chat.index.statusCenter.currentStep': '当前步骤：{stepName}',
+  'pages.chat.index.statusCenter.error': '运行已停止',
+  'pages.chat.index.statusCenter.errorDescription':
+    '这次运行已停止或失败。你可以发送后续消息继续。',
+  'pages.chat.index.statusCenter.reviewAction': '查看操作',
+  'pages.chat.index.statusCenter.reviewBeforeCreate':
+    '创建资源前先确认',
+  'pages.chat.index.statusCenter.runInterventionFallback':
+    '当前 run 正在等待操作员响应。',
+  'pages.chat.index.statusCenter.runInterventionWaiting':
+    '当前有输入或审批等待你处理。',
+  'pages.chat.index.statusCenter.runningTool': '正在运行工具：{toolName}',
+  'pages.chat.index.statusCenter.stopHelp':
+    '停止只会取消当前这次 chat run。',
+  'pages.chat.index.statusCenter.streamingTitle': '正在处理你的请求',
+  'pages.chat.index.statusCenter.toolApprovalWaiting':
+    '当前有工具审批在下方等待处理。',
   'pages.chat.index.status.creating': '创建中',
   'pages.chat.index.status.draft': '草稿',
   'pages.chat.index.status.error': '错误',

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -114,6 +114,15 @@ async function sendPrompt(prompt: string): Promise<void> {
   fireEvent.click(screen.getByRole("button", { name: "Send" }));
 }
 
+function seedConversationHistory(
+  conversations: readonly Record<string, unknown>[]
+): void {
+  window.localStorage.setItem(
+    "aevatar.chat.localHistory.v1:scope-a",
+    JSON.stringify(conversations)
+  );
+}
+
 describe("ChatPage MVP", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -256,6 +265,148 @@ describe("ChatPage MVP", () => {
     const secondBody = JSON.parse((authFetch as jest.Mock).mock.calls[1][1].body);
     expect(secondBody.sessionId).toBe(firstBody.sessionId);
     expect(secondBody.prompt).toContain("Confirm. Please create it now.");
+    expect(await screen.findByRole("button", { name: "Open Workflow Studio" })).toBeTruthy();
+  });
+
+  it("shows a top-level creating summary from runtime step and tool events", async () => {
+    const stream = createControlledSseResponse();
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(
+        createSseResponse([
+          {
+            runFinished: {
+              result: {
+                output: "Plan ready. Please confirm before I create resources.",
+              },
+            },
+          },
+        ])
+      )
+      .mockResolvedValueOnce(stream.response);
+
+    renderWithQueryClient(<ChatPage />);
+    await sendPrompt("Create a workflow from chat");
+    fireEvent.click(await screen.findByRole("button", { name: "Confirm and create" }));
+
+    stream.enqueue({
+      stepStarted: {
+        stepName: "Create workflow draft",
+      },
+      timestamp: 1,
+    });
+    stream.enqueue({
+      toolCallStart: {
+        toolCallId: "tool-1",
+        toolName: "create_team_member",
+      },
+      timestamp: 2,
+    });
+
+    expect(await screen.findByText("Creating workflow")).toBeTruthy();
+    expect(await screen.findByText("Current step: Create workflow draft")).toBeTruthy();
+    expect(await screen.findByText("Running tool: create_team_member")).toBeTruthy();
+    expect(
+      await screen.findByText("Stop only cancels the current chat run.")
+    ).toBeTruthy();
+  });
+
+  it("shows confirmation in the top-level status center for restored conversations", async () => {
+    seedConversationHistory([
+      {
+        createdAt: "2026-07-10T07:00:00.000Z",
+        id: "conv-confirm",
+        messages: [
+          {
+            content: "Plan ready. Please confirm before I create resources.",
+            id: "assistant-confirm",
+            role: "assistant",
+            status: "complete",
+            timestamp: 1,
+          },
+        ],
+        scopeId: "scope-a",
+        status: "needs_confirmation",
+        title: "Workflow planning",
+        updatedAt: "2026-07-10T07:00:00.000Z",
+      },
+    ]);
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Workflow planning" }));
+
+    expect(await screen.findByText("Review before creating resources")).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Confirm and create" })).toBeTruthy();
+  });
+
+  it("surfaces pending operator action in the top-level status center", async () => {
+    seedConversationHistory([
+      {
+        createdAt: "2026-07-10T07:00:00.000Z",
+        id: "conv-action",
+        messages: [
+          {
+            content: "Waiting for approval.",
+            id: "assistant-action",
+            pendingApproval: {
+              argumentsJson: "{\"scopeId\":\"scope-a\"}",
+              isDestructive: false,
+              requestId: "approval-1",
+              timeoutSeconds: 30,
+              toolCallId: "tool-approval-1",
+              toolName: "create_workflow",
+            },
+            role: "assistant",
+            status: "complete",
+            timestamp: 1,
+          },
+        ],
+        scopeId: "scope-a",
+        status: "creating",
+        title: "Workflow approval",
+        updatedAt: "2026-07-10T07:00:00.000Z",
+      },
+    ]);
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Workflow approval" }));
+
+    expect(await screen.findByText("Action required")).toBeTruthy();
+    expect(await screen.findByText("Tool approval is waiting below.")).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "Review action" })).toBeTruthy();
+  });
+
+  it("shows completed next-step guidance in the top-level status center", async () => {
+    seedConversationHistory([
+      {
+        createdAt: "2026-07-10T07:00:00.000Z",
+        id: "conv-complete",
+        messages: [
+          {
+            content: "Created.",
+            id: "assistant-complete",
+            role: "assistant",
+            status: "complete",
+            timestamp: 1,
+          },
+        ],
+        scopeId: "scope-a",
+        status: "completed_with_studio_target",
+        target: {
+          memberId: "member-a",
+          scopeId: "scope-a",
+          teamId: "team-a",
+          workflowId: "workflow-a",
+        },
+        title: "Workflow created",
+        updatedAt: "2026-07-10T07:00:00.000Z",
+      },
+    ]);
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Workflow created" }));
+
+    expect(await screen.findByText("Workflow created")).toBeTruthy();
+    expect(await screen.findByText("Open Studio to review the created workflow.")).toBeTruthy();
     expect(await screen.findByRole("button", { name: "Open Workflow Studio" })).toBeTruthy();
   });
 

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -3,7 +3,6 @@ import {
   EditOutlined,
   MessageOutlined,
   PlusOutlined,
-  SendOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -68,6 +67,17 @@ type ConversationState = {
 type StudioJump = {
   href: string;
   label: string;
+};
+
+type ChatRunStatusCenter = {
+  description: string;
+  detailLines: string[];
+  primaryAction?:
+    | { kind: "confirm"; label: string }
+    | { kind: "focus-action"; label: string }
+    | { kind: "open-target"; label: string };
+  tone: "default" | "processing" | "success" | "warning" | "error";
+  title: string;
 };
 
 function readChatQueryValue(
@@ -359,6 +369,207 @@ function formatRelativeTime(isoString: string): string {
   });
 }
 
+function findLatestAssistantMessage(
+  conversation: ConversationState | null | undefined
+): ChatMessage | null {
+  if (!conversation) {
+    return null;
+  }
+
+  return (
+    [...conversation.messages]
+      .reverse()
+      .find((message) => message.role === "assistant") ?? null
+  );
+}
+
+function findPendingActionMessage(
+  conversation: ConversationState | null | undefined
+): ChatMessage | null {
+  if (!conversation) {
+    return null;
+  }
+
+  return (
+    [...conversation.messages]
+      .reverse()
+      .find(
+        (message) => message.pendingApproval || message.pendingRunIntervention
+      ) ?? null
+  );
+}
+
+function buildChatRunStatusCenter(
+  conversation: ConversationState | null,
+  studioJump: StudioJump | null
+): ChatRunStatusCenter | null {
+  if (!conversation || conversation.messages.length === 0) {
+    return null;
+  }
+
+  const latestAssistantMessage = findLatestAssistantMessage(conversation);
+  const latestRunningStep = [...(latestAssistantMessage?.steps ?? [])]
+    .reverse()
+    .find((step) => step.status === "running");
+  const latestRunningTool = [...(latestAssistantMessage?.toolCalls ?? [])]
+    .reverse()
+    .find((toolCall) => toolCall.status === "running");
+  const pendingActionMessage = findPendingActionMessage(conversation);
+
+  if (pendingActionMessage?.pendingApproval) {
+    return {
+      description: t(
+        "pages.chat.index.statusCenter.toolApprovalWaiting",
+        "Tool approval is waiting below."
+      ),
+      detailLines: [
+        t("pages.chat.index.statusCenter.approvalTool", "Tool: {toolName}", {
+          toolName:
+            pendingActionMessage.pendingApproval.toolName ||
+            pendingActionMessage.pendingApproval.toolCallId ||
+            pendingActionMessage.pendingApproval.requestId,
+        }),
+      ],
+      primaryAction: {
+        kind: "focus-action",
+        label: t("pages.chat.index.statusCenter.reviewAction", "Review action"),
+      },
+      title: t("pages.chat.index.statusCenter.actionRequired", "Action required"),
+      tone: "warning",
+    };
+  }
+
+  if (pendingActionMessage?.pendingRunIntervention) {
+    return {
+      description: t(
+        "pages.chat.index.statusCenter.runInterventionWaiting",
+        "Run input or approval is waiting below."
+      ),
+      detailLines: [
+        pendingActionMessage.pendingRunIntervention.prompt ||
+          t(
+            "pages.chat.index.statusCenter.runInterventionFallback",
+            "This run is waiting for an operator response."
+          ),
+      ],
+      primaryAction: {
+        kind: "focus-action",
+        label: t("pages.chat.index.statusCenter.reviewAction", "Review action"),
+      },
+      title: t("pages.chat.index.statusCenter.actionRequired", "Action required"),
+      tone: "warning",
+    };
+  }
+
+  switch (conversation.status) {
+    case "needs_confirmation":
+      return {
+        description: t(
+          "pages.chat.index.statusCenter.confirmDescription",
+          "No resources are created until you confirm."
+        ),
+        detailLines: [],
+        primaryAction: {
+          kind: "confirm",
+          label: t("pages.chat.index.confirmAndCreate", "Confirm and create"),
+        },
+        title: t(
+          "pages.chat.index.statusCenter.reviewBeforeCreate",
+          "Review before creating resources"
+        ),
+        tone: "warning",
+      };
+    case "creating":
+    case "streaming": {
+      const detailLines: string[] = [];
+      if (latestRunningStep?.name) {
+        detailLines.push(
+          t("pages.chat.index.statusCenter.currentStep", "Current step: {stepName}", {
+            stepName: latestRunningStep.name,
+          })
+        );
+      }
+      if (latestRunningTool?.name) {
+        detailLines.push(
+          t("pages.chat.index.statusCenter.runningTool", "Running tool: {toolName}", {
+            toolName: latestRunningTool.name,
+          })
+        );
+      }
+      detailLines.push(
+        t(
+          "pages.chat.index.statusCenter.stopHelp",
+          "Stop only cancels the current chat run."
+        )
+      );
+
+      return {
+        description: t(
+          "pages.chat.index.statusCenter.creatingDescription",
+          "The current chat run is still working."
+        ),
+        detailLines,
+        title:
+          conversation.status === "creating"
+            ? t(
+                "pages.chat.index.statusCenter.creatingTitle",
+                "Creating workflow"
+              )
+            : t(
+                "pages.chat.index.statusCenter.streamingTitle",
+                "Working on your request"
+              ),
+        tone: "processing",
+      };
+    }
+    case "completed_with_studio_target":
+      return {
+        description: studioJump
+          ? t(
+              "pages.chat.index.statusCenter.completedWithTargetDescription",
+              "Open Studio to review the created workflow."
+            )
+          : t(
+              "pages.chat.index.statusCenter.completedDescription",
+              "The run completed. You can continue in chat."
+            ),
+        detailLines: [],
+        primaryAction: studioJump
+          ? {
+              kind: "open-target",
+              label: studioJump.label,
+            }
+          : undefined,
+        title: t("pages.chat.index.statusCenter.completedTitle", "Workflow created"),
+        tone: "success",
+      };
+    case "completed_text":
+      return {
+        description: t(
+          "pages.chat.index.statusCenter.completedTextDescription",
+          "The run completed. You can continue in chat."
+        ),
+        detailLines: [],
+        title: t("pages.chat.index.statusCenter.completed", "Completed"),
+        tone: "success",
+      };
+    case "error":
+      return {
+        description: t(
+          "pages.chat.index.statusCenter.errorDescription",
+          "This run stopped or failed. You can send a follow-up message to continue."
+        ),
+        detailLines: latestAssistantMessage?.error
+          ? [latestAssistantMessage.error]
+          : [],
+        title: t("pages.chat.index.statusCenter.error", "Run stopped"),
+        tone: "error",
+      };
+    default:
+      return null;
+  }
+}
+
 const ChatPage: React.FC = () => {
   const { token } = theme.useToken();
   const activeConversationRef = useRef<ConversationState | null>(null);
@@ -391,6 +602,14 @@ const ChatPage: React.FC = () => {
     activeConversation?.status === "streaming" ||
     activeConversation?.status === "creating";
   const studioJump = resolveStudioJump(activeConversation?.target);
+  const pendingActionMessage = useMemo(
+    () => findPendingActionMessage(activeConversation),
+    [activeConversation]
+  );
+  const statusCenter = useMemo(
+    () => buildChatRunStatusCenter(activeConversation, studioJump),
+    [activeConversation, studioJump]
+  );
 
   const refreshConversations = useCallback(async () => {
     if (!scopeId) {
@@ -807,6 +1026,19 @@ const ChatPage: React.FC = () => {
 
     history.push(studioJump.href);
   }, [studioJump]);
+  const handleFocusPendingAction = useCallback(() => {
+    if (!pendingActionMessage || typeof document === "undefined") {
+      return;
+    }
+
+    const element = document.getElementById(
+      `chat-message-${pendingActionMessage.id}`
+    );
+    element?.scrollIntoView({ behavior: "smooth", block: "center" });
+    if (element instanceof HTMLElement) {
+      element.focus();
+    }
+  }, [pendingActionMessage]);
 
   const messageCount = activeConversation?.messages.length ?? 0;
 
@@ -1048,13 +1280,100 @@ const ChatPage: React.FC = () => {
                   {formatStatusLabel(activeConversation.status)}
                 </Tag>
               ) : null}
-              {studioJump ? (
-                <Button onClick={handleOpenTarget} type="primary">
-                  {studioJump.label}
-                </Button>
-              ) : null}
             </Space>
           </div>
+
+          {statusCenter ? (
+            <div
+              style={{
+                background:
+                  statusCenter.tone === "warning"
+                    ? token.colorWarningBg
+                    : statusCenter.tone === "success"
+                      ? token.colorSuccessBg
+                      : statusCenter.tone === "error"
+                        ? token.colorErrorBg
+                        : token.colorInfoBg,
+                borderBottom: `1px solid ${
+                  statusCenter.tone === "warning"
+                    ? token.colorWarningBorder
+                    : statusCenter.tone === "success"
+                      ? token.colorSuccessBorder
+                      : statusCenter.tone === "error"
+                        ? token.colorErrorBorder
+                        : token.colorInfoBorder
+                }`,
+                padding: "14px 16px",
+              }}
+            >
+              <div
+                style={{
+                  alignItems: "flex-start",
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 16,
+                  justifyContent: "space-between",
+                }}
+              >
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  <Typography.Text
+                    strong
+                    style={{
+                      color: token.colorTextHeading,
+                      fontSize: 16,
+                      lineHeight: 1.35,
+                    }}
+                  >
+                    {statusCenter.title}
+                  </Typography.Text>
+                  <Typography.Text
+                    style={{
+                      color: token.colorTextSecondary,
+                      fontSize: 13,
+                      lineHeight: 1.6,
+                    }}
+                  >
+                    {statusCenter.description}
+                  </Typography.Text>
+                  {statusCenter.detailLines.map((line) => (
+                    <Typography.Text
+                      key={line}
+                      style={{
+                        color: token.colorTextTertiary,
+                        fontSize: 12,
+                        lineHeight: 1.6,
+                      }}
+                    >
+                      {line}
+                    </Typography.Text>
+                  ))}
+                </div>
+
+                {statusCenter.primaryAction ? (
+                  <Button
+                    onClick={() => {
+                      switch (statusCenter.primaryAction?.kind) {
+                        case "confirm":
+                          handleConfirmCreate();
+                          break;
+                        case "focus-action":
+                          handleFocusPendingAction();
+                          break;
+                        case "open-target":
+                          handleOpenTarget();
+                          break;
+                        default:
+                          break;
+                      }
+                    }}
+                    type="primary"
+                  >
+                    {statusCenter.primaryAction.label}
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
 
           {!scopeId && !authSessionQuery.isLoading ? (
             <Alert
@@ -1119,36 +1438,10 @@ const ChatPage: React.FC = () => {
                 }}
               >
                 {activeConversation?.messages.map((message) => (
-                  <ChatMessageBubble key={message.id} message={message} />
-                ))}
-                {activeConversation?.status === "needs_confirmation" ? (
-                  <div
-                    style={{
-                      background: token.colorWarningBg,
-                      border: `1px solid ${token.colorWarningBorder}`,
-                      borderRadius: token.borderRadius,
-                      marginLeft: 34,
-                      maxWidth: 760,
-                      padding: 12,
-                    }}
-                  >
-                    <Space direction="vertical" size={10}>
-                      <Typography.Text strong>
-                        {t(
-                          "pages.chat.index.reviewPlan",
-                          "Review the plan before creating resources."
-                        )}
-                      </Typography.Text>
-                      <Button
-                        icon={<SendOutlined />}
-                        onClick={handleConfirmCreate}
-                        type="primary"
-                      >
-                        {t("pages.chat.index.confirmAndCreate", "Confirm and create")}
-                      </Button>
-                    </Space>
+                  <div id={`chat-message-${message.id}`} key={message.id} tabIndex={-1}>
+                    <ChatMessageBubble message={message} />
                   </div>
-                ) : null}
+                ))}
               </Space>
             )}
             <div ref={scrollAnchorRef} />


### PR DESCRIPTION
## Problem

Closes #2700.

Chat workflow creation already streamed status into message bodies, but the primary run state and next action stayed fragmented across a small header tag, collapsed message disclosures, and the red stop button in the composer. Users had no single place to see what the current chat run is doing, whether operator action is required, and what they should do next.

## Solution

- Add a top-level Chat run status/action center derived from existing conversation and message runtime state.
- Promote confirmation, operator action review, running step/tool context, stop semantics, and completed next-step guidance into that unified surface.
- Remove the duplicate inline confirmation card so the main CTA appears in one place.
- Add Chat-page tests for creating summaries, restored confirmation state, pending operator action state, and completed next-step guidance.
- Add English and Chinese locale entries for the new status center copy.

## Impacted Paths

- `apps/aevatar-console-web/src/pages/chat/index.tsx`
- `apps/aevatar-console-web/src/pages/chat/index.test.tsx`
- `apps/aevatar-console-web/src/locales/en-US.ts`
- `apps/aevatar-console-web/src/locales/zh-CN.ts`

## Validation

Passed:

- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web test:ui --runTestsByPath src/pages/chat/index.test.tsx --runInBand`
- `pnpm --dir apps/aevatar-console-web build`
- `git diff --check -- apps/aevatar-console-web`
- `bash tools/ci/test_stability_guards.sh`

Observed but not fixed in this PR:

- `pnpm --dir apps/aevatar-console-web test:ui` still fails on existing non-Chat suites, including `src/pages/teams/home.test.tsx`, `src/pages/scopes/invoke.test.tsx`, and `src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx`. These failures were not introduced by the Chat diff and were left out of scope for this issue-focused PR.

## Frontend Boundary Check

- All edits are under `apps/aevatar-console-web/**`.
- No backend, proto, docs, tools, CI, solution, root package, or agent files were changed.

## Browser Verification

- Attempted local browser verification against preview output.
- Blocked by login redirect: opening `http://localhost:5178/chat?scopeId=scope-a` redirected to `/login`, so the authenticated Chat surface was not reachable in this environment.

## FKST Provenance

- Skill: `aevatar-frontend-fkst`
- Issue: `#2700`
- Worktree: `/Users/abigaildeng/.codex/worktrees/fkst-issue-2700`
- Branch: `feat/2026-07-10_chat-run-status-center`
- Commit: `1de88c63c`
