### PR TITLE
Add member deletion frontend

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -596,6 +596,7 @@ const enUSMessages = {
   'teams.members.actions.createFirst': 'Create first member',
   'teams.members.actions.createFirstWorkflow': 'Create first workflow member',
   'teams.members.actions.createWorkflowMember': 'Create workflow member',
+  'teams.members.actions.delete': 'Delete member',
   'teams.members.actions.editInStudio': 'Edit in Studio',
   'teams.members.actions.automate': 'Automate',
   'teams.members.actions.invokeRequiresBinding':
@@ -781,6 +782,16 @@ const enUSMessages = {
   'teams.members.columns.role': 'Role',
   'teams.members.columns.service': 'Service',
   'teams.members.count': '{count, plural, one {# member} other {# members}}',
+  'teams.members.delete.confirm.body': 'Delete',
+  'teams.members.delete.confirm.body.suffix': 'from this Team?',
+  'teams.members.delete.entry.warning':
+    'This member is the Team entry member. Deleting it removes the member authority and clears it from the Team roster; published service artifacts, revisions, and historical runs stay intact.',
+  'teams.members.delete.failed': 'Failed to delete member.',
+  'teams.members.delete.keep': 'Keep member',
+  'teams.members.delete.success': 'Deleted member {member}.',
+  'teams.members.delete.title': 'Delete member',
+  'teams.members.delete.warning':
+    'This removes the Studio member authority and Team roster entry. Published service artifacts, revisions, and historical runs stay intact.',
   'teams.members.description':
     'Review team members, choose the Team entry member, and open workflow members in Studio. Invoke is available only after a workflow member is bound to a published service.',
   'teams.members.empty.description':

--- a/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
@@ -4672,7 +4672,7 @@ const projectMessages = {
   "pages.teams.detail.copy.43": "After the test team, the most recent runs will be displayed.",
   "pages.teams.detail.copy.44": "main service",
   "pages.teams.detail.copy.45": "Overview",
-  "pages.teams.detail.copy.46": "team member",
+  "pages.teams.detail.copy.46": "Team members",
   "pages.teams.detail.copy.47": "Editorial Team",
   "pages.teams.detail.copy.48": "test team",
   "pages.teams.detail.copy.49": "save team",

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -564,6 +564,7 @@ const zhCNMessages = {
   'teams.members.actions.createFirst': '创建第一个成员',
   'teams.members.actions.createFirstWorkflow': '创建第一个工作流成员',
   'teams.members.actions.createWorkflowMember': '创建工作流成员',
+  'teams.members.actions.delete': '删除成员',
   'teams.members.actions.editInStudio': '在 Studio 中编辑',
   'teams.members.actions.automate': '自动化',
   'teams.members.actions.invokeRequiresBinding': '请先绑定这个 Workflow 成员再调用。',
@@ -724,6 +725,16 @@ const zhCNMessages = {
   'teams.members.columns.role': '职责',
   'teams.members.columns.service': '服务',
   'teams.members.count': '{count} 个成员',
+  'teams.members.delete.confirm.body': '删除',
+  'teams.members.delete.confirm.body.suffix': '从这个团队中删除？',
+  'teams.members.delete.entry.warning':
+    '这个成员是团队入口成员。删除后会移除成员权威状态并从团队成员列表中清除；已发布服务产物、修订和历史运行记录会保留。',
+  'teams.members.delete.failed': '删除成员失败。',
+  'teams.members.delete.keep': '保留成员',
+  'teams.members.delete.success': '已删除成员 {member}。',
+  'teams.members.delete.title': '删除成员',
+  'teams.members.delete.warning':
+    '这会移除 Studio 成员权威状态并从团队成员列表中清除；已发布服务产物、修订和历史运行记录会保留。',
   'teams.members.description':
     '在这里查看团队成员、选择团队入口，并进入 Workflow Studio 编辑成员。只有已经绑定到发布服务的 Workflow 成员才可以调用。',
   'teams.members.empty.description':

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -1102,6 +1102,17 @@ jest.mock("@/shared/studio/api", () => ({
       }
       return undefined;
     }),
+    deleteMember: jest.fn(async (input: { scopeId: string; memberId: string }) => {
+      mockStudioMembers = mockStudioMembers.filter(
+        (member) => member.memberId !== input.memberId,
+      );
+      return {
+        status: "delete_accepted",
+        scopeId: input.scopeId,
+        memberId: input.memberId,
+        ackedAt: "2026-07-09T08:12:00Z",
+      };
+    }),
     parseYaml: jest.fn(async (input: { yaml: string }) => ({
       document: input.yaml.includes("name: legacy_draft")
         ? {
@@ -5149,6 +5160,49 @@ describe("StudioPage", () => {
         "Deleted workflow member workspace-demo.",
       );
     });
+  });
+
+  it("deletes a synced Studio member from the inventory rail", async () => {
+    renderStudioPage(
+      "/studio?scopeId=scope-1&teamId=t-alpha&member=member%3Aworkspace-demo&focus=workflow%3Aworkflow-1&tab=studio"
+    );
+
+    fireEvent.click(await screen.findByLabelText("Delete workspace-demo"));
+
+    await waitFor(() => {
+      expect(Modal.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Delete Studio member",
+          okText: "Delete member",
+          cancelText: "Keep member",
+          autoFocusButton: "cancel",
+        })
+      );
+    });
+
+    const confirmConfig = (Modal.confirm as jest.Mock).mock.calls[0]?.[0];
+    expect(confirmConfig.icon).toBeTruthy();
+    await act(async () => {
+      await confirmConfig.onOk();
+    });
+
+    await waitFor(() => {
+      expect(studioApi.deleteMember).toHaveBeenCalledWith({
+        scopeId: "scope-1",
+        memberId: "workspace-demo",
+      });
+    });
+    expect(studioApi.deleteWorkflow).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(message.success).toHaveBeenCalledWith(
+        "Deleted member workspace-demo.",
+      );
+    });
+
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get("member")).toBeNull();
+    expect(searchParams.get("focus")).toBeNull();
   });
 
   it("treats a missing workflow draft as already deleted from the inventory rail", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -1385,6 +1385,25 @@ function upsertStudioMemberRosterMember(
   };
 }
 
+function removeStudioMemberRosterMember(
+  roster: StudioMemberRoster | undefined,
+  scopeId: string,
+  memberId: string,
+): StudioMemberRoster | undefined {
+  const normalizedMemberId = trimOptional(memberId);
+  if (!roster || !normalizedMemberId) {
+    return roster;
+  }
+
+  return {
+    scopeId: trimOptional(roster.scopeId) || trimOptional(scopeId),
+    members: roster.members.filter(
+      (member) => trimOptional(member.memberId) !== normalizedMemberId,
+    ),
+    nextPageToken: roster.nextPageToken ?? null,
+  };
+}
+
 function primeStudioMemberRoster(
   queryClient: ReturnType<typeof useQueryClient>,
   queryKey: readonly unknown[],
@@ -3048,6 +3067,7 @@ const StudioPage: React.FC = () => {
   const handledCreateMemberIntentSnapshotRef = useRef('');
   const executionLogsWindowRef = useRef<Window | null>(null);
   const createMemberNameInputRef = useRef<HTMLInputElement | null>(null);
+  const suppressBuildMemberRoutePersistenceRef = useRef(false);
   const [logsDetached, setLogsDetached] = useState(false);
   const [authRecoveryPending, setAuthRecoveryPending] = useState(false);
   const authSessionQuery = useQuery({
@@ -7673,11 +7693,18 @@ const StudioPage: React.FC = () => {
     if (routeLegacyServiceId && !routeLegacyBackendMemberKey) {
       return;
     }
+    const suppressBuildMemberRoutePersistence =
+      suppressBuildMemberRoutePersistenceRef.current &&
+      studioSurface === 'build' &&
+      !trimOptional(routeSelectedMemberKey) &&
+      !trimOptional(routeState.focusKey);
     const persistedMemberKey =
       canonicalLegacyRouteMemberKey ||
       (studioSurface === 'build'
         ? routeLegacyBackendMemberKey ||
-          trimOptional(persistableBuildMemberKey) ||
+          (suppressBuildMemberRoutePersistence
+            ? undefined
+            : trimOptional(persistableBuildMemberKey) || undefined) ||
           undefined
         : pinnedRouteBackendMemberKey ||
           trimOptional(lifecycleSurfaceMemberKey) ||
@@ -7691,11 +7718,13 @@ const StudioPage: React.FC = () => {
           ? (`workflow:${routeBuildFocus.value}` as const)
           : undefined;
     const persistedFocus =
-      persistedLifecycleFocus ||
-      (persistBuildFocusRoute &&
-      trimOptional(activeBuildFocusKey) !== trimOptional(persistedMemberKey)
-        ? activeBuildFocusKey || undefined
-        : undefined);
+      suppressBuildMemberRoutePersistence
+        ? undefined
+        : persistedLifecycleFocus ||
+          (persistBuildFocusRoute &&
+          trimOptional(activeBuildFocusKey) !== trimOptional(persistedMemberKey)
+            ? activeBuildFocusKey || undefined
+            : undefined);
 
     history.replace(buildStudioRoute({
       scopeId: resolvedStudioScopeId || undefined,
@@ -7712,6 +7741,14 @@ const StudioPage: React.FC = () => {
       executionId: persistExecutionRoute ? selectedExecutionId || undefined : undefined,
       logsMode: logsPopoutMode === 'popout' ? 'popout' : undefined,
     }));
+    if (
+      suppressBuildMemberRoutePersistence &&
+      !trimOptional(selectedWorkflowId) &&
+      !trimOptional(selectedScriptId) &&
+      !trimOptional(templateWorkflow)
+    ) {
+      suppressBuildMemberRoutePersistenceRef.current = false;
+    }
   }, [
     appliedRouteSnapshot,
     activeBuildFocusKey,
@@ -7738,8 +7775,10 @@ const StudioPage: React.FC = () => {
     runPrompt,
     selectedWorkflowRepresentsPublishedMember,
     selectedWorkflowId,
+    selectedScriptId,
     selectedExecutionId,
     studioSurface,
+    templateWorkflow,
     visibleWorkflowSummaries,
     workflowsQuery.isLoading,
   ]);
@@ -9232,14 +9271,223 @@ const StudioPage: React.FC = () => {
       selectedInventoryWorkflowId,
   );
   const selectedInventoryCanDelete = Boolean(
-    selectedInventoryMemberKey.startsWith('workflow:') &&
-      selectedInventoryWorkflowId,
+    (selectedInventoryMemberKey.startsWith('workflow:') &&
+      selectedInventoryWorkflowId) ||
+      (selectedInventoryMemberKey.startsWith('member:') &&
+        resolvedStudioScopeId &&
+        selectedInventoryResolvedMemberId),
   );
   const selectedInventoryDeleteTitle = selectedInventoryMemberKey.startsWith('member:')
-    ? 'Member delete is not available yet.'
+    ? selectedInventoryCanDelete
+      ? `Delete ${selectedInventoryLabel}`
+      : 'Select a synced Studio member to delete.'
     : selectedInventoryCanDelete
       ? `Delete ${selectedInventoryLabel}`
       : 'Select a workflow draft member to delete.';
+  const handleDeleteStudioMember = useCallback(
+    (memberKey: string) => {
+      const memberId =
+        trimOptional(selectedInventoryMemberSummary?.memberId) ||
+        readMemberIdFromMemberKey(memberKey);
+      const scopeId = trimOptional(resolvedStudioScopeId);
+      if (!scopeId || !memberId) {
+        return;
+      }
+
+      const memberLabel =
+        trimOptional(selectedInventoryLabel) || memberId || 'this member';
+
+      Modal.confirm({
+        autoFocusButton: 'cancel',
+        cancelText: t("pages.studio.index.keep.member.3", "Keep member"),
+        centered: true,
+        content: (
+          <div style={{ display: 'grid', gap: 12 }}>
+            <Typography.Text
+              style={{
+                color: '#111827',
+                fontSize: 13,
+                lineHeight: '20px',
+              }}
+            >
+              {t("pages.studio.index.delete.member.confirm.body", "Delete")}
+              <strong>{memberLabel}</strong>{" "}
+              {t(
+                "pages.studio.index.delete.member.confirm.body.suffix",
+                "from the current member inventory?",
+              )}
+            </Typography.Text>
+            <div
+              style={{
+                background: 'rgba(254, 242, 242, 0.92)',
+                border: '1px solid rgba(248, 113, 113, 0.18)',
+                borderRadius: 12,
+                display: 'grid',
+                gap: 4,
+                padding: '10px 12px',
+              }}
+            >
+              <Typography.Text
+                strong
+                style={{
+                  color: '#991b1b',
+                  fontSize: 12,
+                  letterSpacing: 0,
+                }}
+              >
+                {t("pages.studio.index.member.authority", "Member authority")}
+              </Typography.Text>
+              <Typography.Text
+                style={{
+                  color: '#7f1d1d',
+                  fontSize: 12,
+                  lineHeight: '18px',
+                }}
+              >
+                {t(
+                  "pages.studio.index.delete.member.authority.warning",
+                  "This removes the Studio member authority and team roster entry. Published service artifacts, revisions, and historical runs stay intact.",
+                )}
+              </Typography.Text>
+            </div>
+          </div>
+        ),
+        icon: <DeleteOutlined style={{ color: '#dc2626' }} />,
+        okButtonProps: {
+          danger: true,
+        },
+        okText: t("pages.studio.index.delete.member.3", "Delete member"),
+        title: t("pages.studio.index.delete.studio.member", "Delete Studio member"),
+        width: 460,
+        onOk: async () => {
+          setInventoryBusyKey(memberKey);
+          setInventoryBusyAction('delete');
+
+          try {
+            try {
+              await studioApi.deleteMember({
+                scopeId,
+                memberId,
+              });
+            } catch (error) {
+              if (!isStudioApiStatus(error, 404)) {
+                void message.error(
+                  error instanceof Error
+                    ? error.message
+                    : t("pages.studio.index.failed.delete.member", "Failed to delete member."),
+                );
+                return;
+              }
+            }
+
+            setOptimisticStudioMembers((current) =>
+              current.filter(
+                (member) => trimOptional(member.memberId) !== memberId,
+              ),
+            );
+            queryClient.setQueryData<StudioMemberRoster>(
+              studioMembersQueryKey,
+              (current) =>
+                removeStudioMemberRosterMember(current, scopeId, memberId),
+            );
+
+            const invalidations = [
+              queryClient.invalidateQueries({
+                queryKey: studioMembersQueryKey,
+              }),
+              queryClient.invalidateQueries({
+                queryKey: ['teams', 'roster', scopeId],
+              }),
+            ];
+            if (resolvedStudioTeamId) {
+              invalidations.push(
+                queryClient.invalidateQueries({
+                  queryKey: studioTeamSummaryQueryKey,
+                }),
+                queryClient.invalidateQueries({
+                  queryKey: ['teams', 'team-summary', scopeId, resolvedStudioTeamId],
+                }),
+                queryClient.invalidateQueries({
+                  queryKey: ['teams', 'team-members', scopeId, resolvedStudioTeamId],
+                }),
+              );
+            }
+            await Promise.all(invalidations);
+
+            const deletedMemberKey = buildBackendMemberKey(memberId);
+            if (
+              selectedInventoryMemberKey === memberKey ||
+              trimOptional(deletedMemberKey) === trimOptional(workbenchMemberKey) ||
+              trimOptional(deletedMemberKey) === trimOptional(routeState.memberKey)
+            ) {
+              pinnedRouteBackendMemberIdRef.current = '';
+              suppressBuildMemberRoutePersistenceRef.current = true;
+              setPinnedRouteBackendMemberId('');
+              setSelectedWorkflowId('');
+              setSelectedScriptId('');
+              setTemplateWorkflow('');
+              if (studioSurface === 'observe') {
+                setSelectedExecutionId('');
+              }
+              history.replace(
+                buildStudioRoute({
+                  scopeId,
+                  teamId: routeState.teamId || undefined,
+                  returnTo: routeState.returnTo || undefined,
+                  step: 'build',
+                  tab: 'studio',
+                }),
+              );
+            }
+
+            void message.success(
+              t("pages.studio.index.deleted.member", "Deleted member {member}.", {
+                member: memberLabel,
+              }),
+            );
+          } catch (error) {
+            void message.error(
+              error instanceof Error
+                ? error.message
+                : t(
+                    "pages.studio.index.failed.delete.member",
+                    "Failed to delete member.",
+                  ),
+            );
+          } finally {
+            setInventoryBusyKey('');
+            setInventoryBusyAction('');
+          }
+        },
+      });
+    },
+    [
+      queryClient,
+      resolvedStudioScopeId,
+      resolvedStudioTeamId,
+      routeState.memberKey,
+      routeState.returnTo,
+      routeState.teamId,
+      selectedInventoryLabel,
+      selectedInventoryMemberKey,
+      selectedInventoryMemberSummary?.memberId,
+      studioMembersQueryKey,
+      studioSurface,
+      studioTeamSummaryQueryKey,
+      workbenchMemberKey,
+    ],
+  );
+  const handleDeleteInventoryMember = useCallback(
+    (memberKey: string) => {
+      if (memberKey.startsWith('member:')) {
+        handleDeleteStudioMember(memberKey);
+        return;
+      }
+
+      handleDeleteWorkflowMember(memberKey);
+    },
+    [handleDeleteStudioMember, handleDeleteWorkflowMember],
+  );
   const handleSelectStudioMember = useCallback(
     async (memberKey: string) => {
       const normalizedMemberKey = trimOptional(memberKey);
@@ -9694,7 +9942,11 @@ const StudioPage: React.FC = () => {
       key: selectedRailMemberKey || currentFocusMemberKey,
       label: currentMemberLabel,
       canDelete:
-        currentFocusMemberKey.startsWith('workflow:') && Boolean(selectedWorkflowId),
+        (currentFocusMemberKey.startsWith('workflow:') && Boolean(selectedWorkflowId)) ||
+        Boolean(
+          readMemberIdFromMemberKey(selectedRailMemberKey) ||
+            readMemberIdFromMemberKey(currentFocusMemberKey),
+        ),
       canRename: currentMemberCanRename,
       description: currentMemberDescription,
       kind: currentMemberKind,
@@ -9807,6 +10059,7 @@ const StudioPage: React.FC = () => {
             trimOptional(service.defaultServingRevisionId) ||
             trimOptional(service.deploymentStatus),
         }),
+        canDelete: Boolean(memberId),
         tone: resolveServiceMemberTone(service.deploymentStatus),
       }, memberDuplicateKeys);
     }
@@ -9834,6 +10087,7 @@ const StudioPage: React.FC = () => {
             formatStudioMemberLifecycleStage(memberSummary.lifecycleStage) ||
             'Backend member authority',
         }) || 'Backend member authority.',
+        canDelete: Boolean(memberId),
         canRename: Boolean(memberId),
         kind: 'member',
         meta: formatStudioAssetMeta({
@@ -10498,7 +10752,7 @@ const StudioPage: React.FC = () => {
           loading={selectedInventoryBusyAction === 'delete'}
           onClick={() =>
             selectedInventoryCanDelete
-              ? void handleDeleteWorkflowMember(selectedInventoryMemberKey)
+              ? void handleDeleteInventoryMember(selectedInventoryMemberKey)
               : undefined
           }
           title={selectedInventoryDeleteTitle}

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { setLocale } from "@umijs/max";
-import { message } from "antd";
+import { message, Modal } from "antd";
 import React from "react";
 import { scopesApi } from "@/shared/api/scopesApi";
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
@@ -34,6 +34,9 @@ jest.mock("antd", () => {
   const actual = jest.requireActual("antd");
   return {
     ...actual,
+    Modal: Object.assign(actual.Modal, {
+      confirm: jest.fn(),
+    }),
     message: {
       ...actual.message,
       success: jest.fn(),
@@ -890,6 +893,14 @@ jest.mock("@/shared/studio/api", () => ({
       ...mockCreateTeamSummary(),
       lifecycleStage: "archived",
     })),
+    deleteMember: jest.fn(async (_input: { scopeId: string; memberId: string }) => ({
+      ackedAt: "2026-05-01T08:08:00Z",
+      commandId: "cmd-delete-member",
+      correlationId: "corr-delete-member",
+      memberId: _input.memberId,
+      scopeId: _input.scopeId,
+      status: "delete_accepted",
+    })),
     listTeamMembers: jest.fn(async () => mockCreateTeamMembersCatalog()),
     parseYaml: jest.fn(async () => ({
       document: {
@@ -1038,12 +1049,26 @@ describe("TeamDetailPage", () => {
       correlationId: "corr-team-archive",
       ackedAt: "2026-05-01T08:07:00Z",
     }));
+    (studioApi.deleteMember as jest.Mock).mockReset();
+    (studioApi.deleteMember as jest.Mock).mockImplementation(
+      async (_input: { scopeId: string; memberId: string }) => ({
+        ackedAt: "2026-05-01T08:08:00Z",
+        commandId: "cmd-delete-member",
+        correlationId: "corr-delete-member",
+        memberId: _input.memberId,
+        scopeId: _input.scopeId,
+        status: "delete_accepted",
+      }),
+    );
     (studioApi.listTeamMembers as jest.Mock).mockReset();
     (studioApi.listTeamMembers as jest.Mock).mockImplementation(
       async () => mockCreateTeamMembersCatalog(),
     );
     (runtimeRunsApi.streamTeamChat as jest.Mock).mockClear();
+    (Modal.confirm as jest.Mock).mockClear();
     (message.success as jest.Mock).mockClear();
+    (message.info as jest.Mock).mockClear();
+    (message.warning as jest.Mock).mockClear();
     (message.error as jest.Mock).mockClear();
   });
 
@@ -1653,6 +1678,53 @@ describe("TeamDetailPage", () => {
     await waitFor(() => {
       expect(studioApi.getTeam).toHaveBeenCalledTimes(2);
       expect(studioApi.listTeamMembers).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("deletes a Studio member authority from the members tab", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha?memberId=member-team-alpha&tab=members",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("Team Alpha Operator")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "删除成员" }));
+
+    await waitFor(() => {
+      expect(Modal.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cancelText: "保留成员",
+          okButtonProps: { danger: true },
+          okText: "删除成员",
+          title: "删除成员",
+        }),
+      );
+    });
+
+    const confirmCalls = (Modal.confirm as jest.Mock).mock.calls;
+    const confirmConfig = confirmCalls[confirmCalls.length - 1]?.[0] as {
+      onOk?: () => Promise<void>;
+    };
+
+    await act(async () => {
+      await confirmConfig.onOk?.();
+    });
+
+    await waitFor(() => {
+      expect(studioApi.deleteMember).toHaveBeenCalledWith({
+        scopeId: "scope-1",
+        memberId: "member-team-alpha",
+      });
+    });
+    expect(message.success).toHaveBeenCalledWith(
+      "已删除成员 Team Alpha Operator。",
+    );
+    await waitFor(() => {
+      expect(new URLSearchParams(window.location.search).get("memberId")).toBeNull();
+      expect(new URLSearchParams(window.location.search).get("tab")).toBe("members");
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -493,6 +493,7 @@ const TeamDetailPage: React.FC = () => {
     React.useState<TeamTestLastResult | null>(null);
   const [teamTestModalOpen, setTeamTestModalOpen] = React.useState(false);
   const [entryActionBusyMemberId, setEntryActionBusyMemberId] = React.useState("");
+  const [deletingMemberId, setDeletingMemberId] = React.useState("");
   const teamTestAbortRef = React.useRef<AbortController | null>(null);
   const { token } = theme.useToken();
 
@@ -533,6 +534,7 @@ const TeamDetailPage: React.FC = () => {
     setTeamTestStatus("idle");
     setTeamTestModalOpen(routeState.testTeam);
     setEntryActionBusyMemberId("");
+    setDeletingMemberId("");
   }, [routeState.testTeam, scopeId, selectedTeamId]);
 
   React.useEffect(
@@ -1221,7 +1223,7 @@ const TeamDetailPage: React.FC = () => {
   const tabOptions: TeamTabOption[] = [
     { label: t("pages.teams.detail.copy.45", "Overview"), value: "overview" },
     { label: t("teams.detail.tabs.automations", "Automations"), value: "automations" },
-    { label: t("pages.teams.detail.copy.46", "team member"), value: "members" },
+    { label: t("pages.teams.detail.copy.46", "Team members"), value: "members" },
   ];
 
   const initialLoading =
@@ -1640,6 +1642,112 @@ const TeamDetailPage: React.FC = () => {
     teamSummaryQueryKey,
   ]);
 
+  const handleDeleteMember = React.useCallback(
+    (memberId: string) => {
+      const normalizedMemberId = trimText(memberId);
+      if (!scopeId || !selectedTeamId || !normalizedMemberId) {
+        return;
+      }
+
+      const memberRow =
+        teamRosterRows.find((row) => trimText(row.memberId) === normalizedMemberId) ??
+        null;
+      const memberLabel = trimText(memberRow?.name) || normalizedMemberId;
+
+      Modal.confirm({
+        autoFocusButton: "cancel",
+        cancelText: t("teams.members.delete.keep", "Keep member"),
+        centered: true,
+        content: (
+          <div style={{ display: "grid", gap: 12 }}>
+            <Typography.Text>
+              {t("teams.members.delete.confirm.body", "Delete")}{" "}
+              <Typography.Text strong>{memberLabel}</Typography.Text>{" "}
+              {t("teams.members.delete.confirm.body.suffix", "from this Team?")}
+            </Typography.Text>
+            <Typography.Text type="secondary">
+              {memberRow?.isEntryMember
+                ? t("teams.members.delete.entry.warning", "This member is the Team entry member. Deleting it removes the member authority and clears it from the Team roster; published service artifacts, revisions, and historical runs stay intact.")
+                : t("teams.members.delete.warning", "This removes the Studio member authority and Team roster entry. Published service artifacts, revisions, and historical runs stay intact.")}
+            </Typography.Text>
+          </div>
+        ),
+        okButtonProps: { danger: true },
+        okText: t("teams.members.actions.delete", "Delete member"),
+        title: t("teams.members.delete.title", "Delete member"),
+        onOk: async () => {
+          setDeletingMemberId(normalizedMemberId);
+          try {
+            try {
+              await studioApi.deleteMember({
+                scopeId,
+                memberId: normalizedMemberId,
+              });
+            } catch (error) {
+              if (!isStudioApiStatus(error, 404)) {
+                throw error;
+              }
+            }
+
+            queryClient.setQueryData<StudioMemberRoster | undefined>(
+              teamMembersQueryKey,
+              (current) =>
+                current
+                  ? {
+                      ...current,
+                      members: current.members.filter(
+                        (member) =>
+                          trimText(member.memberId) !== normalizedMemberId,
+                      ),
+                    }
+                  : current,
+            );
+            await refreshTeamAuthority();
+            if (
+              trimText(routeState.memberId) === normalizedMemberId ||
+              trimText(preferredMemberId) === normalizedMemberId
+            ) {
+              setPreferredMemberId("");
+              setPreferredServiceId("");
+              setPreferredRunId("");
+              history.replace(
+                buildTeamDetailHref({
+                  scopeId,
+                  teamId: selectedTeamId,
+                  tab: "members",
+                }),
+              );
+            }
+            void message.success(
+              t("teams.members.delete.success", "Deleted member {member}.", {
+                member: memberLabel,
+              }),
+            );
+          } catch (error) {
+            void message.error(
+              describeError(
+                error,
+                t("teams.members.delete.failed", "Failed to delete member."),
+              ),
+            );
+          } finally {
+            setDeletingMemberId("");
+          }
+        },
+      });
+    },
+    [
+      preferredMemberId,
+      queryClient,
+      refreshTeamAuthority,
+      routeState.memberId,
+      scopeId,
+      selectedTeamId,
+      teamMembersQueryKey,
+      teamRosterRows,
+    ],
+  );
+
   const teamTestPanel = (
     <TeamTestPanel
       createMemberHref={createMemberHref}
@@ -1714,10 +1822,16 @@ const TeamDetailPage: React.FC = () => {
     return (
       <TeamMembersTab
         createMemberHref={createMemberHref}
+        deletingMemberId={deletingMemberId}
         entryActionBusyMemberId={entryActionBusyMemberId}
         onClearEntry={
           teamSummaryQuery.data && !isTeamArchived && entryMemberId
             ? () => void handleClearEntry()
+            : undefined
+        }
+        onDeleteMember={
+          teamSummaryQuery.data && !isTeamArchived
+            ? (memberId) => handleDeleteMember(memberId)
             : undefined
         }
         onNavigate={(href) => history.push(href)}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -1,6 +1,7 @@
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,
+  DeleteOutlined,
   HistoryOutlined,
   PlayCircleOutlined,
   PlusOutlined,
@@ -53,8 +54,10 @@ type TeamMembersTabProps = {
   readonly rosterRows?: readonly TeamRosterMemberRow[];
   readonly rosterSyncing?: boolean;
   readonly createMemberHref?: string;
+  readonly deletingMemberId?: string;
   readonly entryActionBusyMemberId?: string;
   readonly onClearEntry?: () => void;
+  readonly onDeleteMember?: (memberId: string) => void;
   readonly onNavigate?: (href: string) => void;
   readonly onSetEntry?: (memberId: string) => void;
 };
@@ -69,7 +72,7 @@ const ellipsisTextStyle: React.CSSProperties = {
 };
 
 const tableGridTemplateColumns =
-  "minmax(260px, 1.4fr) minmax(140px, 0.45fr) minmax(180px, 0.7fr) 220px";
+  "minmax(260px, 1.4fr) minmax(140px, 0.45fr) minmax(180px, 0.7fr) 252px";
 
 const tableShellStyle: React.CSSProperties = {
   borderRadius: 8,
@@ -114,7 +117,8 @@ const responsiveTableStyle = `
   .team-members-table-published-runs-action,
   .team-members-table-automate-action,
   .team-members-table-studio-action,
-  .team-members-table-entry-action {
+  .team-members-table-entry-action,
+  .team-members-table-delete-action {
     min-width: 0 !important;
   }
 }
@@ -292,8 +296,10 @@ const EllipsisText: React.FC<{
 
 const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
   createMemberHref = "",
+  deletingMemberId = "",
   entryActionBusyMemberId = "",
   onClearEntry,
+  onDeleteMember,
   onNavigate,
   onSetEntry,
   rosterError = false,
@@ -304,6 +310,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
   const intl = useIntl();
   const { token } = theme.useToken();
   const isEntryActionBusy = entryActionBusyMemberId.trim().length > 0;
+  const isDeleteActionBusy = deletingMemberId.trim().length > 0;
   const tableFrameStyle: React.CSSProperties = {
     ...tableShellStyle,
     border: `1px solid ${token.colorBorderSecondary}`,
@@ -420,6 +427,12 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                         size="small"
                         style={memberActionButtonBaseStyle}
                       />
+                      <Skeleton.Button
+                        active
+                        className="team-members-table-delete-action"
+                        size="small"
+                        style={memberActionButtonBaseStyle}
+                      />
                     </div>
                   </div>
                 </div>
@@ -510,6 +523,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                         id: "teams.members.actions.workflowOnlyTitle",
                       });
                   const rowBusy = entryActionBusyMemberId === row.memberId;
+                  const rowDeleting = deletingMemberId === row.memberId;
                   const invokeActionLabel = intl.formatMessage({
                     id: "teams.members.actions.invokeWorkflow",
                   });
@@ -531,9 +545,21 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                   ) : (
                     <CheckCircleOutlined />
                   );
+                  const deleteActionLabel = intl.formatMessage({
+                    defaultMessage: "Delete member",
+                    id: "teams.members.actions.delete",
+                  });
                   const buildMemberActionButtonStyle = (
-                    tone: "default" | "primary" | "success" = "default",
+                    tone: "danger" | "default" | "primary" | "success" = "default",
                   ): React.CSSProperties => {
+                    if (tone === "danger") {
+                      return {
+                        ...memberActionButtonBaseStyle,
+                        background: token.colorErrorBg,
+                        color: token.colorError,
+                      };
+                    }
+
                     if (tone === "success") {
                       return {
                         ...memberActionButtonBaseStyle,
@@ -765,7 +791,8 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                                 disabled={
                                   rowBusy ||
                                   (isEntryActionBusy &&
-                                    entryActionBusyMemberId !== row.memberId)
+                                    entryActionBusyMemberId !== row.memberId) ||
+                                  isDeleteActionBusy
                                 }
                                 loading={entryActionBusyMemberId === row.memberId}
                                 onClick={onClearEntry}
@@ -782,13 +809,34 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                                 disabled={
                                   rowBusy ||
                                   (isEntryActionBusy &&
-                                    entryActionBusyMemberId !== row.memberId)
+                                    entryActionBusyMemberId !== row.memberId) ||
+                                  isDeleteActionBusy
                                 }
                                 icon={entryActionIcon}
                                 loading={entryActionBusyMemberId === row.memberId}
                                 onClick={() => onSetEntry(row.memberId)}
                                 size="small"
                                 style={buildMemberActionButtonStyle()}
+                                type="default"
+                              />
+                            </Tooltip>
+                          ) : null}
+                          {onDeleteMember ? (
+                            <Tooltip title={deleteActionLabel}>
+                              <Button
+                                aria-label={deleteActionLabel}
+                                className="team-members-table-action-button team-members-table-delete-action"
+                                disabled={
+                                  rowDeleting ||
+                                  (isDeleteActionBusy &&
+                                    deletingMemberId !== row.memberId) ||
+                                  isEntryActionBusy
+                                }
+                                icon={<DeleteOutlined />}
+                                loading={rowDeleting}
+                                onClick={() => onDeleteMember(row.memberId)}
+                                size="small"
+                                style={buildMemberActionButtonStyle("danger")}
                                 type="default"
                               />
                             </Tooltip>

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -2273,6 +2273,52 @@ describe('studioApi host-session requests', () => {
     );
   });
 
+  it('deletes an existing member with the member delete endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => ({
+        status: 'delete_accepted',
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+        ackedAt: '2026-07-09T08:12:00Z',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.deleteMember({
+        scopeId: 'scope-1',
+        memberId: 'm-alpha',
+      }),
+    ).resolves.toEqual({
+      status: 'delete_accepted',
+      scopeId: 'scope-1',
+      memberId: 'm-alpha',
+      ackedAt: '2026-07-09T08:12:00Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/members/m-alpha',
+      expect.objectContaining({
+        credentials: 'same-origin',
+        method: 'DELETE',
+      }),
+    );
+  });
+
   it('synthesizes a member command response from legacy member detail for team patch responses', async () => {
     persistAuthSession({
       tokens: {

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -1647,12 +1647,34 @@ function normalizeStudioMemberBindingRunRole(
 function normalizeStudioMemberCommandStatus(
   value: string | number | null | undefined
 ): StudioMemberCommandStatus {
-  return normalizeCommandReceiptStatus(value);
+  if (value == null) {
+    return "unknown";
+  }
+
+  const normalized = normalizeEnumValue(value, "status", {
+    "0": "unknown",
+    "1": "accepted",
+    "2": "no_change",
+    "3": "delete_accepted",
+    accepted: "accepted",
+    delete_accepted: "delete_accepted",
+    deleteaccepted: "delete_accepted",
+    no_change: "no_change",
+    nochange: "no_change",
+    unchanged: "no_change",
+    unknown: "unknown",
+  });
+
+  return normalized === "accepted" ||
+    normalized === "delete_accepted" ||
+    normalized === "no_change"
+    ? normalized
+    : "unknown";
 }
 
 function normalizeCommandReceiptStatus(
   value: string | number | null | undefined
-): StudioMemberCommandStatus | StudioTeamCommandStatus {
+): StudioTeamCommandStatus {
   if (value == null) {
     return "unknown";
   }
@@ -2127,6 +2149,20 @@ export const studioApi = {
             agentKind: trimOptional(input.implementationRef.agentKind),
           }),
         }),
+      }
+    );
+  },
+
+  deleteMember(input: {
+    scopeId: string;
+    memberId: string;
+  }): Promise<StudioMemberCommandResponse> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members/${encodeURIComponent(input.memberId.trim())}`,
+      decodeStudioMemberCommandResponse,
+      {
+        method: "DELETE",
+        headers: JSON_HEADERS,
       }
     );
   },

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -610,6 +610,7 @@ export interface StudioMemberBindingAcceptedResponse {
 
 export type StudioMemberCommandStatus =
   | 'accepted'
+  | 'delete_accepted'
   | 'no_change'
   | 'unknown';
 


### PR DESCRIPTION
## Summary
- Add frontend API support for `DELETE /api/scopes/:scopeId/members/:memberId` and decode `delete_accepted` member command responses.
- Add member deletion from the Studio inventory rail for real `member:` identities while preserving workflow draft deletion for `workflow:` identities.
- Add delete actions to the Team members tab with confirmation copy, optimistic roster cleanup, route cleanup, and localized labels.

## Impact
- Operators can delete Studio member authority entries from both Team details and Studio member inventory.
- Published service artifacts, revisions, and historical runs are intentionally left intact.
- The Team members tab label now uses `Team members` casing to match neighboring tabs.

## Validation
- `pnpm --dir apps/aevatar-console-web test -- --runInBand src/shared/studio/api.test.ts src/pages/studio/index.test.tsx`
- `pnpm --dir apps/aevatar-console-web test -- --runInBand src/pages/teams/detail.test.tsx`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
