### PR TITLE
拆分本机密钥来源与明文回退语义

### DIFF
--- a/src/Aevatar.Configuration/AevatarSecretsStore.cs
+++ b/src/Aevatar.Configuration/AevatarSecretsStore.cs
@@ -214,7 +214,14 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
 
         if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
         {
-            try { File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch (Exception ex) when (ObserveRecovery(ex, "Unable to update permissions for the temporary secrets file; continuing.")) { }
+            try
+            {
+                File.SetUnixFileMode(tempFile, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            catch (Exception ex)
+            {
+                LogWarning(ex, "Unable to update permissions for the temporary secrets file; continuing.");
+            }
         }
 
         try
@@ -228,7 +235,10 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
                 if (File.Exists(tempFile))
                     File.Delete(tempFile);
             }
-            catch (Exception ex) when (ObserveRecovery(ex, "Unable to clean up the temporary secrets file after an atomic write attempt; continuing.")) { }
+            catch (Exception ex)
+            {
+                LogWarning(ex, "Unable to clean up the temporary secrets file after an atomic write attempt; continuing.");
+            }
         }
     }
 
@@ -250,8 +260,9 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
             gcm.Decrypt(nonce, ciphertext, tag, plaintext, Encoding.UTF8.GetBytes(Aad));
             return plaintext;
         }
-        catch (Exception ex) when (ObserveRecovery(ex, "Unable to decrypt the encrypted secrets payload; returning no plaintext."))
+        catch (Exception ex)
         {
+            LogWarning(ex, "Unable to decrypt the encrypted secrets payload; returning no plaintext.");
             return null;
         }
     }
@@ -260,6 +271,11 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
 
     private byte[]? TryGetMasterKey()
     {
+        if (!_protectionOptions.UseLocalMasterKeySources)
+        {
+            return null;
+        }
+
         // Priority 1: macOS Keychain
         if (OperatingSystem.IsMacOS())
         {
@@ -297,7 +313,15 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
             p.Start();
             if (!p.WaitForExit(2000))
             {
-                try { p.Kill(entireProcessTree: true); } catch (Exception ex) when (ObserveRecovery(ex, "Unable to stop the timed-out macOS Keychain lookup process; returning no keychain key.")) { }
+                try
+                {
+                    p.Kill(entireProcessTree: true);
+                }
+                catch (Exception ex)
+                {
+                    LogWarning(ex, "Unable to stop the timed-out macOS Keychain lookup process; returning no keychain key.");
+                }
+
                 return null;
             }
 
@@ -307,8 +331,9 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
             var bytes = Convert.FromBase64String(b64);
             return bytes.Length == KeyBytes ? bytes : null;
         }
-        catch (Exception ex) when (ObserveRecovery(ex, "Unable to resolve the macOS Keychain master key; returning no keychain key."))
+        catch (Exception ex)
         {
+            LogWarning(ex, "Unable to resolve the macOS Keychain master key; returning no keychain key.");
             return null;
         }
     }
@@ -321,17 +346,17 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
             var bytes = File.ReadAllBytes(path);
             return bytes.Length == KeyBytes ? bytes : null;
         }
-        catch (Exception ex) when (ObserveRecovery(ex, "Unable to load the file-based master key; returning no master key."))
+        catch (Exception ex)
         {
+            LogWarning(ex, "Unable to load the file-based master key; returning no master key.");
             return null;
         }
     }
 
-    private static bool ObserveRecovery(Exception exception, string message)
+    private static void LogWarning(Exception exception, string message)
     {
         Console.Error.WriteLine(
             $"{nameof(AevatarSecretsStore)}: warning: {message} ExceptionType={exception.GetType().FullName}.");
-        return true;
     }
 
     // ─── Envelope model ───

--- a/src/Aevatar.Configuration/LocalSecretProtectionOptions.cs
+++ b/src/Aevatar.Configuration/LocalSecretProtectionOptions.cs
@@ -1,15 +1,21 @@
 namespace Aevatar.Configuration;
 
-public sealed record LocalSecretProtectionOptions(bool AllowPlaintextSecrets)
+public enum LocalSecretMasterKeySource
+{
+    Auto,
+    Disabled,
+}
+
+public sealed record LocalSecretProtectionOptions(
+    bool AllowPlaintextSecrets,
+    LocalSecretMasterKeySource MasterKeySource = LocalSecretMasterKeySource.Auto)
 {
     public const string AllowPlaintextSecretsEnv = "AEVATAR_ALLOW_PLAINTEXT_SECRETS";
 
     public static LocalSecretProtectionOptions FromEnvironment() =>
         new(IsEnvironmentPlaintextOptInEnabled());
 
-    public static readonly LocalSecretProtectionOptions NoPlaintextNoKeychain = new(false);
-
-    public static readonly LocalSecretProtectionOptions DevelopmentPlaintextNoKeychain = new(true);
+    public bool UseLocalMasterKeySources => MasterKeySource == LocalSecretMasterKeySource.Auto;
 
     public static bool IsEnvironmentPlaintextOptInEnabled() =>
         string.Equals(

--- a/src/Aevatar.Studio.Infrastructure/Storage/FileAevatarSettingsStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/Storage/FileAevatarSettingsStore.cs
@@ -359,6 +359,11 @@ public sealed class FileAevatarSettingsStore : IAevatarSettingsStore
 
     private byte[]? TryGetMasterKey()
     {
+        if (!_protectionOptions.UseLocalMasterKeySources)
+        {
+            return null;
+        }
+
         if (OperatingSystem.IsMacOS())
         {
             var key = TryGetKeychainKey();

--- a/test/Aevatar.Integration.Tests/SecretsStoreTests.cs
+++ b/test/Aevatar.Integration.Tests/SecretsStoreTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.Configuration;
 using FluentAssertions;
+using System.Security.Cryptography;
 
 namespace Aevatar.Integration.Tests;
 
@@ -22,7 +23,7 @@ public class SecretsStoreTests
 
         try
         {
-            var store = new AevatarSecretsStore(path, LocalSecretProtectionOptions.DevelopmentPlaintextNoKeychain);
+            var store = new AevatarSecretsStore(path, PlaintextAllowedNoLocalMasterKeySources);
 
             store.Get("Custom:Value").Should().Be("x");
             store.GetApiKey("deepseek").Should().Be("k1");
@@ -45,7 +46,7 @@ public class SecretsStoreTests
 
         try
         {
-            var act = () => new AevatarSecretsStore(path, LocalSecretProtectionOptions.NoPlaintextNoKeychain);
+            var act = () => new AevatarSecretsStore(path, NoPlaintextNoLocalMasterKeySources);
 
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("*plaintext*AEVATAR_ALLOW_PLAINTEXT_SECRETS*");
@@ -94,7 +95,8 @@ public class SecretsStoreTests
 
         try
         {
-            var store = new AevatarSecretsStore(path, LocalSecretProtectionOptions.NoPlaintextNoKeychain);
+            WriteSiblingMasterKey(path);
+            var store = new AevatarSecretsStore(path, NoPlaintextNoLocalMasterKeySources);
 
             var act = () => store.Set("K1", "V1");
 
@@ -116,12 +118,13 @@ public class SecretsStoreTests
 
         try
         {
-            var store = new AevatarSecretsStore(path, LocalSecretProtectionOptions.DevelopmentPlaintextNoKeychain);
+            WriteSiblingMasterKey(path);
+            var store = new AevatarSecretsStore(path, PlaintextAllowedNoLocalMasterKeySources);
             store.Set("K1", "V1");
             store.Set("K2", "V2");
             store.Remove("K1");
 
-            var reloaded = new AevatarSecretsStore(path, LocalSecretProtectionOptions.DevelopmentPlaintextNoKeychain);
+            var reloaded = new AevatarSecretsStore(path, PlaintextAllowedNoLocalMasterKeySources);
             reloaded.Get("K1").Should().BeNull();
             reloaded.Get("K2").Should().Be("V2");
 
@@ -144,12 +147,12 @@ public class SecretsStoreTests
 
         try
         {
-            var store = new AevatarSecretsStore(path, LocalSecretProtectionOptions.DevelopmentPlaintextNoKeychain);
+            var store = new AevatarSecretsStore(path, PlaintextAllowedNoLocalMasterKeySources);
             store.GetAll().Should().BeEmpty();
 
             store.Set("After", "Write");
 
-            var reloaded = new AevatarSecretsStore(path, LocalSecretProtectionOptions.DevelopmentPlaintextNoKeychain);
+            var reloaded = new AevatarSecretsStore(path, PlaintextAllowedNoLocalMasterKeySources);
             reloaded.Get("After").Should().Be("Write");
         }
         finally
@@ -176,6 +179,19 @@ public class SecretsStoreTests
         {
             // no-op
         }
+    }
+
+    private static LocalSecretProtectionOptions NoPlaintextNoLocalMasterKeySources =>
+        new(false, LocalSecretMasterKeySource.Disabled);
+
+    private static LocalSecretProtectionOptions PlaintextAllowedNoLocalMasterKeySources =>
+        new(true, LocalSecretMasterKeySource.Disabled);
+
+    private static void WriteSiblingMasterKey(string secretsPath)
+    {
+        var directory = Path.GetDirectoryName(secretsPath);
+        Directory.CreateDirectory(directory!);
+        File.WriteAllBytes(Path.Combine(directory!, "masterkey.bin"), RandomNumberGenerator.GetBytes(32));
     }
 
     private sealed class EnvironmentVariableScope : IDisposable

--- a/test/Aevatar.Studio.Tests/FileAevatarSettingsStoreSecretProtectionTests.cs
+++ b/test/Aevatar.Studio.Tests/FileAevatarSettingsStoreSecretProtectionTests.cs
@@ -2,6 +2,7 @@ using Aevatar.Configuration;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Infrastructure.Storage;
 using FluentAssertions;
+using System.Security.Cryptography;
 
 namespace Aevatar.Studio.Tests;
 
@@ -15,7 +16,8 @@ public sealed class FileAevatarSettingsStoreSecretProtectionTests
 
         try
         {
-            var store = new FileAevatarSettingsStore(path, LocalSecretProtectionOptions.NoPlaintextNoKeychain);
+            WriteSiblingMasterKey(path);
+            var store = new FileAevatarSettingsStore(path, NoPlaintextNoLocalMasterKeySources);
             var settings = new StoredAevatarSettings(
                 path,
                 "openai",
@@ -52,7 +54,8 @@ public sealed class FileAevatarSettingsStoreSecretProtectionTests
 
         try
         {
-            var store = new FileAevatarSettingsStore(path, LocalSecretProtectionOptions.DevelopmentPlaintextNoKeychain);
+            WriteSiblingMasterKey(path);
+            var store = new FileAevatarSettingsStore(path, PlaintextAllowedNoLocalMasterKeySources);
             var settings = new StoredAevatarSettings(
                 path,
                 "openai",
@@ -78,5 +81,18 @@ public sealed class FileAevatarSettingsStoreSecretProtectionTests
             if (Directory.Exists(dir))
                 Directory.Delete(dir, recursive: true);
         }
+    }
+
+    private static LocalSecretProtectionOptions NoPlaintextNoLocalMasterKeySources =>
+        new(false, LocalSecretMasterKeySource.Disabled);
+
+    private static LocalSecretProtectionOptions PlaintextAllowedNoLocalMasterKeySources =>
+        new(true, LocalSecretMasterKeySource.Disabled);
+
+    private static void WriteSiblingMasterKey(string secretsPath)
+    {
+        var directory = Path.GetDirectoryName(secretsPath);
+        Directory.CreateDirectory(directory!);
+        File.WriteAllBytes(Path.Combine(directory!, "masterkey.bin"), RandomNumberGenerator.GetBytes(32));
     }
 }

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -23,12 +23,6 @@ src/Aevatar.AI.ToolProviders.Skills/SkillScriptExtractor.cs	119	empty broad catc
 src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs	47	empty broad catch block
 src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs	59	empty broad catch block
 src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs	170	broad catch returns null without visible failure signal
-src/Aevatar.Configuration/AevatarSecretsStore.cs	217	empty broad catch block
-src/Aevatar.Configuration/AevatarSecretsStore.cs	231	empty broad catch block
-src/Aevatar.Configuration/AevatarSecretsStore.cs	253	broad catch returns null without visible failure signal
-src/Aevatar.Configuration/AevatarSecretsStore.cs	300	empty broad catch block
-src/Aevatar.Configuration/AevatarSecretsStore.cs	310	broad catch returns null without visible failure signal
-src/Aevatar.Configuration/AevatarSecretsStore.cs	324	broad catch returns null without visible failure signal
 src/Aevatar.Foundation.Abstractions/Observability/AevatarActivitySource.cs	248	empty broad catch block
 src/Aevatar.Foundation.Abstractions/Observability/AevatarActivitySource.cs	263	empty broad catch block
 src/Aevatar.Foundation.Abstractions/Observability/AevatarActivitySource.cs	275	broad catch returns null without visible failure signal


### PR DESCRIPTION
## Changed files
- `src/Aevatar.Configuration/LocalSecretProtectionOptions.cs`：新增 `LocalSecretMasterKeySource`，将本机 master-key 来源与 plaintext fallback 拆成两个 typed option。
- `src/Aevatar.Configuration/AevatarSecretsStore.cs`、`src/Aevatar.Studio.Infrastructure/Storage/FileAevatarSettingsStore.cs`：两个 store 的 `TryGetMasterKey()` 统一尊重 `UseLocalMasterKeySources`。
- `test/Aevatar.Studio.Tests/FileAevatarSettingsStoreSecretProtectionTests.cs`、`test/Aevatar.Integration.Tests/SecretsStoreTests.cs`：测试显式使用 Disabled source，并通过 sibling `masterkey.bin` 验证不再依赖开发机本机密钥环境。
- `tools/ci/guards/catch_exception_observability_baseline.tsv`：删除已修复的 stale catch-observability baseline。

## Test results
- `bash -lc "dotnet build aevatar.slnx --nologo"`：passed。
- `bash -lc "dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --filter FileAevatarSettingsStoreSecretProtectionTests --nologo"`：passed。
- `bash -lc "dotnet test test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj --filter SecretsStoreTests --nologo"`：passed。
- `bash -lc "bash tools/ci/test_stability_guards.sh"`：passed。
- `bash -lc "dotnet test aevatar.slnx --nologo"`：passed。
- `bash -lc "bash tools/ci/architecture_guards.sh"`：passed。

## Deviations
- scope 扩展仅用于删除 catch-observability guard 提示的 stale baseline；未扩展业务实现范围。
- refactor self-doc: not applicable (HOST_REFACTOR_COMMENT_POLICY=none)
- Closes #2703
⟦AI:AUTO-LOOP⟧
