### PR TITLE
Expose schedule-filtered member run history

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -3248,6 +3248,7 @@ const response = await fetch("{{invokePath}}", {
             scopeId,
             serviceId,
             binding.RunId,
+            string.Empty,
             binding.ActorId,
             binding.EffectiveDefinitionActorId,
             deployment?.RevisionId ?? string.Empty,
@@ -3297,6 +3298,7 @@ const response = await fetch("{{invokePath}}", {
             scopeId,
             serviceId,
             snapshot.RunId,
+            snapshot.ScheduleId,
             // ActorId stays the controllable target so existing resume/signal/stop
             // round-trips keep working; the registry actor is internal infra.
             snapshot.TargetActorId,
@@ -3374,6 +3376,7 @@ const response = await fetch("{{invokePath}}", {
             memberResolution.MemberId,
             memberResolution.PublishedServiceId,
             summary.RunId,
+            summary.ScheduleId,
             summary.ActorId,
             summary.DefinitionActorId,
             summary.RevisionId,
@@ -3392,7 +3395,14 @@ const response = await fetch("{{invokePath}}", {
             summary.LastOutput,
             summary.LastError,
             summary.SagaStatus,
-            summary.DeadLetter);
+            summary.DeadLetter,
+            summary.ImplementationKind,
+            summary.Status,
+            summary.CommandId,
+            summary.CorrelationId,
+            summary.EndpointId,
+            summary.TargetActorId,
+            summary.CreatedAt);
     }
 
     private static ScopeServiceRunDeadLetterHttpResponse? BuildScopeServiceRunDeadLetter(
@@ -4571,6 +4581,7 @@ const response = await fetch("{{invokePath}}", {
         string ScopeId,
         string ServiceId,
         string RunId,
+        string ScheduleId,
         string ActorId,
         string DefinitionActorId,
         string RevisionId,
@@ -4603,6 +4614,7 @@ const response = await fetch("{{invokePath}}", {
         string MemberId,
         string PublishedServiceId,
         string RunId,
+        string ScheduleId,
         string ActorId,
         string DefinitionActorId,
         string RevisionId,
@@ -4621,7 +4633,14 @@ const response = await fetch("{{invokePath}}", {
         string LastOutput,
         string LastError,
         WorkflowSagaStatus SagaStatus,
-        ScopeServiceRunDeadLetterHttpResponse? DeadLetter);
+        ScopeServiceRunDeadLetterHttpResponse? DeadLetter,
+        string ImplementationKind,
+        string Status,
+        string CommandId,
+        string CorrelationId,
+        string EndpointId,
+        string TargetActorId,
+        DateTimeOffset? CreatedAt = null);
 
     public sealed record ScopeServiceRunDeadLetterHttpResponse(
         string FailedCompensationStepId,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
@@ -616,6 +616,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         response.Should().NotBeNull();
         response!.Runs.Select(x => x.RunId).Should().Equal("run-match");
+        response.Runs[0].ScheduleId.Should().Be("schedule-a");
     }
 
     [Fact]
@@ -668,8 +669,16 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
         httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Should().NotBeNull();
         response!.Runs.Select(x => x.RunId).Should().Equal("run-member-match");
+        response.Runs[0].ScheduleId.Should().Be("schedule-member");
         response.Runs[0].ActorId.Should().Be("run-actor-member-registry");
         response.Runs[0].DefinitionActorId.Should().Be("def-member-registry");
+        response.Runs[0].ImplementationKind.Should().Be(ServiceImplementationKind.Workflow.ToString());
+        response.Runs[0].Status.Should().Be(ServiceRunStatus.Completed.ToString());
+        response.Runs[0].CommandId.Should().Be("cmd-run-member-match");
+        response.Runs[0].CorrelationId.Should().Be("corr-run-member-match");
+        response.Runs[0].EndpointId.Should().Be("run");
+        response.Runs[0].TargetActorId.Should().Be("run-actor-member-registry");
+        response.Runs[0].CreatedAt.Should().Be(baseTime.AddHours(1).AddMinutes(-5));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Expose `ScheduleId` on scope service run summaries and member run summaries.
- Keep member run history resolved through `memberId -> publishedServiceId` while returning the service run diagnostics needed by the frontend.
- Add integration assertions for schedule-filtered service and member run history responses.

## Validation
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter ScopeServiceRunQueryEndpointTests --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`
- `git diff --check`

Fixes #2718