### PR TITLE
Fix responsive clipping across Team console surfaces

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -389,6 +389,12 @@ describe('StudioMemberInvokePanel', () => {
     expect(screen.getByRole('button', { name: 'Start run' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Run workflow' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Technical details' })).toBeTruthy();
+    expect(screen.getByTestId('studio-invoke-target-actions')).toHaveStyle({
+      flex: '0 1 auto',
+      flexWrap: 'wrap',
+      maxWidth: '100%',
+      minWidth: 0,
+    });
     expect(screen.queryByRole('button', { name: 'Details' })).toBeNull();
     expect(screen.getByText('Current run')).toBeTruthy();
     expect(screen.getByText('No run result yet')).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
@@ -472,10 +472,12 @@ const memberRunMetricLabelStyle: React.CSSProperties = {
 const targetActionStyle: React.CSSProperties = {
   alignItems: 'center',
   display: 'flex',
-  flex: '0 0 auto',
+  flex: '0 1 auto',
   flexWrap: 'wrap',
   gap: 8,
   justifyContent: 'flex-end',
+  maxWidth: '100%',
+  minWidth: 0,
 };
 
 const memberRunTargetActionStyle: React.CSSProperties = {
@@ -1912,6 +1914,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
               </div>
             </div>
             <div
+              data-testid="studio-invoke-target-actions"
               style={
                 isMemberRunSurface
                   ? memberRunTargetActionStyle

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -96,10 +96,12 @@ const workflowStudioHeaderCss = `
 .workflow-studio-header__identity {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
+  overflow: visible;
+  row-gap: 6px;
+  white-space: normal;
 }
 
 .workflow-studio-header__back-button {
@@ -121,8 +123,9 @@ const workflowStudioHeaderCss = `
 .workflow-studio-header__title-zone {
   align-items: center;
   display: flex;
-  flex: 1 1 auto;
+  flex: 1 1 280px;
   gap: 8px;
+  max-width: 100%;
   min-width: 0;
 }
 
@@ -135,6 +138,7 @@ const workflowStudioHeaderCss = `
   font-weight: 600;
   gap: 6px;
   min-width: 0;
+  overflow: hidden;
 }
 
 .workflow-studio-header__breadcrumb-link {
@@ -169,10 +173,10 @@ const workflowStudioHeaderCss = `
   border: 1px solid transparent;
   border-radius: 6px;
   display: inline-flex;
-  flex: 1 1 220px;
+  flex: 1 1 180px;
   gap: 4px;
-  max-width: 360px;
-  min-width: 96px;
+  max-width: min(360px, 100%);
+  min-width: 0;
   padding: 0 2px 0 6px;
 }
 
@@ -183,7 +187,9 @@ const workflowStudioHeaderCss = `
 }
 
 .workflow-studio-header__title-input {
+  flex: 1 1 auto;
   min-width: 0;
+  width: 100%;
 }
 
 .workflow-studio-header__title-input.ant-input {
@@ -223,7 +229,8 @@ const workflowStudioHeaderCss = `
   align-items: center;
   border: 0;
   display: inline-flex;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
   gap: 6px;
   margin: 0;
   min-inline-size: 0;
@@ -248,10 +255,11 @@ const workflowStudioHeaderCss = `
 .workflow-studio-header__actions {
   align-items: center;
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 4px;
   justify-content: flex-end;
-  min-width: max-content;
+  max-width: 100%;
+  min-width: 0;
   white-space: nowrap;
 }
 
@@ -289,7 +297,7 @@ const workflowStudioHeaderCss = `
   width: 30px;
 }
 
-@media (max-width: 1080px) {
+@media (max-width: 1320px) {
   .workflow-studio-header__breadcrumbs {
     display: none;
   }
@@ -312,6 +320,17 @@ const workflowStudioHeaderCss = `
   }
 }
 
+@media (max-width: 980px) {
+  .workflow-studio-header__row {
+    align-items: start;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workflow-studio-header__actions {
+    justify-content: flex-start;
+  }
+}
+
 @media (max-width: 760px) {
   .workflow-studio-header {
     padding-inline: 10px;
@@ -319,7 +338,6 @@ const workflowStudioHeaderCss = `
 
   .workflow-studio-header__row {
     gap: 10px;
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .workflow-studio-header__title-shell {
@@ -329,7 +347,6 @@ const workflowStudioHeaderCss = `
   .workflow-studio-header__actions {
     justify-content: flex-start;
     min-width: 0;
-    overflow-x: auto;
     padding-bottom: 2px;
   }
 
@@ -691,7 +708,7 @@ const HeaderActions: React.FC<HeaderActionsProps> = ({
         'Workflow primary actions',
       )}
       className="workflow-studio-header__actions"
-      data-nowrap="true"
+      data-responsive-actions="true"
       data-testid="workflow-header-primary-actions"
     >
       <Button

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -170,6 +170,14 @@ jest.mock("@/shared/agui/sseFrameNormalizer", () => ({
   parseBackendSSEStream: jest.fn(),
 }));
 
+function findRenderedStyleText(fragment: string): string {
+  return (
+    Array.from(document.querySelectorAll("style"))
+      .map((styleElement) => styleElement.textContent ?? "")
+      .find((styleText) => styleText.includes(fragment)) ?? ""
+  );
+}
+
 const mockWorkflowDocument = {
   name: "Support workflow",
   roles: [
@@ -3811,7 +3819,26 @@ describe("TeamMemberWorkflowStudioPage", () => {
     const headerMainRow = screen.getByTestId("workflow-header-main-row");
     expect(headerMainRow).toHaveClass("workflow-studio-header__row");
     expect(headerPrimaryActions).toHaveClass("workflow-studio-header__actions");
-    expect(headerPrimaryActions).toHaveAttribute("data-nowrap", "true");
+    expect(headerPrimaryActions).toHaveAttribute("data-responsive-actions", "true");
+    const titleShell = headerIdentity.querySelector(
+      ".workflow-studio-header__title-shell",
+    );
+    expect(titleShell).toBeTruthy();
+    const headerResponsiveRules = findRenderedStyleText(
+      ".workflow-studio-header__identity",
+    );
+    expect(headerResponsiveRules).toContain(
+      ".workflow-studio-header__identity",
+    );
+    expect(headerResponsiveRules).toContain("overflow: visible;");
+    expect(headerResponsiveRules).toContain("flex-wrap: wrap;");
+    expect(headerResponsiveRules).toContain(
+      "max-width: min(360px, 100%);",
+    );
+    expect(headerResponsiveRules).toContain("@media (max-width: 1320px)");
+    expect(headerResponsiveRules).toContain("@media (max-width: 980px)");
+    expect(headerResponsiveRules).toContain("overflow: hidden;");
+    expect(headerResponsiveRules).not.toContain("overflow-x: auto;");
     expect(screen.queryByTestId("workflow-header-context-row")).toBeNull();
     expect(screen.queryByTestId("workflow-header-node-actions")).toBeNull();
     expect(within(headerIdentity).getByRole("link", { name: "Team" })).toHaveAttribute(
@@ -4140,7 +4167,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
         .map((button) => button.getAttribute("aria-label") || button.textContent);
 
     expect(headerMainRow).toHaveClass("workflow-studio-header__row");
-    expect(headerPrimaryActions).toHaveAttribute("data-nowrap", "true");
+    expect(headerPrimaryActions).toHaveAttribute("data-responsive-actions", "true");
     expect(screen.queryByTestId("workflow-header-context-row")).toBeNull();
     expect(screen.queryByTestId("workflow-header-node-actions")).toBeNull();
     expect(readActionButtonNames()).toEqual([

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -2384,6 +2384,10 @@ describe("TeamDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
     await screen.findByLabelText("调用");
 
+    const memberTable = screen.getByTestId("team-members-table");
+    expect(memberTable).toHaveClass("team-members-table-container");
+    expect(memberTable).toHaveAttribute("data-responsive-layout", "container");
+
     const memberRow = document.querySelector(".team-members-table-row");
     expect(memberRow).toBeTruthy();
     expect(memberRow).toHaveStyle({
@@ -2412,15 +2416,6 @@ describe("TeamDetailPage", () => {
       within(memberActions as HTMLElement).getByLabelText("删除成员"),
     ).toBeTruthy();
 
-    const responsiveRules = collectRenderedStyleText();
-    expect(responsiveRules).toContain("@media (max-width: 1180px)");
-    expect(responsiveRules).toContain(
-      "grid-template-columns: minmax(0, 1fr) !important;",
-    );
-    expect(responsiveRules).toContain(
-      ".team-members-table-primary-actions",
-    );
-    expect(responsiveRules).toContain("width: 100% !important;");
   });
 
   it("renders member-owned automations from the backend schedules API", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -329,6 +329,12 @@ function mockCreateScheduledDispatchSummary(overrides?: Record<string, any>) {
   };
 }
 
+function collectRenderedStyleText(): string {
+  return Array.from(document.querySelectorAll("style"))
+    .map((styleElement) => styleElement.textContent ?? "")
+    .join("\n");
+}
+
 function mockCreateRunAudit(scopeId: string, runId: string) {
   return {
     summary: {
@@ -2371,6 +2377,52 @@ describe("TeamDetailPage", () => {
     ).toBeTruthy();
   });
 
+  it("keeps Team member row actions reachable before the tablet layout clips them", async () => {
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "编辑团队" });
+    fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
+    await screen.findByLabelText("调用");
+
+    const memberRow = document.querySelector(".team-members-table-row");
+    expect(memberRow).toBeTruthy();
+    expect(memberRow).toHaveStyle({
+      gridTemplateColumns:
+        "minmax(260px, 1.4fr) minmax(140px, 0.45fr) minmax(180px, 0.7fr) 252px",
+    });
+
+    const memberActions = memberRow?.querySelector(
+      ".team-members-table-primary-actions",
+    ) as HTMLElement | null;
+    expect(memberActions).toBeTruthy();
+    expect(within(memberActions as HTMLElement).getByLabelText("调用")).toBeTruthy();
+    expect(
+      within(memberActions as HTMLElement).getByLabelText("发布运行记录"),
+    ).toBeTruthy();
+    expect(
+      within(memberActions as HTMLElement).getByLabelText("自动化"),
+    ).toBeTruthy();
+    expect(
+      within(memberActions as HTMLElement).getByLabelText("Workflow Studio"),
+    ).toBeTruthy();
+    expect(
+      within(memberActions as HTMLElement).getByLabelText("清除入口成员"),
+    ).toBeTruthy();
+    expect(
+      within(memberActions as HTMLElement).getByLabelText("删除成员"),
+    ).toBeTruthy();
+
+    const responsiveRules = collectRenderedStyleText();
+    expect(responsiveRules).toContain("@media (max-width: 1180px)");
+    expect(responsiveRules).toContain(
+      "grid-template-columns: minmax(0, 1fr) !important;",
+    );
+    expect(responsiveRules).toContain(
+      ".team-members-table-primary-actions",
+    );
+    expect(responsiveRules).toContain("width: 100% !important;");
+  });
+
   it("renders member-owned automations from the backend schedules API", async () => {
     window.history.replaceState(
       {},
@@ -2400,6 +2452,41 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     expect(await screen.findByText("Daily escalation digest")).toBeTruthy();
+    const automationRow = screen.getByLabelText("Daily escalation digest");
+    expect(automationRow).toHaveClass("team-automation-row");
+    expect(automationRow).toHaveStyle({
+      gridTemplateColumns:
+        "minmax(0, 1.16fr) minmax(0, 0.72fr) minmax(0, 0.48fr) max-content",
+      width: "100%",
+    });
+    expect(
+      automationRow.querySelector(".team-automation-row__automation"),
+    ).toBeTruthy();
+    expect(
+      automationRow.querySelector(".team-automation-row__member"),
+    ).toBeTruthy();
+    expect(
+      automationRow.querySelector(".team-automation-row__schedule"),
+    ).toBeTruthy();
+    const automationActions = automationRow.querySelector(
+      ".team-automation-actions",
+    ) as HTMLElement | null;
+    expect(automationActions).toBeTruthy();
+    expect(automationActions?.style.inlineSize).toBe("max-content");
+    expect(automationActions?.style.minWidth).toBe("max-content");
+    expect(within(automationActions as HTMLElement).getByLabelText("编辑")).toBeTruthy();
+    expect(
+      within(automationActions as HTMLElement).getByLabelText("立即运行"),
+    ).toBeTruthy();
+    expect(within(automationActions as HTMLElement).getByLabelText("暂停")).toBeTruthy();
+    expect(within(automationActions as HTMLElement).getByLabelText("删除")).toBeTruthy();
+    const responsiveRules = collectRenderedStyleText();
+    expect(responsiveRules).toContain("@media (max-width: 900px)");
+    expect(responsiveRules).toContain(
+      "grid-template-columns: minmax(0, 1fr) max-content !important;",
+    );
+    expect(responsiveRules).toContain("@media (max-width: 640px)");
+    expect(responsiveRules).toContain("grid-row: auto;");
     expect(screen.getByText("计划")).toBeTruthy();
     expect(screen.getAllByText("运行中").length).toBeGreaterThan(0);
     expect(screen.getAllByText("已暂停").length).toBeGreaterThan(0);

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -230,6 +230,8 @@ const TeamCreatePage: React.FC = () => {
             flexDirection: 'column',
             gap: 18,
             maxWidth: 760,
+            minWidth: 0,
+            width: '100%',
           }}
         >
           <div style={{ display: 'grid', gap: 8 }}>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -131,9 +131,37 @@ const responsiveStyle = `
   transform: translateY(-1px);
 }
 
-@media (max-width: 1180px) {
+@media (max-width: 1320px) {
   .team-automations-layout {
     grid-template-columns: minmax(0, 1fr) !important;
+  }
+}
+
+.team-automation-row > * {
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .team-automation-list-header {
+    display: none !important;
+  }
+
+  .team-automation-row {
+    align-items: start !important;
+    grid-template-columns: minmax(0, 1fr) max-content !important;
+    gap: 12px !important;
+  }
+
+  .team-automation-row__automation,
+  .team-automation-row__member,
+  .team-automation-row__schedule {
+    grid-column: 1;
+  }
+
+  .team-automation-actions {
+    align-self: start;
+    grid-column: 2;
+    grid-row: 1 / span 3;
   }
 }
 
@@ -146,6 +174,16 @@ const responsiveStyle = `
     width: 100%;
   }
 
+  .team-automation-summary {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .team-automation-form-schedule-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+}
+
+@media (max-width: 640px) {
   .team-automation-row {
     grid-template-columns: minmax(0, 1fr) !important;
     gap: 12px !important;
@@ -153,20 +191,10 @@ const responsiveStyle = `
   }
 
   .team-automation-actions {
+    grid-column: 1;
+    grid-row: auto;
     justify-content: flex-start !important;
     width: 100%;
-  }
-
-  .team-automation-list-header {
-    display: none !important;
-  }
-
-  .team-automation-summary {
-    grid-template-columns: minmax(0, 1fr) !important;
-  }
-
-  .team-automation-form-schedule-grid {
-    grid-template-columns: minmax(0, 1fr) !important;
   }
 }
 
@@ -229,9 +257,10 @@ const commitmentRowStyle: React.CSSProperties = {
   display: "grid",
   gap: 14,
   gridTemplateColumns:
-    "minmax(180px, 1.16fr) minmax(132px, 0.72fr) minmax(112px, 0.48fr) minmax(142px, max-content)",
+    "minmax(0, 1.16fr) minmax(0, 0.72fr) minmax(0, 0.48fr) max-content",
   minWidth: 0,
   padding: 14,
+  width: "100%",
 };
 
 const automationSummaryGridStyle: React.CSSProperties = {
@@ -289,10 +318,13 @@ const automationActionGroupBaseStyle: React.CSSProperties = {
   alignItems: "center",
   borderRadius: 12,
   display: "flex",
+  flexWrap: "nowrap",
   gap: 4,
+  inlineSize: "max-content",
   justifyContent: "flex-end",
   justifySelf: "end",
-  minWidth: 0,
+  maxWidth: "100%",
+  minWidth: "max-content",
   padding: 4,
 };
 
@@ -1874,7 +1906,10 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   : undefined,
               }}
             >
-              <div style={{ display: "grid", gap: 7, minWidth: 0 }}>
+              <div
+                className="team-automation-row__automation"
+                style={{ display: "grid", gap: 7, minWidth: 0 }}
+              >
                 <div style={automationNameLineStyle}>
                   {renderStatusPill(schedule, manualRunFeedback)}
                   <Typography.Text ellipsis strong>
@@ -1904,7 +1939,10 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   </Typography.Text>
                 ) : null}
               </div>
-              <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+              <div
+                className="team-automation-row__member"
+                style={{ display: "grid", gap: 5, minWidth: 0 }}
+              >
                 <Typography.Text ellipsis strong>
                   {member?.name ||
                     intl.formatMessage({
@@ -1921,7 +1959,10 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   })}
                 />
               </div>
-              <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+              <div
+                className="team-automation-row__schedule"
+                style={{ display: "grid", gap: 5, minWidth: 0 }}
+              >
                 <FactLine
                   monospace={false}
                   text={scheduleCadence.summary}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.css
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.css
@@ -1,0 +1,58 @@
+.team-members-table-container {
+  container-name: team-members-table;
+  container-type: inline-size;
+}
+
+/* 928px = minimum columns (832px) + gaps (60px) + row inline padding (36px). */
+@container team-members-table (max-width: 928px) {
+  .team-members-table-header {
+    display: none !important;
+  }
+
+  .team-members-table-row {
+    align-items: flex-start !important;
+    gap: 12px !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+    min-height: 0 !important;
+    padding: 16px 18px !important;
+  }
+
+  .team-members-table-actions {
+    justify-content: flex-start !important;
+    width: 100% !important;
+  }
+
+  .team-members-table-primary-actions {
+    justify-content: flex-start !important;
+    width: 100% !important;
+  }
+
+  .team-members-table-invoke-action,
+  .team-members-table-published-runs-action,
+  .team-members-table-automate-action,
+  .team-members-table-studio-action,
+  .team-members-table-entry-action,
+  .team-members-table-delete-action {
+    min-width: 0 !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .team-members-table-primary-actions {
+    justify-content: flex-start !important;
+  }
+}
+
+.team-members-table-action-button {
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.team-members-table-action-button:hover,
+.team-members-table-action-button:focus-visible {
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08) !important;
+  transform: translateY(-1px);
+}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -19,6 +19,7 @@ import {
   DetailPill,
   FactLine,
 } from "../components/TeamDetailPrimitives";
+import "./TeamMembersTab.css";
 
 type TeamRosterMemberRow = {
   readonly automationDisabledReason: string;
@@ -76,8 +77,20 @@ const ellipsisTextStyle: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
+const tableGridMetrics = {
+  actionsMinWidth: 252,
+  columnGap: 20,
+  implementationMinWidth: 140,
+  memberMinWidth: 260,
+  rowPaddingInline: 18,
+  serviceMinWidth: 180,
+} as const;
+
 const tableGridTemplateColumns =
-  "minmax(260px, 1.4fr) minmax(140px, 0.45fr) minmax(180px, 0.7fr) 252px";
+  `minmax(${tableGridMetrics.memberMinWidth}px, 1.4fr) ` +
+  `minmax(${tableGridMetrics.implementationMinWidth}px, 0.45fr) ` +
+  `minmax(${tableGridMetrics.serviceMinWidth}px, 0.7fr) ` +
+  `${tableGridMetrics.actionsMinWidth}px`;
 
 const tableShellStyle: React.CSSProperties = {
   borderRadius: 8,
@@ -94,65 +107,14 @@ const tableInnerStyle: React.CSSProperties = {
   "--team-members-grid-template": tableGridTemplateColumns,
 } as React.CSSProperties;
 
-const responsiveTableStyle = `
-@media (max-width: 1180px) {
-  .team-members-table-header {
-    display: none !important;
-  }
-
-  .team-members-table-row {
-    align-items: flex-start !important;
-    gap: 12px !important;
-    grid-template-columns: minmax(0, 1fr) !important;
-    min-height: 0 !important;
-    padding: 16px 18px !important;
-  }
-
-  .team-members-table-actions {
-    justify-content: flex-start !important;
-    width: 100% !important;
-  }
-
-  .team-members-table-primary-actions {
-    justify-content: flex-start !important;
-    width: 100% !important;
-  }
-
-  .team-members-table-invoke-action,
-  .team-members-table-published-runs-action,
-  .team-members-table-automate-action,
-  .team-members-table-studio-action,
-  .team-members-table-entry-action,
-  .team-members-table-delete-action {
-    min-width: 0 !important;
-  }
-}
-
-@media (max-width: 420px) {
-  .team-members-table-primary-actions {
-    justify-content: flex-start !important;
-  }
-}
-
-.team-members-table-action-button {
-  transition: background-color 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
-}
-
-.team-members-table-action-button:hover,
-.team-members-table-action-button:focus-visible {
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08) !important;
-  transform: translateY(-1px);
-}
-`;
-
 const tableHeaderStyle: React.CSSProperties = {
   alignItems: "center",
   display: "grid",
   fontSize: 12,
   fontWeight: 700,
-  gap: 20,
+  gap: tableGridMetrics.columnGap,
   gridTemplateColumns: tableGridTemplateColumns,
-  padding: "10px 18px",
+  padding: `10px ${tableGridMetrics.rowPaddingInline}px`,
 };
 
 const tableHeaderActionStyle: React.CSSProperties = {
@@ -163,10 +125,10 @@ const tableHeaderActionStyle: React.CSSProperties = {
 const rosterRowBaseStyle: React.CSSProperties = {
   alignItems: "center",
   display: "grid",
-  gap: 20,
+  gap: tableGridMetrics.columnGap,
   gridTemplateColumns: tableGridTemplateColumns,
   minHeight: 82,
-  padding: "14px 18px",
+  padding: `14px ${tableGridMetrics.rowPaddingInline}px`,
 };
 
 const memberNameRowStyle: React.CSSProperties = {
@@ -366,10 +328,14 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
             {statusDescription}
           </Typography.Text>
         </div>
-        <div style={tableFrameStyle}>
+        <div
+          className="team-members-table-container"
+          data-responsive-layout="container"
+          data-testid="team-members-table"
+          style={tableFrameStyle}
+        >
           <div style={tableScrollStyle}>
             <div style={tableInnerStyle}>
-              <style>{responsiveTableStyle}</style>
               {renderTableHeader()}
               {memberRosterSkeletonRowKeys.map((key, index) => (
                 <div
@@ -514,10 +480,14 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
             })}
           />
         ) : rosterRows.length > 0 ? (
-          <div style={tableFrameStyle}>
+          <div
+            className="team-members-table-container"
+            data-responsive-layout="container"
+            data-testid="team-members-table"
+            style={tableFrameStyle}
+          >
             <div style={tableScrollStyle}>
               <div style={tableInnerStyle}>
-                <style>{responsiveTableStyle}</style>
                 {renderTableHeader()}
                 {rosterRows.map((row, index) => {
                   const invokeDisabledReason = row.workflowSupported

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -95,7 +95,7 @@ const tableInnerStyle: React.CSSProperties = {
 } as React.CSSProperties;
 
 const responsiveTableStyle = `
-@media (max-width: 760px) {
+@media (max-width: 1180px) {
   .team-members-table-header {
     display: none !important;
   }

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -99,6 +99,7 @@ const surfaceStyle = (
   display: "flex",
   flexDirection: "column",
   gap: 16,
+  minWidth: 0,
   padding: 20,
 });
 
@@ -201,7 +202,15 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
             justifyContent: "space-between",
           }}
         >
-          <div style={{ display: "flex", flex: "1 1 520px", flexDirection: "column", gap: 8 }}>
+          <div
+            style={{
+              display: "flex",
+              flex: "1 1 520px",
+              flexDirection: "column",
+              gap: 8,
+              minWidth: 0,
+            }}
+          >
             <Space wrap size={[8, 6]}>
               <Typography.Text strong style={{ fontSize: 16 }}>
                 {intl.formatMessage({ id: "teams.detail.overview.status.title" })}


### PR DESCRIPTION
## Problem

Team console controls could be clipped at intermediate viewport widths even when the document itself had no horizontal overflow. The affected layouts used viewport breakpoints or non-shrinking action groups instead of the actual component width.

## Solution

- Recompose Team automation rows before their content exceeds the available panel width.
- Keep Workflow Studio identity controls visible while the action toolbar wraps independently.
- Drive Team Members table composition from its own inline size with a CSS container query derived from the wide table minimum.
- Allow Member Invoke summary actions to shrink and wrap inside the mobile surface.
- Add focused component coverage for the responsive layout and action-accessibility contracts.

## Validation

- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web test:ui` (114 suites, 945 tests)
- `pnpm --dir apps/aevatar-console-web build`
- `bash tools/ci/test_stability_guards.sh`
- Authenticated local Chrome audit: 10 canonical Team routes at 390px, 768px, 1024px, 1280px, and 1512px (50/50 without document overflow, clipped controls, horizontal control escape, or incoherent control overlap)

Closes #2725.

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2725
- Worktree: /var/folders/5b/_fs5d4rj2wx1l4q4sytg3fhm0000gp/T/fkst-host-run-rt.czlrGR/worktrees/devloop-aevatarAI-aevatar-2725-1288217972
- Branch: devloop/issue/aevatarAI/aevatar/2725/ready-consensus-github-devloop-issue-aevatarAI-aevatar-2725-2026-07-13T09-11-23Z-1288217972
- Operator: potter-sun
- Freshness: Reproduced and validated against the current authenticated application on 2026-07-13

⟦AI:FKST⟧
