### PR TITLE
Fix NyxID resource server identity

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdBrokerOptions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdBrokerOptions.cs
@@ -3,14 +3,21 @@ using Aevatar.GAgents.Channel.Identity;
 namespace Aevatar.GAgents.Channel.Identity.Broker;
 
 /// <summary>
-/// Non-secret static defaults for the NyxID broker integration. Authority,
-/// client_id, and HMAC key all come from <c>IAevatarOAuthClientProvider</c>
-/// at runtime; this options object retains only values that don't change
-/// across deployments. No appsettings binding required (the cluster-
-/// singleton actor seeds everything).
+/// Non-secret static configuration for the NyxID broker integration. OAuth
+/// authority, client_id, and HMAC key come from
+/// <c>IAevatarOAuthClientProvider</c>; the canonical resource-server base is
+/// deployment configuration because it is not an OAuth-client fact.
 /// </summary>
 public sealed class NyxIdBrokerOptions
 {
+    public const string ResourceServerBaseUrlConfigurationKey = "Aevatar:NyxId:ApiBaseUrl";
+
+    /// <summary>
+    /// Canonical NyxID API base used to construct RFC 8707 resource URIs.
+    /// This is deliberately separate from the browser-facing OAuth authority.
+    /// </summary>
+    public string ResourceServerBaseUrl { get; set; } = string.Empty;
+
     /// <summary>
     /// Deprecated compatibility hook. The effective OAuth scope requested at
     /// <c>/oauth/authorize</c> and registered through DCR is always

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -76,6 +76,12 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
 
     private string ResolveRedirectUri() => NyxIdRedirectUriResolver.Resolve(_logger);
 
+    private string RequiredServiceResourceUri() =>
+        AevatarOAuthClientResources.RequiredServiceResourceUri(_options.ResourceServerBaseUrl);
+
+    private string[] RequiredResourceUris() =>
+        AevatarOAuthClientResources.RequiredResourceUris(_options.ResourceServerBaseUrl);
+
     public async Task<BindingChallenge> StartExternalBindingAsync(
         ExternalSubjectRef externalSubject,
         CancellationToken ct = default)
@@ -188,7 +194,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         };
         if (!string.IsNullOrWhiteSpace(scope.Value))
             form.Add(new KeyValuePair<string, string>("scope", scope.Value));
-        foreach (var resource in AevatarOAuthClientResources.RequiredResourceUris(snapshot.NyxIdAuthority))
+        foreach (var resource in RequiredResourceUris())
             form.Add(new KeyValuePair<string, string>("resource", resource));
 
         using var request = new HttpRequestMessage(
@@ -211,7 +217,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             {
                 throw new BindingServiceAccessMismatchException(
                     externalSubject,
-                    AevatarOAuthClientResources.RequiredServiceResourceUri(snapshot.NyxIdAuthority),
+                    RequiredServiceResourceUri(),
                     "NyxID returned invalid_target for aevatar's required service on token-exchange.");
             }
             _logger.LogError(
@@ -227,11 +233,11 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             ?? throw new InvalidOperationException("NyxID returned an empty token-exchange response.");
 
         if (!string.IsNullOrWhiteSpace(payload.AccessToken)
-            && !AccessTokenContainsRequiredResource(payload.AccessToken, snapshot.NyxIdAuthority))
+            && !AccessTokenContainsRequiredResource(payload.AccessToken, _options.ResourceServerBaseUrl))
         {
             throw new BindingServiceAccessMismatchException(
                 externalSubject,
-                AevatarOAuthClientResources.RequiredServiceResourceUri(snapshot.NyxIdAuthority),
+                RequiredServiceResourceUri(),
                 "NyxID binding token does not grant aevatar's required service resource.");
         }
 
@@ -311,7 +317,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             new("redirect_uri", redirectUri),
             new("client_id", snapshot.ClientId),
         };
-        foreach (var resource in AevatarOAuthClientResources.RequiredResourceUris(snapshot.NyxIdAuthority))
+        foreach (var resource in RequiredResourceUris())
             form.Add(new KeyValuePair<string, string>("resource", resource));
 
         using var request = new HttpRequestMessage(
@@ -329,7 +335,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             if ((int)response.StatusCode == 400 && IsInvalidTarget(body))
             {
                 throw new NyxIdRequiredServiceAccessException(
-                    AevatarOAuthClientResources.RequiredServiceResourceUri(snapshot.NyxIdAuthority));
+                    RequiredServiceResourceUri());
             }
             _logger.LogError(
                 "NyxID authorization-code exchange failed: status={StatusCode}, body={Body}",
@@ -368,7 +374,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             $"client_id={Uri.EscapeDataString(snapshot.ClientId)}",
             $"redirect_uri={Uri.EscapeDataString(redirectUri)}",
             $"scope={Uri.EscapeDataString(AevatarOAuthClientScopes.AuthorizationScope)}",
-            $"resource={Uri.EscapeDataString(AevatarOAuthClientResources.RequiredServiceResourceUri(snapshot.NyxIdAuthority))}",
+            $"resource={Uri.EscapeDataString(RequiredServiceResourceUri())}",
             $"state={Uri.EscapeDataString(stateToken)}",
             $"code_challenge={Uri.EscapeDataString(codeChallenge)}",
             "code_challenge_method=S256",
@@ -411,7 +417,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         }
     }
 
-    private static bool AccessTokenContainsRequiredResource(string accessToken, string nyxIdAuthority)
+    private static bool AccessTokenContainsRequiredResource(string accessToken, string nyxIdApiBaseUrl)
     {
         var parts = accessToken.Split('.');
         if (parts.Length != 3)
@@ -434,7 +440,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
                 resources.EnumerateArray()
                     .Where(static item => item.ValueKind == JsonValueKind.String)
                     .Select(static item => item.GetString()!),
-                nyxIdAuthority);
+                nyxIdApiBaseUrl);
         }
         catch (FormatException)
         {

--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -181,7 +181,7 @@ public static class IdentityServiceCollectionExtensions
                 AevatarOAuthClientGAgent.WellKnownId,
                 "channel-identity.oauth-rebuild"));
 
-        // ─── Broker (self-bootstrapping, no appsettings dependency) ───
+        // ─── Broker (OAuth client self-bootstrapping) ───
         // Register broker as a *singleton* and inject IHttpClientFactory so
         // each call resolves a fresh HttpClient backed by the factory's
         // rotating handler pool. The earlier shape — AddHttpClient<T>()
@@ -189,7 +189,14 @@ public static class IdentityServiceCollectionExtensions
         // resolved HttpClient + HttpMessageHandler inside the singleton and
         // silently defeated the 2-min handler rotation, so long-running
         // silos would never pick up DNS / TLS-cert changes.
-        services.AddOptions<NyxIdBrokerOptions>();
+        var brokerOptions = services.AddOptions<NyxIdBrokerOptions>();
+        if (configuration is not null)
+        {
+            brokerOptions.Configure(options =>
+                options.ResourceServerBaseUrl =
+                    configuration[NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey]?.Trim().TrimEnd('/')
+                    ?? string.Empty);
+        }
         services.TryAddSingleton<StateTokenCodec>();
         services.AddHttpClient(NyxIdRemoteCapabilityBroker.HttpClientName);
         services.TryAddSingleton<NyxIdRemoteCapabilityBroker>();

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientResources.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientResources.cs
@@ -7,20 +7,20 @@ public static class AevatarOAuthClientResources
 {
     public const string RequiredServiceSlug = "aevatar";
 
-    public static string RequiredServiceResourceUri(string nyxIdAuthority)
+    public static string RequiredServiceResourceUri(string nyxIdApiBaseUrl)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(nyxIdAuthority);
-        return $"{nyxIdAuthority.TrimEnd('/')}/api/v1/proxy/s/{RequiredServiceSlug}";
+        ArgumentException.ThrowIfNullOrWhiteSpace(nyxIdApiBaseUrl);
+        return $"{nyxIdApiBaseUrl.Trim().TrimEnd('/')}/api/v1/proxy/s/{RequiredServiceSlug}";
     }
 
-    public static string[] RequiredResourceUris(string nyxIdAuthority) =>
-        [RequiredServiceResourceUri(nyxIdAuthority)];
+    public static string[] RequiredResourceUris(string nyxIdApiBaseUrl) =>
+        [RequiredServiceResourceUri(nyxIdApiBaseUrl)];
 
     public static bool ContainsRequiredResource(
         IEnumerable<string>? resources,
-        string nyxIdAuthority)
+        string nyxIdApiBaseUrl)
     {
-        var required = RequiredServiceResourceUri(nyxIdAuthority);
+        var required = RequiredServiceResourceUri(nyxIdApiBaseUrl);
         return resources?.Any(resource => string.Equals(
             resource?.Trim(),
             required,

--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -4,7 +4,7 @@ import {
   refreshNyxIDTokenSet,
 } from "./backend";
 
-const requiredResource = "https://nyx.example/api/v1/proxy/s/aevatar";
+const requiredResource = "https://nyx-api.example/api/v1/proxy/s/aevatar";
 
 describe("NyxID backend auth API", () => {
   const originalFetch = global.fetch;
@@ -189,7 +189,7 @@ describe("NyxID backend auth API", () => {
       "Content-Type": "application/x-www-form-urlencoded",
     });
     expect(String(init.body)).toBe(
-      "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=broker-client-1&resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Faevatar",
+      "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=broker-client-1&resource=https%3A%2F%2Fnyx-api.example%2Fapi%2Fv1%2Fproxy%2Fs%2Faevatar",
     );
   });
 

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -14,7 +14,7 @@ const runtimeConfig: NyxIDRuntimeConfig = {
   redirectUri: "http://localhost:8000/auth/callback",
   scope: "openid profile email",
 };
-const requiredResource = "https://nyx.example/api/v1/proxy/s/aevatar";
+const requiredResource = "https://nyx-api.example/api/v1/proxy/s/aevatar";
 
 function installLocationAssignSpy() {
   const assign = jest.fn();
@@ -259,7 +259,7 @@ describe("NyxIDAuthClient", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/nyxid/config");
     expect(fetchMock.mock.calls[1][0]).toBe("https://nyx.example/oauth/token");
     expect(String(fetchMock.mock.calls[1][1]?.body)).toBe(
-      "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=broker-client-1&resource=https%3A%2F%2Fnyx.example%2Fapi%2Fv1%2Fproxy%2Fs%2Faevatar",
+      "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=broker-client-1&resource=https%3A%2F%2Fnyx-api.example%2Fapi%2Fv1%2Fproxy%2Fs%2Faevatar",
     );
   });
 

--- a/apps/aevatar-console-web/src/shared/auth/fetch.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/fetch.test.ts
@@ -91,10 +91,10 @@ describe('authFetch', () => {
         ok: true,
         status: 200,
         json: async () => ({
-          baseUrl: "https://nyx.example",
+          baseUrl: "https://nyx-ui.example",
           clientId: "broker-client-1",
           scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-          resources: ["https://nyx.example/api/v1/proxy/s/aevatar"],
+          resources: ["https://nyx-api.example/api/v1/proxy/s/aevatar"],
         }),
       } as Response)
       .mockResolvedValueOnce({
@@ -114,7 +114,7 @@ describe('authFetch', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/nyxid/config");
-    expect(fetchMock.mock.calls[1][0]).toBe("https://nyx.example/oauth/token");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://nyx-ui.example/oauth/token");
     const [input, init] = fetchMock.mock.calls[2] as [
       string,
       RequestInit | undefined,

--- a/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
+++ b/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
@@ -15,7 +15,7 @@ NyxID 2026-07-06 至 2026-07-08 的 OAuth 更新把第三方应用 service acces
 
 `aevatar` service 是 Studio 登录、channel binding 和后续定时调用正常工作的必要资源,不是可选 UI 偏好. 因此最终 contract 为:
 
-- 控制台登录与 channel `/init` 的 `/oauth/authorize` 请求都显式携带 `resource={nyxid_authority}/api/v1/proxy/s/aevatar`.
+- 控制台登录与 channel `/init` 的 `/oauth/authorize` 请求都显式携带 `resource={nyxid_api_base_url}/api/v1/proxy/s/aevatar`. `nyxid_api_base_url` 对应 NyxID backend `BASE_URL` / Aevatar `Aevatar:NyxId:ApiBaseUrl`,不得从浏览器 OAuth authority 或 JWT issuer 派生.
 - authorization-code exchange、控制台 refresh 和 broker token-exchange 同样携带该 resource. 即使用户在 consent 页取消 Aevatar service,token exchange 也会以 `invalid_target` 失败,不会生成一个表面登录成功但无法工作的 binding.
 - broker 每次拿到短期 access token 后校验 `resources` claim. 旧 binding、allow-all grandfather grant 或缺少 Aevatar service 的 grant 会被归类为 service-access mismatch,由调用侧清理本地 binding 并引导重新 `/init`.
 - `/api/auth/nyxid/config` 向前端返回 typed `resources` 列表;前端不得自行猜 service ID,也不得把 Developer App 默认项当作授权事实.

--- a/docs/canon/backend-console.md
+++ b/docs/canon/backend-console.md
@@ -41,14 +41,14 @@ Nyx/OIDC deployment facts are host configuration, not page source:
 | `Aevatar:BackendConsole:OidcAuthority` | Browser OIDC authority; falls back to existing Nyx/Auth authority config when empty. |
 | `Aevatar:BackendConsole:OidcClientId` | Public OIDC client id used by browser PKCE. |
 | `Aevatar:BackendConsole:OidcScope` | Browser OIDC scope. |
-| `Aevatar:BackendConsole:OidcResources` | Additional RFC 8707 resource indicators. The host always includes `{OidcAuthority}/api/v1/proxy/s/aevatar`. |
-| `Aevatar:BackendConsole:NyxApiBaseUrl` | Nyx REST API base used by admin-only owner resolution. |
+| `Aevatar:BackendConsole:OidcResources` | Additional RFC 8707 resource indicators. The host always includes `{NyxApiBaseUrl}/api/v1/proxy/s/aevatar`. |
+| `Aevatar:BackendConsole:NyxApiBaseUrl` | Canonical NyxID API/resource-server base. It falls back only to `Aevatar:NyxId:ApiBaseUrl`, never to the browser OIDC authority. |
 | `Aevatar:BackendConsole:StorageKey` | Shared browser localStorage/sessionStorage prefix. |
 | `Aevatar:BackendConsole:DefaultReturnPath` | Safe default redirect path after `/auto/callback`. |
 
 Each configurable HTML asset contains `__BACKEND_CONSOLE_CONFIG__`. The serving helper replaces that placeholder with JSON rendered from `BackendConsoleOptions`. The six `HOST_BACKEND_CONSOLE_*` environment variables are optional overrides for host deployment, but `.refactor-loop/host.env` is not a production configuration source.
 
-The OIDC client id and resource indicators are public browser values, not secrets. Every configurable console page appends each injected resource to both `/oauth/authorize` and the authorization-code exchange at `/oauth/token`; the shared `/auto/callback` follows the same contract. Secrets still belong in the existing host secret/config mechanisms and must not be injected into page assets.
+The OIDC client id and resource indicators are public browser values, not secrets. Every configurable console page appends each injected resource to both `/oauth/authorize` and the authorization-code exchange at `/oauth/token`; the shared `/auto/callback` follows the same contract. The OIDC authority owns browser authorization, while `NyxApiBaseUrl` owns RFC 8707 resource identity; these hosts may differ and must not be substituted for each other. Secrets still belong in the existing host secret/config mechanisms and must not be injected into page assets.
 
 ## 3. Endpoint Boundary
 

--- a/src/Aevatar.BackendConsole.Hosting/BackendConsoleHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.BackendConsole.Hosting/BackendConsoleHostingServiceCollectionExtensions.cs
@@ -61,8 +61,6 @@ public static class BackendConsoleHostingServiceCollectionExtensions
         {
             options.NyxApiBaseUrl =
                 configuration["Aevatar:NyxId:ApiBaseUrl"]
-                ?? configuration["Aevatar:NyxId:Authority"]
-                ?? configuration["Aevatar:Authentication:Authority"]
                 ?? string.Empty;
         }
     }
@@ -79,20 +77,31 @@ public static class BackendConsoleHostingServiceCollectionExtensions
 
     private static void NormalizeOidcResources(BackendConsoleOptions options)
     {
+        options.NyxApiBaseUrl = options.NyxApiBaseUrl.Trim().TrimEnd('/');
         var resources = options.OidcResources
             .Select(resource => resource.Trim())
             .Where(resource => resource.Length > 0)
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        if (string.IsNullOrWhiteSpace(options.OidcAuthority))
+        if (string.IsNullOrWhiteSpace(options.NyxApiBaseUrl))
         {
             options.OidcResources = resources;
             return;
         }
 
         var requiredResource =
-            $"{options.OidcAuthority.Trim().TrimEnd('/')}/api/v1/proxy/s/aevatar";
+            $"{options.NyxApiBaseUrl.Trim().TrimEnd('/')}/api/v1/proxy/s/aevatar";
+        var legacyAuthorityResource = string.IsNullOrWhiteSpace(options.OidcAuthority)
+            ? null
+            : $"{options.OidcAuthority.Trim().TrimEnd('/')}/api/v1/proxy/s/aevatar";
+        if (!string.Equals(legacyAuthorityResource, requiredResource, StringComparison.Ordinal))
+        {
+            resources = resources
+                .Where(resource => !string.Equals(resource, legacyAuthorityResource, StringComparison.Ordinal))
+                .ToArray();
+        }
+
         options.OidcResources = resources.Contains(requiredResource, StringComparer.Ordinal)
             ? resources
             : [requiredResource, .. resources];

--- a/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.Studio.Hosting.Endpoints;
 
@@ -43,6 +44,7 @@ public static class NyxIdLoginFinalizationEndpoints
 
     internal static async Task<IResult> HandleConfigAsync(
         [FromServices] IAevatarOAuthClientProvider oauthClientProvider,
+        [FromServices] IOptions<NyxIdBrokerOptions> brokerOptions,
         CancellationToken ct = default)
     {
         try
@@ -54,7 +56,8 @@ public static class NyxIdLoginFinalizationEndpoints
                 Scope: string.IsNullOrWhiteSpace(snapshot.OauthScope)
                     ? AevatarOAuthClientScopes.AuthorizationScope
                     : snapshot.OauthScope.Trim(),
-                Resources: AevatarOAuthClientResources.RequiredResourceUris(snapshot.NyxIdAuthority)));
+                Resources: AevatarOAuthClientResources.RequiredResourceUris(
+                    brokerOptions.Value.ResourceServerBaseUrl)));
         }
         catch (AevatarOAuthClientNotProvisionedException)
         {

--- a/test/Aevatar.Capabilities.Tests/BackendConsoleAssetServiceTests.cs
+++ b/test/Aevatar.Capabilities.Tests/BackendConsoleAssetServiceTests.cs
@@ -20,7 +20,9 @@ public sealed class BackendConsoleAssetServiceTests
                 ["Aevatar:BackendConsole:OidcClientId"] = "client-example",
                 ["Aevatar:BackendConsole:OidcScope"] = "openid profile",
                 ["Aevatar:BackendConsole:OidcResources:0"] = "https://resource.example.test/custom",
-                ["Aevatar:BackendConsole:NyxApiBaseUrl"] = "https://api.example.test",
+                ["Aevatar:BackendConsole:OidcResources:1"] =
+                    "https://id.example.test/api/v1/proxy/s/aevatar",
+                ["Aevatar:BackendConsole:NyxApiBaseUrl"] = " https://api.example.test/// ",
                 ["Aevatar:BackendConsole:StorageKey"] = "console:test",
                 ["Aevatar:BackendConsole:DefaultReturnPath"] = "/admin",
             })
@@ -40,7 +42,7 @@ public sealed class BackendConsoleAssetServiceTests
         html.Should().Contain("\"authority\":\"https://id.example.test\"");
         html.Should().Contain("\"clientId\":\"client-example\"");
         html.Should().Contain(
-            "\"resources\":[\"https://id.example.test/api/v1/proxy/s/aevatar\",\"https://resource.example.test/custom\"]");
+            "\"resources\":[\"https://api.example.test/api/v1/proxy/s/aevatar\",\"https://resource.example.test/custom\"]");
         html.Should().Contain("\"nyxidApi\":\"https://api.example.test\"");
         html.Should().Contain("\"storageKey\":\"console:test\"");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");
@@ -71,7 +73,7 @@ public sealed class BackendConsoleAssetServiceTests
         html.Should().Contain("\"authority\":\"https://env-id.example.test\"");
         html.Should().Contain("\"clientId\":\"env-client\"");
         html.Should().Contain("\"scope\":\"env-scope\"");
-        html.Should().Contain("\"resources\":[\"https://env-id.example.test/api/v1/proxy/s/aevatar\"]");
+        html.Should().Contain("\"resources\":[\"https://env-api.example.test/api/v1/proxy/s/aevatar\"]");
         html.Should().Contain("\"nyxidApi\":\"https://env-api.example.test\"");
         html.Should().Contain("\"storageKey\":\"env-storage\"");
         html.Should().Contain("\"defaultReturnPath\":\"/voice\"");
@@ -108,7 +110,7 @@ public sealed class BackendConsoleAssetServiceTests
         html.Should().Contain("\"authority\":\"https://auth.example.test\"");
         html.Should().Contain("\"clientId\":\"client-example\"");
         html.Should().Contain("\"scope\":\"openid profile\"");
-        html.Should().Contain("\"resources\":[\"https://auth.example.test/api/v1/proxy/s/aevatar\"]");
+        html.Should().Contain("\"resources\":[\"https://nyx-api.example.test/api/v1/proxy/s/aevatar\"]");
         html.Should().Contain("\"nyxidApi\":\"https://nyx-api.example.test\"");
         html.Should().Contain("\"storageKey\":\"console:test\"");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");

--- a/test/Aevatar.Capabilities.Tests/BackendConsoleStaticAssetEndpointTests.cs
+++ b/test/Aevatar.Capabilities.Tests/BackendConsoleStaticAssetEndpointTests.cs
@@ -33,7 +33,7 @@ public sealed class BackendConsoleStaticAssetEndpointTests
         html.Should().Contain("https://id.example.test");
         html.Should().Contain("client-example");
         html.Should().Contain("console:test");
-        html.Should().Contain("\"resources\":[\"https://id.example.test/api/v1/proxy/s/aevatar\"]");
+        html.Should().Contain("\"resources\":[\"https://api.example.test/api/v1/proxy/s/aevatar\"]");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");
         html.Should().NotContain("https://nyx.chrono-ai.fun");
         html.Should().NotContain("https://nyx-api.chrono-ai.fun");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelsEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelsEndpointsTests.cs
@@ -87,6 +87,7 @@ public sealed class ChannelsEndpointsTests
                 ["Aevatar:BackendConsole:OidcAuthority"] = "https://id.example.test",
                 ["Aevatar:BackendConsole:OidcClientId"] = "client-example",
                 ["Aevatar:BackendConsole:OidcScope"] = "openid profile",
+                ["Aevatar:BackendConsole:NyxApiBaseUrl"] = "https://api.example.test",
                 ["Aevatar:BackendConsole:StorageKey"] = "console:test",
             })
             .Build();
@@ -109,7 +110,7 @@ public sealed class ChannelsEndpointsTests
         html.Should().Contain("https://id.example.test");
         html.Should().Contain("client-example");
         html.Should().Contain("console:test");
-        html.Should().Contain("\"resources\":[\"https://id.example.test/api/v1/proxy/s/aevatar\"]");
+        html.Should().Contain("\"resources\":[\"https://api.example.test/api/v1/proxy/s/aevatar\"]");
         html.Should().Contain("searchParams.append(\"resource\"");
         html.Should().Contain("form.append(\"resource\"");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -19,7 +19,9 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
 {
     private static readonly byte[] HmacKey =
         Convert.FromHexString("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
-    private const string RequiredResource = "https://nyxid.test/api/v1/proxy/s/aevatar";
+    private const string OAuthAuthority = "https://nyx-ui.test";
+    private const string ResourceServerBaseUrl = "https://nyx-api.test";
+    private const string RequiredResource = $"{ResourceServerBaseUrl}/api/v1/proxy/s/aevatar";
 
     private readonly string? _savedOverride;
 
@@ -118,6 +120,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         result.TokenType.Should().Be("Bearer");
         result.ExpiresIn.Should().Be(1800);
         result.Scope.Should().Be("openid profile proxy");
+        handler.LastRequestUri.Should().Be($"{OAuthAuthority}/oauth/token");
         QueryHelpers.ParseQuery($"?{handler.LastRequestBody}")["resource"]
             .Should().ContainSingle().Which.Should().Be(RequiredResource);
     }
@@ -131,7 +134,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         var challenge = await broker.StartExternalBindingAsync(SampleSubject());
 
         var uri = new Uri(challenge.AuthorizeUrl);
-        uri.GetLeftPart(UriPartial.Path).Should().Be("https://nyxid.test/oauth/authorize");
+        uri.GetLeftPart(UriPartial.Path).Should().Be($"{OAuthAuthority}/oauth/authorize");
         var query = QueryHelpers.ParseQuery(uri.Query);
         query["client_id"].Should().ContainSingle().Which.Should().Be("client-1");
         query["redirect_uri"].Should().ContainSingle().Which.Should().Be(expectedRedirectUri);
@@ -260,10 +263,13 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         HttpMessageHandler? httpHandler = null)
     {
         var provider = new FakeOAuthClientProvider(snapshot);
+        options ??= new NyxIdBrokerOptions();
+        if (string.IsNullOrWhiteSpace(options.ResourceServerBaseUrl))
+            options.ResourceServerBaseUrl = $" {ResourceServerBaseUrl}/// ";
         return new NyxIdRemoteCapabilityBroker(
             new FakeHttpClientFactory(httpHandler),
             provider,
-            Options.Create(options ?? new NyxIdBrokerOptions()),
+            Options.Create(options),
             new StateTokenCodec(provider),
             new EmptyBindingQueryPort(),
             new FakeTimeProvider(DateTimeOffset.Parse("2026-04-30T10:00:00Z")),
@@ -276,7 +282,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         HmacKid: "v1",
         HmacKey: HmacKey,
         HmacKeyRotatedAt: DateTimeOffset.Parse("2026-04-30T09:00:00Z"),
-        NyxIdAuthority: "https://nyxid.test",
+        NyxIdAuthority: OAuthAuthority,
         BrokerCapabilityObserved: true,
         BrokerCapabilityObservedAt: DateTimeOffset.Parse("2026-04-30T09:00:00Z"),
         RedirectUri: redirectUri,
@@ -333,6 +339,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         private readonly string _body;
 
         public string? LastRequestBody { get; private set; }
+        public string? LastRequestUri { get; private set; }
 
         private StubHandler(HttpStatusCode statusCode, string body)
         {
@@ -346,6 +353,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            LastRequestUri = request.RequestUri?.ToString();
             LastRequestBody = request.Content is null
                 ? null
                 : await request.Content.ReadAsStringAsync(cancellationToken);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -9,6 +9,7 @@ using Aevatar.Foundation.Abstractions.HumanInteraction;
 using Aevatar.GAgents.Authoring.Lark;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Aevatar.GAgents.Channel.Identity.DependencyInjection;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.NyxIdRelay.Outbound;
@@ -22,6 +23,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -213,11 +215,21 @@ public sealed class ServiceCollectionExtensionsTests
     public void AddChannelIdentity_RegistersCommittedStateProjectionActivationProvider()
     {
         var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] =
+                    " https://nyx-api.example.test/// ",
+            })
+            .Build();
 
-        services.AddChannelIdentity(new ConfigurationBuilder().Build());
+        services.AddChannelIdentity(configuration);
+        using var provider = services.BuildServiceProvider();
 
         AssertProjectionActivationProviderRegistered<ChannelIdentityCommittedStateProjectionActivationPlanProvider>(
             services);
+        provider.GetRequiredService<IOptions<NyxIdBrokerOptions>>()
+            .Value.ResourceServerBaseUrl.Should().Be("https://nyx-api.example.test");
         services.Should().NotContain(descriptor =>
             descriptor.ServiceType == typeof(IHostedService) &&
             descriptor.ImplementationType == typeof(AevatarOAuthClientEsAclStartupGuard));

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -12,6 +12,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.Studio.Tests;
 
@@ -27,19 +28,23 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
                 HmacKid: "kid",
                 HmacKey: [1, 2, 3],
                 HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
-                NyxIdAuthority: "https://nyx.example/",
+                NyxIdAuthority: "https://nyx-ui.example/",
                 BrokerCapabilityObserved: true,
                 BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch,
-                OauthScope: "openid broker proxy")));
+                OauthScope: "openid broker proxy")),
+            Options.Create(new NyxIdBrokerOptions
+            {
+                ResourceServerBaseUrl = " https://nyx-api.example/// ",
+            }));
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginConfigurationResponse>(result);
 
         statusCode.Should().Be(StatusCodes.Status200OK);
         payload.Should().BeEquivalentTo(new NyxIdLoginConfigurationResponse(
-            "https://nyx.example",
+            "https://nyx-ui.example",
             "broker-client-1",
             "openid broker proxy",
-            ["https://nyx.example/api/v1/proxy/s/aevatar"]));
+            ["https://nyx-api.example/api/v1/proxy/s/aevatar"]));
     }
 
     [Fact]
@@ -54,7 +59,11 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
                 HmacKeyRotatedAt: DateTimeOffset.UnixEpoch,
                 NyxIdAuthority: "https://nyx.example/",
                 BrokerCapabilityObserved: true,
-                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch)));
+                BrokerCapabilityObservedAt: DateTimeOffset.UnixEpoch)),
+            Options.Create(new NyxIdBrokerOptions
+            {
+                ResourceServerBaseUrl = "https://nyx-api.example",
+            }));
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginConfigurationResponse>(result);
 
@@ -66,7 +75,11 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
     public async Task Config_ShouldReturnUnavailable_WhenBrokerOAuthClientIsNotProvisioned()
     {
         var result = await NyxIdLoginFinalizationEndpoints.HandleConfigAsync(
-            new NotProvisionedAevatarOAuthClientProvider());
+            new NotProvisionedAevatarOAuthClientProvider(),
+            Options.Create(new NyxIdBrokerOptions
+            {
+                ResourceServerBaseUrl = "https://nyx-api.example",
+            }));
 
         var context = NewHttpContext();
         await result.ExecuteAsync(context);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConsoleStaticAssetEndpointTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConsoleStaticAssetEndpointTests.cs
@@ -35,7 +35,7 @@ public sealed class WorkflowConsoleStaticAssetEndpointTests
         html.Should().Contain("https://id.example.test");
         html.Should().Contain("client-example");
         html.Should().Contain("console:test");
-        html.Should().Contain("\"resources\":[\"https://id.example.test/api/v1/proxy/s/aevatar\"]");
+        html.Should().Contain("\"resources\":[\"https://api.example.test/api/v1/proxy/s/aevatar\"]");
         html.Should().Contain("searchParams.append(\"resource\"");
         html.Should().Contain("form.append(\"resource\"");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");

--- a/tools/ci/main_flow_runtime_smoke.sh
+++ b/tools/ci/main_flow_runtime_smoke.sh
@@ -52,6 +52,7 @@ start_host() {
     ASPNETCORE_ENVIRONMENT=Development \
     ASPNETCORE_URLS="http://127.0.0.1:${HTTP_PORT}" \
     AEVATAR_NYXID_AUTHORITY="http://127.0.0.1:${HTTP_PORT}" \
+    AEVATAR_Aevatar__NyxId__ApiBaseUrl="http://127.0.0.1:${HTTP_PORT}" \
     AEVATAR_OAUTH_REDIRECT_BASE_URL="http://127.0.0.1:${HTTP_PORT}" \
     Aevatar__Authentication__Enabled=false \
     AEVATAR_ActorRuntime__Provider=Orleans \


### PR DESCRIPTION
## Problem

NyxID validates RFC 8707 resource indicators against its backend `BASE_URL`. Aevatar derived the required service resource from the browser-facing OAuth authority, producing `https://nyx.chrono-ai.fun/api/v1/proxy/s/aevatar` instead of the canonical `https://nyx-api.chrono-ai.fun/api/v1/proxy/s/aevatar`. NyxID therefore returned `invalid_target` during login/token exchange.

The deployed public SPA bundle is also stale and does not send the backend-provided `resource` during authorization.

## Solution

- Bind a typed broker resource-server base from `Aevatar:NyxId:ApiBaseUrl`.
- Keep OAuth authorize/token/binding endpoints on the OAuth authority while constructing and validating all resource URIs from the NyxID API base.
- Return the canonical resource from Studio auth config and inject it into all backend-console shells, removing the authority fallback.
- Filter the legacy authority-derived resource when explicitly configured.
- Add regression fixtures with distinct OAuth UI and resource API hosts.
- Correct the NyxID resource identity documentation and runtime smoke configuration.

## Impact

This changes NyxID authorization, code exchange, broker token exchange, JWT resource validation, Studio login config, backend/admin console assets, shared static consoles, and frontend auth regression coverage. No actor state or protobuf contract changes are involved.

## Verification

- Channel identity/runtime focused tests: 14 passed
- Studio login finalization focused tests: 16 passed
- Backend console/capability focused tests: 12 passed
- Workflow console asset focused tests: 2 passed
- `pnpm --dir apps/aevatar-console-web test --runInBand src/shared/auth/backend.test.ts src/shared/auth/client.test.ts src/shared/auth/fetch.test.ts`: 14 passed
- `pnpm --dir apps/aevatar-console-web tsc`: passed
- `pnpm --dir apps/aevatar-console-web build`: passed
- `bash tools/ci/test_stability_guards.sh`: passed
- `bash tools/docs/lint.sh`: passed
- `bash tools/ci/architecture_guards.sh`: passed, including 15 architecture tests
- `dotnet build aevatar.slnx --nologo`: passed with 0 errors

Only existing NuGet and obsolete API warnings were emitted.

## Deployment Note

Deploying the backend repairs `/admin`, but it is not sufficient for the public SPA. Rebuild and publish `apps/aevatar-console-web` so the stale immutable `umi.a38e429f.js` bundle is replaced; that bundle predates resource propagation and otherwise leaves the frontend login flow broken.