### PR TITLE
Add fail-closed Team Automation consent review

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -805,8 +805,6 @@ const enUSMessages = {
   'teams.automations.form.backendRequired': 'Creation unavailable',
   'teams.automations.form.close': 'Close',
   'teams.automations.form.create': 'Create automation',
-  'teams.automations.form.createWithConsent':
-    'Create with Agent Key consent',
   'teams.automations.form.cron': 'Cron expression',
   'teams.automations.form.cronAria': 'Cron expression',
   'teams.automations.form.cronFiveFieldHint':
@@ -887,11 +885,7 @@ const enUSMessages = {
     'Only workflow members can have recurring work.',
   'teams.automations.messages.createFailed':
     'Automation was not created: {message}',
-  'teams.automations.messages.createAccepted':
-    'Automation creation request accepted.',
   'teams.automations.messages.createSuccess': 'Automation created.',
-  'teams.automations.messages.consentRequired':
-    'Review and consent to the automation-dedicated Agent Key before creating.',
   'teams.automations.messages.cronRequired': 'Enter a cron expression first.',
   'teams.automations.messages.deleteSuccess': 'Automation deleted.',
   'teams.automations.messages.disableSuccess': 'Automation paused.',

--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -793,7 +793,20 @@ const enUSMessages = {
   'teams.automations.error.title': 'Automations could not load',
   'teams.automations.form.cadence': 'Cadence',
   'teams.automations.form.cadenceAria': 'Automation cadence',
+  'teams.automations.form.agentKeyConsent':
+    'I consent to Aevatar creating an automation-dedicated Agent Key for this schedule.',
+  'teams.automations.form.agentKeyExpiry': 'Expires {time}',
+  'teams.automations.form.agentKeyManaged': 'Aevatar managed',
+  'teams.automations.form.agentKeyMode': 'Credential mode · {mode}',
+  'teams.automations.form.agentKeyNoRawKey':
+    'Browser never receives the raw Agent Key',
+  'teams.automations.form.agentKeyPlan':
+    'Automation dedicated Agent Key',
+  'teams.automations.form.backendRequired': 'Creation unavailable',
+  'teams.automations.form.close': 'Close',
   'teams.automations.form.create': 'Create automation',
+  'teams.automations.form.createWithConsent':
+    'Create with Agent Key consent',
   'teams.automations.form.cron': 'Cron expression',
   'teams.automations.form.cronAria': 'Cron expression',
   'teams.automations.form.cronFiveFieldHint':
@@ -812,11 +825,19 @@ const enUSMessages = {
     "Targets the member's published service.",
   'teams.automations.form.member': 'Member',
   'teams.automations.form.memberAria': 'Automation member',
+  'teams.automations.form.nodeGrants': 'Node grants',
+  'teams.automations.form.permissionDigest':
+    'Permission digest · {permissionDigest}',
+  'teams.automations.form.planChanged':
+    'The authorization plan changed. Refresh the review before creating.',
+  'teams.automations.form.policyVersion':
+    'Policy version · {policyVersion}',
   'teams.automations.form.preset.custom': 'Custom cron',
   'teams.automations.form.preset.dailyMorning': 'Daily · 09:00',
   'teams.automations.form.preset.hourly': 'Hourly',
   'teams.automations.form.preset.weekdaysMorning': 'Weekdays · 09:00',
   'teams.automations.form.preset.weeklyMonday': 'Monday · 09:00',
+  'teams.automations.form.preparingReview': 'Preparing review',
   'teams.automations.form.preview': 'Preview next runs',
   'teams.automations.form.previewEmpty':
     'Preview the cadence to confirm the next scheduled runs.',
@@ -828,8 +849,22 @@ const enUSMessages = {
     'Optional. Up to {maxLength} characters.',
   'teams.automations.form.promptPlaceholder':
     'Summarize escalations, blocked accounts, and follow-up owners.',
+  'teams.automations.form.refreshReview': 'Refresh review',
+  'teams.automations.form.reviewErrorBody':
+    'The mock contract could not prepare the review. Keep the draft and try again.',
+  'teams.automations.form.reviewErrorTitle':
+    'Permission review needs attention',
+  'teams.automations.form.reviewPermissions': 'Review permissions',
+  'teams.automations.form.reviewPlaceholder':
+    'Review is prepared after the draft cadence and target are ready.',
+  'teams.automations.form.previewOnlyNotice':
+    'Preview only. No automation or Agent Key is created until the scoped backend is connected.',
   'teams.automations.form.save': 'Save changes',
   'teams.automations.form.scheduleReadsAs': 'Schedule reads as',
+  'teams.automations.form.section.permissionReview':
+    '4. Review Agent Key consent',
+  'teams.automations.form.section.permissionReviewHint':
+    'Browser login authorization only confirms this consent. Automation uses a dedicated Agent Key managed by Aevatar.',
   'teams.automations.form.section.schedule': '3. Schedule',
   'teams.automations.form.section.scheduleHint':
     'Choose a common cadence or switch to custom cron for advanced schedules.',
@@ -839,6 +874,7 @@ const enUSMessages = {
   'teams.automations.form.section.work': '2. Work to run',
   'teams.automations.form.section.workHint':
     'Name the automation and optionally add a prompt for each run.',
+  'teams.automations.form.serviceGrants': 'Service grants',
   'teams.automations.form.timezone': 'Timezone',
   'teams.automations.form.timezoneAria': 'Timezone',
   'teams.automations.form.title': 'New member automation',
@@ -851,7 +887,11 @@ const enUSMessages = {
     'Only workflow members can have recurring work.',
   'teams.automations.messages.createFailed':
     'Automation was not created: {message}',
+  'teams.automations.messages.createAccepted':
+    'Automation creation request accepted.',
   'teams.automations.messages.createSuccess': 'Automation created.',
+  'teams.automations.messages.consentRequired':
+    'Review and consent to the automation-dedicated Agent Key before creating.',
   'teams.automations.messages.cronRequired': 'Enter a cron expression first.',
   'teams.automations.messages.deleteSuccess': 'Automation deleted.',
   'teams.automations.messages.disableSuccess': 'Automation paused.',
@@ -865,6 +905,8 @@ const enUSMessages = {
     'Service identity is still loading.',
   'teams.automations.messages.serviceIdentityMissing':
     'The selected member does not have a service identity yet.',
+  'teams.automations.messages.reviewFailed':
+    'Permission review could not be prepared: {message}',
   'teams.automations.messages.updateFailed':
     'Automation was not updated: {message}',
   'teams.automations.messages.updateSuccess': 'Automation updated.',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -766,8 +766,6 @@ const zhCNMessages = {
   'teams.automations.form.cadenceAria': '自动化节奏',
   'teams.automations.form.close': '关闭',
   'teams.automations.form.create': '创建自动化',
-  'teams.automations.form.createWithConsent':
-    '同意 Agent Key 授权并创建',
   'teams.automations.form.cron': 'Cron 表达式',
   'teams.automations.form.cronAria': 'Cron 表达式',
   'teams.automations.form.cronFiveFieldHint':
@@ -840,10 +838,6 @@ const zhCNMessages = {
   'teams.automations.member.unknown': '未知成员',
   'teams.automations.member.workflowOnly':
     '只有 Workflow 成员可以添加周期任务。',
-  'teams.automations.messages.consentRequired':
-    '创建前请审查并同意使用自动化专用 Agent Key。',
-  'teams.automations.messages.createAccepted':
-    '自动化创建请求已受理。',
   'teams.automations.messages.createFailed': '自动化未创建：{message}',
   'teams.automations.messages.createSuccess': '自动化已创建。',
   'teams.automations.messages.cronRequired': '请先填写 Cron 表达式。',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -752,9 +752,22 @@ const zhCNMessages = {
   'teams.automations.error.description':
     '刷新页面，或等定时任务服务可用后再试。',
   'teams.automations.error.title': '自动化加载失败',
+  'teams.automations.form.agentKeyConsent':
+    '我同意 Aevatar 为此定时任务创建专用的 Agent Key。',
+  'teams.automations.form.agentKeyExpiry': '到期时间：{time}',
+  'teams.automations.form.agentKeyManaged': '由 Aevatar 托管',
+  'teams.automations.form.agentKeyMode': '凭据模式：{mode}',
+  'teams.automations.form.agentKeyNoRawKey':
+    '浏览器不会接收 Agent Key 原文',
+  'teams.automations.form.agentKeyPlan':
+    '自动化专用 Agent Key',
+  'teams.automations.form.backendRequired': '暂不可创建',
   'teams.automations.form.cadence': '节奏',
   'teams.automations.form.cadenceAria': '自动化节奏',
+  'teams.automations.form.close': '关闭',
   'teams.automations.form.create': '创建自动化',
+  'teams.automations.form.createWithConsent':
+    '同意 Agent Key 授权并创建',
   'teams.automations.form.cron': 'Cron 表达式',
   'teams.automations.form.cronAria': 'Cron 表达式',
   'teams.automations.form.cronFiveFieldHint':
@@ -772,11 +785,19 @@ const zhCNMessages = {
   'teams.automations.form.identityReady': '目标为该成员的已发布服务。',
   'teams.automations.form.member': '成员',
   'teams.automations.form.memberAria': '自动化成员',
+  'teams.automations.form.nodeGrants': '节点权限',
+  'teams.automations.form.permissionDigest':
+    '权限摘要：{permissionDigest}',
+  'teams.automations.form.planChanged':
+    '授权计划已变更，请刷新后重新确认。',
+  'teams.automations.form.policyVersion':
+    '策略版本：{policyVersion}',
   'teams.automations.form.preset.custom': '自定义 Cron',
   'teams.automations.form.preset.dailyMorning': '每天 · 09:00',
   'teams.automations.form.preset.hourly': '每小时',
   'teams.automations.form.preset.weekdaysMorning': '工作日 · 09:00',
   'teams.automations.form.preset.weeklyMonday': '周一 · 09:00',
+  'teams.automations.form.preparingReview': '正在准备审查',
   'teams.automations.form.preview': '预览后续运行',
   'teams.automations.form.previewEmpty': '先预览节奏，确认后续触发。',
   'teams.automations.form.previewHint': '保存前通过定时任务服务预览。',
@@ -785,8 +806,22 @@ const zhCNMessages = {
   'teams.automations.form.promptLimit': '选填，最多 {maxLength} 个字符。',
   'teams.automations.form.promptPlaceholder':
     '汇总升级工单、受阻账号和后续负责人。',
+  'teams.automations.form.refreshReview': '刷新审查',
+  'teams.automations.form.reviewErrorBody':
+    '无法准备权限审查。草稿已保留，请重试。',
+  'teams.automations.form.reviewErrorTitle':
+    '权限审查需要处理',
+  'teams.automations.form.reviewPermissions': '审查权限',
+  'teams.automations.form.reviewPlaceholder':
+    '目标和运行节奏准备好后即可审查权限。',
+  'teams.automations.form.previewOnlyNotice':
+    '当前仅供预览。在接入专用后端契约前，不会创建自动化或 Agent Key。',
   'teams.automations.form.save': '保存修改',
   'teams.automations.form.scheduleReadsAs': '计划解读为',
+  'teams.automations.form.section.permissionReview':
+    '4. 审查 Agent Key 授权',
+  'teams.automations.form.section.permissionReviewHint':
+    '浏览器登录授权仅用于确认本次同意；自动化将使用由 Aevatar 托管的专用 Agent Key。',
   'teams.automations.form.section.schedule': '3. 运行节奏',
   'teams.automations.form.section.scheduleHint':
     '选择常用节奏，或切换到自定义 Cron 配置高级计划。',
@@ -796,6 +831,7 @@ const zhCNMessages = {
   'teams.automations.form.section.work': '2. 要执行的任务',
   'teams.automations.form.section.workHint':
     '给自动化命名，可选填写每次触发时发送给成员的 Prompt。',
+  'teams.automations.form.serviceGrants': '服务权限',
   'teams.automations.form.timezone': '时区',
   'teams.automations.form.timezoneAria': '时区',
   'teams.automations.form.title': '新建成员自动化',
@@ -804,6 +840,10 @@ const zhCNMessages = {
   'teams.automations.member.unknown': '未知成员',
   'teams.automations.member.workflowOnly':
     '只有 Workflow 成员可以添加周期任务。',
+  'teams.automations.messages.consentRequired':
+    '创建前请审查并同意使用自动化专用 Agent Key。',
+  'teams.automations.messages.createAccepted':
+    '自动化创建请求已受理。',
   'teams.automations.messages.createFailed': '自动化未创建：{message}',
   'teams.automations.messages.createSuccess': '自动化已创建。',
   'teams.automations.messages.cronRequired': '请先填写 Cron 表达式。',
@@ -813,6 +853,8 @@ const zhCNMessages = {
   'teams.automations.messages.previewFailed': '预览失败：{message}',
   'teams.automations.messages.promptTooLong':
     '周期 Prompt 最多 {maxLength} 个字符。',
+  'teams.automations.messages.reviewFailed':
+    '无法准备权限审查：{message}',
   'teams.automations.messages.runNowFailed': '立即运行请求失败：{message}',
   'teams.automations.messages.runNowSuccess': '已请求立即运行。',
   'teams.automations.messages.serviceIdentityLoading': '服务身份仍在加载中。',

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -363,21 +363,6 @@ function mockCreateTeamAutomationPermissionReview(
   };
 }
 
-function mockCreateTeamAutomationReceipt(overrides?: Record<string, any>) {
-  return {
-    scheduleId: "sch-alpha",
-    scheduleActorId: "schedule-actor-alpha",
-    accepted: true,
-    commandId: "cmd-team-automation-alpha",
-    correlationId: "corr-team-automation-alpha",
-    ackedAt: "2026-06-10T08:35:00Z",
-    ackStage: "accepted",
-    permissionDigest: "perm-digest-alpha-v1",
-    policyVersion: "agent-key-policy-v1",
-    ...overrides,
-  };
-}
-
 const forbiddenAutomationSecretMarkers = [
   "fullKey",
   "full_key",
@@ -745,7 +730,6 @@ jest.mock("@/shared/api/scheduledDispatchApi", () => ({
 jest.mock("@/shared/api/teamAutomationApi", () => ({
   teamAutomationApi: {
     preflightCreate: jest.fn(async () => mockCreateTeamAutomationPermissionReview()),
-    create: jest.fn(async () => mockCreateTeamAutomationReceipt()),
   },
 }));
 
@@ -1065,10 +1049,6 @@ describe("TeamDetailPage", () => {
     (teamAutomationApi.preflightCreate as jest.Mock).mockReset();
     (teamAutomationApi.preflightCreate as jest.Mock).mockImplementation(
       async () => mockCreateTeamAutomationPermissionReview(),
-    );
-    (teamAutomationApi.create as jest.Mock).mockReset();
-    (teamAutomationApi.create as jest.Mock).mockImplementation(
-      async () => mockCreateTeamAutomationReceipt(),
     );
     (scheduledDispatchApi.update as jest.Mock).mockReset();
     (scheduledDispatchApi.update as jest.Mock).mockImplementation(async () => ({
@@ -2854,7 +2834,6 @@ describe("TeamDetailPage", () => {
     );
     expect(createButton).toBeDisabled();
     fireEvent.click(createButton);
-    expect(teamAutomationApi.create).not.toHaveBeenCalled();
     expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
     expectNoAutomationSecretMarkers(reviewPayload);
     expectNoAutomationSecretMarkers(
@@ -2899,7 +2878,6 @@ describe("TeamDetailPage", () => {
     ).toBeDisabled();
     fireEvent.click(within(dialog).getByRole("button", { name: /关.*闭/ }));
 
-    expect(teamAutomationApi.create).not.toHaveBeenCalled();
     expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
 
     fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
@@ -2952,7 +2930,6 @@ describe("TeamDetailPage", () => {
       await screen.findByLabelText(/我同意 Aevatar 为此定时任务创建专用的 Agent Key/),
     ).toBeTruthy();
     expect(teamAutomationApi.preflightCreate).toHaveBeenCalledTimes(2);
-    expect(teamAutomationApi.create).not.toHaveBeenCalled();
   });
 
   it("previews next runs from the automation form", async () => {
@@ -3038,7 +3015,6 @@ describe("TeamDetailPage", () => {
         name: "暂不可创建",
       }),
     );
-    expect(teamAutomationApi.create).not.toHaveBeenCalled();
     expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
     expect(message.error).not.toHaveBeenCalledWith("保存前请先描述周期任务。");
   });
@@ -3132,7 +3108,6 @@ describe("TeamDetailPage", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "暂不可创建" }),
     );
-    expect(teamAutomationApi.create).not.toHaveBeenCalled();
     expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
   });
 
@@ -3160,7 +3135,6 @@ describe("TeamDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
     expect(await screen.findByText("凭据模式：dedicated-per-schedule")).toBeTruthy();
     expect(teamAutomationApi.preflightCreate).toHaveBeenCalledTimes(2);
-    expect(teamAutomationApi.create).not.toHaveBeenCalled();
     expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -8,6 +8,7 @@ import { runtimeActorsApi } from "@/shared/api/runtimeActorsApi";
 import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
 import { scheduledDispatchApi } from "@/shared/api/scheduledDispatchApi";
+import { teamAutomationApi } from "@/shared/api/teamAutomationApi";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
 import { studioApi } from "@/shared/studio/api";
 import {
@@ -327,6 +328,72 @@ function mockCreateScheduledDispatchSummary(overrides?: Record<string, any>) {
     deleted: false,
     ...overrides,
   };
+}
+
+function mockCreateTeamAutomationPermissionReview(
+  overrides?: Record<string, any>,
+) {
+  return {
+    status: "ready",
+    permissionDigest: "perm-digest-alpha-v1",
+    policyVersion: "agent-key-policy-v1",
+    credentialPlan: {
+      mode: "dedicated-per-schedule",
+      hostedBy: "Aevatar",
+      browserReceivesRawKey: false,
+      expiresAt: "2026-09-30T00:00:00Z",
+    },
+    serviceGrants: [
+      {
+        grantId: "service-chat-invoke",
+        targetId: "svc-alpha",
+        displayName: "Published service svc-alpha",
+        permission: "Invoke workflow chat endpoint",
+      },
+    ],
+    nodeGrants: [
+      {
+        grantId: "workflow-runtime-start",
+        targetId: "workflow-runtime",
+        displayName: "Workflow runtime",
+        permission: "Start scheduled workflow runs",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function mockCreateTeamAutomationReceipt(overrides?: Record<string, any>) {
+  return {
+    scheduleId: "sch-alpha",
+    scheduleActorId: "schedule-actor-alpha",
+    accepted: true,
+    commandId: "cmd-team-automation-alpha",
+    correlationId: "corr-team-automation-alpha",
+    ackedAt: "2026-06-10T08:35:00Z",
+    ackStage: "accepted",
+    permissionDigest: "perm-digest-alpha-v1",
+    policyVersion: "agent-key-policy-v1",
+    ...overrides,
+  };
+}
+
+const forbiddenAutomationSecretMarkers = [
+  "fullKey",
+  "full_key",
+  "OAuth token",
+  "oauth token",
+  "SecretReference",
+  "apiKeyId",
+  "ak-alpha",
+] as const;
+
+function expectNoAutomationSecretMarkers(value: unknown) {
+  const serialized =
+    typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  for (const marker of forbiddenAutomationSecretMarkers) {
+    expect(serialized).not.toContain(marker);
+  }
 }
 
 function collectRenderedStyleText(): string {
@@ -675,6 +742,13 @@ jest.mock("@/shared/api/scheduledDispatchApi", () => ({
   },
 }));
 
+jest.mock("@/shared/api/teamAutomationApi", () => ({
+  teamAutomationApi: {
+    preflightCreate: jest.fn(async () => mockCreateTeamAutomationPermissionReview()),
+    create: jest.fn(async () => mockCreateTeamAutomationReceipt()),
+  },
+}));
+
 jest.mock("@/shared/agui/sseFrameNormalizer", () => ({
   parseBackendSSEStream: jest.fn(async function* () {
     yield {
@@ -988,6 +1062,14 @@ describe("TeamDetailPage", () => {
       ackedAt: "2026-06-10T08:35:00Z",
       ackStage: "accepted",
     }));
+    (teamAutomationApi.preflightCreate as jest.Mock).mockReset();
+    (teamAutomationApi.preflightCreate as jest.Mock).mockImplementation(
+      async () => mockCreateTeamAutomationPermissionReview(),
+    );
+    (teamAutomationApi.create as jest.Mock).mockReset();
+    (teamAutomationApi.create as jest.Mock).mockImplementation(
+      async () => mockCreateTeamAutomationReceipt(),
+    );
     (scheduledDispatchApi.update as jest.Mock).mockReset();
     (scheduledDispatchApi.update as jest.Mock).mockImplementation(async () => ({
       scheduleId: "sch-alpha",
@@ -2689,7 +2771,7 @@ describe("TeamDetailPage", () => {
     expect(screen.getAllByText("已触发").length).toBeGreaterThan(0);
   });
 
-  it("creates member recurring work with the published service identity", async () => {
+  it("creates member recurring work after Agent Key permission review and consent", async () => {
     window.history.replaceState(
       {},
       "",
@@ -2707,12 +2789,15 @@ describe("TeamDetailPage", () => {
         totalCount: 1,
       });
 
-    renderWithQueryClient(React.createElement(TeamDetailPage));
+    const { queryClient } = renderWithQueryClient(
+      React.createElement(TeamDetailPage),
+    );
 
     fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
     expect(await screen.findByText("1. 目标成员")).toBeTruthy();
     expect(screen.getByText("2. 要执行的任务")).toBeTruthy();
     expect(screen.getByText("3. 运行节奏")).toBeTruthy();
+    expect(screen.getByText("4. 审查 Agent Key 授权")).toBeTruthy();
     const defaultTimezone =
       Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
     expect(screen.getByText(`工作日 09:00 · ${defaultTimezone}`)).toBeTruthy();
@@ -2730,55 +2815,144 @@ describe("TeamDetailPage", () => {
       target: { value: "Asia/Shanghai" },
     });
     expect(scheduledDispatchApi.listAll).toHaveBeenCalledTimes(1);
-    fireEvent.click(screen.getByRole("button", { name: "创建自动化" }));
+    fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
 
     await waitFor(() => {
-      expect(scheduledDispatchApi.create).toHaveBeenCalled();
+      expect(teamAutomationApi.preflightCreate).toHaveBeenCalled();
     });
-    const payload = (scheduledDispatchApi.create as jest.Mock).mock.calls[0][0];
-    expect(payload).toEqual(
+    const reviewPayload = (teamAutomationApi.preflightCreate as jest.Mock).mock
+      .calls[0][0];
+    expect(reviewPayload).toEqual(
       expect.objectContaining({
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        memberId: "member-team-alpha",
+        publishedServiceId: "alpha-service",
+        serviceRevisionId: "rev-2",
         displayName: "Daily escalation digest",
         cronExpression: "0 9 * * 1-5",
         timezone: "Asia/Shanghai",
         enabled: true,
-        headers: {
-          source: "team-automations",
-        },
-        workflowChatTarget: {
-          identity: {
-            tenantId: "scope-1",
-            appId: "default",
-            namespace: "default",
-            serviceId: "alpha-service",
-          },
-          prompt: "Summarize escalations and follow-up owners.",
-          revisionId: "rev-2",
-        },
+        prompt: "Summarize escalations and follow-up owners.",
       }),
     );
-    expect(JSON.stringify(payload)).not.toContain("member-team-alpha");
-    expect(JSON.stringify(payload)).not.toContain("wf-team-alpha");
-    expect(message.success).toHaveBeenCalledWith("自动化已创建。");
-    expect(scheduledDispatchApi.listAll).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(screen.getAllByText("Daily escalation digest").length).toBeGreaterThan(
-        0,
-      );
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
+    expect(screen.getByText("凭据模式：dedicated-per-schedule")).toBeTruthy();
+    expect(screen.getByText("由 Aevatar 托管")).toBeTruthy();
+    expect(
+      screen.getByText("浏览器不会接收 Agent Key 原文"),
+    ).toBeTruthy();
+    expect(screen.getByText("服务权限")).toBeTruthy();
+    expect(screen.getByText("节点权限")).toBeTruthy();
+    expect(screen.getByText("权限摘要：perm-digest-alpha-v1")).toBeTruthy();
+    const createButton = screen.getByRole("button", {
+      name: "暂不可创建",
     });
-    expect(screen.getByText("正在等待计划同步")).toBeTruthy();
-
-    await waitFor(
-      () => {
-        expect(scheduledDispatchApi.listAll).toHaveBeenCalledTimes(2);
-      },
-      { timeout: 2_000 },
+    expect(createButton).toBeDisabled();
+    fireEvent.click(
+      screen.getByLabelText(/我同意 Aevatar 为此定时任务创建专用的 Agent Key/),
     );
-    await waitFor(() => {
-      expect(screen.getAllByText("Daily escalation digest").length).toBeGreaterThan(
-        0,
-      );
+    expect(createButton).toBeDisabled();
+    fireEvent.click(createButton);
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
+    expectNoAutomationSecretMarkers(reviewPayload);
+    expectNoAutomationSecretMarkers(
+      queryClient.getQueryCache().getAll().map((query) => query.state.data),
+    );
+    expectNoAutomationSecretMarkers(document.body.textContent ?? "");
+    expect(screen.getByText(
+      "当前仅供预览。在接入专用后端契约前，不会创建自动化或 Agent Key。",
+    )).toBeTruthy();
+    expect(message.success).not.toHaveBeenCalledWith(
+      "自动化创建请求已受理。",
+    );
+    expect(scheduledDispatchApi.listAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not submit when permission review closes before consent and keeps the draft", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha?memberId=member-team-alpha&tab=automations",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
+    const dialog = await screen.findByRole("dialog", {
+      name: "新建成员自动化",
     });
+    fireEvent.change(within(dialog).getByLabelText("自动化名称"), {
+      target: { value: "Draft escalation digest" },
+    });
+    fireEvent.change(within(dialog).getByLabelText(/周期 Prompt/), {
+      target: { value: "Keep this draft after review closes." },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "审查权限" }));
+
+    expect(await within(dialog).findByText("凭据模式：dedicated-per-schedule")).toBeTruthy();
+    expect(
+      within(dialog).getByRole("button", {
+        name: "暂不可创建",
+      }),
+    ).toBeDisabled();
+    fireEvent.click(within(dialog).getByRole("button", { name: /关.*闭/ }));
+
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
+    const reopenedDialog = await screen.findByRole("dialog", {
+      name: "新建成员自动化",
+    });
+    expect(within(reopenedDialog).getByLabelText("自动化名称")).toHaveValue(
+      "Draft escalation digest",
+    );
+    expect(within(reopenedDialog).getByLabelText(/周期 Prompt/)).toHaveValue(
+      "Keep this draft after review closes.",
+    );
+    expect(
+      within(reopenedDialog).getByText(
+        "目标和运行节奏准备好后即可审查权限。",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("blocks consent when the permission plan changes and requires a fresh review", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha?memberId=member-team-alpha&tab=automations",
+    );
+    (teamAutomationApi.preflightCreate as jest.Mock)
+      .mockResolvedValueOnce(
+        mockCreateTeamAutomationPermissionReview({
+          status: "plan-changed",
+          warning: "权限范围已更新，请重新审查。",
+        }),
+      )
+      .mockResolvedValueOnce(mockCreateTeamAutomationPermissionReview());
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
+    fireEvent.change(await screen.findByLabelText("自动化名称"), {
+      target: { value: "Daily escalation digest" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
+
+    expect(await screen.findByText("权限范围已更新，请重新审查。")).toBeTruthy();
+    expect(
+      screen.queryByLabelText(/我同意 Aevatar 为此定时任务创建专用的 Agent Key/),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "刷新审查" }));
+
+    expect(
+      await screen.findByLabelText(/我同意 Aevatar 为此定时任务创建专用的 Agent Key/),
+    ).toBeTruthy();
+    expect(teamAutomationApi.preflightCreate).toHaveBeenCalledTimes(2);
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
   });
 
   it("previews next runs from the automation form", async () => {
@@ -2843,28 +3017,30 @@ describe("TeamDetailPage", () => {
     fireEvent.change(within(dialog).getByLabelText("自动化名称"), {
       target: { value: "Daily escalation digest" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "创建自动化" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "审查权限" }));
 
     await waitFor(() => {
-      expect(scheduledDispatchApi.create).toHaveBeenCalled();
+      expect(teamAutomationApi.preflightCreate).toHaveBeenCalled();
     });
-    expect((scheduledDispatchApi.create as jest.Mock).mock.calls[0][0]).toEqual(
+    expect((teamAutomationApi.preflightCreate as jest.Mock).mock.calls[0][0]).toEqual(
       expect.objectContaining({
         displayName: "Daily escalation digest",
-        workflowChatTarget: {
-          identity: {
-            tenantId: "scope-1",
-            appId: "default",
-            namespace: "default",
-            serviceId: "alpha-service",
-          },
-          prompt: "",
-          revisionId: "rev-2",
-        },
+        prompt: "",
+        publishedServiceId: "alpha-service",
+        serviceRevisionId: "rev-2",
       }),
     );
+    fireEvent.click(
+      within(dialog).getByLabelText(/我同意 Aevatar 为此定时任务创建专用的 Agent Key/),
+    );
+    fireEvent.click(
+      within(dialog).getByRole("button", {
+        name: "暂不可创建",
+      }),
+    );
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
     expect(message.error).not.toHaveBeenCalledWith("保存前请先描述周期任务。");
-    expect(message.success).toHaveBeenCalledWith("自动化已创建。");
   });
 
   it("creates member recurring work with the default service revision when the active serving revision is missing", async () => {
@@ -2896,18 +3072,14 @@ describe("TeamDetailPage", () => {
     fireEvent.change(screen.getByLabelText(/周期 Prompt/), {
       target: { value: "Summarize escalations and follow-up owners." },
     });
-    fireEvent.click(screen.getByRole("button", { name: "创建自动化" }));
+    fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
 
     await waitFor(() => {
-      expect(scheduledDispatchApi.create).toHaveBeenCalled();
+      expect(teamAutomationApi.preflightCreate).toHaveBeenCalled();
     });
-    const payload = (scheduledDispatchApi.create as jest.Mock).mock.calls[0][0];
-    expect(payload.workflowChatTarget).toEqual(
-      expect.objectContaining({
-        revisionId: "rev-2",
-      }),
-    );
-    expect(message.success).toHaveBeenCalledWith("自动化已创建。");
+    const payload = (teamAutomationApi.preflightCreate as jest.Mock).mock.calls[0][0];
+    expect(payload).toEqual(expect.objectContaining({ serviceRevisionId: "rev-2" }));
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
   });
 
   it("creates member recurring work without a revision when no serving revision is available", async () => {
@@ -2937,34 +3109,41 @@ describe("TeamDetailPage", () => {
     fireEvent.change(await screen.findByLabelText(/周期 Prompt/), {
       target: { value: "Summarize escalations and follow-up owners." },
     });
-    fireEvent.click(screen.getByRole("button", { name: "创建自动化" }));
+    fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
 
     await waitFor(() => {
-      expect(scheduledDispatchApi.create).toHaveBeenCalled();
+      expect(teamAutomationApi.preflightCreate).toHaveBeenCalled();
     });
-    const payload = (scheduledDispatchApi.create as jest.Mock).mock.calls[0][0];
-    expect(payload.workflowChatTarget).toEqual({
-      identity: {
-        tenantId: "scope-1",
-        appId: "default",
-        namespace: "default",
-        serviceId: "alpha-service",
-      },
-      prompt: "Summarize escalations and follow-up owners.",
-    });
-    expect(message.success).toHaveBeenCalledWith("自动化已创建。");
+    const payload = (teamAutomationApi.preflightCreate as jest.Mock).mock.calls[0][0];
+    expect(payload).toEqual(
+      expect.objectContaining({
+        publishedServiceId: "alpha-service",
+        prompt: "Summarize escalations and follow-up owners.",
+      }),
+    );
+    expect(payload).not.toEqual(
+      expect.objectContaining({
+        serviceRevisionId: expect.any(String),
+      }),
+    );
+    fireEvent.click(
+      screen.getByLabelText(/我同意 Aevatar 为此定时任务创建专用的 Agent Key/),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "暂不可创建" }),
+    );
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
   });
 
-  it("keeps schedule create failures inside the automations flow", async () => {
+  it("keeps the draft and recovers when permission preflight fails", async () => {
     window.history.replaceState(
       {},
       "",
       "/scopes/scope-1/teams/t-alpha?memberId=member-team-alpha&tab=automations",
     );
-    (scheduledDispatchApi.create as jest.Mock).mockRejectedValueOnce(
-      new Error(
-        "One or more validation errors occurred.: $.serviceInvocation.payload.value: The JSON value could not be converted to Google.Protobuf.ByteString.",
-      ),
+    (teamAutomationApi.preflightCreate as jest.Mock).mockRejectedValueOnce(
+      new Error("Mock permission review failed."),
     );
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
@@ -2973,14 +3152,16 @@ describe("TeamDetailPage", () => {
     fireEvent.change(await screen.findByLabelText(/周期 Prompt/), {
       target: { value: "Summarize escalations and follow-up owners." },
     });
-    fireEvent.click(screen.getByRole("button", { name: "创建自动化" }));
-
-    await waitFor(() => {
-      expect(message.error).toHaveBeenCalledWith(
-        "自动化未创建：One or more validation errors occurred.: $.serviceInvocation.payload.value: The JSON value could not be converted to Google.Protobuf.ByteString.",
-      );
-    });
-    expect(message.success).not.toHaveBeenCalledWith("自动化已创建。");
+    fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
+    expect(await screen.findByText("权限审查需要处理")).toBeTruthy();
+    expect(screen.getByLabelText(/周期 Prompt/)).toHaveValue(
+      "Summarize escalations and follow-up owners.",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "审查权限" }));
+    expect(await screen.findByText("凭据模式：dedicated-per-schedule")).toBeTruthy();
+    expect(teamAutomationApi.preflightCreate).toHaveBeenCalledTimes(2);
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
+    expect(scheduledDispatchApi.create).not.toHaveBeenCalled();
   });
 
   it("edits member recurring work with the published service identity", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -780,6 +780,309 @@ function hasBackendObservedManualRun(
     lastFireAt >= scheduledFireAt;
 }
 
+function useTeamAutomationPermissionReview() {
+  const intl = useIntl();
+  const [stage, setStage] = React.useState<TeamAutomationCreateStage>("draft");
+  const [review, setReview] =
+    React.useState<TeamAutomationPermissionReview | null>(null);
+  const [consentChecked, setConsentChecked] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const mutation = useMutation({
+    mutationFn: teamAutomationApi.preflightCreate,
+    onError: (cause) => {
+      const detail = cause instanceof Error ? cause.message : String(cause);
+      setStage("error");
+      setError(detail);
+      void message.error(
+        intl.formatMessage(
+          {
+            id: "teams.automations.messages.reviewFailed",
+            defaultMessage: "Permission review could not be prepared: {message}",
+          },
+          { message: detail },
+        ),
+      );
+    },
+    onMutate: () => {
+      setConsentChecked(false);
+      setError("");
+      setStage("preflight");
+    },
+    onSuccess: (nextReview) => {
+      setReview(nextReview);
+      setStage(
+        nextReview.status === "plan-changed"
+          ? "planChanged"
+          : "permissionReview",
+      );
+    },
+  });
+  const reset = React.useCallback(() => {
+    setReview(null);
+    setConsentChecked(false);
+    setError("");
+    setStage("draft");
+  }, []);
+  const setConsent = React.useCallback((checked: boolean) => {
+    setConsentChecked(checked);
+    setStage(checked ? "consent" : "permissionReview");
+  }, []);
+
+  return { consentChecked, error, mutation, reset, review, setConsent, stage };
+}
+
+function TeamAutomationGrantList({
+  grants,
+  title,
+}: {
+  readonly grants: TeamAutomationPermissionReview["serviceGrants"];
+  readonly title: string;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      <Typography.Text strong>{title}</Typography.Text>
+      {grants.map((grant) => (
+        <Typography.Text key={grant.grantId} style={{ fontSize: 12 }}>
+          {grant.displayName} · {grant.permission}
+        </Typography.Text>
+      ))}
+    </div>
+  );
+}
+
+function TeamAutomationPermissionReviewPanel({
+  consentChecked,
+  error,
+  onConsentChange,
+  review,
+  stage,
+}: {
+  readonly consentChecked: boolean;
+  readonly error: string;
+  readonly onConsentChange: (checked: boolean) => void;
+  readonly review: TeamAutomationPermissionReview | null;
+  readonly stage: TeamAutomationCreateStage;
+}) {
+  const intl = useIntl();
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      style={{
+        ...modalSectionStyle,
+        background: token.colorBgContainer,
+        border: `1px solid ${token.colorBorderSecondary}`,
+      }}
+    >
+      <div style={{ display: "grid", gap: 2 }}>
+        <Typography.Text strong>
+          {intl.formatMessage({
+            id: "teams.automations.form.section.permissionReview",
+            defaultMessage: "4. Review Agent Key consent",
+          })}
+        </Typography.Text>
+        <Typography.Text style={{ fontSize: 12 }} type="secondary">
+          {intl.formatMessage({
+            id: "teams.automations.form.section.permissionReviewHint",
+            defaultMessage:
+              "Browser login authorization only confirms this consent. Automation uses a dedicated Agent Key managed by Aevatar.",
+          })}
+        </Typography.Text>
+      </div>
+
+      {stage === "preflight" ? (
+        <div
+          style={{
+            background: token.colorFillQuaternary,
+            border: `1px solid ${token.colorBorderSecondary}`,
+            borderRadius: 10,
+            padding: 12,
+          }}
+        >
+          <Skeleton active paragraph={{ rows: 2 }} title={false} />
+        </div>
+      ) : null}
+
+      {stage === "error" ? (
+        <div
+          role="alert"
+          style={{
+            background: token.colorErrorBg,
+            border: `1px solid ${token.colorErrorBorder}`,
+            borderRadius: 10,
+            color: token.colorErrorText,
+            display: "grid",
+            gap: 4,
+            padding: 12,
+          }}
+        >
+          <Typography.Text strong>
+            {intl.formatMessage({
+              id: "teams.automations.form.reviewErrorTitle",
+              defaultMessage: "Permission review needs attention",
+            })}
+          </Typography.Text>
+          <Typography.Text style={{ color: token.colorErrorText }}>
+            {error ||
+              intl.formatMessage({
+                id: "teams.automations.form.reviewErrorBody",
+                defaultMessage:
+                  "The mock contract could not prepare the review. Keep the draft and try again.",
+              })}
+          </Typography.Text>
+        </div>
+      ) : null}
+
+      {review ? (
+        <div style={{ display: "grid", gap: 12 }}>
+          {stage === "planChanged" ? (
+            <div
+              role="status"
+              style={{
+                background: token.colorWarningBg,
+                border: `1px solid ${token.colorWarningBorder}`,
+                borderRadius: 10,
+                color: token.colorWarningText,
+                padding: 12,
+              }}
+            >
+              <Typography.Text style={{ color: token.colorWarningText }}>
+                {review.warning ||
+                  intl.formatMessage({
+                    id: "teams.automations.form.planChanged",
+                    defaultMessage:
+                      "The authorization plan changed. Refresh the review before creating.",
+                  })}
+              </Typography.Text>
+            </div>
+          ) : null}
+
+          <div
+            style={{
+              background: token.colorFillQuaternary,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              borderRadius: 10,
+              display: "grid",
+              gap: 10,
+              padding: 12,
+            }}
+          >
+            <div style={{ display: "grid", gap: 4 }}>
+              <Typography.Text strong>
+                {intl.formatMessage({
+                  id: "teams.automations.form.agentKeyPlan",
+                  defaultMessage: "Automation dedicated Agent Key",
+                })}
+              </Typography.Text>
+              <FactLine
+                text={intl.formatMessage(
+                  {
+                    id: "teams.automations.form.agentKeyMode",
+                    defaultMessage: "Credential mode · {mode}",
+                  },
+                  { mode: review.credentialPlan.mode },
+                )}
+              />
+              <FactLine
+                text={intl.formatMessage({
+                  id: "teams.automations.form.agentKeyManaged",
+                  defaultMessage: "Aevatar managed",
+                })}
+              />
+              <FactLine
+                text={intl.formatMessage({
+                  id: "teams.automations.form.agentKeyNoRawKey",
+                  defaultMessage: "Browser never receives the raw Agent Key",
+                })}
+              />
+              <FactLine
+                text={intl.formatMessage(
+                  {
+                    id: "teams.automations.form.agentKeyExpiry",
+                    defaultMessage: "Expires {time}",
+                  },
+                  { time: formatScheduleTime(review.credentialPlan.expiresAt, "--") },
+                )}
+              />
+              <FactLine
+                text={intl.formatMessage(
+                  {
+                    id: "teams.automations.form.permissionDigest",
+                    defaultMessage: "Permission digest · {permissionDigest}",
+                  },
+                  { permissionDigest: review.permissionDigest },
+                )}
+              />
+              <FactLine
+                text={intl.formatMessage(
+                  {
+                    id: "teams.automations.form.policyVersion",
+                    defaultMessage: "Policy version · {policyVersion}",
+                  },
+                  { policyVersion: review.policyVersion },
+                )}
+              />
+            </div>
+            <div
+              className="team-automation-form-schedule-grid"
+              style={{
+                display: "grid",
+                gap: 12,
+                gridTemplateColumns: "minmax(0, 1fr) minmax(0, 1fr)",
+              }}
+            >
+              <TeamAutomationGrantList
+                grants={review.serviceGrants}
+                title={intl.formatMessage({
+                  id: "teams.automations.form.serviceGrants",
+                  defaultMessage: "Service grants",
+                })}
+              />
+              <TeamAutomationGrantList
+                grants={review.nodeGrants}
+                title={intl.formatMessage({
+                  id: "teams.automations.form.nodeGrants",
+                  defaultMessage: "Node grants",
+                })}
+              />
+            </div>
+          </div>
+
+          {stage !== "planChanged" ? (
+            <div style={{ display: "grid", gap: 6 }}>
+              <Checkbox
+                checked={consentChecked}
+                onChange={(event) => onConsentChange(event.target.checked)}
+              >
+                {intl.formatMessage({
+                  id: "teams.automations.form.agentKeyConsent",
+                  defaultMessage:
+                    "I consent to Aevatar creating an automation-dedicated Agent Key for this schedule.",
+                })}
+              </Checkbox>
+              <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                {intl.formatMessage({
+                  id: "teams.automations.form.previewOnlyNotice",
+                  defaultMessage:
+                    "Preview only. No automation or Agent Key is created until the scoped backend is connected.",
+                })}
+              </Typography.Text>
+            </div>
+          ) : null}
+        </div>
+      ) : stage !== "preflight" && stage !== "error" ? (
+        <Typography.Text style={{ fontSize: 12 }} type="secondary">
+          {intl.formatMessage({
+            id: "teams.automations.form.reviewPlaceholder",
+            defaultMessage:
+              "Review is prepared after the draft cadence and target are ready.",
+          })}
+        </Typography.Text>
+      ) : null}
+    </div>
+  );
+}
+
 const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   members = [],
   scopeId,
@@ -821,13 +1124,15 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const [formState, setFormState] = React.useState<AutomationFormState>(() =>
     buildDefaultAutomationFormState(),
   );
-  const [createStage, setCreateStage] =
-    React.useState<TeamAutomationCreateStage>("draft");
-  const [permissionReview, setPermissionReview] =
-    React.useState<TeamAutomationPermissionReview | null>(null);
-  const [agentKeyConsentChecked, setAgentKeyConsentChecked] =
-    React.useState(false);
-  const [createReviewError, setCreateReviewError] = React.useState("");
+  const {
+    consentChecked: agentKeyConsentChecked,
+    error: createReviewError,
+    mutation: permissionReviewMutation,
+    reset: resetPermissionReview,
+    review: permissionReview,
+    setConsent: setAgentKeyConsentChecked,
+    stage: createStage,
+  } = useTeamAutomationPermissionReview();
   const [hasPreservedCreateDraft, setHasPreservedCreateDraft] =
     React.useState(false);
   const scheduleQueryKey = React.useMemo(
@@ -1176,36 +1481,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       setPreview(result);
     },
   });
-  const permissionReviewMutation = useMutation({
-    mutationFn: ({
-      draft,
-    }: {
-      readonly draft: TeamAutomationCreateDraft;
-    }) => teamAutomationApi.preflightCreate(draft),
-    onError: (error) => {
-      const detail = error instanceof Error ? error.message : String(error);
-      setCreateStage("error");
-      setCreateReviewError(detail);
-      void message.error(
-        intl.formatMessage(
-          {
-            id: "teams.automations.messages.reviewFailed",
-            defaultMessage: "Permission review could not be prepared: {message}",
-          },
-          { message: detail },
-        ),
-      );
-    },
-    onMutate: () => {
-      setAgentKeyConsentChecked(false);
-      setCreateReviewError("");
-      setCreateStage("preflight");
-    },
-    onSuccess: (review) => {
-      setPermissionReview(review);
-      setCreateStage(review.status === "plan-changed" ? "planChanged" : "permissionReview");
-    },
-  });
   const updateMutation = useMutation({
     mutationFn: ({
       input,
@@ -1323,12 +1598,9 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         : buildDefaultAutomationFormState(member?.memberId ?? ""),
     );
     setPreview(null);
-    setPermissionReview(null);
-    setAgentKeyConsentChecked(false);
-    setCreateReviewError("");
-    setCreateStage("draft");
+    resetPermissionReview();
     setCreateOpen(true);
-  }, [hasPreservedCreateDraft, selectedMember]);
+  }, [hasPreservedCreateDraft, resetPermissionReview, selectedMember]);
 
   const openEdit = React.useCallback(
     (schedule: ScheduledDispatchSummary) => {
@@ -1350,13 +1622,10 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         timezone: trimText(schedule.timezone) || resolveDefaultTimezone(),
       });
       setPreview(null);
-      setPermissionReview(null);
-      setAgentKeyConsentChecked(false);
-      setCreateReviewError("");
-      setCreateStage("draft");
+      resetPermissionReview();
       setCreateOpen(true);
     },
-    [cronPresets, findMemberForSchedule, selectedMember],
+    [cronPresets, findMemberForSchedule, resetPermissionReview, selectedMember],
   );
 
   const updateForm = React.useCallback(
@@ -1366,15 +1635,12 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         ...patch,
       }));
       setPreview(null);
-      setPermissionReview(null);
-      setAgentKeyConsentChecked(false);
-      setCreateReviewError("");
-      setCreateStage("draft");
+      resetPermissionReview();
       if (!isEditingAutomation) {
         setHasPreservedCreateDraft(true);
       }
     },
-    [isEditingAutomation],
+    [isEditingAutomation, resetPermissionReview],
   );
 
   const previewNextRuns = React.useCallback(async () => {
@@ -1521,7 +1787,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       createStage === "error" ||
       createStage === "planChanged"
     ) {
-      await permissionReviewMutation.mutateAsync({ draft });
+      await permissionReviewMutation.mutateAsync(draft);
       return;
     }
   }, [
@@ -2399,10 +2665,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
             setCreateOpen(false);
             setEditingSchedule(null);
             setPreview(null);
-            setPermissionReview(null);
-            setAgentKeyConsentChecked(false);
-            setCreateReviewError("");
-            setCreateStage("draft");
+            resetPermissionReview();
           }
         }}
         onOk={handleSaveAutomation}
@@ -2761,246 +3024,13 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
           </div>
 
           {!isEditingAutomation ? (
-            <div
-              style={{
-                ...modalSectionStyle,
-                background: token.colorBgContainer,
-                border: `1px solid ${token.colorBorderSecondary}`,
-              }}
-            >
-              <div style={{ display: "grid", gap: 2 }}>
-                <Typography.Text strong>
-                  {intl.formatMessage({
-                    id: "teams.automations.form.section.permissionReview",
-                    defaultMessage: "4. Review Agent Key consent",
-                  })}
-                </Typography.Text>
-                <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                  {intl.formatMessage({
-                    id: "teams.automations.form.section.permissionReviewHint",
-                    defaultMessage:
-                      "Browser login authorization only confirms this consent. Automation uses a dedicated Agent Key managed by Aevatar.",
-                  })}
-                </Typography.Text>
-              </div>
-
-              {createStage === "preflight" ? (
-                <div
-                  style={{
-                    background: token.colorFillQuaternary,
-                    border: `1px solid ${token.colorBorderSecondary}`,
-                    borderRadius: 10,
-                    padding: 12,
-                  }}
-                >
-                  <Skeleton active paragraph={{ rows: 2 }} title={false} />
-                </div>
-              ) : null}
-
-              {createStage === "error" ? (
-                <div
-                  role="alert"
-                  style={{
-                    background: token.colorErrorBg,
-                    border: `1px solid ${token.colorErrorBorder}`,
-                    borderRadius: 10,
-                    color: token.colorErrorText,
-                    display: "grid",
-                    gap: 4,
-                    padding: 12,
-                  }}
-                >
-                  <Typography.Text strong>
-                    {intl.formatMessage({
-                      id: "teams.automations.form.reviewErrorTitle",
-                      defaultMessage: "Permission review needs attention",
-                    })}
-                  </Typography.Text>
-                  <Typography.Text style={{ color: token.colorErrorText }}>
-                    {createReviewError ||
-                      intl.formatMessage({
-                        id: "teams.automations.form.reviewErrorBody",
-                        defaultMessage:
-                          "The mock contract could not prepare the review. Keep the draft and try again.",
-                      })}
-                  </Typography.Text>
-                </div>
-              ) : null}
-
-              {permissionReview ? (
-                <div style={{ display: "grid", gap: 12 }}>
-                  {createStage === "planChanged" ? (
-                    <div
-                      role="status"
-                      style={{
-                        background: token.colorWarningBg,
-                        border: `1px solid ${token.colorWarningBorder}`,
-                        borderRadius: 10,
-                        color: token.colorWarningText,
-                        padding: 12,
-                      }}
-                    >
-                      <Typography.Text style={{ color: token.colorWarningText }}>
-                        {permissionReview.warning ||
-                          intl.formatMessage({
-                            id: "teams.automations.form.planChanged",
-                            defaultMessage:
-                              "The authorization plan changed. Refresh the review before creating.",
-                          })}
-                      </Typography.Text>
-                    </div>
-                  ) : null}
-
-                  <div
-                    style={{
-                      background: token.colorFillQuaternary,
-                      border: `1px solid ${token.colorBorderSecondary}`,
-                      borderRadius: 10,
-                      display: "grid",
-                      gap: 10,
-                      padding: 12,
-                    }}
-                  >
-                    <div style={{ display: "grid", gap: 4 }}>
-                      <Typography.Text strong>
-                        {intl.formatMessage({
-                          id: "teams.automations.form.agentKeyPlan",
-                          defaultMessage: "Automation dedicated Agent Key",
-                        })}
-                      </Typography.Text>
-                      <FactLine
-                        text={intl.formatMessage(
-                          {
-                            id: "teams.automations.form.agentKeyMode",
-                            defaultMessage: "Credential mode · {mode}",
-                          },
-                          { mode: permissionReview.credentialPlan.mode },
-                        )}
-                      />
-                      <FactLine
-                        text={intl.formatMessage({
-                          id: "teams.automations.form.agentKeyManaged",
-                          defaultMessage: "Aevatar managed",
-                        })}
-                      />
-                      <FactLine
-                        text={intl.formatMessage({
-                          id: "teams.automations.form.agentKeyNoRawKey",
-                          defaultMessage:
-                            "Browser never receives the raw Agent Key",
-                        })}
-                      />
-                      <FactLine
-                        text={intl.formatMessage(
-                          {
-                            id: "teams.automations.form.agentKeyExpiry",
-                            defaultMessage: "Expires {time}",
-                          },
-                          {
-                            time: formatScheduleTime(
-                              permissionReview.credentialPlan.expiresAt,
-                              "--",
-                            ),
-                          },
-                        )}
-                      />
-                      <FactLine
-                        text={intl.formatMessage(
-                          {
-                            id: "teams.automations.form.permissionDigest",
-                            defaultMessage:
-                              "Permission digest · {permissionDigest}",
-                          },
-                          {
-                            permissionDigest: permissionReview.permissionDigest,
-                          },
-                        )}
-                      />
-                      <FactLine
-                        text={intl.formatMessage(
-                          {
-                            id: "teams.automations.form.policyVersion",
-                            defaultMessage: "Policy version · {policyVersion}",
-                          },
-                          { policyVersion: permissionReview.policyVersion },
-                        )}
-                      />
-                    </div>
-
-                    <div
-                      className="team-automation-form-schedule-grid"
-                      style={{
-                        display: "grid",
-                        gap: 12,
-                        gridTemplateColumns:
-                          "minmax(0, 1fr) minmax(0, 1fr)",
-                      }}
-                    >
-                      <div style={{ display: "grid", gap: 6 }}>
-                        <Typography.Text strong>
-                          {intl.formatMessage({
-                            id: "teams.automations.form.serviceGrants",
-                            defaultMessage: "Service grants",
-                          })}
-                        </Typography.Text>
-                        {permissionReview.serviceGrants.map((grant) => (
-                          <Typography.Text key={grant.grantId} style={{ fontSize: 12 }}>
-                            {grant.displayName} · {grant.permission}
-                          </Typography.Text>
-                        ))}
-                      </div>
-                      <div style={{ display: "grid", gap: 6 }}>
-                        <Typography.Text strong>
-                          {intl.formatMessage({
-                            id: "teams.automations.form.nodeGrants",
-                            defaultMessage: "Node grants",
-                          })}
-                        </Typography.Text>
-                        {permissionReview.nodeGrants.map((grant) => (
-                          <Typography.Text key={grant.grantId} style={{ fontSize: 12 }}>
-                            {grant.displayName} · {grant.permission}
-                          </Typography.Text>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-
-                  {createStage !== "planChanged" ? (
-                    <div style={{ display: "grid", gap: 6 }}>
-                      <Checkbox
-                        checked={agentKeyConsentChecked}
-                        onChange={(event) => {
-                          const checked = event.target.checked;
-                          setAgentKeyConsentChecked(checked);
-                          setCreateStage(checked ? "consent" : "permissionReview");
-                        }}
-                      >
-                        {intl.formatMessage({
-                          id: "teams.automations.form.agentKeyConsent",
-                          defaultMessage:
-                            "I consent to Aevatar creating an automation-dedicated Agent Key for this schedule.",
-                        })}
-                      </Checkbox>
-                      <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                        {intl.formatMessage({
-                          id: "teams.automations.form.previewOnlyNotice",
-                          defaultMessage:
-                            "Preview only. No automation or Agent Key is created until the scoped backend is connected.",
-                        })}
-                      </Typography.Text>
-                    </div>
-                  ) : null}
-                </div>
-              ) : createStage !== "preflight" && createStage !== "error" ? (
-                <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                  {intl.formatMessage({
-                    id: "teams.automations.form.reviewPlaceholder",
-                    defaultMessage:
-                      "Review is prepared after the draft cadence and target are ready.",
-                  })}
-                </Typography.Text>
-              ) : null}
-            </div>
+            <TeamAutomationPermissionReviewPanel
+              consentChecked={agentKeyConsentChecked}
+              error={createReviewError}
+              onConsentChange={setAgentKeyConsentChecked}
+              review={permissionReview}
+              stage={createStage}
+            />
           ) : null}
         </div>
       </Modal>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -12,6 +12,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
+  Checkbox,
   Input,
   Modal,
   Segmented,
@@ -36,6 +37,11 @@ import {
   type ScheduledDispatchRunNowReceipt,
   type ScheduledDispatchSummary,
 } from "@/shared/api/scheduledDispatchApi";
+import {
+  teamAutomationApi,
+  type TeamAutomationCreateDraft,
+  type TeamAutomationPermissionReview,
+} from "@/shared/api/teamAutomationApi";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
 import type { ServiceIdentity } from "@/shared/models/services";
 import {
@@ -83,6 +89,14 @@ type AutomationFormState = {
   readonly timezone: string;
 };
 
+type TeamAutomationCreateStage =
+  | "draft"
+  | "preflight"
+  | "permissionReview"
+  | "consent"
+  | "planChanged"
+  | "error";
+
 type ManualRunFeedback = Pick<
   ScheduledDispatchRunNowReceipt,
   "ackedAt" | "commandId" | "correlationId" | "scheduledFireAt"
@@ -97,6 +111,97 @@ const createdScheduleHighlightMs = 4_000;
 const customPreset = "custom";
 const defaultPreset = "weekdays-0900";
 const defaultCronExpression = "0 9 * * 1-5";
+
+function buildDefaultAutomationFormState(memberId = ""): AutomationFormState {
+  return {
+    cronExpression: defaultCronExpression,
+    displayName: "",
+    enabled: true,
+    memberId,
+    preset: defaultPreset,
+    prompt: "",
+    timezone: resolveDefaultTimezone(),
+  };
+}
+
+function hasAutomationDraft(formState: AutomationFormState): boolean {
+  return Boolean(
+    formState.displayName.trim() ||
+      formState.prompt.trim() ||
+      formState.memberId.trim() ||
+      formState.cronExpression.trim() !== defaultCronExpression ||
+      formState.preset !== defaultPreset ||
+      formState.timezone.trim() !== resolveDefaultTimezone() ||
+      !formState.enabled,
+  );
+}
+
+function buildScheduledDispatchEditInput({
+  cronExpression,
+  displayName,
+  enabled,
+  prompt,
+  serviceIdentity,
+  serviceRevisionId,
+  timezone,
+}: {
+  readonly cronExpression: string;
+  readonly displayName: string;
+  readonly enabled: boolean;
+  readonly prompt: string;
+  readonly serviceIdentity: ServiceIdentity;
+  readonly serviceRevisionId: string;
+  readonly timezone?: string;
+}): ScheduledDispatchConfigurationInput {
+  return {
+    displayName,
+    cronExpression,
+    timezone,
+    enabled,
+    headers: { source: "team-automations" },
+    workflowChatTarget: {
+      identity: serviceIdentity,
+      prompt,
+      ...(serviceRevisionId ? { revisionId: serviceRevisionId } : {}),
+    },
+  };
+}
+
+function buildTeamAutomationCreateDraft({
+  cronExpression,
+  displayName,
+  enabled,
+  member,
+  prompt,
+  scopeId,
+  serviceRevisionId,
+  teamId,
+  timezone,
+}: {
+  readonly cronExpression: string;
+  readonly displayName: string;
+  readonly enabled: boolean;
+  readonly member: TeamAutomationMemberRow;
+  readonly prompt: string;
+  readonly scopeId: string;
+  readonly serviceRevisionId: string;
+  readonly teamId: string;
+  readonly timezone?: string;
+}): TeamAutomationCreateDraft {
+  return {
+    scopeId,
+    teamId,
+    memberId: member.memberId,
+    publishedServiceId:
+      trimText(member.serviceIdentity?.serviceId) || trimText(member.serviceId),
+    serviceRevisionId: serviceRevisionId || undefined,
+    displayName,
+    prompt,
+    cronExpression,
+    timezone,
+    enabled,
+  };
+}
 
 const pageGridStyle: React.CSSProperties = {
   alignItems: "start",
@@ -713,15 +818,18 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const highlightScheduleRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const [formState, setFormState] = React.useState<AutomationFormState>(() => ({
-    cronExpression: defaultCronExpression,
-    displayName: "",
-    enabled: true,
-    memberId: "",
-    preset: defaultPreset,
-    prompt: "",
-    timezone: resolveDefaultTimezone(),
-  }));
+  const [formState, setFormState] = React.useState<AutomationFormState>(() =>
+    buildDefaultAutomationFormState(),
+  );
+  const [createStage, setCreateStage] =
+    React.useState<TeamAutomationCreateStage>("draft");
+  const [permissionReview, setPermissionReview] =
+    React.useState<TeamAutomationPermissionReview | null>(null);
+  const [agentKeyConsentChecked, setAgentKeyConsentChecked] =
+    React.useState(false);
+  const [createReviewError, setCreateReviewError] = React.useState("");
+  const [hasPreservedCreateDraft, setHasPreservedCreateDraft] =
+    React.useState(false);
   const scheduleQueryKey = React.useMemo(
     () => ["scheduled-dispatches", "team", scopeId, teamId] as const,
     [scopeId, teamId],
@@ -1039,77 +1147,6 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     },
     [],
   );
-  const showCreatedScheduleFeedback = React.useCallback(
-    ({
-      input,
-      member,
-      receipt,
-    }: {
-      readonly input: ScheduledDispatchConfigurationInput;
-      readonly member: TeamAutomationMemberRow;
-      readonly receipt: ScheduledDispatchMutationReceipt;
-    }) => {
-      const scheduleId = trimText(receipt.scheduleId);
-      const serviceId = trimText(member.serviceIdentity?.serviceId) || trimText(member.serviceId);
-      if (!scheduleId || !serviceId) {
-        return;
-      }
-
-      const now = new Date().toISOString();
-      const pendingSchedule: ScheduledDispatchSummary = {
-        scheduleId,
-        displayName: trimText(input.displayName),
-        targetKind: "service_invocation",
-        targetActorId: "",
-        payloadTypeUrl: "",
-        serviceKey: [
-          input.workflowChatTarget.identity.tenantId,
-          input.workflowChatTarget.identity.appId,
-          input.workflowChatTarget.identity.namespace,
-          serviceId,
-        ]
-          .map(trimText)
-          .filter(Boolean)
-          .join(":"),
-        serviceId,
-        serviceEndpointId: "chat",
-        prompt: trimText(input.workflowChatTarget.prompt),
-        cronExpression: input.cronExpression,
-        timezone: trimText(input.timezone) || resolveDefaultTimezone(),
-        enabled: input.enabled ?? true,
-        createdAt: now,
-        updatedAt: now,
-        nextFireAt: null,
-        lastFireAt: null,
-        lastTargetActorId: "",
-        lastCommandId: receipt.commandId,
-        lastCorrelationId: receipt.correlationId,
-        lastError: "",
-        fireCount: 0,
-        failureCount: 0,
-        headers: { ...(input.headers ?? {}) },
-        scheduleActorId: receipt.scheduleActorId,
-        scheduleKind: "workflow",
-        deleted: false,
-      };
-
-      setPendingCreatedSchedules((current) => [
-        pendingSchedule,
-        ...current.filter((schedule) => trimText(schedule.scheduleId) !== scheduleId),
-      ]);
-      setHighlightedScheduleId(scheduleId);
-      if (highlightScheduleRef.current) {
-        clearTimeout(highlightScheduleRef.current);
-      }
-      highlightScheduleRef.current = setTimeout(() => {
-        highlightScheduleRef.current = null;
-        setHighlightedScheduleId((current) =>
-          current === scheduleId ? "" : current,
-        );
-      }, createdScheduleHighlightMs);
-    },
-    [],
-  );
   React.useEffect(
     () => () => {
       if (delayedScheduleRefreshRef.current) {
@@ -1139,41 +1176,34 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       setPreview(result);
     },
   });
-  const createMutation = useMutation({
+  const permissionReviewMutation = useMutation({
     mutationFn: ({
-      input,
-      member,
+      draft,
     }: {
-      readonly input: ScheduledDispatchConfigurationInput;
-      readonly member: TeamAutomationMemberRow;
-    }) =>
-      scheduledDispatchApi.create(input).then((receipt) => ({
-        input,
-        member,
-        receipt,
-      })),
+      readonly draft: TeamAutomationCreateDraft;
+    }) => teamAutomationApi.preflightCreate(draft),
     onError: (error) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      setCreateStage("error");
+      setCreateReviewError(detail);
       void message.error(
         intl.formatMessage(
           {
-            id: "teams.automations.messages.createFailed",
-            defaultMessage: "Automation was not created: {message}",
+            id: "teams.automations.messages.reviewFailed",
+            defaultMessage: "Permission review could not be prepared: {message}",
           },
-          { message: error instanceof Error ? error.message : String(error) },
+          { message: detail },
         ),
       );
     },
-    onSuccess: ({ input, member, receipt }) => {
-      void message.success(
-        intl.formatMessage({
-          id: "teams.automations.messages.createSuccess",
-          defaultMessage: "Automation created.",
-        }),
-      );
-      showCreatedScheduleFeedback({ input, member, receipt });
-      setCreateOpen(false);
-      setPreview(null);
-      scheduleDelayedRefresh();
+    onMutate: () => {
+      setAgentKeyConsentChecked(false);
+      setCreateReviewError("");
+      setCreateStage("preflight");
+    },
+    onSuccess: (review) => {
+      setPermissionReview(review);
+      setCreateStage(review.status === "plan-changed" ? "planChanged" : "permissionReview");
     },
   });
   const updateMutation = useMutation({
@@ -1287,18 +1317,18 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const openCreate = React.useCallback(() => {
     const member = selectedMember;
     setEditingSchedule(null);
-    setFormState({
-      cronExpression: defaultCronExpression,
-      displayName: "",
-      enabled: true,
-      memberId: member?.memberId ?? "",
-      preset: defaultPreset,
-      prompt: "",
-      timezone: resolveDefaultTimezone(),
-    });
+    setFormState((current) =>
+      hasPreservedCreateDraft
+        ? current
+        : buildDefaultAutomationFormState(member?.memberId ?? ""),
+    );
     setPreview(null);
+    setPermissionReview(null);
+    setAgentKeyConsentChecked(false);
+    setCreateReviewError("");
+    setCreateStage("draft");
     setCreateOpen(true);
-  }, [selectedMember]);
+  }, [hasPreservedCreateDraft, selectedMember]);
 
   const openEdit = React.useCallback(
     (schedule: ScheduledDispatchSummary) => {
@@ -1309,6 +1339,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         cronPresets.find((item) => item.cronExpression === cronExpression)?.value ??
         customPreset;
       setEditingSchedule(schedule);
+      setHasPreservedCreateDraft(false);
       setFormState({
         cronExpression,
         displayName: trimText(schedule.displayName),
@@ -1319,6 +1350,10 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         timezone: trimText(schedule.timezone) || resolveDefaultTimezone(),
       });
       setPreview(null);
+      setPermissionReview(null);
+      setAgentKeyConsentChecked(false);
+      setCreateReviewError("");
+      setCreateStage("draft");
       setCreateOpen(true);
     },
     [cronPresets, findMemberForSchedule, selectedMember],
@@ -1331,8 +1366,15 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         ...patch,
       }));
       setPreview(null);
+      setPermissionReview(null);
+      setAgentKeyConsentChecked(false);
+      setCreateReviewError("");
+      setCreateStage("draft");
+      if (!isEditingAutomation) {
+        setHasPreservedCreateDraft(true);
+      }
     },
-    [],
+    [isEditingAutomation],
   );
 
   const previewNextRuns = React.useCallback(async () => {
@@ -1365,10 +1407,9 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     });
   }, [previewNextRuns]);
 
-  const saveAutomation = React.useCallback(async () => {
+  const validateAutomationDraft = React.useCallback(() => {
     const member = activeFormMember;
     const serviceIdentity = member?.serviceIdentity;
-    const serviceRevisionId = trimText(member?.serviceRevisionId);
     const prompt = formState.prompt.trim();
     const cronExpression = formState.cronExpression.trim();
     if (!member || !serviceIdentity) {
@@ -1384,7 +1425,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                 "The selected member does not have a service identity yet.",
             }),
       );
-      return;
+      return null;
     }
     if (prompt.length > scheduledWorkflowPromptMaxLength) {
       void message.error(
@@ -1397,7 +1438,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
           { maxLength: scheduledWorkflowPromptMaxLength },
         ),
       );
-      return;
+      return null;
     }
     if (!cronExpression) {
       void message.error(
@@ -1406,9 +1447,11 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
           defaultMessage: "Enter a cron expression first.",
         }),
       );
-      return;
+      return null;
     }
-    const input: ScheduledDispatchConfigurationInput = {
+
+    return {
+      cronExpression,
       displayName:
         formState.displayName.trim() ||
         intl.formatMessage(
@@ -1418,42 +1461,80 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
           },
           { memberName: member.name },
         ),
-      cronExpression,
+      member,
+      prompt,
+      serviceIdentity,
+      serviceRevisionId: trimText(member.serviceRevisionId),
       timezone: trimText(formState.timezone) || undefined,
-      enabled: formState.enabled,
-      headers: {
-        source: "team-automations",
-      },
-      workflowChatTarget: {
-        identity: serviceIdentity,
-        prompt,
-        ...(serviceRevisionId ? { revisionId: serviceRevisionId } : {}),
-      },
     };
+  }, [activeFormMember, formState, intl, serviceIdentitiesLoading]);
 
+  const saveAutomation = React.useCallback(async () => {
+    if (permissionReviewMutation.isPending) {
+      return;
+    }
+
+    const validatedDraft = validateAutomationDraft();
+    if (!validatedDraft) {
+      return;
+    }
+    const {
+      cronExpression,
+      displayName,
+      member,
+      prompt,
+      serviceIdentity,
+      serviceRevisionId,
+      timezone,
+    } = validatedDraft;
     if (isEditingAutomation) {
       await updateMutation.mutateAsync({
-        input,
+        input: buildScheduledDispatchEditInput({
+          displayName,
+          cronExpression,
+          timezone,
+          enabled: formState.enabled,
+          serviceIdentity,
+          serviceRevisionId,
+          prompt,
+        }),
         scheduleId: editingScheduleId,
       });
       return;
     }
 
-    await createMutation.mutateAsync({ input, member });
+    const draft = buildTeamAutomationCreateDraft({
+      scopeId,
+      teamId,
+      member,
+      serviceRevisionId,
+      displayName,
+      prompt,
+      cronExpression,
+      timezone,
+      enabled: formState.enabled,
+    });
+
+    if (
+      !permissionReview ||
+      createStage === "draft" ||
+      createStage === "error" ||
+      createStage === "planChanged"
+    ) {
+      await permissionReviewMutation.mutateAsync({ draft });
+      return;
+    }
   }, [
-    activeFormMember,
-    createMutation,
+    createStage,
     editingScheduleId,
-    formState.cronExpression,
-    formState.displayName,
     formState.enabled,
-    formState.prompt,
-    formState.timezone,
-    intl,
     isEditingAutomation,
-    serviceIdentitiesLoading,
-    showCreatedScheduleFeedback,
+    permissionReview,
+    permissionReviewMutation,
+    scopeId,
+    teamId,
     updateMutation,
+    validateAutomationDraft,
   ]);
 
   const handleSaveAutomation = React.useCallback(() => {
@@ -1891,7 +1972,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
               : schedule.displayName;
 
           return (
-            <div
+            <article
               aria-label={rowAriaLabel}
               className="team-automation-row"
               key={scheduleId}
@@ -2034,7 +2115,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   onClick: () => deleteMutation.mutate(scheduleId),
                 })}
               </div>
-            </div>
+            </article>
           );
         })}
       </div>
@@ -2054,7 +2135,9 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     intl,
   );
   const canCreateAutomation = Boolean(activeFormMember?.serviceIdentity);
-  const formSubmitting = createMutation.isPending || updateMutation.isPending;
+  const formSubmitting =
+    updateMutation.isPending ||
+    permissionReviewMutation.isPending;
   const formTitle = isEditingAutomation
     ? intl.formatMessage({
         id: "teams.automations.form.editTitle",
@@ -2069,10 +2152,26 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
         id: "teams.automations.form.save",
         defaultMessage: "Save changes",
       })
-    : intl.formatMessage({
-        id: "teams.automations.form.create",
-        defaultMessage: "Create automation",
-      });
+    : createStage === "preflight"
+      ? intl.formatMessage({
+          id: "teams.automations.form.preparingReview",
+          defaultMessage: "Preparing review",
+        })
+      : createStage === "permissionReview" ||
+          createStage === "consent"
+        ? intl.formatMessage({
+            id: "teams.automations.form.backendRequired",
+            defaultMessage: "Creation unavailable",
+          })
+        : createStage === "planChanged"
+          ? intl.formatMessage({
+              id: "teams.automations.form.refreshReview",
+              defaultMessage: "Refresh review",
+            })
+          : intl.formatMessage({
+              id: "teams.automations.form.reviewPermissions",
+              defaultMessage: "Review permissions",
+            });
 
   return (
     <div className="team-automations-layout" style={pageGridStyle}>
@@ -2271,20 +2370,39 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
       </div>
 
       <Modal
+        cancelText={intl.formatMessage({
+          id: "teams.automations.form.close",
+          defaultMessage: "Close",
+        })}
         confirmLoading={formSubmitting}
         okButtonProps={{
           disabled:
+            formSubmitting ||
             !activeFormMember ||
             promptTooLong ||
             Boolean(formCronValidationMessage) ||
-            !canCreateAutomation,
+            !canCreateAutomation ||
+            (!isEditingAutomation &&
+              (createStage === "permissionReview" || createStage === "consent")),
         }}
         okText={formOkText}
         onCancel={() => {
           if (!formSubmitting) {
+            if (isEditingAutomation) {
+              setHasPreservedCreateDraft(false);
+              setFormState(
+                buildDefaultAutomationFormState(selectedMember?.memberId ?? ""),
+              );
+            } else {
+              setHasPreservedCreateDraft(hasAutomationDraft(formState));
+            }
             setCreateOpen(false);
             setEditingSchedule(null);
             setPreview(null);
+            setPermissionReview(null);
+            setAgentKeyConsentChecked(false);
+            setCreateReviewError("");
+            setCreateStage("draft");
           }
         }}
         onOk={handleSaveAutomation}
@@ -2641,6 +2759,249 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
               )}
             </div>
           </div>
+
+          {!isEditingAutomation ? (
+            <div
+              style={{
+                ...modalSectionStyle,
+                background: token.colorBgContainer,
+                border: `1px solid ${token.colorBorderSecondary}`,
+              }}
+            >
+              <div style={{ display: "grid", gap: 2 }}>
+                <Typography.Text strong>
+                  {intl.formatMessage({
+                    id: "teams.automations.form.section.permissionReview",
+                    defaultMessage: "4. Review Agent Key consent",
+                  })}
+                </Typography.Text>
+                <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                  {intl.formatMessage({
+                    id: "teams.automations.form.section.permissionReviewHint",
+                    defaultMessage:
+                      "Browser login authorization only confirms this consent. Automation uses a dedicated Agent Key managed by Aevatar.",
+                  })}
+                </Typography.Text>
+              </div>
+
+              {createStage === "preflight" ? (
+                <div
+                  style={{
+                    background: token.colorFillQuaternary,
+                    border: `1px solid ${token.colorBorderSecondary}`,
+                    borderRadius: 10,
+                    padding: 12,
+                  }}
+                >
+                  <Skeleton active paragraph={{ rows: 2 }} title={false} />
+                </div>
+              ) : null}
+
+              {createStage === "error" ? (
+                <div
+                  role="alert"
+                  style={{
+                    background: token.colorErrorBg,
+                    border: `1px solid ${token.colorErrorBorder}`,
+                    borderRadius: 10,
+                    color: token.colorErrorText,
+                    display: "grid",
+                    gap: 4,
+                    padding: 12,
+                  }}
+                >
+                  <Typography.Text strong>
+                    {intl.formatMessage({
+                      id: "teams.automations.form.reviewErrorTitle",
+                      defaultMessage: "Permission review needs attention",
+                    })}
+                  </Typography.Text>
+                  <Typography.Text style={{ color: token.colorErrorText }}>
+                    {createReviewError ||
+                      intl.formatMessage({
+                        id: "teams.automations.form.reviewErrorBody",
+                        defaultMessage:
+                          "The mock contract could not prepare the review. Keep the draft and try again.",
+                      })}
+                  </Typography.Text>
+                </div>
+              ) : null}
+
+              {permissionReview ? (
+                <div style={{ display: "grid", gap: 12 }}>
+                  {createStage === "planChanged" ? (
+                    <div
+                      role="status"
+                      style={{
+                        background: token.colorWarningBg,
+                        border: `1px solid ${token.colorWarningBorder}`,
+                        borderRadius: 10,
+                        color: token.colorWarningText,
+                        padding: 12,
+                      }}
+                    >
+                      <Typography.Text style={{ color: token.colorWarningText }}>
+                        {permissionReview.warning ||
+                          intl.formatMessage({
+                            id: "teams.automations.form.planChanged",
+                            defaultMessage:
+                              "The authorization plan changed. Refresh the review before creating.",
+                          })}
+                      </Typography.Text>
+                    </div>
+                  ) : null}
+
+                  <div
+                    style={{
+                      background: token.colorFillQuaternary,
+                      border: `1px solid ${token.colorBorderSecondary}`,
+                      borderRadius: 10,
+                      display: "grid",
+                      gap: 10,
+                      padding: 12,
+                    }}
+                  >
+                    <div style={{ display: "grid", gap: 4 }}>
+                      <Typography.Text strong>
+                        {intl.formatMessage({
+                          id: "teams.automations.form.agentKeyPlan",
+                          defaultMessage: "Automation dedicated Agent Key",
+                        })}
+                      </Typography.Text>
+                      <FactLine
+                        text={intl.formatMessage(
+                          {
+                            id: "teams.automations.form.agentKeyMode",
+                            defaultMessage: "Credential mode · {mode}",
+                          },
+                          { mode: permissionReview.credentialPlan.mode },
+                        )}
+                      />
+                      <FactLine
+                        text={intl.formatMessage({
+                          id: "teams.automations.form.agentKeyManaged",
+                          defaultMessage: "Aevatar managed",
+                        })}
+                      />
+                      <FactLine
+                        text={intl.formatMessage({
+                          id: "teams.automations.form.agentKeyNoRawKey",
+                          defaultMessage:
+                            "Browser never receives the raw Agent Key",
+                        })}
+                      />
+                      <FactLine
+                        text={intl.formatMessage(
+                          {
+                            id: "teams.automations.form.agentKeyExpiry",
+                            defaultMessage: "Expires {time}",
+                          },
+                          {
+                            time: formatScheduleTime(
+                              permissionReview.credentialPlan.expiresAt,
+                              "--",
+                            ),
+                          },
+                        )}
+                      />
+                      <FactLine
+                        text={intl.formatMessage(
+                          {
+                            id: "teams.automations.form.permissionDigest",
+                            defaultMessage:
+                              "Permission digest · {permissionDigest}",
+                          },
+                          {
+                            permissionDigest: permissionReview.permissionDigest,
+                          },
+                        )}
+                      />
+                      <FactLine
+                        text={intl.formatMessage(
+                          {
+                            id: "teams.automations.form.policyVersion",
+                            defaultMessage: "Policy version · {policyVersion}",
+                          },
+                          { policyVersion: permissionReview.policyVersion },
+                        )}
+                      />
+                    </div>
+
+                    <div
+                      className="team-automation-form-schedule-grid"
+                      style={{
+                        display: "grid",
+                        gap: 12,
+                        gridTemplateColumns:
+                          "minmax(0, 1fr) minmax(0, 1fr)",
+                      }}
+                    >
+                      <div style={{ display: "grid", gap: 6 }}>
+                        <Typography.Text strong>
+                          {intl.formatMessage({
+                            id: "teams.automations.form.serviceGrants",
+                            defaultMessage: "Service grants",
+                          })}
+                        </Typography.Text>
+                        {permissionReview.serviceGrants.map((grant) => (
+                          <Typography.Text key={grant.grantId} style={{ fontSize: 12 }}>
+                            {grant.displayName} · {grant.permission}
+                          </Typography.Text>
+                        ))}
+                      </div>
+                      <div style={{ display: "grid", gap: 6 }}>
+                        <Typography.Text strong>
+                          {intl.formatMessage({
+                            id: "teams.automations.form.nodeGrants",
+                            defaultMessage: "Node grants",
+                          })}
+                        </Typography.Text>
+                        {permissionReview.nodeGrants.map((grant) => (
+                          <Typography.Text key={grant.grantId} style={{ fontSize: 12 }}>
+                            {grant.displayName} · {grant.permission}
+                          </Typography.Text>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  {createStage !== "planChanged" ? (
+                    <div style={{ display: "grid", gap: 6 }}>
+                      <Checkbox
+                        checked={agentKeyConsentChecked}
+                        onChange={(event) => {
+                          const checked = event.target.checked;
+                          setAgentKeyConsentChecked(checked);
+                          setCreateStage(checked ? "consent" : "permissionReview");
+                        }}
+                      >
+                        {intl.formatMessage({
+                          id: "teams.automations.form.agentKeyConsent",
+                          defaultMessage:
+                            "I consent to Aevatar creating an automation-dedicated Agent Key for this schedule.",
+                        })}
+                      </Checkbox>
+                      <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                        {intl.formatMessage({
+                          id: "teams.automations.form.previewOnlyNotice",
+                          defaultMessage:
+                            "Preview only. No automation or Agent Key is created until the scoped backend is connected.",
+                        })}
+                      </Typography.Text>
+                    </div>
+                  ) : null}
+                </div>
+              ) : createStage !== "preflight" && createStage !== "error" ? (
+                <Typography.Text style={{ fontSize: 12 }} type="secondary">
+                  {intl.formatMessage({
+                    id: "teams.automations.form.reviewPlaceholder",
+                    defaultMessage:
+                      "Review is prepared after the draft cadence and target are ready.",
+                  })}
+                </Typography.Text>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </Modal>
     </div>

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -24,38 +24,6 @@ describe("teamAutomationApi", () => {
     );
   });
 
-  it("rejects missing consent and never fabricates an accepted receipt", async () => {
-    await expect(
-      teamAutomationApi.create({
-        draft,
-        permissionDigest: "digest-alpha",
-        policyVersion: "policy-alpha",
-        consent: {
-          accepted: false,
-          acceptedAt: "",
-          browserLoginConsent: false,
-          automationAgentKeyConsent: false,
-        },
-      }),
-    ).rejects.toThrow("Team Automation Agent Key consent is required.");
-
-    await expect(
-      teamAutomationApi.create({
-        draft,
-        permissionDigest: "digest-alpha",
-        policyVersion: "policy-alpha",
-        consent: {
-          accepted: true,
-          acceptedAt: "2026-07-14T00:00:00Z",
-          browserLoginConsent: true,
-          automationAgentKeyConsent: true,
-        },
-      }),
-    ).rejects.toThrow(
-      "Team Automation creation is unavailable until the scoped backend contract is connected.",
-    );
-  });
-
   it("builds an explicit mock review without conflating member and service identities", () => {
     const review = buildMockTeamAutomationPermissionReview(draft);
 

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -1,0 +1,87 @@
+import {
+  buildMockTeamAutomationPermissionReview,
+  teamAutomationApi,
+  type TeamAutomationCreateDraft,
+} from "@/shared/api/teamAutomationApi";
+
+const draft: TeamAutomationCreateDraft = {
+  scopeId: "scope-alpha",
+  teamId: "team-alpha",
+  memberId: "m-alpha",
+  publishedServiceId: "svc-alpha",
+  serviceRevisionId: "rev-alpha",
+  displayName: "Daily review",
+  prompt: "Summarize open work.",
+  cronExpression: "0 9 * * 1-5",
+  timezone: "Asia/Singapore",
+  enabled: true,
+};
+
+describe("teamAutomationApi", () => {
+  it("fails closed until the scoped backend preflight contract is connected", async () => {
+    await expect(teamAutomationApi.preflightCreate(draft)).rejects.toThrow(
+      "Team Automation permission review is unavailable until the scoped backend contract is connected.",
+    );
+  });
+
+  it("rejects missing consent and never fabricates an accepted receipt", async () => {
+    await expect(
+      teamAutomationApi.create({
+        draft,
+        permissionDigest: "digest-alpha",
+        policyVersion: "policy-alpha",
+        consent: {
+          accepted: false,
+          acceptedAt: "",
+          browserLoginConsent: false,
+          automationAgentKeyConsent: false,
+        },
+      }),
+    ).rejects.toThrow("Team Automation Agent Key consent is required.");
+
+    await expect(
+      teamAutomationApi.create({
+        draft,
+        permissionDigest: "digest-alpha",
+        policyVersion: "policy-alpha",
+        consent: {
+          accepted: true,
+          acceptedAt: "2026-07-14T00:00:00Z",
+          browserLoginConsent: true,
+          automationAgentKeyConsent: true,
+        },
+      }),
+    ).rejects.toThrow(
+      "Team Automation creation is unavailable until the scoped backend contract is connected.",
+    );
+  });
+
+  it("builds an explicit mock review without conflating member and service identities", () => {
+    const review = buildMockTeamAutomationPermissionReview(draft);
+
+    expect(review.status).toBe("ready");
+    expect(review.serviceGrants[0]).toEqual(
+      expect.objectContaining({
+        targetId: "svc-alpha",
+        displayName: "Published service svc-alpha at rev-alpha",
+      }),
+    );
+    expect(JSON.stringify(review)).not.toContain("m-alpha");
+    expect(review.credentialPlan.browserReceivesRawKey).toBe(false);
+  });
+
+  it("normalizes blank service identity only inside the mock boundary", () => {
+    const review = buildMockTeamAutomationPermissionReview({
+      ...draft,
+      publishedServiceId: "   ",
+      serviceRevisionId: "   ",
+    });
+
+    expect(review.serviceGrants[0]).toEqual(
+      expect.objectContaining({
+        targetId: "svc-alpha",
+        displayName: "Published service svc-alpha",
+      }),
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -1,0 +1,140 @@
+export type TeamAutomationCreateDraft = {
+  readonly scopeId: string;
+  readonly teamId: string;
+  readonly memberId: string;
+  readonly publishedServiceId: string;
+  readonly serviceRevisionId?: string;
+  readonly displayName: string;
+  readonly prompt: string;
+  readonly cronExpression: string;
+  readonly timezone?: string;
+  readonly enabled: boolean;
+};
+
+export type TeamAutomationGrant = {
+  readonly grantId: string;
+  readonly targetId: string;
+  readonly displayName: string;
+  readonly permission: string;
+};
+
+export type TeamAutomationCredentialPlan = {
+  readonly mode: "dedicated-per-schedule";
+  readonly hostedBy: "Aevatar";
+  readonly browserReceivesRawKey: false;
+  readonly expiresAt: string;
+};
+
+export type TeamAutomationPermissionReview = {
+  readonly status: "ready" | "plan-changed";
+  readonly permissionDigest: string;
+  readonly policyVersion: string;
+  readonly credentialPlan: TeamAutomationCredentialPlan;
+  readonly serviceGrants: readonly TeamAutomationGrant[];
+  readonly nodeGrants: readonly TeamAutomationGrant[];
+  readonly warning?: string;
+};
+
+export type TeamAutomationConsent = {
+  readonly accepted: boolean;
+  readonly acceptedAt: string;
+  readonly browserLoginConsent: boolean;
+  readonly automationAgentKeyConsent: boolean;
+};
+
+export type TeamAutomationCreateInput = {
+  readonly draft: TeamAutomationCreateDraft;
+  readonly permissionDigest: string;
+  readonly policyVersion: string;
+  readonly consent: TeamAutomationConsent;
+};
+
+export type TeamAutomationCreateReceipt = {
+  readonly scheduleId: string;
+  readonly scheduleActorId: string;
+  readonly accepted: boolean;
+  readonly commandId: string;
+  readonly correlationId: string;
+  readonly ackedAt: string;
+  readonly ackStage: "accepted";
+  readonly permissionDigest: string;
+  readonly policyVersion: string;
+};
+
+const teamAutomationMockFixtureIds = {
+  publishedServiceId: "svc-alpha",
+} as const;
+
+export interface TeamAutomationPermissionReviewPort {
+  preflightCreate(
+    draft: TeamAutomationCreateDraft,
+  ): Promise<TeamAutomationPermissionReview>;
+  create(input: TeamAutomationCreateInput): Promise<TeamAutomationCreateReceipt>;
+}
+
+function trimText(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function buildMockTeamAutomationPermissionReview(
+  draft: TeamAutomationCreateDraft,
+): TeamAutomationPermissionReview {
+  const publishedServiceId =
+    trimText(draft.publishedServiceId) ||
+    teamAutomationMockFixtureIds.publishedServiceId;
+  const serviceRevisionId = trimText(draft.serviceRevisionId);
+
+  return {
+    status: "ready",
+    permissionDigest: "perm-digest-alpha-v1",
+    policyVersion: "agent-key-policy-v1",
+    credentialPlan: {
+      mode: "dedicated-per-schedule",
+      hostedBy: "Aevatar",
+      browserReceivesRawKey: false,
+      expiresAt: "2026-09-30T00:00:00Z",
+    },
+    serviceGrants: [
+      {
+        grantId: "service-chat-invoke",
+        targetId: publishedServiceId,
+        displayName: serviceRevisionId
+          ? `Published service ${publishedServiceId} at ${serviceRevisionId}`
+          : `Published service ${publishedServiceId}`,
+        permission: "Invoke workflow chat endpoint",
+      },
+    ],
+    nodeGrants: [
+      {
+        grantId: "workflow-runtime-start",
+        targetId: "workflow-runtime",
+        displayName: "Workflow runtime",
+        permission: "Start scheduled workflow runs",
+      },
+    ],
+  };
+}
+
+async function preflightCreateTeamAutomation(
+  _draft: TeamAutomationCreateDraft,
+): Promise<TeamAutomationPermissionReview> {
+  throw new Error(
+    "Team Automation permission review is unavailable until the scoped backend contract is connected.",
+  );
+}
+
+async function createTeamAutomation(
+  input: TeamAutomationCreateInput,
+): Promise<TeamAutomationCreateReceipt> {
+  if (!input.consent.accepted) {
+    throw new Error("Team Automation Agent Key consent is required.");
+  }
+  throw new Error(
+    "Team Automation creation is unavailable until the scoped backend contract is connected.",
+  );
+}
+
+export const teamAutomationApi: TeamAutomationPermissionReviewPort = {
+  preflightCreate: preflightCreateTeamAutomation,
+  create: createTeamAutomation,
+};

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -35,42 +35,9 @@ export type TeamAutomationPermissionReview = {
   readonly warning?: string;
 };
 
-export type TeamAutomationConsent = {
-  readonly accepted: boolean;
-  readonly acceptedAt: string;
-  readonly browserLoginConsent: boolean;
-  readonly automationAgentKeyConsent: boolean;
-};
-
-export type TeamAutomationCreateInput = {
-  readonly draft: TeamAutomationCreateDraft;
-  readonly permissionDigest: string;
-  readonly policyVersion: string;
-  readonly consent: TeamAutomationConsent;
-};
-
-export type TeamAutomationCreateReceipt = {
-  readonly scheduleId: string;
-  readonly scheduleActorId: string;
-  readonly accepted: boolean;
-  readonly commandId: string;
-  readonly correlationId: string;
-  readonly ackedAt: string;
-  readonly ackStage: "accepted";
-  readonly permissionDigest: string;
-  readonly policyVersion: string;
-};
-
 const teamAutomationMockFixtureIds = {
   publishedServiceId: "svc-alpha",
 } as const;
-
-export interface TeamAutomationPermissionReviewPort {
-  preflightCreate(
-    draft: TeamAutomationCreateDraft,
-  ): Promise<TeamAutomationPermissionReview>;
-  create(input: TeamAutomationCreateInput): Promise<TeamAutomationCreateReceipt>;
-}
 
 function trimText(value: string | null | undefined): string {
   return value?.trim() ?? "";
@@ -123,18 +90,6 @@ async function preflightCreateTeamAutomation(
   );
 }
 
-async function createTeamAutomation(
-  input: TeamAutomationCreateInput,
-): Promise<TeamAutomationCreateReceipt> {
-  if (!input.consent.accepted) {
-    throw new Error("Team Automation Agent Key consent is required.");
-  }
-  throw new Error(
-    "Team Automation creation is unavailable until the scoped backend contract is connected.",
-  );
-}
-
-export const teamAutomationApi: TeamAutomationPermissionReviewPort = {
+export const teamAutomationApi = {
   preflightCreate: preflightCreateTeamAutomation,
-  create: createTeamAutomation,
 };


### PR DESCRIPTION
Implements the Team Automation consent UI and typed mock-contract stage without advancing into #2743 backend wiring. Production remains fail closed: the browser can review and record local consent state, but cannot dispatch creation, receive a fabricated ACK, or synthesize a schedule fact.

## Changed files

- `TeamAutomationsTab.tsx`: adds review, consent, plan-change, retry, preserved-draft, and preview-only states while preserving existing edit behavior.
- `teamAutomationApi.ts` and `teamAutomationApi.test.ts`: define typed draft/review/consent/receipt contracts, explicit mock review generation, consent enforcement, and disabled production transport behavior.
- `detail.test.tsx`: covers distinct identities, secret exclusion, preview-only consent, plan changes, preflight recovery, and draft preservation.
- `en-US.ts` and `zh-CN.ts`: add complete localized consent and fail-closed UI copy.

## Test results

- `pnpm --dir apps/aevatar-console-web tsc`: passed.
- Focused Team/API suite: passed, 83/83.
- Full frontend suite: changed suites passed; aggregate 1044/1045 due one unrelated existing Studio test timeout. The exact timed-out test passed alone in 8.638 seconds.
- `pnpm --dir apps/aevatar-console-web build`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `git diff --check`: passed.

## Deviations

- Scoped backend preflight/create wiring is deliberately deferred to #2743. The production port rejects and the final creation action is disabled.
- No canonical routes or identity conversion rules were changed.

Closes #2742

⟦AI:AUTO-LOOP⟧
