### PR TITLE
Fix local demo serving activation readiness

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Demo/GAgentServiceDemoBootstrapHostedService.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Demo/GAgentServiceDemoBootstrapHostedService.cs
@@ -17,6 +17,7 @@ internal sealed class GAgentServiceDemoBootstrapHostedService : IHostedService
     private readonly IOptions<GAgentServiceDemoOptions> _options;
     private readonly IHostEnvironment _hostEnvironment;
     private readonly ILogger<GAgentServiceDemoBootstrapHostedService> _logger;
+    private readonly TimeProvider _timeProvider;
 
     public GAgentServiceDemoBootstrapHostedService(
         IServiceCommandPort commandPort,
@@ -24,7 +25,8 @@ internal sealed class GAgentServiceDemoBootstrapHostedService : IHostedService
         IServiceServingQueryPort servingQueryPort,
         IOptions<GAgentServiceDemoOptions> options,
         IHostEnvironment hostEnvironment,
-        ILogger<GAgentServiceDemoBootstrapHostedService> logger)
+        ILogger<GAgentServiceDemoBootstrapHostedService> logger,
+        TimeProvider? timeProvider = null)
     {
         _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
         _lifecycleQueryPort = lifecycleQueryPort ?? throw new ArgumentNullException(nameof(lifecycleQueryPort));
@@ -32,6 +34,7 @@ internal sealed class GAgentServiceDemoBootstrapHostedService : IHostedService
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _hostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -157,6 +160,10 @@ internal sealed class GAgentServiceDemoBootstrapHostedService : IHostedService
                 ct);
         }
 
+        var trafficView = await _servingQueryPort.GetServiceTrafficViewAsync(identity, ct);
+        if (HasExpectedActiveTrafficView(trafficView, identity, expectedTarget))
+            return;
+
         var deployments = await _lifecycleQueryPort.GetServiceDeploymentsAsync(identity, ct);
         if (!HasExpectedDeployment(deployments, expectedTarget))
         {
@@ -180,6 +187,41 @@ internal sealed class GAgentServiceDemoBootstrapHostedService : IHostedService
                     Targets = { expectedTarget.Clone() },
                 },
                 ct);
+        }
+
+        await ObserveExpectedActiveTrafficViewAsync(identity, expectedTarget, options, ct);
+    }
+
+    private async Task ObserveExpectedActiveTrafficViewAsync(
+        ServiceIdentity identity,
+        ServiceServingTargetSpec expectedTarget,
+        GAgentServiceDemoOptions options,
+        CancellationToken ct)
+    {
+        var serviceKey = ServiceKeys.Build(identity);
+        var timeout = options.ReadinessObservationTimeout < TimeSpan.Zero
+            ? TimeSpan.Zero
+            : options.ReadinessObservationTimeout;
+        var pollInterval = options.ReadinessObservationPollInterval < TimeSpan.Zero
+            ? TimeSpan.Zero
+            : options.ReadinessObservationPollInterval;
+        var deadline = _timeProvider.GetUtcNow().Add(timeout);
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var trafficView = await _servingQueryPort.GetServiceTrafficViewAsync(identity, ct);
+            if (HasExpectedActiveTrafficView(trafficView, identity, expectedTarget))
+                return;
+
+            if (_timeProvider.GetUtcNow() >= deadline)
+            {
+                throw new InvalidOperationException(
+                    $"Demo service '{serviceKey}' has no active serving traffic view.");
+            }
+
+            if (pollInterval > TimeSpan.Zero)
+                await Task.Delay(pollInterval, _timeProvider, ct);
         }
     }
 
@@ -251,6 +293,27 @@ internal sealed class GAgentServiceDemoBootstrapHostedService : IHostedService
             string.Equals(x.RevisionId, expectedTarget.RevisionId, StringComparison.Ordinal) &&
             string.Equals(x.PrimaryActorId, expectedTarget.PrimaryActorId, StringComparison.Ordinal) &&
             string.Equals(x.Status, ServiceDeploymentStatus.Active.ToString(), StringComparison.Ordinal));
+    }
+
+    private static bool HasExpectedActiveTrafficView(
+        ServiceTrafficViewSnapshot? snapshot,
+        ServiceIdentity identity,
+        ServiceServingTargetSpec expectedTarget)
+    {
+        if (snapshot == null)
+            return false;
+
+        if (!string.Equals(snapshot.ServiceKey, ServiceKeys.Build(identity), StringComparison.Ordinal))
+            return false;
+
+        return snapshot.Endpoints.Any(endpoint =>
+            string.Equals(endpoint.EndpointId, "chat", StringComparison.Ordinal) &&
+            endpoint.Targets.Any(target =>
+                string.Equals(target.DeploymentId, expectedTarget.DeploymentId, StringComparison.Ordinal) &&
+                string.Equals(target.RevisionId, expectedTarget.RevisionId, StringComparison.Ordinal) &&
+                string.Equals(target.PrimaryActorId, expectedTarget.PrimaryActorId, StringComparison.Ordinal) &&
+                target.AllocationWeight == expectedTarget.AllocationWeight &&
+                string.Equals(target.ServingState, expectedTarget.ServingState.ToString(), StringComparison.Ordinal)));
     }
 
     private static bool HasExpectedServingTarget(

--- a/src/platform/Aevatar.GAgentService.Hosting/Demo/GAgentServiceDemoOptions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Demo/GAgentServiceDemoOptions.cs
@@ -9,4 +9,8 @@ public sealed class GAgentServiceDemoOptions
     public string AppId { get; set; } = "gagent-service";
 
     public string Namespace { get; set; } = "samples";
+
+    public TimeSpan ReadinessObservationTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    public TimeSpan ReadinessObservationPollInterval { get; set; } = TimeSpan.FromMilliseconds(200);
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceDemoBootstrapHostedServiceTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceDemoBootstrapHostedServiceTests.cs
@@ -135,6 +135,57 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_WhenDeploymentAndServingTargetsAlreadyActive_ShouldOnlyWaitForTrafficView()
+    {
+        var commandPort = new RecordingServiceCommandPort();
+        var queryPort = new RecordingServiceQueryPort
+        {
+            ActiveTrafficQueryThreshold = 3,
+        };
+        queryPort.SeedPublishedDefaultDemoServices();
+        queryPort.SeedActiveDeploymentAndServingSet();
+        var hostedService = CreateHostedService(
+            commandPort,
+            queryPort,
+            new GAgentServiceDemoOptions
+            {
+                Enabled = true,
+                ReadinessObservationTimeout = TimeSpan.FromMilliseconds(100),
+                ReadinessObservationPollInterval = TimeSpan.FromMilliseconds(1),
+            },
+            Environments.Development);
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        commandPort.ActivateServiceRevisionCommands.Should().BeEmpty();
+        commandPort.ReplaceServingTargetsCommands.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenReadinessObservationDurationsAreNegative_ShouldClampAndFailClearly()
+    {
+        var commandPort = new RecordingServiceCommandPort();
+        var queryPort = new RecordingServiceQueryPort();
+        queryPort.SeedPublishedDefaultDemoServices();
+        var hostedService = CreateHostedService(
+            commandPort,
+            queryPort,
+            new GAgentServiceDemoOptions
+            {
+                Enabled = true,
+                ReadinessObservationTimeout = TimeSpan.FromMilliseconds(-1),
+                ReadinessObservationPollInterval = TimeSpan.FromMilliseconds(-1),
+            },
+            Environments.Development);
+
+        var act = () => hostedService.StartAsync(CancellationToken.None);
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Demo service 'demo:gagent-service:samples:demo-uppercase' has no active serving traffic view.");
+    }
+
+    [Fact]
     public async Task StartAsync_WhenExplicitlyDisabled_ShouldSkipBootstrapEvenInDevelopment()
     {
         var commandPort = new RecordingServiceCommandPort();
@@ -330,6 +381,8 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
 
         public bool ReturnActiveTrafficAfterFirstTrafficQuery { get; init; }
 
+        public int? ActiveTrafficQueryThreshold { get; init; }
+
         public void SeedPublishedDefaultDemoServices()
         {
             foreach (var serviceId in DemoServiceIds)
@@ -368,6 +421,38 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
             }
         }
 
+        public void SeedActiveDeploymentAndServingSet()
+        {
+            foreach (var serviceId in DemoServiceIds)
+            {
+                var identity = CreateDemoIdentity(serviceId);
+                var serviceKey = ServiceKeys.Build(identity);
+                var target = CreateActiveServingTarget(identity);
+                _deployments[serviceKey] = new ServiceDeploymentCatalogSnapshot(
+                    serviceKey,
+                    [new ServiceDeploymentSnapshot(
+                        target.DeploymentId,
+                        target.RevisionId,
+                        target.PrimaryActorId,
+                        ServiceDeploymentStatus.Active.ToString(),
+                        DateTimeOffset.UnixEpoch,
+                        DateTimeOffset.UnixEpoch)],
+                    DateTimeOffset.UnixEpoch);
+                _servingSets[serviceKey] = new ServiceServingSetSnapshot(
+                    serviceKey,
+                    1,
+                    string.Empty,
+                    [new ServiceServingTargetSnapshot(
+                        target.DeploymentId,
+                        target.RevisionId,
+                        target.PrimaryActorId,
+                        target.AllocationWeight,
+                        target.ServingState,
+                        ["chat"])],
+                    DateTimeOffset.UnixEpoch);
+            }
+        }
+
         public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult(_services.GetValueOrDefault(ServiceKeys.Build(identity)));
 
@@ -402,7 +487,8 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
             var serviceKey = ServiceKeys.Build(identity);
             _trafficViewQueryCounts[serviceKey] = _trafficViewQueryCounts.GetValueOrDefault(serviceKey) + 1;
             if (ReturnActiveTrafficImmediately ||
-                ReturnActiveTrafficAfterFirstTrafficQuery && _trafficViewQueryCounts[serviceKey] > 1)
+                ReturnActiveTrafficAfterFirstTrafficQuery && _trafficViewQueryCounts[serviceKey] > 1 ||
+                ActiveTrafficQueryThreshold.HasValue && _trafficViewQueryCounts[serviceKey] >= ActiveTrafficQueryThreshold.Value)
             {
                 return Task.FromResult<ServiceTrafficViewSnapshot?>(CreateActiveTrafficView(identity));
             }
@@ -421,7 +507,7 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
 
         private static ServiceTrafficViewSnapshot CreateActiveTrafficView(ServiceIdentity identity)
         {
-            var deploymentId = $"{ServiceActorIds.Deployment(identity)}:builtin-v1";
+            var target = CreateActiveServingTarget(identity);
             return new ServiceTrafficViewSnapshot(
                 ServiceKeys.Build(identity),
                 1,
@@ -429,12 +515,23 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
                 [new ServiceTrafficEndpointSnapshot(
                     "chat",
                     [new ServiceTrafficTargetSnapshot(
-                        deploymentId,
-                        "builtin-v1",
-                        $"gagent-service:workflow-definition:{deploymentId}",
-                        100,
-                        ServiceServingState.Active.ToString())])],
+                        target.DeploymentId,
+                        target.RevisionId,
+                        target.PrimaryActorId,
+                        target.AllocationWeight,
+                        target.ServingState)])],
                 DateTimeOffset.UnixEpoch);
+        }
+
+        private static ServiceTrafficTargetSnapshot CreateActiveServingTarget(ServiceIdentity identity)
+        {
+            var deploymentId = $"{ServiceActorIds.Deployment(identity)}:builtin-v1";
+            return new ServiceTrafficTargetSnapshot(
+                deploymentId,
+                "builtin-v1",
+                $"gagent-service:workflow-definition:{deploymentId}",
+                100,
+                ServiceServingState.Active.ToString());
         }
     }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceDemoBootstrapHostedServiceTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceDemoBootstrapHostedServiceTests.cs
@@ -17,7 +17,10 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
     public async Task StartAsync_WhenEnabled_ShouldBootstrapAllDemoWorkflowServices()
     {
         var commandPort = new RecordingServiceCommandPort();
-        var queryPort = new RecordingServiceQueryPort();
+        var queryPort = new RecordingServiceQueryPort
+        {
+            ReturnActiveTrafficAfterFirstTrafficQuery = true,
+        };
         var hostedService = CreateHostedService(
             commandPort,
             queryPort,
@@ -55,6 +58,80 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
             x.Targets[0].ServingState == ServiceServingState.Active &&
             x.Targets[0].EnabledEndpointIds.Count == 1 &&
             x.Targets[0].EnabledEndpointIds[0] == "chat");
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenTrafficViewAlreadyActive_ShouldNotRepairServingTargets()
+    {
+        var commandPort = new RecordingServiceCommandPort();
+        var queryPort = new RecordingServiceQueryPort
+        {
+            ReturnActiveTrafficImmediately = true,
+        };
+        queryPort.SeedPublishedDefaultDemoServices();
+        var hostedService = CreateHostedService(
+            commandPort,
+            queryPort,
+            new GAgentServiceDemoOptions
+            {
+                Enabled = true,
+            },
+            Environments.Development);
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        commandPort.ActivateServiceRevisionCommands.Should().BeEmpty();
+        commandPort.ReplaceServingTargetsCommands.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenDefaultServingHasNoActiveTrafficView_ShouldRepairThenFailClearly()
+    {
+        var commandPort = new RecordingServiceCommandPort();
+        var queryPort = new RecordingServiceQueryPort();
+        queryPort.SeedPublishedDefaultDemoServices();
+        var hostedService = CreateHostedService(
+            commandPort,
+            queryPort,
+            new GAgentServiceDemoOptions
+            {
+                Enabled = true,
+                ReadinessObservationTimeout = TimeSpan.Zero,
+                ReadinessObservationPollInterval = TimeSpan.Zero,
+            },
+            Environments.Development);
+
+        var act = () => hostedService.StartAsync(CancellationToken.None);
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("Demo service 'demo:gagent-service:samples:demo-uppercase' has no active serving traffic view.");
+        commandPort.ActivateServiceRevisionCommands.Should().ContainSingle();
+        commandPort.ReplaceServingTargetsCommands.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenDefaultServingTrafficViewConvergesAfterRepair_ShouldPassReadiness()
+    {
+        var commandPort = new RecordingServiceCommandPort();
+        var queryPort = new RecordingServiceQueryPort
+        {
+            ReturnActiveTrafficAfterFirstTrafficQuery = true,
+        };
+        queryPort.SeedPublishedDefaultDemoServices();
+        var hostedService = CreateHostedService(
+            commandPort,
+            queryPort,
+            new GAgentServiceDemoOptions
+            {
+                Enabled = true,
+            },
+            Environments.Development);
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        commandPort.ActivateServiceRevisionCommands.Should().HaveCount(3);
+        commandPort.ReplaceServingTargetsCommands.Should().HaveCount(3);
     }
 
     [Fact]
@@ -236,8 +313,63 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
 
     private sealed class RecordingServiceQueryPort : IServiceLifecycleQueryPort, IServiceServingQueryPort
     {
+        private static readonly string[] DemoServiceIds =
+        [
+            "demo-uppercase",
+            "demo-count-lines",
+            "demo-take-first-three",
+        ];
+
+        private readonly Dictionary<string, int> _trafficViewQueryCounts = [];
+        private readonly Dictionary<string, ServiceCatalogSnapshot> _services = [];
+        private readonly Dictionary<string, ServiceRevisionCatalogSnapshot> _revisions = [];
+        private readonly Dictionary<string, ServiceDeploymentCatalogSnapshot> _deployments = [];
+        private readonly Dictionary<string, ServiceServingSetSnapshot> _servingSets = [];
+
+        public bool ReturnActiveTrafficImmediately { get; init; }
+
+        public bool ReturnActiveTrafficAfterFirstTrafficQuery { get; init; }
+
+        public void SeedPublishedDefaultDemoServices()
+        {
+            foreach (var serviceId in DemoServiceIds)
+            {
+                var identity = CreateDemoIdentity(serviceId);
+                var serviceKey = ServiceKeys.Build(identity);
+                _services[serviceKey] = new ServiceCatalogSnapshot(
+                    serviceKey,
+                    identity.TenantId,
+                    identity.AppId,
+                    identity.Namespace,
+                    identity.ServiceId,
+                    serviceId,
+                    "builtin-v1",
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    [],
+                    [],
+                    DateTimeOffset.UnixEpoch);
+                _revisions[serviceKey] = new ServiceRevisionCatalogSnapshot(
+                    serviceKey,
+                    [new ServiceRevisionSnapshot(
+                        "builtin-v1",
+                        ServiceImplementationKind.Workflow.ToString(),
+                        ServiceRevisionStatus.Published.ToString(),
+                        string.Empty,
+                        string.Empty,
+                        [],
+                        null,
+                        null,
+                        DateTimeOffset.UnixEpoch,
+                        null)],
+                    DateTimeOffset.UnixEpoch);
+            }
+        }
+
         public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult<ServiceCatalogSnapshot?>(null);
+            Task.FromResult(_services.GetValueOrDefault(ServiceKeys.Build(identity)));
 
         public Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
             string tenantId,
@@ -248,13 +380,13 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
             Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
 
         public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult<ServiceRevisionCatalogSnapshot?>(null);
+            Task.FromResult(_revisions.GetValueOrDefault(ServiceKeys.Build(identity)));
 
         public Task<ServiceDeploymentCatalogSnapshot?> GetServiceDeploymentsAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult<ServiceDeploymentCatalogSnapshot?>(null);
+            Task.FromResult(_deployments.GetValueOrDefault(ServiceKeys.Build(identity)));
 
         public Task<ServiceServingSetSnapshot?> GetServiceServingSetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult<ServiceServingSetSnapshot?>(null);
+            Task.FromResult(_servingSets.GetValueOrDefault(ServiceKeys.Build(identity)));
 
         public Task<ServiceRolloutSnapshot?> GetServiceRolloutAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult<ServiceRolloutSnapshot?>(null);
@@ -265,8 +397,45 @@ public sealed class GAgentServiceDemoBootstrapHostedServiceTests
             CancellationToken ct = default) =>
             Task.FromResult<ServiceRolloutCommandObservationSnapshot?>(null);
 
-        public Task<ServiceTrafficViewSnapshot?> GetServiceTrafficViewAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult<ServiceTrafficViewSnapshot?>(null);
+        public Task<ServiceTrafficViewSnapshot?> GetServiceTrafficViewAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            var serviceKey = ServiceKeys.Build(identity);
+            _trafficViewQueryCounts[serviceKey] = _trafficViewQueryCounts.GetValueOrDefault(serviceKey) + 1;
+            if (ReturnActiveTrafficImmediately ||
+                ReturnActiveTrafficAfterFirstTrafficQuery && _trafficViewQueryCounts[serviceKey] > 1)
+            {
+                return Task.FromResult<ServiceTrafficViewSnapshot?>(CreateActiveTrafficView(identity));
+            }
+
+            return Task.FromResult<ServiceTrafficViewSnapshot?>(null);
+        }
+
+        private static ServiceIdentity CreateDemoIdentity(string serviceId) =>
+            new()
+            {
+                TenantId = "demo",
+                AppId = "gagent-service",
+                Namespace = "samples",
+                ServiceId = serviceId,
+            };
+
+        private static ServiceTrafficViewSnapshot CreateActiveTrafficView(ServiceIdentity identity)
+        {
+            var deploymentId = $"{ServiceActorIds.Deployment(identity)}:builtin-v1";
+            return new ServiceTrafficViewSnapshot(
+                ServiceKeys.Build(identity),
+                1,
+                string.Empty,
+                [new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [new ServiceTrafficTargetSnapshot(
+                        deploymentId,
+                        "builtin-v1",
+                        $"gagent-service:workflow-definition:{deploymentId}",
+                        100,
+                        ServiceServingState.Active.ToString())])],
+                DateTimeOffset.UnixEpoch);
+        }
     }
 
     private sealed class RecordingHostEnvironment : IHostEnvironment


### PR DESCRIPTION
## Summary
- Ensure local demo bootstrap observes the active service traffic view before startup completes.
- Repair missing demo deployment/serving targets through the existing command path, then fail clearly if the read model never exposes active traffic.
- Add focused tests for already-active traffic, repair/fail, repair/converge, active deployment/serving-set wait, negative readiness bounds, and disabled bootstrap behavior.

## Test plan
- [x] `dotnet test /Users/liyingpei/Desktop/Code/aevatar/test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --no-restore --filter GAgentServiceDemoBootstrapHostedServiceTests --logger "console;verbosity=minimal"` (7 passed)
- [x] `dotnet test /Users/liyingpei/Desktop/Code/aevatar/test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --no-restore --filter GAgentServiceDemoBootstrapHostedServiceTests --collect:"XPlat Code Coverage" --results-directory /tmp/aevatar-coverage-1948-after` (7 passed; demo bootstrap readiness observer line-rate/branch-rate 100%)
- [x] `dotnet restore /Users/liyingpei/Desktop/Code/aevatar/aevatar.slnx --nologo`
- [x] `dotnet build /Users/liyingpei/Desktop/Code/aevatar/aevatar.slnx --nologo --no-restore -v minimal`
- [ ] `bash /Users/liyingpei/Desktop/Code/aevatar/tools/ci/test_stability_guards.sh` failed locally after initial guard checks with Homebrew Python `pyexpat` / `/usr/lib/libexpat.1.dylib` import error.

Refs #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)