### PR TITLE
[codex] Remove frontend NyxID resource defaults

### DIFF
--- a/apps/aevatar-console-web/.env.example
+++ b/apps/aevatar-console-web/.env.example
@@ -25,7 +25,6 @@ NYXID_BASE_URL=https://nyx.chrono-ai.fun
 NYXID_CLIENT_ID=
 NYXID_REDIRECT_URI=http://127.0.0.1:5173/auth/callback
 NYXID_SCOPE="openid profile email roles groups"
-NYXID_DEFAULT_SERVICE_SLUGS="aevatar,ornn-api,chrono-llm-public,chrono-sandbox"
 
 # Ornn skills platform
 # Optional. Defaults to the public Ornn instance when omitted.

--- a/apps/aevatar-console-web/.env.production.example
+++ b/apps/aevatar-console-web/.env.production.example
@@ -9,7 +9,6 @@ NYXID_BASE_URL=https://nyx.example.com
 NYXID_CLIENT_ID=replace-with-public-client-id
 NYXID_REDIRECT_URI=https://console.example.com/auth/callback
 NYXID_SCOPE="openid profile email roles groups"
-NYXID_DEFAULT_SERVICE_SLUGS="aevatar,ornn-api,chrono-llm-public,chrono-sandbox"
 
 # Ornn skills platform for the browser client
 ORNN_BASE_URL=https://ornn.example.com

--- a/apps/aevatar-console-web/README.md
+++ b/apps/aevatar-console-web/README.md
@@ -60,11 +60,8 @@ starts from the backend-provided `baseUrl`, `clientId`, and `scope`, so the
 client id matches backend token finalization.
 `NYXID_REDIRECT_URI` must exactly match the Studio login callback registered in
 NyxID when you override it locally.
-`NYXID_DEFAULT_SERVICE_SLUGS` is the comma-separated set of NyxID services requested
-during login. When it is unset or empty, the console does not request default services.
-Only include organization-scoped services such as `api-lark-bot` when every intended
-sign-in account can access that organization; NyxID rejects the full authorization
-request when any requested service is unknown or unavailable to the current user.
+Default service preselection is owned by the NyxID OAuth Client
+`default_service_catalog_slugs`; the browser does not send OAuth `resource` parameters.
 `ORNN_BASE_URL` controls the Ornn skills endpoint used by Studio Settings. If you omit it, the frontend falls back to the public Ornn instance.
 If you change `.env.local`, restart `pnpm dev` so Umi reloads the injected env values.
 

--- a/apps/aevatar-console-web/config/config.ts
+++ b/apps/aevatar-console-web/config/config.ts
@@ -159,9 +159,6 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
     'process.env.NYXID_REDIRECT_URI': JSON.stringify(
       process.env.NYXID_REDIRECT_URI,
     ),
-    'process.env.NYXID_DEFAULT_SERVICE_SLUGS': JSON.stringify(
-      process.env.NYXID_DEFAULT_SERVICE_SLUGS,
-    ),
     'process.env.ORNN_BASE_URL': JSON.stringify(process.env.ORNN_BASE_URL),
     'process.env.AEVATAR_CONSOLE_TEAM_FIRST_ENABLED': JSON.stringify(
       process.env.AEVATAR_CONSOLE_TEAM_FIRST_ENABLED,

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -13,12 +13,6 @@ const runtimeConfig: NyxIDRuntimeConfig = {
   clientId: "console-client-1",
   redirectUri: "http://localhost:8000/auth/callback",
   scope: "openid profile email",
-  defaultServiceSlugs: [
-    "aevatar",
-    "ornn-api",
-    "chrono-llm-public",
-    "chrono-sandbox",
-  ],
 };
 
 function installLocationAssignSpy() {
@@ -106,12 +100,7 @@ describe("NyxIDAuthClient", () => {
     expect(authorizeUrl.searchParams.get("scope")).toBe(
       "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
     );
-    expect(authorizeUrl.searchParams.getAll("resource")).toEqual([
-      "https://nyx.example/api/v1/proxy/s/aevatar",
-      "https://nyx.example/api/v1/proxy/s/ornn-api",
-      "https://nyx.example/api/v1/proxy/s/chrono-llm-public",
-      "https://nyx.example/api/v1/proxy/s/chrono-sandbox",
-    ]);
+    expect(authorizeUrl.searchParams.getAll("resource")).toEqual([]);
 
     const pending = JSON.parse(
       window.localStorage.getItem(

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -115,13 +115,6 @@ export class NyxIDAuthClient {
     url.searchParams.set('code_challenge', codeChallenge);
     url.searchParams.set('code_challenge_method', 'S256');
     url.searchParams.set('state', state);
-    for (const serviceSlug of this.config.defaultServiceSlugs) {
-      const resourceUri = new URL(
-        `/api/v1/proxy/s/${encodeURIComponent(serviceSlug)}`,
-        loginConfig.baseUrl,
-      );
-      url.searchParams.append('resource', resourceUri.toString());
-    }
     if (options.prompt) {
       url.searchParams.set('prompt', options.prompt);
     }

--- a/apps/aevatar-console-web/src/shared/auth/config.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/config.test.ts
@@ -7,7 +7,6 @@ describe('NyxID runtime config', () => {
     process.env = {
       ...originalEnv,
     };
-    delete process.env.NYXID_DEFAULT_SERVICE_SLUGS;
     window.history.replaceState({}, '', '/login');
   });
 
@@ -24,7 +23,6 @@ describe('NyxID runtime config', () => {
       clientId: '',
       redirectUri: `${window.location.origin}/auth/callback`,
       scope: '',
-      defaultServiceSlugs: [],
       configurationError: undefined,
     });
   });
@@ -38,7 +36,6 @@ describe('NyxID runtime config', () => {
       clientId: '',
       redirectUri: 'http://localhost:5173/auth/callback',
       scope: '',
-      defaultServiceSlugs: [],
       configurationError: undefined,
     });
   });
@@ -55,7 +52,6 @@ describe('NyxID runtime config', () => {
       clientId: '',
       redirectUri: `${window.location.origin}/auth/callback`,
       scope: '',
-      defaultServiceSlugs: [],
       configurationError: undefined,
     });
   });
@@ -69,41 +65,8 @@ describe('NyxID runtime config', () => {
       clientId: '',
       redirectUri: '',
       scope: '',
-      defaultServiceSlugs: [],
       configurationError:
         'NYXID_REDIRECT_URI must be a valid http(s) URL or a root-relative path such as /auth/callback.',
     });
-  });
-
-  it('normalizes configured default services and removes duplicates', () => {
-    process.env.NYXID_DEFAULT_SERVICE_SLUGS =
-      '" aevatar, ornn-api,chrono-llm-public,chrono-sandbox,api-lark-bot,ornn-api "';
-
-    expect(getNyxIDRuntimeConfig().defaultServiceSlugs).toEqual([
-      'aevatar',
-      'ornn-api',
-      'chrono-llm-public',
-      'chrono-sandbox',
-      'api-lark-bot',
-    ]);
-  });
-
-  it('allows default service requests to be disabled explicitly', () => {
-    process.env.NYXID_DEFAULT_SERVICE_SLUGS = '';
-
-    expect(getNyxIDRuntimeConfig().defaultServiceSlugs).toEqual([]);
-  });
-
-  it('disables NyxID auth when a configured default service slug is invalid', () => {
-    process.env.NYXID_DEFAULT_SERVICE_SLUGS = 'aevatar,Chrono Sandbox';
-
-    expect(getNyxIDRuntimeConfig()).toEqual(
-      expect.objectContaining({
-        enabled: false,
-        defaultServiceSlugs: [],
-        configurationError:
-          "NYXID_DEFAULT_SERVICE_SLUGS contains invalid service slug 'Chrono Sandbox'. Use comma-separated lowercase letters, numbers, and hyphens.",
-      }),
-    );
   });
 });

--- a/apps/aevatar-console-web/src/shared/auth/config.ts
+++ b/apps/aevatar-console-web/src/shared/auth/config.ts
@@ -4,12 +4,10 @@ export interface NyxIDRuntimeConfig {
   readonly clientId: string;
   readonly redirectUri: string;
   readonly scope: string;
-  readonly defaultServiceSlugs: readonly string[];
   readonly configurationError?: string;
 }
 
 const DEFAULT_REDIRECT_PATH = '/auth/callback';
-const SERVICE_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 function trimOptional(value?: string): string | undefined {
   let normalized = value?.trim();
@@ -117,76 +115,22 @@ function buildConfigurationError(
   return `${variableName} must be a valid http(s) URL or a root-relative path such as ${exampleValue}.`;
 }
 
-function parseDefaultServiceSlugs(value?: string): {
-  readonly slugs: readonly string[];
-  readonly error?: string;
-} {
-  if (value === undefined) {
-    return { slugs: [] };
-  }
-
-  let normalized = value.trim();
-  if (
-    (normalized.startsWith('"') && normalized.endsWith('"')) ||
-    (normalized.startsWith("'") && normalized.endsWith("'"))
-  ) {
-    normalized = normalized.slice(1, -1).trim();
-  }
-
-  if (
-    normalized.localeCompare('undefined', undefined, {
-      sensitivity: 'accent',
-    }) === 0 ||
-    normalized.localeCompare('null', undefined, {
-      sensitivity: 'accent',
-    }) === 0
-  ) {
-    return { slugs: [] };
-  }
-
-  if (!normalized) {
-    return { slugs: [] };
-  }
-
-  const slugs = Array.from(
-    new Set(
-      normalized
-        .split(',')
-        .map((slug) => slug.trim())
-        .filter(Boolean),
-    ),
-  );
-  const invalidSlug = slugs.find((slug) => !SERVICE_SLUG_PATTERN.test(slug));
-  if (invalidSlug) {
-    return {
-      slugs: [],
-      error: `NYXID_DEFAULT_SERVICE_SLUGS contains invalid service slug '${invalidSlug}'. Use comma-separated lowercase letters, numbers, and hyphens.`,
-    };
-  }
-
-  return { slugs };
-}
-
 export function getNyxIDRuntimeConfig(): NyxIDRuntimeConfig {
   const redirectUri =
     trimOptional(process.env.NYXID_REDIRECT_URI) ?? resolveDefaultRedirectUri();
   const normalizedRedirectUri = tryResolveHttpUrl(redirectUri, {
     allowRelative: true,
   });
-  const defaultServices = parseDefaultServiceSlugs(
-    process.env.NYXID_DEFAULT_SERVICE_SLUGS,
-  );
   const configurationError = !normalizedRedirectUri
     ? buildConfigurationError('NYXID_REDIRECT_URI', '/auth/callback')
-    : defaultServices.error;
+    : undefined;
 
   return {
-    enabled: Boolean(normalizedRedirectUri) && !configurationError,
+    enabled: Boolean(normalizedRedirectUri),
     baseUrl: '',
     clientId: '',
     redirectUri: normalizedRedirectUri ?? '',
     scope: '',
-    defaultServiceSlugs: defaultServices.slugs,
     configurationError,
   };
 }

--- a/apps/aevatar-console-web/src/shared/auth/session.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/session.test.ts
@@ -66,7 +66,6 @@ describe('auth session storage', () => {
       clientId: 'client-1',
       redirectUri: 'http://127.0.0.1:5173/auth/callback',
       scope: 'openid profile email',
-      defaultServiceSlugs: [],
     });
 
     expect(state.isAuthenticated).toBe(false);


### PR DESCRIPTION
## Problem

The console owned a second list of default NyxID services through `NYXID_DEFAULT_SERVICE_SLUGS` and converted that list into OAuth `resource` parameters. Those browser defaults duplicated NyxID OAuth Client configuration and turned a preselection preference into a fixed authorization contract.

## Solution

- Remove frontend parsing and validation for `NYXID_DEFAULT_SERVICE_SLUGS`.
- Stop appending service `resource` parameters to the browser authorize URL.
- Remove the environment definitions and examples.
- Assert that the authorize URL contains no browser-owned `resource` values.
- Document NyxID OAuth Client `default_service_catalog_slugs` as the single source for default preselection.

## Impact

Users can keep the complete service set they confirm on the NyxID Consent page. The console no longer needs a deployment-specific copy of service defaults.

NyxID administrators should configure these OAuth Client defaults separately:

- `aevatar`
- `ornn-api`
- `chrono-llm-public`
- `chrono-sandbox`

No UI or API schema changes are included.

## Verification

- `pnpm --dir apps/aevatar-console-web install --frozen-lockfile`
- `pnpm --dir apps/aevatar-console-web run tsc`
- `pnpm --dir apps/aevatar-console-web exec jest --runInBand` (130 suites, 1039 tests passed)
- `pnpm --dir apps/aevatar-console-web run build`
- `bash tools/ci/test_stability_guards.sh`

## Documentation

The console README and environment examples now point service default ownership to the NyxID OAuth Client instead of frontend runtime configuration.
