### PR TITLE
[codex] Preserve NyxID consent during login

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -320,8 +320,9 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         var snapshot = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
         if (requireProvisionedRedirectUri)
             EnsureClientCurrent(snapshot, redirectUri);
-        var requiredResources = RequiredResourceUris();
 
+        // The authorization code already carries the user's finalized Consent selection.
+        // Repeating resource here would narrow that grant to Aevatar's minimum runtime set.
         var form = new List<KeyValuePair<string, string>>
         {
             new("grant_type", "authorization_code"),
@@ -330,8 +331,6 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             new("redirect_uri", redirectUri),
             new("client_id", snapshot.ClientId),
         };
-        foreach (var resource in requiredResources)
-            form.Add(new KeyValuePair<string, string>("resource", resource));
 
         using var request = new HttpRequestMessage(
             HttpMethod.Post,
@@ -345,11 +344,6 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         if (!response.IsSuccessStatusCode)
         {
             var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            if ((int)response.StatusCode == 400 && IsInvalidTarget(body))
-            {
-                throw new NyxIdRequiredServiceAccessException(
-                    requiredResources);
-            }
             _logger.LogError(
                 "NyxID authorization-code exchange failed: status={StatusCode}, body={Body}",
                 (int)response.StatusCode,

--- a/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
+++ b/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
@@ -6,6 +6,19 @@ owner: eanzhao
 
 # ADR-0018: Per-User NyxID Binding via OAuth Broker
 
+## Update 2026-07-16 - authorization code 保留最终 Consent service 边界
+
+授权页完成后,authorization code 已经承载用户最终确认的 service 集合.如果 aevatar 在 authorization-code exchange 再发送固定 `resource` 集合,NyxID 会按 RFC 8707 将 access token、refresh grant 与 broker binding 收窄到该集合,丢失用户在 Consent 页面额外选择的 service.这也解释了 refresh token 请求不带 `resource` 时权限恢复为完整 Consent 集合的现象.
+
+当前 contract 调整为:
+
+- Studio 浏览器不再从环境变量维护默认 service,也不在 `/oauth/authorize` 拼装 `resource`.默认预选由 NyxID OAuth Client 的 `default_service_catalog_slugs` 负责,最终授权集合由用户在 Consent 页面确认.
+- channel `/init` 的 `/oauth/authorize` 仍显式请求 `aevatar`、默认 LLM、Ornn 与 Sandbox 四个运行必需 resource,确保 binding 具备最低运行能力;用户在 Consent 页面增加的其他 service 仍属于同一个最终 grant.
+- authorization-code exchange 必须省略 `resource`,直接继承 authorization code 中已经完成的 Consent service 边界,不得由 callback/finalization 再次缩窄.
+- broker 的短期 token-exchange 仍携带四个运行必需 resource,并校验返回 token 的 `resources` claim.这一步只为当前 runtime 调用签发最小权限 token,不改写 binding 的完整 service grant.
+
+本节取代 2026-07-15 中“authorization-code exchange 重复发送必需 resource”以及 2026-07-10 中由 Studio 浏览器维护 resource 列表的决定.
+
 ## Update 2026-07-15 - 完整 service grant 与 binding 原地授权审阅
 
 生产 Lark bot 暴露出一条 resource contract 断裂:sender 在 `/init` 前可以回复;`/init` 后 runtime 改用 sender binding token,调用默认 `chrono-llm-public`、Ornn `ornn-api` 与 Sandbox `chrono-sandbox` route 时被 NyxID 以 `api_key_scope_forbidden` 拒绝.线上 token 的 `allowed_service_ids` 只有 `aevatar`,没有实际被调用的 LLM、Ornn 与 Sandbox service.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -101,7 +101,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
     }
 
     [Fact]
-    public async Task ExchangeAuthorizationCodeAsync_MapsRefreshTokenFromNyxIdTokenResponse()
+    public async Task ExchangeAuthorizationCodeAsync_PreservesFinalizedConsentWhenMappingTokenResponse()
     {
         var handler = StubHandler.Text(HttpStatusCode.OK,
             """
@@ -129,8 +129,8 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         result.ExpiresIn.Should().Be(1800);
         result.Scope.Should().Be("openid profile proxy");
         handler.LastRequestUri.Should().Be($"{OAuthAuthority}/oauth/token");
-        QueryHelpers.ParseQuery($"?{handler.LastRequestBody}")["resource"]
-            .Should().Equal(RequiredResources);
+        QueryHelpers.ParseQuery($"?{handler.LastRequestBody}")
+            .ContainsKey("resource").Should().BeFalse();
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
     }
 
     [Fact]
-    public async Task BindingFlow_UsesTheSameRequiredResourcesFromAuthorizeThroughBindingExchange()
+    public async Task BindingFlow_PreservesConsentAndScopesBrokerTokenExchange()
     {
         const string bindingId = "bnd-e2e-user";
         var accessToken = CreateAccessToken(RequiredResources);
@@ -246,7 +246,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
 
         var authorizationCodeForm = QueryHelpers.ParseQuery($"?{handler.Requests[0].Body}");
         authorizationCodeForm["grant_type"].Should().ContainSingle().Which.Should().Be("authorization_code");
-        authorizationCodeForm["resource"].Should().Equal(RequiredResources);
+        authorizationCodeForm.ContainsKey("resource").Should().BeFalse();
 
         var bindingExchangeForm = QueryHelpers.ParseQuery($"?{handler.Requests[1].Body}");
         bindingExchangeForm["grant_type"].Should().ContainSingle().Which.Should()
@@ -354,19 +354,6 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
             new CapabilityScope { Value = AevatarOAuthClientScopes.Proxy });
 
         var exception = await act.Should().ThrowAsync<BindingServiceAccessMismatchException>();
-        exception.Which.RequiredResources.Should().Equal(RequiredResources);
-    }
-
-    [Fact]
-    public async Task ExchangeAuthorizationCodeAsync_MapsInvalidTargetToRequiredServiceAccess()
-    {
-        var broker = NewBroker(
-            NewSnapshot(NyxIdRedirectUriResolver.Resolve()),
-            httpHandler: StubHandler.Text(HttpStatusCode.BadRequest, """{"error":"invalid_target"}"""));
-
-        var act = () => broker.ExchangeAuthorizationCodeAsync("auth-code", "verifier");
-
-        var exception = await act.Should().ThrowAsync<NyxIdRequiredServiceAccessException>();
         exception.Which.RequiredResources.Should().Equal(RequiredResources);
     }
 


### PR DESCRIPTION
## Problem

NyxID Consent can finalize a broader user-selected service set, but Aevatar repeated its fixed four-resource minimum during the authorization-code exchange. NyxID correctly treated that token request as a narrower RFC 8707 resource request, so the access token, refresh grant, and broker binding lost services the user had selected on the Consent page.

This also explains why a later refresh without `resource` restored the complete Consent boundary.

## Solution

- Omit `resource` from authorization-code exchange so the code's finalized Consent service boundary remains authoritative.
- Keep the four required runtime resources on the channel `/authorize` request.
- Keep the required resource set and claim validation on short-lived Broker token exchange.
- Cover the three distinct request boundaries in Broker tests and record the contract in ADR-0018.

## Impact

New Studio login and channel binding finalization no longer discard services added on the NyxID Consent page. Runtime calls still receive least-privilege short-lived tokens scoped to Aevatar, the default LLM, Ornn, and Sandbox.

Affected paths:

- `NyxIdRemoteCapabilityBroker` authorization-code exchange
- Channel and Studio NyxID callback finalization through the shared Broker
- NyxID binding contract documentation

No API schema changes are included.

## Verification

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --filter FullyQualifiedName~NyxIdRemoteCapabilityBrokerTests --nologo` (14 passed)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`
- `bash tools/docs/lint.sh`

## Documentation

ADR-0018 now documents Consent as the final service-grant boundary and distinguishes it from the short-lived Broker token resource request.
