### PR TITLE
Implement NyxID service grant replacement

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Audit/ExternalIdentityBindingAuditTranslators.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Audit/ExternalIdentityBindingAuditTranslators.cs
@@ -43,6 +43,34 @@ public sealed class ExternalIdentityBoundAuditTranslator
             });
 }
 
+public sealed class ExternalIdentityBindingReplacedAuditTranslator
+    : SubjectBearingCommittedAuditTranslatorBase<ExternalIdentityBindingReplacedEvent>
+{
+    public ExternalIdentityBindingReplacedAuditTranslator(IAuditActorIdentityHasher? actorIdentityHasher = null)
+        : base(actorIdentityHasher)
+    {
+    }
+
+    public override string EventTypeUrl =>
+        AuditCommittedEventTypeUrl.FromDescriptor(ExternalIdentityBindingReplacedEvent.Descriptor);
+
+    protected override CommittedAuditSeed BuildSeed(
+        CommittedAuditTranslationContext context,
+        ExternalIdentityBindingReplacedEvent evt) =>
+        new(
+            "identity.external-binding.replaced",
+            "external_identity_binding",
+            evt.ExternalSubject?.Platform ?? string.Empty,
+            ScopeId: string.Empty,
+            SensitivityLevel: AuditSensitivityLevel.Restricted,
+            ResultSummary: "External identity binding replaced.",
+            Annotations: new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["platform"] = evt.ExternalSubject?.Platform ?? string.Empty,
+                ["reason"] = evt.Reason ?? string.Empty,
+            });
+}
+
 public sealed class ExternalIdentityBindingRevokedAuditTranslator
     : SubjectBearingCommittedAuditTranslatorBase<ExternalIdentityBindingRevokedEvent>
 {

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/INyxIdBindingRetirementPort.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/INyxIdBindingRetirementPort.cs
@@ -1,0 +1,15 @@
+namespace Aevatar.GAgents.Channel.Identity.Broker;
+
+/// <summary>
+/// Narrow infrastructure port used by the binding actor to retire a specific
+/// superseded or unadopted NyxID broker binding after the local replacement
+/// fact has committed.
+/// </summary>
+public interface INyxIdBindingRetirementPort
+{
+    /// <summary>
+    /// Revokes <paramref name="bindingId"/> at NyxID. Implementations must be
+    /// idempotent and treat an already missing/revoked binding as success.
+    /// </summary>
+    Task RetireAsync(string bindingId, CancellationToken ct = default);
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -28,7 +28,10 @@ namespace Aevatar.GAgents.Channel.Identity.Broker;
 /// 2-min handler rotation: stale DNS, expired sockets, and TLS-cert refreshes
 /// would never be picked up on long-running silos.
 /// </remarks>
-public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxIdBrokerCallbackClient
+public sealed class NyxIdRemoteCapabilityBroker :
+    INyxIdCapabilityBroker,
+    INyxIdBrokerCallbackClient,
+    INyxIdBindingRetirementPort
 {
     public const string AuthorizeEndpoint = "/oauth/authorize";
     public const string TokenEndpoint = "/oauth/token";
@@ -165,6 +168,9 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         response.EnsureSuccessStatusCode();
     }
 
+    public Task RetireAsync(string bindingId, CancellationToken ct = default) =>
+        RevokeBindingByIdAsync(bindingId, ct);
+
     public async Task<CapabilityHandle> IssueShortLivedAsync(
         ExternalSubjectRef externalSubject,
         CapabilityScope scope,
@@ -202,8 +208,11 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         };
         if (!string.IsNullOrWhiteSpace(scope.Value))
             form.Add(new KeyValuePair<string, string>("scope", scope.Value));
-        foreach (var resource in requiredResources)
-            form.Add(new KeyValuePair<string, string>("resource", resource));
+        // The binding already owns the user's finalized Consent service set.
+        // Sending resource here would narrow every short-lived token back to
+        // Aevatar's configured minimum and make optional services selected in
+        // the consent UI unusable. Inherit the full grant, then validate that
+        // the configured runtime minimum is still present in the issued token.
 
         using var request = new HttpRequestMessage(
             HttpMethod.Post,

--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -97,6 +97,8 @@ public static class IdentityServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IAuditCommittedEventTranslator, ExternalIdentityBoundAuditTranslator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IAuditCommittedEventTranslator, ExternalIdentityBindingReplacedAuditTranslator>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IAuditCommittedEventTranslator, ExternalIdentityBindingRevokedAuditTranslator>());
         services.AddAuditCommittedFactMaterializer<ExternalIdentityBindingMaterializationContext>();
 
@@ -162,10 +164,10 @@ public static class IdentityServiceCollectionExtensions
             static command => new ChannelIdentityOAuthCommandTarget(
                 command.ExternalSubject.ToActorId(),
                 "channel-identity.broker-revocation"));
-        services.AddIdentityOAuthCommandDispatch<RefreshBindingCommand, ExternalIdentityBindingGAgent>(
+        services.AddIdentityOAuthCommandDispatch<ReplaceBindingCommand, ExternalIdentityBindingGAgent>(
             static command => new ChannelIdentityOAuthCommandTarget(
                 command.ExternalSubject.ToActorId(),
-                "channel-identity.oauth-refresh"));
+                "channel-identity.oauth-replace"));
         services.AddIdentityOAuthCommandDispatch<RebuildBindingProjectionCommand, ExternalIdentityBindingGAgent>(
             static command => new ChannelIdentityOAuthCommandTarget(
                 command.ExternalSubject.ToActorId(),
@@ -209,6 +211,7 @@ public static class IdentityServiceCollectionExtensions
         services.TryAddSingleton<NyxIdRemoteCapabilityBroker>();
         services.TryAddSingleton<INyxIdCapabilityBroker>(sp => sp.GetRequiredService<NyxIdRemoteCapabilityBroker>());
         services.TryAddSingleton<INyxIdBrokerCallbackClient>(sp => sp.GetRequiredService<NyxIdRemoteCapabilityBroker>());
+        services.TryAddSingleton<INyxIdBindingRetirementPort>(sp => sp.GetRequiredService<NyxIdRemoteCapabilityBroker>());
 
         // ─── Binding revocation reconciler (observed-invalid_grant self-heal) ───
         // Event-sources a local revoke when a turn observes BindingRevokedException

--- a/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
@@ -4,8 +4,10 @@ using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.Channel.Identity;
@@ -37,8 +39,17 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
         StateTransitionMatcher
             .Match(current, evt)
             .On<ExternalIdentityBoundEvent>(ApplyBound)
+            .On<ExternalIdentityBindingReplacedEvent>(ApplyReplaced)
+            .On<ExternalIdentityBindingRetirementQueuedEvent>(ApplyRetirementQueued)
+            .On<ExternalIdentityBindingRetiredEvent>(ApplyRetired)
             .On<ExternalIdentityBindingRevokedEvent>(ApplyRevoked)
             .OrCurrent();
+
+    protected override async Task OnActivateAsync(CancellationToken ct)
+    {
+        await base.OnActivateAsync(ct);
+        await RetirePendingBindingsAsync(ct);
+    }
 
     // ─── Commands ───
 
@@ -114,17 +125,19 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
     }
 
     /// <summary>
-    /// Replaces a stale local binding after NyxID has proven the previous binding
-    /// unusable and authorization-code exchange has returned a new binding id.
+    /// Atomically replaces the active binding after authorization-code exchange
+    /// has returned and validated a new binding id. The expected previous id is
+    /// checked inside the actor turn so a stale callback cannot overwrite a
+    /// newer authorization result.
     /// </summary>
     [EventHandler]
-    public async Task HandleRefreshBinding(RefreshBindingCommand cmd)
+    public async Task HandleReplaceBinding(ReplaceBindingCommand cmd)
     {
         ArgumentNullException.ThrowIfNull(cmd);
 
         if (cmd.ExternalSubject is null)
         {
-            Logger.LogWarning("RefreshBinding rejected: external_subject is required.");
+            Logger.LogWarning("ReplaceBinding rejected: external_subject is required.");
             return;
         }
 
@@ -134,7 +147,17 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
         if (string.IsNullOrEmpty(cmd.BindingId))
         {
             Logger.LogWarning(
-                "RefreshBinding rejected: binding_id is required for {Platform}:{Tenant}:{User}",
+                "ReplaceBinding rejected: binding_id is required for {Platform}:{Tenant}:{User}",
+                cmd.ExternalSubject.Platform,
+                cmd.ExternalSubject.Tenant,
+                cmd.ExternalSubject.ExternalUserId);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(cmd.ExpectedPreviousBindingId))
+        {
+            Logger.LogWarning(
+                "ReplaceBinding rejected: expected_previous_binding_id is required for {Platform}:{Tenant}:{User}",
                 cmd.ExternalSubject.Platform,
                 cmd.ExternalSubject.Tenant,
                 cmd.ExternalSubject.ExternalUserId);
@@ -145,7 +168,7 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
         if (string.Equals(previousBindingId, cmd.BindingId, StringComparison.Ordinal))
         {
             Logger.LogInformation(
-                "RefreshBinding skipped: binding unchanged for {Platform}:{Tenant}:{User} (binding_id={BindingId})",
+                "ReplaceBinding skipped: binding already current for {Platform}:{Tenant}:{User} (binding_id={BindingId})",
                 cmd.ExternalSubject.Platform,
                 cmd.ExternalSubject.Tenant,
                 cmd.ExternalSubject.ExternalUserId,
@@ -153,24 +176,52 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
             // Self-heal a wiped readmodel without appending an event (same rationale as
             // the CommitBinding discard branch).
             await RepublishCurrentBindingStateAsync();
+            await RetirePendingBindingsAsync();
             return;
         }
 
-        await PersistDomainEventAsync(new ExternalIdentityBoundEvent
+        if (!string.Equals(previousBindingId, cmd.ExpectedPreviousBindingId, StringComparison.Ordinal))
+        {
+            Logger.LogWarning(
+                "ReplaceBinding compare-and-swap rejected for {Platform}:{Tenant}:{User} (expected={ExpectedBindingId}, current={CurrentBindingId}, incoming={IncomingBindingId})",
+                cmd.ExternalSubject.Platform,
+                cmd.ExternalSubject.Tenant,
+                cmd.ExternalSubject.ExternalUserId,
+                cmd.ExpectedPreviousBindingId,
+                previousBindingId,
+                cmd.BindingId);
+
+            await QueueBindingRetirementAsync(
+                cmd.ExternalSubject,
+                cmd.BindingId,
+                "replacement_compare_and_swap_rejected");
+            await RetirePendingBindingsAsync();
+            return;
+        }
+
+        var reason = string.IsNullOrWhiteSpace(cmd.Reason) ? "unspecified" : cmd.Reason;
+        await PersistDomainEventAsync(new ExternalIdentityBindingReplacedEvent
         {
             ExternalSubject = cmd.ExternalSubject.Clone(),
+            PreviousBindingId = previousBindingId,
             BindingId = cmd.BindingId,
-            BoundAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            ReplacedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Reason = reason,
         });
 
         Logger.LogInformation(
-            "Refreshed external identity binding: {Platform}:{Tenant}:{User} (previous={PreviousBindingId}, current={BindingId}, reason={Reason})",
+            "Replaced external identity binding: {Platform}:{Tenant}:{User} (previous={PreviousBindingId}, current={BindingId}, reason={Reason})",
             cmd.ExternalSubject.Platform,
             cmd.ExternalSubject.Tenant,
             cmd.ExternalSubject.ExternalUserId,
             previousBindingId,
             cmd.BindingId,
-            string.IsNullOrWhiteSpace(cmd.Reason) ? "unspecified" : cmd.Reason);
+            reason);
+
+        // The replacement fact is committed before any external revocation.
+        // A failed NyxID call leaves the old id in actor state for activation-
+        // time reconciliation and never puts the newly adopted binding at risk.
+        await RetirePendingBindingsAsync();
     }
 
     /// <summary>
@@ -286,6 +337,77 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
             BoundAt = State.BoundAt,
         });
 
+    private async Task QueueBindingRetirementAsync(
+        ExternalSubjectRef subject,
+        string bindingId,
+        string reason,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(bindingId)
+            || string.Equals(State.BindingId, bindingId, StringComparison.Ordinal)
+            || State.PendingRetirementBindingIds.Contains(bindingId))
+        {
+            return;
+        }
+
+        await PersistDomainEventAsync(new ExternalIdentityBindingRetirementQueuedEvent
+        {
+            ExternalSubject = subject.Clone(),
+            BindingId = bindingId,
+            QueuedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Reason = reason,
+        }, ct);
+    }
+
+    private async Task RetirePendingBindingsAsync(CancellationToken ct = default)
+    {
+        if (State.PendingRetirementBindingIds.Count == 0)
+            return;
+
+        var retirementPort = Services.GetService<INyxIdBindingRetirementPort>();
+        if (retirementPort is null)
+        {
+            Logger.LogWarning(
+                "Pending NyxID binding retirement cannot run because {Port} is unavailable for actor={ActorId}.",
+                nameof(INyxIdBindingRetirementPort),
+                Id);
+            return;
+        }
+
+        foreach (var bindingId in State.PendingRetirementBindingIds.ToArray())
+        {
+            if (string.Equals(State.BindingId, bindingId, StringComparison.Ordinal))
+            {
+                Logger.LogError(
+                    "Refusing to retire the current NyxID binding for actor={ActorId}, binding_id={BindingId}.",
+                    Id,
+                    bindingId);
+                continue;
+            }
+
+            try
+            {
+                await retirementPort.RetireAsync(bindingId, ct);
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "NyxID binding retirement remains pending for actor={ActorId}, binding_id={BindingId}.",
+                    Id,
+                    bindingId);
+                continue;
+            }
+
+            await PersistDomainEventAsync(new ExternalIdentityBindingRetiredEvent
+            {
+                ExternalSubject = State.ExternalSubject?.Clone(),
+                BindingId = bindingId,
+                RetiredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            }, ct);
+        }
+    }
+
     // ─── Identity guard ───
 
     // Defensive routing check: when the runtime has set this actor's Id (always
@@ -332,6 +454,52 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
         next.BoundAt = evt.BoundAt;
         next.RevokedAt = null;
         return next;
+    }
+
+    private static ExternalIdentityBindingState ApplyReplaced(
+        ExternalIdentityBindingState current,
+        ExternalIdentityBindingReplacedEvent evt)
+    {
+        var next = current.Clone();
+        next.ExternalSubject ??= evt.ExternalSubject?.Clone();
+        next.BindingId = evt.BindingId ?? string.Empty;
+        next.BoundAt = evt.ReplacedAt;
+        next.RevokedAt = null;
+        AddPendingRetirement(next, evt.PreviousBindingId);
+        return next;
+    }
+
+    private static ExternalIdentityBindingState ApplyRetirementQueued(
+        ExternalIdentityBindingState current,
+        ExternalIdentityBindingRetirementQueuedEvent evt)
+    {
+        var next = current.Clone();
+        AddPendingRetirement(next, evt.BindingId);
+        return next;
+    }
+
+    private static ExternalIdentityBindingState ApplyRetired(
+        ExternalIdentityBindingState current,
+        ExternalIdentityBindingRetiredEvent evt)
+    {
+        var next = current.Clone();
+        for (var index = next.PendingRetirementBindingIds.Count - 1; index >= 0; index--)
+        {
+            if (string.Equals(next.PendingRetirementBindingIds[index], evt.BindingId, StringComparison.Ordinal))
+                next.PendingRetirementBindingIds.RemoveAt(index);
+        }
+
+        return next;
+    }
+
+    private static void AddPendingRetirement(ExternalIdentityBindingState state, string? bindingId)
+    {
+        if (!string.IsNullOrWhiteSpace(bindingId)
+            && !string.Equals(state.BindingId, bindingId, StringComparison.Ordinal)
+            && !state.PendingRetirementBindingIds.Contains(bindingId))
+        {
+            state.PendingRetirementBindingIds.Add(bindingId);
+        }
     }
 
     private static ExternalIdentityBindingState ApplyRevoked(

--- a/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs
@@ -50,6 +50,9 @@ public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProvide
 
     private static bool IsExternalIdentityBindingEvent(Any payload) =>
         payload.Is(ExternalIdentityBoundEvent.Descriptor) ||
+        payload.Is(ExternalIdentityBindingReplacedEvent.Descriptor) ||
+        payload.Is(ExternalIdentityBindingRetirementQueuedEvent.Descriptor) ||
+        payload.Is(ExternalIdentityBindingRetiredEvent.Descriptor) ||
         payload.Is(ExternalIdentityBindingRevokedEvent.Descriptor);
 
     private static bool IsAevatarOAuthClientEvent(Any payload) =>

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
@@ -23,6 +23,10 @@ message ExternalIdentityBindingState {
   string binding_id = 2;
   google.protobuf.Timestamp bound_at = 3;
   google.protobuf.Timestamp revoked_at = 4;
+  // Superseded or unadopted NyxID bindings awaiting best-effort upstream
+  // revocation. Keeping this work in actor state makes cleanup recoverable
+  // after process failure without making an in-memory reconciler authoritative.
+  repeated string pending_retirement_binding_ids = 5;
 }
 
 // Issued by the OAuth callback handler after exchanging the authorization code
@@ -45,14 +49,15 @@ message RevokeBindingCommand {
   string reason = 2;
 }
 
-// Issued when the local binding points at a stale/revoked NyxID binding and a
-// fresh authorization-code exchange returned a replacement binding_id. Unlike
-// CommitBindingCommand, this command intentionally replaces an active binding in
-// one actor turn after the caller has verified the previous binding is unusable.
-message RefreshBindingCommand {
+// Issued after a fresh authorization-code exchange returns a verified binding
+// that should replace the current binding. expected_previous_binding_id gives
+// the owning actor compare-and-swap semantics, so a stale callback cannot
+// overwrite a newer binding selected by another authorization flow.
+message ReplaceBindingCommand {
   aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
   string binding_id = 2;
-  string reason = 3;
+  string expected_previous_binding_id = 3;
+  string reason = 4;
 }
 
 // Operator/maintenance command: re-materialize the current-state readmodel for
@@ -69,6 +74,33 @@ message ExternalIdentityBoundEvent {
   aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
   string binding_id = 2;
   google.protobuf.Timestamp bound_at = 3;
+}
+
+// Persisted when an active binding is atomically replaced. Applying the event
+// makes binding_id current and queues previous_binding_id for upstream cleanup.
+message ExternalIdentityBindingReplacedEvent {
+  aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
+  string previous_binding_id = 2;
+  string binding_id = 3;
+  google.protobuf.Timestamp replaced_at = 4;
+  string reason = 5;
+}
+
+// Persisted when a newly issued binding loses a compare-and-swap race and was
+// therefore never adopted. The actor retains it until NyxID revocation succeeds.
+message ExternalIdentityBindingRetirementQueuedEvent {
+  aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
+  string binding_id = 2;
+  google.protobuf.Timestamp queued_at = 3;
+  string reason = 4;
+}
+
+// Persisted only after NyxID confirms a superseded/unadopted binding is revoked
+// (404/410 are treated as already retired by the infrastructure adapter).
+message ExternalIdentityBindingRetiredEvent {
+  aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
+  string binding_id = 2;
+  google.protobuf.Timestamp retired_at = 3;
 }
 
 // Persisted when RevokeBindingCommand is accepted by the actor.

--- a/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
+++ b/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
@@ -6,17 +6,20 @@ owner: eanzhao
 
 # ADR-0018: Per-User NyxID Binding via OAuth Broker
 
-## Update 2026-07-16 - authorization code 保留最终 Consent service 边界
+## Update 2026-07-16 - 完整 Consent service 边界与 Studio 后端授权契约
 
-授权页完成后,authorization code 已经承载用户最终确认的 service 集合.如果 aevatar 在 authorization-code exchange 再发送固定 `resource` 集合,NyxID 会按 RFC 8707 将 access token、refresh grant 与 broker binding 收窄到该集合,丢失用户在 Consent 页面额外选择的 service.这也解释了 refresh token 请求不带 `resource` 时权限恢复为完整 Consent 集合的现象.
+授权页完成后,authorization code 与 broker binding 已经承载用户最终确认的 service 集合.如果 aevatar 在 authorization-code exchange 或后续 binding token-exchange 再发送固定 `resource` 集合,NyxID 会按 RFC 8707 将本次 token 收窄到该集合,使用户在 Consent 页面额外选择的 service 对 Aevatar runtime 不可用.配置化必需 resource 因此只能是校验下限,不能成为用户授权上限.
 
 当前 contract 调整为:
 
 - Studio 浏览器不再从环境变量维护默认 service,也不在 `/oauth/authorize` 拼装 `resource`.默认预选由 NyxID OAuth Client 的 `default_service_catalog_slugs` 负责,最终授权集合由用户在 Consent 页面确认.
 - `/api/auth/nyxid/config` 只返回 Studio 登录所需的 authority、client id 与 scope,不再暴露服务器内部的必需 resource 集合,避免把运行时最低依赖误解为用户授权上限.
+- Studio finalization 提供默认值为 `false` 的 typed `serviceAccessReview` 请求字段,供未来前端在用户主动发起授权审查时传入 `true`.前端应以 `prompt=consent` 进入 NyxID 的权威 Consent 页面,不得在 Aevatar 实现第二个 service picker 或宣称能够创建 NyxID 尚不支持的新 service.
 - channel `/init` 的 `/oauth/authorize` 仍显式请求配置化的运行必需 resource 集合:核心 `aevatar`、`Aevatar:NyxId:DefaultRoute`、`Aevatar:Ornn:NyxIdSlug`、`Aevatar:NyxId:SandboxServiceSlug` 以及 `Aevatar:NyxId:AdditionalRequiredServiceSlugs`;用户在 Consent 页面增加的其他 service 仍属于同一个最终 grant.
 - authorization-code exchange 必须省略 `resource`,直接继承 authorization code 中已经完成的 Consent service 边界,不得由 callback/finalization 再次缩窄.
-- broker 的短期 token-exchange 仍携带上述配置化最低集合,并校验返回 token 的 `resources` claim.这一步只为当前 runtime 调用签发最小权限 token,不改写 binding 的完整 service grant.
+- broker 的短期 token-exchange 同样省略 `resource`,继承完整 binding grant,再校验返回 token 的 `resources` claim 覆盖上述配置化最低集合.短 TTL、`proxy` scope 与用户 Consent 仍限制能力;在调用方尚无 typed target-resource 参数前,不得用部署最低集合静默删除用户明确授予的可选 service.
+- Studio finalization 只在显式 `serviceAccessReview` 或现有 binding 已失效时替换 binding.新 binding 必须先按 ID 完成一次短期 token 校验;actor 通过 `expected_previous_binding_id` 做 compare-and-swap,提交 replacement 后才撤销旧 binding.清理失败保存在 actor-owned `pending_retirement_binding_ids`,激活时继续对账,不使用进程内 registry.
+- NyxID [PR #1151](https://github.com/ChronoAIProject/NyxID/pull/1151) 部署后,channel `/init` 继续使用更窄的 `binding_grant_id` / `binding_updated` 原地更新协议;Studio replacement 是浏览器登录 flow 的 Aevatar 侧兼容路径,不要求修改 NyxID.
 
 本节取代 2026-07-15 中“authorization-code exchange 重复发送必需 resource”以及 2026-07-10 中由 Studio 浏览器维护 resource 列表的决定.
 
@@ -29,8 +32,8 @@ owner: eanzhao
 最终 resource contract 调整为:
 
 - binding 的必需 resource 集合是 `aevatar`、部署默认 LLM、Ornn 与 Sandbox service. Mainnet Host 分别从 `Aevatar:NyxId:DefaultRoute`、`Aevatar:Ornn:NyxIdSlug` 和 `Aevatar:NyxId:SandboxServiceSlug` 注入实际 slug;Sandbox 未配置时使用 tool provider 的默认值 `chrono-sandbox`.`NyxIdBrokerOptions.AdditionalRequiredServiceSlugs` 作为其他 provider 的可配置扩展点,Identity 层不维护第二份 provider 默认值.
-- channel `/oauth/authorize` 与 broker token-exchange 使用同一配置化必需集合;Studio `/oauth/authorize`、authorization-code exchange 与 `/api/auth/nyxid/config` 不携带该集合,以保留用户最终 Consent 边界.
-- broker 收到短期 access token 后必须验证 `resources` claim 覆盖整个必需集合. 只含 `aevatar` 的 token 不再视为可用 sender capability.
+- channel `/oauth/authorize` 使用配置化必需集合;Studio `/oauth/authorize`、authorization-code exchange、broker token-exchange 与 `/api/auth/nyxid/config` 不携带该集合,以保留用户最终 Consent 边界.
+- broker 收到短期 access token 后必须验证 `resources` claim 覆盖整个必需集合.只含 `aevatar` 的 token 不再视为可用 sender capability,但覆盖必需集合之外的用户授权必须保留.
 - NyxID binding grant 是服务授权的唯一事实源;aevatar 只持有 opaque `binding_id`. 已绑定 sender 再次 `/init` 时,aevatar 仅把 `SHA-256(binding_id)` 放入浏览器可见的 `binding_grant_id`,同时把同一哈希封入 HMAC state 作为 callback 预期值;raw binding credential 不离开服务端.
 - NyxID 按 authenticated user、OAuth client 与 exact external subject 校验待审阅 binding,在 consent 页面展示当前授权、应用必需服务与可选新增服务. 必需服务不可单独取消;用户可拒绝整个请求,也可增删其他可选服务.
 - 授权确认后 NyxID 以 optimistic rotation 原地替换 binding 背后的 refresh grant,返回 `binding_updated=true`,不返回新 `binding_id`. aevatar callback 校验本地 binding 哈希未变化后直接成功,不提交新的 binding actor 事件.
@@ -57,7 +60,7 @@ NyxID 2026-07-06 至 2026-07-08 的 OAuth 更新把第三方应用 service acces
 
 - channel `/init` 的 `/oauth/authorize` 请求显式携带配置化必需 resource 集合. `nyxid_api_base_url` 对应 NyxID backend `BASE_URL` / Aevatar `Aevatar:NyxId:ApiBaseUrl`,不得从浏览器 OAuth authority 或 JWT issuer 派生；各 service slug 由对应 provider 配置注入.控制台登录不发送该集合.
 - NyxID authorization decision 必须从用户仍选中的 `resource` 在服务端解析并合并对应 service ID;前端异步加载的 service picker 只是展示与附加选择,不能成为授权事实源. 用户只有明确取消某个 resource 才会把对应 service 从本次 grant 中移除.
-- authorization-code exchange 与控制台 refresh 省略 `resource`,继承完整 Consent 边界;broker token-exchange 携带配置化必需集合.如果 binding 未授权任一必需 resource,broker token-exchange 会以 `invalid_target` 失败.
+- authorization-code exchange、控制台 refresh 与 broker token-exchange 都省略 `resource`,继承完整 Consent 边界;Aevatar 再校验短期 token 是否覆盖配置化必需集合.
 - broker 每次拿到短期 access token 后校验 `resources` claim. 旧 binding、allow-all grandfather grant 或缺少任一必需 service 的 grant会被归类为 service-access mismatch;调用侧保留 binding 并引导 `/init` 原地更新 grant.
 - `/api/auth/nyxid/config` 不返回 resource 列表;前端不得自行猜 service ID,也不得把 Developer App 默认项当作授权事实.
 
@@ -354,6 +357,8 @@ ADR 核心决策已 lock。以下是边界细节,reviewer 在 final review 提�
 - 剩余 orphan binding 只可能来自 cleanup 失败或 callback 中断。aevatar 侧 ADR 不假设 NyxID reaper 行为;NyxID#549 SHOULD 自行处理 orphan binding(超时自动 revoke 或定期 reap),但不构成 aevatar 实现依赖
 
 已绑定 grant review 的并发语义不同:state token 固定携带开始审阅时的 `expected_binding_hash`;NyxID 只原地更新该 binding 的 refresh grant,aevatar callback 再与当前 readmodel 中的 binding hash 对账. 对账失败返回 conflict,不得把 review 结果解释成新 binding 或覆盖本地 actor.
+
+未来 Studio 浏览器接入 `serviceAccessReview` 时不得把 raw binding 放入 URL,也不得依赖 NyxID 原地更新扩展.授权码返回的新 binding 先由 Aevatar 校验必需 scope/resources,再把 `{expected_previous_binding_id,new_binding_id}` 作为 typed command 交给 binding actor.只有 actor 当前值仍等于 expected 值才提交 `ExternalIdentityBindingReplacedEvent`;提交后旧值进入持久化 retirement 队列并调用 NyxID revoke.并发失败的新 binding 同样进入 retirement 队列,不得覆盖获胜 binding.
 
 ### 3. Callback Handler 错误 UX
 

--- a/docs/adr/0040-current-state-readmodel-dr-rebuild.md
+++ b/docs/adr/0040-current-state-readmodel-dr-rebuild.md
@@ -46,7 +46,7 @@ a new domain event.**
    nothing to the event store. Because a current-state materializer rebuilds a row from the
    `state_root` snapshot alone and projection writes are monotonic covering writes, one
    re-emission rebuilds a wiped row and is an idempotent no-op on a healthy one.
-2. `ExternalIdentityBindingGAgent` self-heals on the idempotent `CommitBinding`/`RefreshBinding`
+2. `ExternalIdentityBindingGAgent` self-heals on the idempotent `CommitBinding`/`ReplaceBinding`
    discard branches (so a re-auth via `/init` or Studio login rebuilds a wiped row), and
    handles a new maintenance command `RebuildBindingProjectionCommand`.
 3. An operator-gated endpoint `POST /api/oauth/nyxid-binding/rebuild` (Mainnet host, same

--- a/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
@@ -71,7 +71,7 @@ public static class NyxIdLoginFinalizationEndpoints
         [FromServices] INyxIdCapabilityBroker capabilityBroker,
         [FromServices] IExternalIdentityBindingQueryPort bindingQueryPort,
         [FromServices] ICommandDispatchService<CommitBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingDispatch,
-        [FromServices] ICommandDispatchService<RefreshBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingRefreshDispatch,
+        [FromServices] ICommandDispatchService<ReplaceBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingReplaceDispatch,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct = default)
     {
@@ -151,37 +151,85 @@ public static class NyxIdLoginFinalizationEndpoints
         if (existingBinding != null)
         {
             if (string.Equals(existingBinding.Value, exchange.BindingId, StringComparison.Ordinal))
-                return Results.Ok(BuildResponse(exchange, user, bindingDispatchAccepted: false));
-
-            var probeResult = await ProbeExistingBindingAsync(capabilityBroker, subject, logger, ct).ConfigureAwait(false);
-            if (probeResult == ExistingBindingProbeResult.Usable)
             {
-                await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+                var sameBindingProbe = await ProbeIssuedBindingAsync(
+                    capabilityBroker,
+                    subject,
+                    exchange.BindingId,
+                    logger,
+                    ct).ConfigureAwait(false);
+                if (sameBindingProbe != IssuedBindingProbeResult.Usable)
+                    return BuildIssuedBindingProbeError(sameBindingProbe);
+
                 return Results.Ok(BuildResponse(exchange, user, bindingDispatchAccepted: false));
             }
 
-            if (probeResult == ExistingBindingProbeResult.Unavailable)
+            var replacementReason = "studio_service_access_review";
+            if (!request.ServiceAccessReview)
+            {
+                var probeResult = await ProbeExistingBindingAsync(capabilityBroker, subject, logger, ct).ConfigureAwait(false);
+                if (probeResult == ExistingBindingProbeResult.Usable)
+                {
+                    await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+                    return Results.Ok(BuildResponse(exchange, user, bindingDispatchAccepted: false));
+                }
+
+                if (probeResult == ExistingBindingProbeResult.Unavailable)
+                {
+                    await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+                    return Results.Json(new
+                    {
+                        error = "binding_probe_failed",
+                        detail = "NyxID owner binding could not be verified; retry login finalization later.",
+                    }, statusCode: StatusCodes.Status503ServiceUnavailable);
+                }
+
+                replacementReason = "nyxid_login_recovery";
+            }
+
+            var issuedBindingProbe = await ProbeIssuedBindingAsync(
+                capabilityBroker,
+                subject,
+                exchange.BindingId,
+                logger,
+                ct).ConfigureAwait(false);
+            if (issuedBindingProbe != IssuedBindingProbeResult.Usable)
+            {
+                await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+                return BuildIssuedBindingProbeError(issuedBindingProbe);
+            }
+
+            var replaceResult = await DispatchReplaceBindingAsync(
+                bindingReplaceDispatch,
+                subject,
+                existingBinding.Value,
+                exchange.BindingId,
+                replacementReason,
+                logger,
+                ct).ConfigureAwait(false);
+            if (replaceResult != BindingDispatchOutcome.Accepted)
             {
                 await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
                 return Results.Json(new
                 {
-                    error = "binding_probe_failed",
-                    detail = "NyxID owner binding could not be verified; retry login finalization later.",
-                }, statusCode: StatusCodes.Status503ServiceUnavailable);
-            }
-
-            var refreshResult = await DispatchRefreshBindingAsync(bindingRefreshDispatch, subject, exchange.BindingId, logger, ct).ConfigureAwait(false);
-            if (refreshResult != BindingDispatchOutcome.Accepted)
-            {
-                await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
-                return Results.Json(new
-                {
-                    error = refreshResult == BindingDispatchOutcome.Rejected ? "actor_dispatch_rejected" : "actor_dispatch_failed",
-                    detail = "Stale NyxID owner binding could not be queued for local refresh.",
+                    error = replaceResult == BindingDispatchOutcome.Rejected ? "actor_dispatch_rejected" : "actor_dispatch_failed",
+                    detail = "NyxID owner binding replacement could not be queued.",
                 }, statusCode: StatusCodes.Status503ServiceUnavailable);
             }
 
             return Results.Ok(BuildResponse(exchange, user, bindingDispatchAccepted: true));
+        }
+
+        var newBindingProbe = await ProbeIssuedBindingAsync(
+            capabilityBroker,
+            subject,
+            exchange.BindingId,
+            logger,
+            ct).ConfigureAwait(false);
+        if (newBindingProbe != IssuedBindingProbeResult.Usable)
+        {
+            await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+            return BuildIssuedBindingProbeError(newBindingProbe);
         }
 
         var commitResult = await DispatchCommitBindingAsync(bindingDispatch, subject, exchange.BindingId, logger, ct).ConfigureAwait(false);
@@ -202,6 +250,14 @@ public static class NyxIdLoginFinalizationEndpoints
     {
         Usable,
         Stale,
+        Unavailable,
+    }
+
+    private enum IssuedBindingProbeResult
+    {
+        Usable,
+        MissingRequiredAccess,
+        Invalid,
         Unavailable,
     }
 
@@ -267,6 +323,71 @@ public static class NyxIdLoginFinalizationEndpoints
         }
     }
 
+    private static async Task<IssuedBindingProbeResult> ProbeIssuedBindingAsync(
+        INyxIdCapabilityBroker capabilityBroker,
+        ExternalSubjectRef subject,
+        string bindingId,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            await capabilityBroker
+                .IssueShortLivedByBindingIdAsync(
+                    subject,
+                    bindingId,
+                    new CapabilityScope { Value = AevatarOAuthClientScopes.Proxy },
+                    ct)
+                .ConfigureAwait(false);
+            return IssuedBindingProbeResult.Usable;
+        }
+        catch (BindingScopeMismatchException ex)
+        {
+            logger.LogInformation(ex, "New NyxID binding lacks the required proxy scope.");
+            return IssuedBindingProbeResult.MissingRequiredAccess;
+        }
+        catch (BindingServiceAccessMismatchException ex)
+        {
+            logger.LogInformation(ex, "New NyxID binding lacks one or more required services.");
+            return IssuedBindingProbeResult.MissingRequiredAccess;
+        }
+        catch (BindingRevokedException ex)
+        {
+            logger.LogWarning(ex, "New NyxID binding was already revoked before adoption.");
+            return IssuedBindingProbeResult.Invalid;
+        }
+        catch (BindingNotFoundException ex)
+        {
+            logger.LogWarning(ex, "New NyxID binding was not found before adoption.");
+            return IssuedBindingProbeResult.Invalid;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "New NyxID binding could not be verified before adoption.");
+            return IssuedBindingProbeResult.Unavailable;
+        }
+    }
+
+    private static IResult BuildIssuedBindingProbeError(IssuedBindingProbeResult probeResult) =>
+        probeResult switch
+        {
+            IssuedBindingProbeResult.MissingRequiredAccess => Results.Json(new
+            {
+                error = "required_service_access_missing",
+                detail = "Return to NyxID and keep every service marked as required by Aevatar selected.",
+            }, statusCode: StatusCodes.Status409Conflict),
+            IssuedBindingProbeResult.Invalid => Results.Json(new
+            {
+                error = "issued_binding_invalid",
+                detail = "NyxID issued a binding that was unavailable before Aevatar could adopt it.",
+            }, statusCode: StatusCodes.Status502BadGateway),
+            _ => Results.Json(new
+            {
+                error = "issued_binding_probe_failed",
+                detail = "The new NyxID service grant could not be verified; retry later.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable),
+        };
+
     private static async Task<BindingDispatchOutcome> DispatchCommitBindingAsync(
         ICommandDispatchService<CommitBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingDispatch,
         ExternalSubjectRef subject,
@@ -298,31 +419,34 @@ public static class NyxIdLoginFinalizationEndpoints
         }
     }
 
-    private static async Task<BindingDispatchOutcome> DispatchRefreshBindingAsync(
-        ICommandDispatchService<RefreshBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingRefreshDispatch,
+    private static async Task<BindingDispatchOutcome> DispatchReplaceBindingAsync(
+        ICommandDispatchService<ReplaceBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> bindingReplaceDispatch,
         ExternalSubjectRef subject,
+        string expectedPreviousBindingId,
         string bindingId,
+        string reason,
         ILogger logger,
         CancellationToken ct)
     {
         try
         {
-            var accepted = await bindingRefreshDispatch.DispatchAsync(new RefreshBindingCommand
+            var accepted = await bindingReplaceDispatch.DispatchAsync(new ReplaceBindingCommand
             {
                 ExternalSubject = subject,
                 BindingId = bindingId.Trim(),
-                Reason = "nyxid_login_refresh",
+                ExpectedPreviousBindingId = expectedPreviousBindingId.Trim(),
+                Reason = reason,
             }, ct).ConfigureAwait(false);
 
             if (accepted.Succeeded && accepted.Receipt != null)
                 return BindingDispatchOutcome.Accepted;
 
-            logger.LogError("NyxID login finalization stale binding refresh dispatch rejected: error={Error}.", accepted.Error);
+            logger.LogError("NyxID login finalization binding replacement dispatch rejected: error={Error}.", accepted.Error);
             return BindingDispatchOutcome.Rejected;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "NyxID login finalization failed to dispatch RefreshBindingCommand for {Platform}:{Tenant}:{User}.",
+            logger.LogError(ex, "NyxID login finalization failed to dispatch ReplaceBindingCommand for {Platform}:{Tenant}:{User}.",
                 subject.Platform,
                 subject.Tenant,
                 subject.ExternalUserId);
@@ -453,6 +577,7 @@ public sealed record NyxIdLoginFinalizationRequest
     public string? Code { get; init; }
     public string? CodeVerifier { get; init; }
     public string? RedirectUri { get; init; }
+    public bool ServiceAccessReview { get; init; }
 }
 
 public sealed record NyxIdLoginFinalizationResponse(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateProjectionActivationPlanProviderTests.cs
@@ -2,6 +2,7 @@ using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.GAgents.Channel.Identity;
 using Aevatar.Testing;
 using FluentAssertions;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
@@ -17,17 +18,29 @@ public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProvide
     {
         var provider = new ChannelIdentityCommittedStateProjectionActivationPlanProvider();
 
-        var plans = provider.GetPlans(BuildCommittedStateContext(
-            typeof(ExternalIdentityBindingGAgent),
+        IMessage[] stateEvents =
+        [
             new ExternalIdentityBoundEvent(),
-            "external-identity-binding:lark:t:u")).ToArray();
+            new ExternalIdentityBindingReplacedEvent(),
+            new ExternalIdentityBindingRetirementQueuedEvent(),
+            new ExternalIdentityBindingRetiredEvent(),
+            new ExternalIdentityBindingRevokedEvent(),
+        ];
 
-        plans.Should().ContainSingle();
-        AssertDurablePlan(
-            plans[0],
-            typeof(ExternalIdentityBindingMaterializationRuntimeLease),
-            "external-identity-binding:lark:t:u",
-            "external-identity-binding");
+        foreach (var stateEvent in stateEvents)
+        {
+            var plans = provider.GetPlans(BuildCommittedStateContext(
+                typeof(ExternalIdentityBindingGAgent),
+                stateEvent,
+                "external-identity-binding:lark:t:u")).ToArray();
+
+            plans.Should().ContainSingle();
+            AssertDurablePlan(
+                plans[0],
+                typeof(ExternalIdentityBindingMaterializationRuntimeLease),
+                "external-identity-binding:lark:t:u",
+                "external-identity-binding");
+        }
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingAuditTranslatorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingAuditTranslatorTests.cs
@@ -72,6 +72,33 @@ public sealed class ExternalIdentityBindingAuditTranslatorTests
     }
 
     [Fact]
+    public void ReplacedTranslator_RecordsReason_AndNeverLeaksEitherBindingId()
+    {
+        var hasher = CreateHasher();
+        var evt = new ExternalIdentityBindingReplacedEvent
+        {
+            ExternalSubject = new ExternalSubjectRef { Platform = "lark", Tenant = "tenant-1", ExternalUserId = RawUser },
+            PreviousBindingId = SecretBindingId,
+            BindingId = "nyx-binding-SECRET-next",
+            Reason = "studio_service_access_review",
+        };
+
+        var record = new ExternalIdentityBindingReplacedAuditTranslator(hasher)
+            .Translate(Context(), Any.Pack(evt))
+            .Should()
+            .ContainSingle()
+            .Subject;
+
+        record.OperationName.Should().Be("identity.external-binding.replaced");
+        record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Restricted);
+        record.Annotations.Should().Contain("reason", "studio_service_access_review");
+        var serialized = System.Text.Encoding.UTF8.GetString(record.ToByteArray()) + record;
+        serialized.Should().NotContain(RawUser);
+        serialized.Should().NotContain(SecretBindingId);
+        serialized.Should().NotContain("nyx-binding-SECRET-next");
+    }
+
+    [Fact]
     public void BoundTranslator_WhenNoHasher_SkipsInsteadOfLeaking()
     {
         var evt = new ExternalIdentityBoundEvent

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
@@ -4,6 +4,7 @@ using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Identity;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,7 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
     //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
     //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     private ExternalIdentityBindingGAgent _agent = null!;
+    private RecordingBindingRetirementPort _retirementPort = null!;
     private ServiceProvider _serviceProvider = null!;
 
     public async Task InitializeAsync()
@@ -37,6 +39,8 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         // continuation timers; tests register a no-op so the dispatch path
         // is exercised without bringing up a real Orleans cluster.
         services.AddSingleton<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler, NoopCallbackScheduler>();
+        _retirementPort = new RecordingBindingRetirementPort();
+        services.AddSingleton<INyxIdBindingRetirementPort>(_retirementPort);
 
         _serviceProvider = services.BuildServiceProvider();
 
@@ -135,7 +139,7 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleRefreshBinding_ReplacesActiveBinding()
+    public async Task HandleReplaceBinding_ReplacesExpectedBindingThenRetiresIt()
     {
         var subject = SampleSubject();
         await _agent.HandleCommitBinding(new CommitBindingCommand
@@ -144,20 +148,23 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
             BindingId = "bnd_first",
         });
 
-        await _agent.HandleRefreshBinding(new RefreshBindingCommand
+        await _agent.HandleReplaceBinding(new ReplaceBindingCommand
         {
             ExternalSubject = subject,
             BindingId = "bnd_second",
-            Reason = "nyxid_login_refresh",
+            ExpectedPreviousBindingId = "bnd_first",
+            Reason = "studio_service_access_review",
         });
 
         _agent.State.BindingId.Should().Be("bnd_second");
         _agent.State.BoundAt.Should().NotBeNull();
         _agent.State.RevokedAt.Should().BeNull();
+        _agent.State.PendingRetirementBindingIds.Should().BeEmpty();
+        _retirementPort.RetiredBindingIds.Should().Equal("bnd_first");
     }
 
     [Fact]
-    public async Task HandleRefreshBinding_IsNoOpWhenBindingIdIsUnchanged()
+    public async Task HandleReplaceBinding_IsNoOpWhenBindingIdIsAlreadyCurrent()
     {
         var subject = SampleSubject();
         await _agent.HandleCommitBinding(new CommitBindingCommand
@@ -167,15 +174,77 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         });
         var afterFirstVersion = _agent.EventSourcing!.CurrentVersion;
 
-        await _agent.HandleRefreshBinding(new RefreshBindingCommand
+        await _agent.HandleReplaceBinding(new ReplaceBindingCommand
         {
             ExternalSubject = subject,
             BindingId = "bnd_first",
-            Reason = "nyxid_login_refresh",
+            ExpectedPreviousBindingId = "bnd_first",
+            Reason = "studio_service_access_review",
         });
 
         _agent.State.BindingId.Should().Be("bnd_first");
         _agent.EventSourcing!.CurrentVersion.Should().Be(afterFirstVersion);
+        _retirementPort.RetiredBindingIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleReplaceBinding_RejectsStaleExpectedBindingAndRetiresIncomingBinding()
+    {
+        var subject = SampleSubject();
+        await _agent.HandleCommitBinding(new CommitBindingCommand
+        {
+            ExternalSubject = subject,
+            BindingId = "bnd_current",
+        });
+
+        await _agent.HandleReplaceBinding(new ReplaceBindingCommand
+        {
+            ExternalSubject = subject,
+            BindingId = "bnd_unadopted",
+            ExpectedPreviousBindingId = "bnd_stale",
+            Reason = "studio_service_access_review",
+        });
+
+        _agent.State.BindingId.Should().Be("bnd_current");
+        _agent.State.PendingRetirementBindingIds.Should().BeEmpty();
+        _retirementPort.RetiredBindingIds.Should().Equal("bnd_unadopted");
+    }
+
+    [Fact]
+    public async Task HandleReplaceBinding_PersistsFailedRetirementAndRetriesOnActivation()
+    {
+        var subject = SampleSubject();
+        await _agent.HandleCommitBinding(new CommitBindingCommand
+        {
+            ExternalSubject = subject,
+            BindingId = "bnd_first",
+        });
+        _retirementPort.Failure = new HttpRequestException("NyxID unavailable");
+
+        await _agent.HandleReplaceBinding(new ReplaceBindingCommand
+        {
+            ExternalSubject = subject,
+            BindingId = "bnd_second",
+            ExpectedPreviousBindingId = "bnd_first",
+            Reason = "studio_service_access_review",
+        });
+
+        _agent.State.BindingId.Should().Be("bnd_second");
+        _agent.State.PendingRetirementBindingIds.Should().Equal("bnd_first");
+
+        _retirementPort.Failure = null;
+        var reactivated = new ExternalIdentityBindingGAgent
+        {
+            Services = _serviceProvider,
+            EventSourcingBehaviorFactory =
+                _serviceProvider.GetRequiredService<IEventSourcingBehaviorFactory<ExternalIdentityBindingState>>(),
+        };
+
+        await reactivated.ActivateAsync();
+
+        reactivated.State.BindingId.Should().Be("bnd_second");
+        reactivated.State.PendingRetirementBindingIds.Should().BeEmpty();
+        _retirementPort.RetiredBindingIds.Should().Contain("bnd_first");
     }
 
     [Fact]
@@ -321,6 +390,21 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
             string actorId,
             CancellationToken ct = default) =>
             Task.CompletedTask;
+    }
+
+    private sealed class RecordingBindingRetirementPort : INyxIdBindingRetirementPort
+    {
+        public Exception? Failure { get; set; }
+        public List<string> RetiredBindingIds { get; } = [];
+
+        public Task RetireAsync(string bindingId, CancellationToken ct = default)
+        {
+            if (Failure is not null)
+                return Task.FromException(Failure);
+
+            RetiredBindingIds.Add(bindingId);
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class InMemoryEventStore : IEventStore

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -200,10 +200,11 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
     }
 
     [Fact]
-    public async Task BindingFlow_PreservesConsentAndScopesBrokerTokenExchange()
+    public async Task BindingFlow_PreservesCompleteConsentAcrossBrokerTokenExchange()
     {
         const string bindingId = "bnd-e2e-user";
-        var accessToken = CreateAccessToken(RequiredResources);
+        const string optionalResource = $"{ResourceServerBaseUrl}/api/v1/proxy/s/user-selected-service";
+        var accessToken = CreateAccessToken([.. RequiredResources, optionalResource]);
         var handler = new SequenceHandler(
             JsonSerializer.Serialize(new
             {
@@ -252,7 +253,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         bindingExchangeForm["grant_type"].Should().ContainSingle().Which.Should()
             .Be("urn:ietf:params:oauth:grant-type:token-exchange");
         bindingExchangeForm["subject_token"].Should().ContainSingle().Which.Should().Be(bindingId);
-        bindingExchangeForm["resource"].Should().Equal(RequiredResources);
+        bindingExchangeForm.ContainsKey("resource").Should().BeFalse();
     }
 
     [Fact]
@@ -312,8 +313,8 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
             new CapabilityScope { Value = AevatarOAuthClientScopes.Proxy });
 
         result.AccessToken.Should().Be(accessToken);
-        QueryHelpers.ParseQuery($"?{handler.LastRequestBody}")["resource"]
-            .Should().Equal(RequiredResources);
+        QueryHelpers.ParseQuery($"?{handler.LastRequestBody}")
+            .ContainsKey("resource").Should().BeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -100,7 +100,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             queryPort,
             dispatch,
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
@@ -143,7 +143,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             queryPort,
             dispatch,
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
@@ -155,7 +155,47 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
     }
 
     [Fact]
-    public async Task Finalize_ShouldRefreshBinding_WhenExistingBindingIsRevoked()
+    public async Task Finalize_ShouldReplaceUsableBinding_ForExplicitServiceAccessReview()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            BindingId: "bnd-reviewed",
+            IdToken: CreateIdToken(new { uid = "owner-user-1" }),
+            AccessToken: "access-token"));
+        var queryPort = new FakeExternalIdentityBindingQueryPort();
+        queryPort.Bindings[SubjectKey(OwnerSubject("owner-user-1"))] = "bnd-existing";
+        var replaceDispatch = new RecordingBindingReplaceDispatch();
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+                ServiceAccessReview = true,
+            },
+            broker,
+            new UsableCapabilityBroker(),
+            queryPort,
+            new RecordingBindingDispatch(),
+            replaceDispatch,
+            NullLoggerFactory.Instance);
+
+        var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status200OK);
+        payload!.BindingDispatchAccepted.Should().BeTrue();
+        broker.RevokedBindingIds.Should().BeEmpty();
+        replaceDispatch.Commands.Should().ContainSingle().Which.Should().BeEquivalentTo(new ReplaceBindingCommand
+        {
+            ExternalSubject = OwnerSubject("owner-user-1"),
+            BindingId = "bnd-reviewed",
+            ExpectedPreviousBindingId = "bnd-existing",
+            Reason = "studio_service_access_review",
+        });
+    }
+
+    [Fact]
+    public async Task Finalize_ShouldReplaceBinding_WhenExistingBindingIsRevoked()
     {
         var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
             BindingId: "bnd-new",
@@ -164,7 +204,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         var queryPort = new FakeExternalIdentityBindingQueryPort();
         queryPort.Bindings[SubjectKey(OwnerSubject("owner-user-1"))] = "bnd-existing";
         var dispatch = new RecordingBindingDispatch();
-        var refreshDispatch = new RecordingBindingRefreshDispatch();
+        var replaceDispatch = new RecordingBindingReplaceDispatch();
 
         var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
             new NyxIdLoginFinalizationRequest { Code = "auth-code", CodeVerifier = "pkce-verifier", RedirectUri = "http://localhost/auth/callback" },
@@ -172,7 +212,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new RevokedCapabilityBroker(),
             queryPort,
             dispatch,
-            refreshDispatch,
+            replaceDispatch,
             NullLoggerFactory.Instance);
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
@@ -180,11 +220,12 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         statusCode.Should().Be(StatusCodes.Status200OK);
         payload!.BindingDispatchAccepted.Should().BeTrue();
         broker.RevokedBindingIds.Should().BeEmpty();
-        refreshDispatch.Commands.Should().ContainSingle().Which.Should().BeEquivalentTo(new RefreshBindingCommand
+        replaceDispatch.Commands.Should().ContainSingle().Which.Should().BeEquivalentTo(new ReplaceBindingCommand
         {
             ExternalSubject = OwnerSubject("owner-user-1"),
             BindingId = "bnd-new",
-            Reason = "nyxid_login_refresh",
+            ExpectedPreviousBindingId = "bnd-existing",
+            Reason = "nyxid_login_recovery",
         });
         dispatch.Commands.Should().BeEmpty();
     }
@@ -199,7 +240,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         var queryPort = new FakeExternalIdentityBindingQueryPort();
         queryPort.Bindings[SubjectKey(OwnerSubject("owner-user-1"))] = "bnd-existing";
         var dispatch = new RecordingBindingDispatch();
-        var refreshDispatch = new RecordingBindingRefreshDispatch();
+        var replaceDispatch = new RecordingBindingReplaceDispatch();
 
         var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
             new NyxIdLoginFinalizationRequest { Code = "auth-code", CodeVerifier = "pkce-verifier", RedirectUri = "http://localhost/auth/callback" },
@@ -207,7 +248,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new FailingCapabilityBroker(),
             queryPort,
             dispatch,
-            refreshDispatch,
+            replaceDispatch,
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -215,12 +256,12 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
         broker.RevokedBindingIds.Should().ContainSingle().Which.Should().Be("bnd-new");
-        refreshDispatch.Commands.Should().BeEmpty();
+        replaceDispatch.Commands.Should().BeEmpty();
         dispatch.Commands.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task Finalize_ShouldRefreshBinding_WhenExistingBindingLacksRequiredService()
+    public async Task Finalize_ShouldReplaceBinding_WhenExistingBindingLacksRequiredService()
     {
         var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
             BindingId: "bnd-new",
@@ -228,7 +269,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             AccessToken: "access-token"));
         var queryPort = new FakeExternalIdentityBindingQueryPort();
         queryPort.Bindings[SubjectKey(OwnerSubject("owner-user-1"))] = "bnd-existing";
-        var refreshDispatch = new RecordingBindingRefreshDispatch();
+        var replaceDispatch = new RecordingBindingReplaceDispatch();
 
         var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
             new NyxIdLoginFinalizationRequest { Code = "auth-code", CodeVerifier = "pkce-verifier", RedirectUri = "http://localhost/auth/callback" },
@@ -236,14 +277,20 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new ServiceAccessMismatchCapabilityBroker(),
             queryPort,
             new RecordingBindingDispatch(),
-            refreshDispatch,
+            replaceDispatch,
             NullLoggerFactory.Instance);
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
 
         statusCode.Should().Be(StatusCodes.Status200OK);
         payload!.BindingDispatchAccepted.Should().BeTrue();
-        refreshDispatch.Commands.Should().ContainSingle().Which.BindingId.Should().Be("bnd-new");
+        replaceDispatch.Commands.Should().ContainSingle().Which.Should().BeEquivalentTo(new ReplaceBindingCommand
+        {
+            ExternalSubject = OwnerSubject("owner-user-1"),
+            BindingId = "bnd-new",
+            ExpectedPreviousBindingId = "bnd-existing",
+            Reason = "nyxid_login_recovery",
+        });
     }
 
     [Fact]
@@ -261,7 +308,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var (statusCode, payload) = await ExecuteJsonAsync<LoginErrorResponse>(result);
@@ -273,6 +320,37 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
     }
 
     [Fact]
+    public async Task Finalize_ShouldRejectAndRevokeNewBinding_WhenIssuedGrantLacksRequiredService()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            BindingId: "bnd-insufficient",
+            IdToken: CreateIdToken(new { uid = "owner-user-1" }),
+            AccessToken: "access-token"));
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+            },
+            broker,
+            new IssuedBindingServiceAccessMismatchCapabilityBroker(),
+            new FakeExternalIdentityBindingQueryPort(),
+            new RecordingBindingDispatch(),
+            new RecordingBindingReplaceDispatch(),
+            NullLoggerFactory.Instance);
+
+        var (statusCode, payload) = await ExecuteJsonAsync<LoginErrorResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status409Conflict);
+        payload.Should().Be(new LoginErrorResponse(
+            "required_service_access_missing",
+            "Return to NyxID and keep every service marked as required by Aevatar selected."));
+        broker.RevokedBindingIds.Should().Equal("bnd-insufficient");
+    }
+
+    [Fact]
     public async Task Finalize_ShouldRejectMissingCode()
     {
         var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
@@ -281,7 +359,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -299,7 +377,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -317,7 +395,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -335,7 +413,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -353,7 +431,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -373,7 +451,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -397,7 +475,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RejectingBindingDispatch(),
-            new RecordingBindingRefreshDispatch(),
+            new RecordingBindingReplaceDispatch(),
             NullLoggerFactory.Instance);
 
         var context = NewHttpContext();
@@ -523,15 +601,20 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             CapabilityScope scope,
             CancellationToken ct = default);
 
-        public Task<CapabilityHandle> IssueShortLivedByBindingIdAsync(
+        public virtual Task<CapabilityHandle> IssueShortLivedByBindingIdAsync(
             ExternalSubjectRef externalSubject,
             string bindingId,
             CapabilityScope scope,
             CancellationToken ct = default) =>
-            IssueShortLivedAsync(externalSubject, scope, ct);
+            Task.FromResult(new CapabilityHandle
+            {
+                AccessToken = "issued-binding-probe-token",
+                Scope = scope.Value,
+                ExpiresAtUnix = 3600,
+            });
     }
 
-    private sealed class UsableCapabilityBroker : StubCapabilityBroker
+    private class UsableCapabilityBroker : StubCapabilityBroker
     {
         public override Task<CapabilityHandle> IssueShortLivedAsync(
             ExternalSubjectRef externalSubject,
@@ -565,6 +648,18 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
                 ["https://api.example.test/api/v1/proxy/s/aevatar"]);
     }
 
+    private sealed class IssuedBindingServiceAccessMismatchCapabilityBroker : UsableCapabilityBroker
+    {
+        public override Task<CapabilityHandle> IssueShortLivedByBindingIdAsync(
+            ExternalSubjectRef externalSubject,
+            string bindingId,
+            CapabilityScope scope,
+            CancellationToken ct = default) =>
+            throw new BindingServiceAccessMismatchException(
+                externalSubject,
+                ["https://api.example.test/api/v1/proxy/s/aevatar"]);
+    }
+
     private sealed class FailingCapabilityBroker : StubCapabilityBroker
     {
         public override Task<CapabilityHandle> IssueShortLivedAsync(
@@ -589,13 +684,13 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         }
     }
 
-    private sealed class RecordingBindingRefreshDispatch
-        : ICommandDispatchService<RefreshBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>
+    private sealed class RecordingBindingReplaceDispatch
+        : ICommandDispatchService<ReplaceBindingCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>
     {
-        public List<RefreshBindingCommand> Commands { get; } = [];
+        public List<ReplaceBindingCommand> Commands { get; } = [];
 
         public Task<CommandDispatchResult<ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>> DispatchAsync(
-            RefreshBindingCommand command,
+            ReplaceBindingCommand command,
             CancellationToken ct = default)
         {
             Commands.Add(command);


### PR DESCRIPTION
## Problem

Studio login currently reuses a healthy owner binding even when the user has explicitly returned to NyxID Consent to change service access. The newly issued binding is treated as an orphan, so the reviewed grant never becomes Aevatar runtime authority.

Broker token exchange also sent Aevatar's configured minimum RFC 8707 resources on every request. That narrowed short-lived tokens and made optional services selected by the user unavailable.

## Solution

- Add the typed `serviceAccessReview` finalization signal, defaulting to normal-login behavior when absent or `false`.
- Validate every newly issued binding before adoption.
- Replace bindings through actor-owned compare-and-swap using `expected_previous_binding_id`.
- Commit replacement before retiring the previous binding.
- Persist failed retirement work in actor state and retry it on activation.
- Retire unadopted bindings that lose a compare-and-swap race.
- Omit `resource` from binding token exchange so the complete Consent grant is inherited, then validate the configured required-resource floor from the returned token.
- Update projection activation, audit translation, DI, tests, and ADRs.

## Scope and ownership

This PR is backend-only. It does not modify `apps/aevatar-console-web`.

Frontend integration is tracked by #2800. Aevatar must only initiate the authoritative NyxID Consent flow; it must not add a second service picker. NyxID was inspected but not modified.

Lark in-place grant review remains tracked by #2754 and https://github.com/ChronoAIProject/NyxID/pull/1151.

## Impact paths

- Channel identity binding actor and protobuf contracts
- NyxID capability broker token exchange and binding retirement adapter
- Studio NyxID login finalization
- Identity projection activation and restricted audit facts
- ADR-0018 and ADR-0040

## Verification

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~Aevatar.GAgents.ChannelRuntime.Tests.Identity"` — 229 passed
- `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~NyxIdLoginFinalizationEndpointsTests"` — 18 passed
- `dotnet test test/Aevatar.Architecture.Tests/Aevatar.Architecture.Tests.csproj --no-restore --nologo` — 165 passed, 1 skipped
- `bash tools/ci/test_stability_guards.sh` — passed
- `bash tools/ci/architecture_guards.sh` — passed, including protobuf/projection/workflow guards and docs lint (75 files, 0 errors)
- `git diff --check` — passed
