### PR TITLE
[codex] Persist NyxID consent defaults through DCR

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.GAgents.Channel.Identity.Endpoints;
 
@@ -378,6 +379,7 @@ public static class IdentityOAuthEndpoints
     internal static Task<IResult> HandleAevatarOAuthClientRebuildAsync(
         HttpContext http,
         [FromBody] RebuildAevatarOAuthClientRequest? body,
+        [FromServices] IOptions<NyxIdBrokerOptions> brokerOptions,
         [FromServices] ICommandDispatchService<ProvisionAevatarOAuthClientCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> rebuildDispatch,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct) =>
@@ -385,6 +387,7 @@ public static class IdentityOAuthEndpoints
             http,
             body,
             http.RequestServices.GetService<IPlatformAdminAuthorizer>(),
+            brokerOptions,
             rebuildDispatch,
             loggerFactory,
             ct);
@@ -397,6 +400,7 @@ public static class IdentityOAuthEndpoints
         HttpContext http,
         RebuildAevatarOAuthClientRequest? body,
         IPlatformAdminAuthorizer? adminAuthorizer,
+        IOptions<NyxIdBrokerOptions> brokerOptions,
         ICommandDispatchService<ProvisionAevatarOAuthClientCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> rebuildDispatch,
         ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -424,6 +428,9 @@ public static class IdentityOAuthEndpoints
         var redirectUri = NyxIdRedirectUriResolver.Resolve(logger);
         var redirectUris = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris(logger);
         var oauthScope = AevatarOAuthClientScopes.AuthorizationScope;
+        var defaultServiceCatalogSlugs = AevatarOAuthClientResources.RequiredServiceSlugs(
+            brokerOptions.Value.RequiredLlmServiceSlug,
+            brokerOptions.Value.AdditionalRequiredServiceSlugs);
 
         // Validate Unix-seconds before dispatching: AevatarOAuthClient
         // ProjectionProvider later calls DateTimeOffset.FromUnixTimeSeconds
@@ -465,6 +472,7 @@ public static class IdentityOAuthEndpoints
                 RedirectUri = redirectUri,
             };
             command.RedirectUris.AddRange(redirectUris);
+            command.DefaultServiceCatalogSlugs.AddRange(defaultServiceCatalogSlugs);
             accepted = await rebuildDispatch
                 .DispatchAsync(command, ct)
                 .ConfigureAwait(false);

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -1,5 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,15 +24,18 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
 
     private readonly ICommandDispatchService<EnsureAevatarOAuthClientProvisionedCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> _provisioningDispatch;
     private readonly AevatarOAuthClientBootstrapOptions _options;
+    private readonly NyxIdBrokerOptions _brokerOptions;
     private readonly ILogger<AevatarOAuthClientBootstrapService> _logger;
 
     public AevatarOAuthClientBootstrapService(
         ICommandDispatchService<EnsureAevatarOAuthClientProvisionedCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> provisioningDispatch,
         IOptions<AevatarOAuthClientBootstrapOptions> options,
+        IOptions<NyxIdBrokerOptions> brokerOptions,
         ILogger<AevatarOAuthClientBootstrapService> logger)
     {
         _provisioningDispatch = provisioningDispatch ?? throw new ArgumentNullException(nameof(provisioningDispatch));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _brokerOptions = brokerOptions?.Value ?? throw new ArgumentNullException(nameof(brokerOptions));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -70,6 +74,9 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         // authorize / token time — both call sites use NyxIdRedirectUriResolver.
         var redirectUri = NyxIdRedirectUriResolver.Resolve(_logger);
         var redirectUris = NyxIdRedirectUriResolver.ResolveRegisteredRedirectUris(_logger);
+        var defaultServiceCatalogSlugs = AevatarOAuthClientResources.RequiredServiceSlugs(
+            _brokerOptions.RequiredLlmServiceSlug,
+            _brokerOptions.AdditionalRequiredServiceSlugs);
         ValidateStartupProvisioningBoundary(authority, redirectUri);
         var forceReprovision = string.Equals(
             Environment.GetEnvironmentVariable(ForceDcrOnStartupEnvVar),
@@ -91,6 +98,7 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
             ForceReprovision = forceReprovision,
         };
         command.RedirectUris.AddRange(redirectUris);
+        command.DefaultServiceCatalogSlugs.AddRange(defaultServiceCatalogSlugs);
 
         var accepted = await _provisioningDispatch
             .DispatchAsync(command, ct)

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -141,6 +141,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         }
 
         var expectedRedirectUris = NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri);
+        var expectedDefaultServiceCatalogSlugs =
+            ResolveDefaultServiceCatalogSlugs(cmd.DefaultServiceCatalogSlugs);
         var sameClient = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal);
         var forceReprovision = cmd.ForceReprovision && !State.ForceReprovisionConsumed;
@@ -163,8 +165,20 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             && (State.RedirectUris.Count == 0
                 || !RedirectUriListsEqual(State.RedirectUris, expectedRedirectUris));
         var oauthScopeDrifted = sameClient && !AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope);
+        // Empty means an older caller did not supply this newly-added intent.
+        // Such callers may not clear or drift a value already owned by state.
+        var defaultServicesDrifted = sameClient
+            && expectedDefaultServiceCatalogSlugs.Length > 0
+            && !DefaultServiceCatalogSlugListsEqual(
+                State.DefaultServiceCatalogSlugs,
+                expectedDefaultServiceCatalogSlugs);
 
-        if (sameClient && !forceReprovision && !redirectUriDrifted && !redirectUriListDrifted && !oauthScopeDrifted)
+        if (sameClient
+            && !forceReprovision
+            && !redirectUriDrifted
+            && !redirectUriListDrifted
+            && !oauthScopeDrifted
+            && !defaultServicesDrifted)
         {
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
@@ -211,6 +225,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 State.OauthScope,
                 AevatarOAuthClientScopes.AuthorizationScope);
         }
+        if (defaultServicesDrifted)
+        {
+            Logger.LogWarning(
+                "Aevatar OAuth client consent defaults drifted: stored='{Stored}', required='{Required}'. " +
+                "Re-running DCR to register a new client_id with the configured catalog defaults.",
+                string.Join(",", State.DefaultServiceCatalogSlugs),
+                string.Join(",", expectedDefaultServiceCatalogSlugs));
+        }
         if (forceReprovision)
         {
             Logger.LogWarning(
@@ -236,7 +258,12 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // DCR call itself is bounded.
         var clientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName;
         var registration = await registrar
-            .RegisterPublicClientAsync(cmd.NyxidAuthority, clientName, expectedRedirectUris, CancellationToken.None)
+            .RegisterPublicClientAsync(
+                cmd.NyxidAuthority,
+                clientName,
+                expectedRedirectUris,
+                expectedDefaultServiceCatalogSlugs,
+                CancellationToken.None)
             .ConfigureAwait(false);
 
         // Cluster-shared Garnet event store + brief two-pod overlap during
@@ -253,6 +280,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var previousRedirectUri = State.RedirectUri;
         var previousRedirectUris = State.RedirectUris.ToArray();
         var previousOauthScope = State.OauthScope;
+        var previousDefaultServiceCatalogSlugs = State.DefaultServiceCatalogSlugs.ToArray();
         var provisioned = new AevatarOAuthClientProvisionedEvent
         {
             ClientId = registration.ClientId,
@@ -263,6 +291,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
         };
         provisioned.RedirectUris.AddRange(expectedRedirectUris);
+        provisioned.DefaultServiceCatalogSlugs.AddRange(expectedDefaultServiceCatalogSlugs);
         await PersistDomainEventAsync(
             provisioned,
             onOptimisticConcurrencyConflict: occ => AbsorbPeerDcrProvisioningAsync(cmd, registration.ClientId, occ));
@@ -282,9 +311,11 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             redirectUriDrifted,
             redirectUriListDrifted,
             oauthScopeDrifted,
+            defaultServicesDrifted,
             previousRedirectUri,
             previousRedirectUris,
-            previousOauthScope);
+            previousOauthScope,
+            previousDefaultServiceCatalogSlugs);
 
         Logger.LogInformation(
             "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uris={RedirectUris}",
@@ -341,6 +372,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             ForceReprovision = State.ProvisioningRetryForceReprovision,
         };
         command.RedirectUris.AddRange(State.ProvisioningRetryRedirectUris);
+        command.DefaultServiceCatalogSlugs.AddRange(
+            State.ProvisioningRetryDefaultServiceCatalogSlugs);
         await HandleEnsureProvisionedAsync(command, allowPendingRetryBypass: true).ConfigureAwait(false);
     }
 
@@ -362,7 +395,10 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             || evt.ForceReprovision != State.ProvisioningRetryForceReprovision
             || !RedirectUriListsEqual(
                 NormalizeProvisioningRedirectUris(evt.RedirectUris, evt.RedirectUri),
-                State.ProvisioningRetryRedirectUris))
+                State.ProvisioningRetryRedirectUris)
+            || !DefaultServiceCatalogSlugListsEqual(
+                evt.DefaultServiceCatalogSlugs,
+                State.ProvisioningRetryDefaultServiceCatalogSlugs))
         {
             return false;
         }
@@ -377,13 +413,23 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         return evt.CallbackGeneration <= 0 || evt.CallbackGeneration == State.ProvisioningRetryCallbackGeneration;
     }
 
-    private bool StateMatchesProvisioningIntent(EnsureAevatarOAuthClientProvisionedCommand cmd) =>
-        !string.IsNullOrEmpty(State.ClientId)
-        && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
-        && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
-        && RedirectUriListsEqual(State.RedirectUris, NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri))
-        && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
-        && HasHmacKey;
+    private bool StateMatchesProvisioningIntent(EnsureAevatarOAuthClientProvisionedCommand cmd)
+    {
+        var expectedDefaultServiceCatalogSlugs =
+            ResolveDefaultServiceCatalogSlugs(cmd.DefaultServiceCatalogSlugs);
+        return !string.IsNullOrEmpty(State.ClientId)
+               && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
+               && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+               && RedirectUriListsEqual(
+                   State.RedirectUris,
+                   NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri))
+               && (expectedDefaultServiceCatalogSlugs.Length == 0
+                   || DefaultServiceCatalogSlugListsEqual(
+                       State.DefaultServiceCatalogSlugs,
+                       expectedDefaultServiceCatalogSlugs))
+               && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
+               && HasHmacKey;
+    }
 
     private async Task ScheduleProvisioningRetryAsync(
         EnsureAevatarOAuthClientProvisionedCommand cmd,
@@ -414,6 +460,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             ForceReprovision = normalized.ForceReprovision,
         };
         callbackPayload.RedirectUris.AddRange(normalized.RedirectUris);
+        callbackPayload.DefaultServiceCatalogSlugs.AddRange(
+            normalized.DefaultServiceCatalogSlugs);
         var lease = await ScheduleSelfDurableTimeoutAsync(
                 callbackId,
                 delay,
@@ -435,6 +483,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             ForceReprovision = normalized.ForceReprovision,
         };
         scheduled.RedirectUris.AddRange(normalized.RedirectUris);
+        scheduled.DefaultServiceCatalogSlugs.AddRange(
+            normalized.DefaultServiceCatalogSlugs);
         await PersistDomainEventAsync(scheduled).ConfigureAwait(false);
 
         Logger.LogWarning(
@@ -461,11 +511,13 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         bool redirectUriDrifted,
         bool redirectUriListDrifted,
         bool oauthScopeDrifted,
+        bool defaultServicesDrifted,
         string previousRedirectUri,
         IReadOnlyCollection<string> previousRedirectUris,
-        string previousOauthScope)
+        string previousOauthScope,
+        IReadOnlyCollection<string> previousDefaultServiceCatalogSlugs)
     {
-        var events = new List<IMessage>(capacity: 3);
+        var events = new List<IMessage>(capacity: 4);
         var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
         if (redirectUriDrifted)
         {
@@ -500,12 +552,23 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 ReconciledAt = now,
             });
         }
+        if (defaultServicesDrifted)
+        {
+            events.Add(new AevatarOAuthClientDriftReconciledEvent
+            {
+                DriftKind = "default_service_catalog_slugs",
+                PreviousValue = string.Join(",", previousDefaultServiceCatalogSlugs),
+                ExpectedValue = string.Join(",", State.DefaultServiceCatalogSlugs),
+                ActiveClientId = State.ClientId,
+                ReconciledAt = now,
+            });
+        }
 
         if (events.Count > 0)
             await PersistDomainEventsAsync(events).ConfigureAwait(false);
     }
 
-    private static EnsureAevatarOAuthClientProvisionedCommand? NormalizeEnsureProvisionedCommand(
+    private EnsureAevatarOAuthClientProvisionedCommand? NormalizeEnsureProvisionedCommand(
         EnsureAevatarOAuthClientProvisionedCommand cmd)
     {
         if (string.IsNullOrWhiteSpace(cmd.NyxidAuthority) || string.IsNullOrWhiteSpace(cmd.RedirectUri))
@@ -519,6 +582,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             ForceReprovision = cmd.ForceReprovision,
         };
         normalized.RedirectUris.AddRange(NormalizeProvisioningRedirectUris(cmd.RedirectUris, normalized.RedirectUri));
+        normalized.DefaultServiceCatalogSlugs.AddRange(
+            ResolveDefaultServiceCatalogSlugs(cmd.DefaultServiceCatalogSlugs));
         return normalized;
     }
 
@@ -543,6 +608,26 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             && storedValues.SequenceEqual(expected, StringComparer.Ordinal);
     }
 
+    private static string[] NormalizeDefaultServiceCatalogSlugs(IEnumerable<string> slugs) =>
+        AevatarOAuthClientResources.NormalizeServiceSlugs(slugs);
+
+    private string[] ResolveDefaultServiceCatalogSlugs(IEnumerable<string> slugs)
+    {
+        var normalized = NormalizeDefaultServiceCatalogSlugs(slugs);
+        return normalized.Length > 0
+            ? normalized
+            : State.DefaultServiceCatalogSlugs.ToArray();
+    }
+
+    private static bool DefaultServiceCatalogSlugListsEqual(
+        IEnumerable<string> stored,
+        IReadOnlyCollection<string> expected)
+    {
+        var storedValues = NormalizeDefaultServiceCatalogSlugs(stored);
+        return storedValues.Length == expected.Count
+               && storedValues.SequenceEqual(expected, StringComparer.Ordinal);
+    }
+
     private static TimeSpan ComputeRetryDelay(int attempt)
     {
         var exponent = Math.Max(0, Math.Min(attempt - 1, 20));
@@ -564,10 +649,16 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // this callback. A peer healed the drift iff the cluster's stored
         // record now matches the command's intended shape.
         var expectedRedirectUris = NormalizeProvisioningRedirectUris(cmd.RedirectUris, cmd.RedirectUri);
+        var expectedDefaultServiceCatalogSlugs =
+            ResolveDefaultServiceCatalogSlugs(cmd.DefaultServiceCatalogSlugs);
         var peerHealed = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
             && RedirectUriListsEqual(State.RedirectUris, expectedRedirectUris)
+            && (expectedDefaultServiceCatalogSlugs.Length == 0
+                || DefaultServiceCatalogSlugListsEqual(
+                    State.DefaultServiceCatalogSlugs,
+                    expectedDefaultServiceCatalogSlugs))
             && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
             && HasHmacKey;
 
@@ -588,10 +679,13 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         Logger.LogError(
             "Aevatar OAuth client OCC race did not converge on the desired shape after replay; actor-owned retry will re-evaluate. "
             + "stored_client_id={StoredClientId}, stored_redirect_uris={StoredRedirectUris}, expected_redirect_uris={ExpectedRedirectUris}, "
+            + "stored_default_service_catalog_slugs={StoredDefaultServiceCatalogSlugs}, expected_default_service_catalog_slugs={ExpectedDefaultServiceCatalogSlugs}, "
             + "orphan_client_id={OrphanClientId}, expected_version={Expected}, actual_version={Actual}.",
             State.ClientId,
             string.Join(",", State.RedirectUris),
             string.Join(",", expectedRedirectUris),
+            string.Join(",", State.DefaultServiceCatalogSlugs),
+            string.Join(",", expectedDefaultServiceCatalogSlugs),
             orphanClientId,
             occ.ExpectedVersion,
             occ.ActualVersion);
@@ -626,12 +720,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     /// production bootstrap path uses
     /// <see cref="HandleEnsureProvisioned"/> instead so the actor (not the
     /// caller) mediates the DCR call. Idempotent: re-issuing the same
-    /// snapshot (client_id + authority + redirect_uri + oauth_scope) is a
+    /// snapshot (client_id + authority + redirect_uri + oauth_scope + consent
+    /// defaults) is a
     /// no-op. Always seeds a fresh HMAC key when the state has none —
     /// bootstrap and provisioning are single-step.
     /// </summary>
     /// <remarks>
-    /// The same-snapshot check covers redirect_uri + oauth_scope on top of
+    /// The same-snapshot check covers redirect_uri + oauth_scope + consent
+    /// defaults on top of
     /// client_id + authority because the operator-rebuild path
     /// (<c>POST /api/oauth/aevatar-client/rebuild</c>, issue #549) must be
     /// able to heal a wedged actor whose state has the right client_id but
@@ -667,10 +763,16 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var redirectUris = cmd.RedirectUris.Count == 0
             ? State.RedirectUris.Count == 0 ? NormalizeProvisioningRedirectUris(Array.Empty<string>(), redirectUri) : State.RedirectUris.ToArray()
             : NormalizeProvisioningRedirectUris(cmd.RedirectUris, redirectUri);
+        var defaultServiceCatalogSlugs = cmd.DefaultServiceCatalogSlugs.Count == 0
+            ? State.DefaultServiceCatalogSlugs.ToArray()
+            : NormalizeDefaultServiceCatalogSlugs(cmd.DefaultServiceCatalogSlugs);
         var sameSnapshot = string.Equals(State.ClientId, cmd.ClientId, StringComparison.Ordinal)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, redirectUri, StringComparison.Ordinal)
             && RedirectUriListsEqual(State.RedirectUris, redirectUris)
+            && DefaultServiceCatalogSlugListsEqual(
+                State.DefaultServiceCatalogSlugs,
+                defaultServiceCatalogSlugs)
             && string.Equals(State.OauthScope, oauthScope, StringComparison.Ordinal);
         if (!sameSnapshot)
         {
@@ -684,6 +786,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 RedirectUri = redirectUri,
             };
             provisioned.RedirectUris.AddRange(redirectUris);
+            provisioned.DefaultServiceCatalogSlugs.AddRange(defaultServiceCatalogSlugs);
             await PersistDomainEventAsync(provisioned);
             Logger.LogInformation(
                 "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}, redirect_uris={RedirectUris}",
@@ -814,6 +917,9 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.RedirectUri = evt.RedirectUri ?? string.Empty;
         next.RedirectUris.Clear();
         next.RedirectUris.AddRange(NormalizeProvisioningRedirectUris(evt.RedirectUris, next.RedirectUri));
+        next.DefaultServiceCatalogSlugs.Clear();
+        next.DefaultServiceCatalogSlugs.AddRange(
+            NormalizeDefaultServiceCatalogSlugs(evt.DefaultServiceCatalogSlugs));
         next.OauthScope = evt.OauthScope ?? string.Empty;
         // Re-provisioning resets the broker observation: a new client_id
         // starts with broker_capability_enabled=false until ops flips it.
@@ -863,6 +969,9 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryRedirectUri = evt.RedirectUri ?? string.Empty;
         next.ProvisioningRetryRedirectUris.Clear();
         next.ProvisioningRetryRedirectUris.AddRange(NormalizeProvisioningRedirectUris(evt.RedirectUris, next.ProvisioningRetryRedirectUri));
+        next.ProvisioningRetryDefaultServiceCatalogSlugs.Clear();
+        next.ProvisioningRetryDefaultServiceCatalogSlugs.AddRange(
+            NormalizeDefaultServiceCatalogSlugs(evt.DefaultServiceCatalogSlugs));
         next.ProvisioningRetryClientName = evt.ClientName ?? string.Empty;
         next.ProvisioningRetryForceReprovision = evt.ForceReprovision;
         next.ProvisioningRetryCallbackId = evt.CallbackId ?? string.Empty;
@@ -882,6 +991,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         next.ProvisioningRetryAuthority = string.Empty;
         next.ProvisioningRetryRedirectUri = string.Empty;
         next.ProvisioningRetryRedirectUris.Clear();
+        next.ProvisioningRetryDefaultServiceCatalogSlugs.Clear();
         next.ProvisioningRetryClientName = string.Empty;
         next.ProvisioningRetryForceReprovision = false;
         next.ProvisioningRetryCallbackId = string.Empty;

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientResources.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientResources.cs
@@ -21,6 +21,18 @@ public static class AevatarOAuthClientResources
         string nyxIdApiBaseUrl,
         string? requiredLlmServiceSlug,
         IEnumerable<string>? additionalRequiredServiceSlugs = null)
+        => RequiredServiceSlugs(requiredLlmServiceSlug, additionalRequiredServiceSlugs)
+            .Select(serviceSlug => ServiceResourceUri(nyxIdApiBaseUrl, serviceSlug))
+            .ToArray();
+
+    /// <summary>
+    /// Returns the canonical service slugs required by Aevatar's NyxID flows.
+    /// Consent defaults and RFC 8707 runtime resources both derive from this
+    /// list so provider configuration cannot drift across the two contracts.
+    /// </summary>
+    public static string[] RequiredServiceSlugs(
+        string? requiredLlmServiceSlug,
+        IEnumerable<string>? additionalRequiredServiceSlugs = null)
     {
         var serviceSlugs = new List<string> { RequiredServiceSlug };
         if (!string.IsNullOrWhiteSpace(requiredLlmServiceSlug))
@@ -31,10 +43,7 @@ public static class AevatarOAuthClientResources
                 static serviceSlug => !string.IsNullOrWhiteSpace(serviceSlug)));
         }
 
-        return serviceSlugs
-            .Select(serviceSlug => ServiceResourceUri(nyxIdApiBaseUrl, serviceSlug))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+        return NormalizeServiceSlugs(serviceSlugs);
     }
 
     public static string[] MissingRequiredResources(
@@ -69,6 +78,16 @@ public static class AevatarOAuthClientResources
         }
 
         return normalized;
+    }
+
+    internal static string[] NormalizeServiceSlugs(IEnumerable<string> serviceSlugs)
+    {
+        ArgumentNullException.ThrowIfNull(serviceSlugs);
+        return serviceSlugs
+            .Where(static serviceSlug => !string.IsNullOrWhiteSpace(serviceSlug))
+            .Select(NormalizeServiceSlug)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     internal static bool IsValidServiceSlug(string? serviceSlug)

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdDynamicClientRegistrationClient.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdDynamicClientRegistrationClient.cs
@@ -46,18 +46,29 @@ public class NyxIdDynamicClientRegistrationClient
         CancellationToken ct = default) =>
         RegisterPublicClientAsync(authority, clientName, [redirectUri], ct);
 
+    public virtual Task<RegistrationResult> RegisterPublicClientAsync(
+        string authority,
+        string clientName,
+        IReadOnlyCollection<string> redirectUris,
+        CancellationToken ct = default) =>
+        RegisterPublicClientAsync(authority, clientName, redirectUris, [], ct);
+
     public virtual async Task<RegistrationResult> RegisterPublicClientAsync(
         string authority,
         string clientName,
         IReadOnlyCollection<string> redirectUris,
+        IReadOnlyCollection<string> defaultServiceCatalogSlugs,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(authority);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientName);
         ArgumentNullException.ThrowIfNull(redirectUris);
+        ArgumentNullException.ThrowIfNull(defaultServiceCatalogSlugs);
         var normalizedRedirectUris = NyxIdRedirectUriResolver.NormalizeRedirectUris(redirectUris);
         if (normalizedRedirectUris.Count == 0)
             throw new ArgumentException("At least one redirect URI is required.", nameof(redirectUris));
+        var normalizedDefaultServiceCatalogSlugs =
+            AevatarOAuthClientResources.NormalizeServiceSlugs(defaultServiceCatalogSlugs);
 
         var url = $"{authority.TrimEnd('/')}{RegisterEndpoint}";
         var request = new RegistrationRequest
@@ -68,6 +79,7 @@ public class NyxIdDynamicClientRegistrationClient
             ResponseTypes = ["code"],
             TokenEndpointAuthMethod = "none",
             Scope = AevatarOAuthClientScopes.AuthorizationScope,
+            DefaultServiceCatalogSlugs = normalizedDefaultServiceCatalogSlugs,
         };
 
         using var response = await _http.PostAsJsonAsync(url, request, JsonOptions, ct).ConfigureAwait(false);
@@ -88,6 +100,16 @@ public class NyxIdDynamicClientRegistrationClient
 
         if (string.IsNullOrWhiteSpace(registration.ClientId))
             throw new InvalidOperationException("NyxID DCR response did not include a client_id.");
+
+        var confirmedDefaultServiceCatalogSlugs = AevatarOAuthClientResources.NormalizeServiceSlugs(
+            registration.DefaultServiceCatalogSlugs ?? []);
+        if (!normalizedDefaultServiceCatalogSlugs.SequenceEqual(
+                confirmedDefaultServiceCatalogSlugs,
+                StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "NyxID DCR response did not confirm the requested default_service_catalog_slugs.");
+        }
 
         var issuedAt = registration.ClientIdIssuedAt > 0
             ? DateTimeOffset.FromUnixTimeSeconds(registration.ClientIdIssuedAt)
@@ -114,6 +136,7 @@ public class NyxIdDynamicClientRegistrationClient
         public string[] ResponseTypes { get; init; } = Array.Empty<string>();
         public string TokenEndpointAuthMethod { get; init; } = "none";
         public string? Scope { get; init; }
+        public string[] DefaultServiceCatalogSlugs { get; init; } = [];
     }
 
     private sealed record RegistrationResponse
@@ -125,6 +148,7 @@ public class NyxIdDynamicClientRegistrationClient
         public string[]? ResponseTypes { get; init; }
         public string? TokenEndpointAuthMethod { get; init; }
         public string? Scope { get; init; }
+        public string[]? DefaultServiceCatalogSlugs { get; init; }
         public long ClientIdIssuedAt { get; init; }
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -98,6 +98,12 @@ message AevatarOAuthClientState {
   // rotation grace window. Set only when a rotation demoted an existing
   // ref-backed key; empty on initial seed and for legacy state.
   aevatar.credentials.SecretReference previous_hmac_key_ref = 27;
+  // NyxID catalog slugs registered as user-editable consent defaults for the
+  // active client_id. Empty means legacy/unknown; a non-empty provisioning
+  // intent detects this drift and re-registers the client.
+  repeated string default_service_catalog_slugs = 30;
+  // Consent defaults captured for the pending actor-owned provisioning retry.
+  repeated string provisioning_retry_default_service_catalog_slugs = 31;
 }
 
 // Issued by the bootstrap startup service from every silo on cluster cold-
@@ -119,6 +125,9 @@ message EnsureAevatarOAuthClientProvisionedCommand {
   // must disable the startup env switch after one successful run to avoid
   // creating a new NyxID client on every restart.
   bool force_reprovision = 5;
+  // NyxID catalog slugs to preselect on the consent screen. These are hints,
+  // not grants; the user retains the final service-access decision.
+  repeated string default_service_catalog_slugs = 7;
 }
 
 // Durable self-callback payload fired when an actor-owned OAuth provisioning
@@ -137,6 +146,7 @@ message AevatarOAuthClientProvisioningRetryFiredEvent {
   int64 fired_at_unix_ms = 8;
   repeated string redirect_uris = 9;
   bool force_reprovision = 10;
+  repeated string default_service_catalog_slugs = 12;
 }
 
 // Issued by tests / manual operator scripts that already hold a client_id
@@ -164,6 +174,9 @@ message ProvisionAevatarOAuthClientCommand {
   // Full redirect URI allowlist pinned for the supplied client_id. Empty means
   // preserve existing list or fall back to [redirect_uri] for legacy callers.
   repeated string redirect_uris = 6;
+  // Consent defaults pinned for the supplied client_id. Empty preserves the
+  // actor's existing value for legacy/manual callers.
+  repeated string default_service_catalog_slugs = 8;
 }
 
 // Issued by ops to force a fresh HMAC key rotation. Old tokens signed with
@@ -200,6 +213,7 @@ message AevatarOAuthClientProvisioningRetryScheduledEvent {
   google.protobuf.Timestamp scheduled_at = 9;
   repeated string redirect_uris = 10;
   bool force_reprovision = 11;
+  repeated string default_service_catalog_slugs = 13;
 }
 
 // Persisted when provisioning reaches a terminal successful branch and the
@@ -249,6 +263,8 @@ message AevatarOAuthClientProvisionedEvent {
   string oauth_scope = 6;
   // Full redirect URI allowlist registered with NyxID at this DCR call.
   repeated string redirect_uris = 7;
+  // User-editable consent defaults confirmed by NyxID at this DCR call.
+  repeated string default_service_catalog_slugs = 9;
 }
 
 // Persisted when the actor seeds or rotates its HMAC key. On rotation, the

--- a/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
+++ b/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
@@ -6,6 +6,19 @@ owner: eanzhao
 
 # ADR-0018: Per-User NyxID Binding via OAuth Broker
 
+## Update 2026-07-16 - DCR 持久化 Consent 默认服务
+
+Studio 浏览器不发送 RFC 8707 `resource`,因此登录页的默认勾选必须来自 OAuth Client 自身的 provisioning contract.此前 aevatar 曾发送非契约字段 `default_services`,NyxID `/oauth/register` 会静默忽略它;aevatar 随后又删除了无法验证的 actor 字段,最终生产 client 的 `default_service_catalog_slugs` 一直是空数组.
+
+当前 contract 为:
+
+- NyxID `POST /oauth/register` 接受并回显 `default_service_catalog_slugs`,与 Developer App/Admin 写路径共用 active catalog 校验.默认项只是用户可修改的 Consent hint,不是授权 grant.
+- Aevatar bootstrap 从 `NyxIdBrokerOptions.RequiredLlmServiceSlug` 与 `AdditionalRequiredServiceSlugs` 复用同一组 provider 配置,加上核心 `aevatar` slug,生成默认 catalog 列表;Mainnet 当前结果是 `aevatar`、`chrono-llm-public`、`ornn-api`、`chrono-sandbox`.
+- `EnsureAevatarOAuthClientProvisionedCommand`、provisioned event、actor state 与 durable retry payload 都携带 typed `default_service_catalog_slugs`.已有 actor state 为空时视为 drift并重新 DCR;旧 caller 未提供该新增字段时不得清空已有事实.
+- DCR client 必须校验 NyxID 响应回显同一默认列表.旧 NyxID 静默忽略字段时,本次 provisioning 失败并进入 actor-owned retry,不能持久化一个虚假的“已配置”事实.部署顺序必须先 NyxID、后 Aevatar,避免旧 NyxID 已创建但无法确认的 orphan client.
+- `/api/auth/nyxid/config` 只返回浏览器真正使用的 `baseUrl/clientId/scope`,不再暴露已从 Studio authorize/refresh 移除的 `resources` 假 contract.
+- channel `/init` authorize 与 broker 短期 token-exchange 继续请求并校验四个运行必需 resource;authorization-code exchange 继续继承用户最终 Consent,不发送 `resource`.
+
 ## Update 2026-07-16 - authorization code 保留最终 Consent service 边界
 
 授权页完成后,authorization code 已经承载用户最终确认的 service 集合.如果 aevatar 在 authorization-code exchange 再发送固定 `resource` 集合,NyxID 会按 RFC 8707 将 access token、refresh grant 与 broker binding 收窄到该集合,丢失用户在 Consent 页面额外选择的 service.这也解释了 refresh token 请求不带 `resource` 时权限恢复为完整 Consent 集合的现象.
@@ -61,7 +74,7 @@ NyxID 2026-07-06 至 2026-07-08 的 OAuth 更新把第三方应用 service acces
 - broker 每次拿到短期 access token 后校验 `resources` claim. 旧 binding、allow-all grandfather grant 或缺少任一必需 service 的 grant会被归类为 service-access mismatch;调用侧保留 binding 并引导 `/init` 原地更新 grant.
 - `/api/auth/nyxid/config` 不返回 resource 列表;前端不得自行猜 service ID,也不得把 Developer App 默认项当作授权事实.
 
-NyxID 当前 `/oauth/register` 的 `RegisterClientRequest` 不接受 Developer App 的默认 service 字段. 因此 aevatar 不在 DCR 中发送 `default_services`,也不在 actor state/readmodel 中记录无法从 NyxID 验证的“已注册默认项”. Developer App 可以额外配置同名默认项改善 consent 展示,但它不是运行正确性的事实源.
+NyxID `/oauth/register` 现在接受并回显 `default_service_catalog_slugs`;aevatar 只在响应确认后把该列表提交为 actor-owned provisioning 事实.默认项改善 Consent 展示,但仍不是运行权限的事实源.
 
 ## Update 2026-04-30 — NyxID#576 / PR #578 contract alignment
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -39,6 +40,11 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         command.NyxidAuthority.Should().Be(environment.Authority);
         command.RedirectUri.Should().Be(environment.RedirectUri);
         command.RedirectUris.Should().Equal(environment.RedirectUri, environment.ConsoleRedirectUri);
+        command.DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
         command.ClientName.Should().Be("aevatar");
         command.ForceReprovision.Should().BeFalse();
     }
@@ -72,6 +78,11 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         command.NyxidAuthority.Should().Be(environment.Authority);
         command.RedirectUri.Should().Be(environment.RedirectUri);
         command.RedirectUris.Should().Equal(environment.RedirectUri, environment.ConsoleRedirectUri);
+        command.DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
         command.ClientName.Should().Be("aevatar");
         command.ForceReprovision.Should().BeFalse();
     }
@@ -225,6 +236,11 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         new(
             dispatch,
             Options.Create(new AevatarOAuthClientBootstrapOptions { Enabled = enabled }),
+            Options.Create(new NyxIdBrokerOptions
+            {
+                RequiredLlmServiceSlug = "chrono-llm-public",
+                AdditionalRequiredServiceSlugs = ["ornn-api", "chrono-sandbox"],
+            }),
             NullLogger<AevatarOAuthClientBootstrapService>.Instance);
 
     private static ChannelIdentityOAuthAcceptedReceipt OAuthClientReceipt() =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -84,14 +84,31 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
             ClientName = "aevatar",
+            DefaultServiceCatalogSlugs =
+            {
+                "aevatar",
+                "chrono-llm-public",
+                "ornn-api",
+                "chrono-sandbox",
+            },
         });
 
         _registrar.Calls.Should().HaveCount(1);
         _registrar.Calls[0].Authority.Should().Be("https://nyxid.test");
         _registrar.Calls[0].RedirectUris.Should().Equal("https://aevatar.test/api/oauth/nyxid-callback");
+        _registrar.Calls[0].DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
         _agent.State.ClientId.Should().Be(_registrar.NextClientId);
         _agent.State.NyxidAuthority.Should().Be("https://nyxid.test");
         _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+        _agent.State.DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
         // New writes store the key in the vault and leave [hmac_key] empty; the
         // state carries only a ref that resolves to 32 raw bytes.
         _agent.State.HmacKey.Length.Should().Be(0, "new writes leave the legacy plaintext field empty");
@@ -357,6 +374,78 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleEnsureProvisioned_ReDcrs_WhenConsentDefaultsDrift()
+    {
+        var initial = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            DefaultServiceCatalogSlugs = { "aevatar", "chrono-llm-public" },
+        };
+        await _agent.HandleEnsureProvisioned(initial);
+
+        var expanded = initial.Clone();
+        expanded.DefaultServiceCatalogSlugs.Add("ornn-api");
+        expanded.DefaultServiceCatalogSlugs.Add("chrono-sandbox");
+        _registrar.NextClientId = "client-after-default-service-drift";
+
+        await _agent.HandleEnsureProvisioned(expanded);
+
+        _registrar.Calls.Should().HaveCount(2);
+        _registrar.Calls[1].DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
+        _agent.State.ClientId.Should().Be("client-after-default-service-drift");
+        _agent.State.DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
+        (await ReadEventsAsync<AevatarOAuthClientDriftReconciledEvent>())
+            .Should()
+            .ContainSingle(e => e.DriftKind == "default_service_catalog_slugs");
+    }
+
+    [Fact]
+    public async Task HandleEnsureProvisioned_LegacyCommandPreservesConsentDefaultsDuringOtherDrift()
+    {
+        var initial = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://old.test/api/oauth/nyxid-callback",
+            DefaultServiceCatalogSlugs =
+            {
+                "aevatar",
+                "chrono-llm-public",
+                "ornn-api",
+                "chrono-sandbox",
+            },
+        };
+        await _agent.HandleEnsureProvisioned(initial);
+
+        _registrar.NextClientId = "client-after-legacy-command-redirect-drift";
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://new.test/api/oauth/nyxid-callback",
+        });
+
+        _registrar.Calls.Should().HaveCount(2);
+        _registrar.Calls[1].DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
+        _agent.State.DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
+    }
+
+    [Fact]
     public async Task HandleEnsureProvisioned_ReDcrs_WhenLegacyScopeIsMissingProxy()
     {
         var redirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback";
@@ -391,6 +480,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
             ClientName = "aevatar",
+            DefaultServiceCatalogSlugs = { "aevatar", "chrono-llm-public" },
         });
 
         _agent.State.ClientId.Should().BeEmpty();
@@ -398,12 +488,18 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.ProvisioningRetryAuthority.Should().Be("https://nyxid.test");
         _agent.State.ProvisioningRetryRedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
         _agent.State.ProvisioningRetryRedirectUris.Should().Equal("https://aevatar.test/api/oauth/nyxid-callback");
+        _agent.State.ProvisioningRetryDefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public");
         _agent.State.ProvisioningRetryClientName.Should().Be("aevatar");
         _agent.State.ProvisioningRetryDueUnixMs.Should().BeGreaterThan(0);
         _agent.State.ProvisioningRetryCallbackGeneration.Should().Be(1);
         _agent.State.ProvisioningRetryLastError.Should().Contain("nyxid unavailable");
         _callbackScheduler.TimeoutRequests.Should().ContainSingle();
         _callbackScheduler.TimeoutRequests[0].DueTime.Should().Be(AevatarOAuthClientGAgent.InitialRetryDelay);
+        _callbackScheduler.TimeoutRequests[0].TriggerEnvelope.Payload
+            .Unpack<AevatarOAuthClientProvisioningRetryFiredEvent>()
+            .DefaultServiceCatalogSlugs.Should().Equal("aevatar", "chrono-llm-public");
         (await ReadEventsAsync<AevatarOAuthClientProvisioningRetryScheduledEvent>())
             .Should()
             .ContainSingle();
@@ -954,7 +1050,11 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     private sealed class RecordingDcrClient
     {
         public string NextClientId { get; set; } = "client-first";
-        public List<(string Authority, string ClientName, string[] RedirectUris)> Calls { get; } = new();
+        public List<(
+            string Authority,
+            string ClientName,
+            string[] RedirectUris,
+            string[] DefaultServiceCatalogSlugs)> Calls { get; } = new();
         public Exception? ThrowOnRegister { get; set; }
 
         /// <summary>
@@ -978,9 +1078,17 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             }
 
             public override async Task<RegistrationResult> RegisterPublicClientAsync(
-                string authority, string clientName, IReadOnlyCollection<string> redirectUris, CancellationToken ct = default)
+                string authority,
+                string clientName,
+                IReadOnlyCollection<string> redirectUris,
+                IReadOnlyCollection<string> defaultServiceCatalogSlugs,
+                CancellationToken ct = default)
             {
-                _owner.Calls.Add((authority, clientName, redirectUris.ToArray()));
+                _owner.Calls.Add((
+                    authority,
+                    clientName,
+                    redirectUris.ToArray(),
+                    defaultServiceCatalogSlugs.ToArray()));
                 if (_owner.OnRegistered is not null)
                     await _owner.OnRegistered().ConfigureAwait(false);
                 if (_owner.ThrowOnRegister is not null)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildAdminAuthEndpointTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildAdminAuthEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Aevatar.GAgents.Channel.Identity.Endpoints;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -92,6 +93,11 @@ public sealed class IdentityOAuthClientRebuildAdminAuthEndpointTests
 
         dispatch.Commands.Should().ContainSingle();
         dispatch.Commands[0].ClientId.Should().Be(OperatorClientId);
+        dispatch.Commands[0].DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
         authorizer.ResolvedBearers.Should().ContainSingle().Which.Should().Be(AdminBearer);
 
         var (_, statusCode) = await ReadJsonAsync(result);
@@ -116,10 +122,18 @@ public sealed class IdentityOAuthClientRebuildAdminAuthEndpointTests
                 client_id: OperatorClientId,
                 client_id_issued_at_unix: 1700000000),
             adminAuthorizer: authorizer,
+            brokerOptions: BrokerOptions(),
             rebuildDispatch: dispatch,
             loggerFactory: NullLoggerFactory.Instance,
             ct: default);
     }
+
+    private static IOptions<NyxIdBrokerOptions> BrokerOptions() =>
+        Options.Create(new NyxIdBrokerOptions
+        {
+            RequiredLlmServiceSlug = "chrono-llm-public",
+            AdditionalRequiredServiceSlugs = ["ornn-api", "chrono-sandbox"],
+        });
 
     private sealed class FakePlatformAdminAuthorizer(
         bool elevated,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildEndpointTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildEndpointTests.cs
@@ -3,11 +3,13 @@ using System.Text.Json;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Aevatar.GAgents.Channel.Identity.Endpoints;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
@@ -115,6 +117,11 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
         cmd.RedirectUri.Should().Be(NyxIdRedirectUriResolver.Resolve());
         cmd.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
         cmd.NyxidAuthority.Should().NotBeNullOrWhiteSpace();
+        cmd.DefaultServiceCatalogSlugs.Should().Equal(
+            "aevatar",
+            "chrono-llm-public",
+            "ornn-api",
+            "chrono-sandbox");
 
         var ctx = NewHttpContext();
         await result.ExecuteAsync(ctx);
@@ -182,10 +189,18 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
             http: http,
             body: body,
             adminAuthorizer: authorizer,
+            brokerOptions: BrokerOptions(),
             rebuildDispatch: dispatch,
             loggerFactory: NullLoggerFactory.Instance,
             ct: ct);
     }
+
+    private static IOptions<NyxIdBrokerOptions> BrokerOptions() =>
+        Options.Create(new NyxIdBrokerOptions
+        {
+            RequiredLlmServiceSlug = "chrono-llm-public",
+            AdditionalRequiredServiceSlugs = ["ornn-api", "chrono-sandbox"],
+        });
 
     private sealed class FakePlatformAdminAuthorizer(
         bool elevated,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdDynamicClientRegistrationClientTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdDynamicClientRegistrationClientTests.cs
@@ -67,6 +67,64 @@ public sealed class NyxIdDynamicClientRegistrationClientTests
     }
 
     [Fact]
+    public async Task RegisterPublicClient_SendsAndVerifiesDefaultServiceCatalogSlugs()
+    {
+        var handler = StubHandler.Json(HttpStatusCode.OK, new
+        {
+            client_id = "client-issued",
+            default_service_catalog_slugs = new[]
+            {
+                "aevatar",
+                "chrono-llm-public",
+                "ornn-api",
+                "chrono-sandbox",
+            },
+        });
+        var registrar = new NyxIdDynamicClientRegistrationClient(
+            new HttpClient(handler), NullLogger<NyxIdDynamicClientRegistrationClient>.Instance);
+
+        await registrar.RegisterPublicClientAsync(
+            "https://nyxid.test",
+            "aevatar",
+            ["https://aevatar.test/api/oauth/nyxid-callback"],
+            [
+                " aevatar ",
+                "chrono-llm-public",
+                "ornn-api",
+                "chrono-sandbox",
+                "aevatar",
+            ]);
+
+        var request = await handler.Last!.Content!.ReadFromJsonAsync<JsonElement>();
+        request.GetProperty("default_service_catalog_slugs")
+            .EnumerateArray()
+            .Select(static item => item.GetString())
+            .Should()
+            .Equal(
+                "aevatar",
+                "chrono-llm-public",
+                "ornn-api",
+                "chrono-sandbox");
+    }
+
+    [Fact]
+    public async Task RegisterPublicClient_Throws_WhenNyxIdDoesNotConfirmConsentDefaults()
+    {
+        var handler = StubHandler.Json(HttpStatusCode.OK, new { client_id = "client-issued" });
+        var registrar = new NyxIdDynamicClientRegistrationClient(
+            new HttpClient(handler), NullLogger<NyxIdDynamicClientRegistrationClient>.Instance);
+
+        var act = () => registrar.RegisterPublicClientAsync(
+            "https://nyxid.test",
+            "aevatar",
+            ["https://aevatar.test/api/oauth/nyxid-callback"],
+            ["aevatar"]);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*did not confirm*default_service_catalog_slugs*");
+    }
+
+    [Fact]
     public async Task RegisterPublicClient_FallsBackIssuedAt_WhenServerOmitsTimestamp()
     {
         var handler = StubHandler.Json(HttpStatusCode.OK, new { client_id = "client-no-ts" });


### PR DESCRIPTION
## Problem

Aevatar's NyxID OAuth client was provisioned with an empty `default_service_catalog_slugs` list. Studio correctly stopped sending browser-owned OAuth `resource` parameters, but DCR had no verified contract for the consent defaults, so the NyxID consent page still opened without Aevatar's expected services selected.

The intended defaults are derived from the existing provider configuration:

- `aevatar`
- `chrono-llm-public`
- `ornn-api`
- `chrono-sandbox`

## Solution

- derive consent defaults from `NyxIdBrokerOptions`, the same source used for runtime resource requirements
- carry the defaults through typed protobuf commands, committed events, actor state, durable retries, and operator rebuilds
- send the exact NyxID DCR field `default_service_catalog_slugs`
- require NyxID to echo the same list before committing provisioning state
- detect empty or changed actor state as drift and re-run DCR
- preserve existing defaults when an older pod sends a command without the new field
- document the contract and deployment order in ADR-0018

The defaults only preselect services on the consent page. The user's final consent remains authoritative.

## Coordination And Deployment

1. Aevatar frontend PR [#2793](https://github.com/aevatarAI/aevatar/pull/2793) is already merged and removes browser-supplied OAuth `resource` defaults.
2. Deploy NyxID PR [ChronoAIProject/NyxID#1182](https://github.com/ChronoAIProject/NyxID/pull/1182) first. An older NyxID silently ignores the field, so Aevatar intentionally rejects a missing echo instead of persisting a false success.
3. Deploy this Aevatar PR second. Existing actor state with an empty default list will trigger one new DCR registration.
4. If the cluster requires explicit broker enablement, enable `broker_capability_enabled` on the newly issued client in NyxID Admin before retiring the previous client.

## Validation

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~AevatarOAuthClient|FullyQualifiedName~NyxIdDynamicClientRegistrationClient"` (74 passed)
- `DIFF_RANGE=origin/feature/integrate...HEAD bash tools/ci/architecture_guards.sh`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/docs/lint.sh`
- `git diff --check origin/feature/integrate...HEAD`
