### PR TITLE
Add explicit audit lifecycle semantics

### DIFF
--- a/docs/canon/audit-trail.md
+++ b/docs/canon/audit-trail.md
@@ -33,20 +33,31 @@ Required artifact shape:
 
 | Field family | Meaning |
 |---|---|
-| `audit_id` | Stable audit artifact id. |
-| `captured_at` | Capture timestamp from the writing plane. |
+| `audit_id`, `event_kind`, `subject`, `source` | Stable event identity and producer-owned subject. |
+| `occurred_at`, `recorded_at` | Time the fact occurred and time the capture plane recorded it. |
+| `schema_version` | Version of the durable audit payload contract. |
 | `capture_plane` | One of `boundary_endpoint`, `tool_execution`, or `projection_artifact`. |
-| `action` | Allowlisted action name such as request accepted, tool started, tool completed, or committed artifact observed. |
+| `lifecycle_phase` | When the event kind owns lifecycle semantics: `accepted`, `running`, `waiting_approval`, or `terminal` for the immutable fact's subject. |
+| `terminal_outcome` | Exactly one of `succeeded`, `failed`, `cancelled`, or `timed_out` on terminal records; absent otherwise. |
+| `failure` | Stable code, category, retryability, failed phase, and sanitized message for failed or timed-out terminal records. |
 | `resource` | Typed resource summary, such as scope, service, workflow, run, connector, or channel resource. |
 | `actor_identity` | Sanitized identity key and `identity_key_id`, never a raw subject or credential. |
-| `correlation` | Request, command, run, trace, or projection correlation ids that are already safe to expose. |
+| `correlation` | W3C `traceparent`/`tracestate`, OpenTelemetry `trace_id`/`span_id`, and safe request, command, run, correlation, or causation ids. |
+| `provenance` | Applicable scope, team, member, workflow, published-service, run, causation, correlation, and committed actor sequence identities. |
 | `committed_fact_ref` | Optional reference to the committed feed item and state version when the artifact is about a committed fact. |
-| `outcome` | Allowlisted result summary, error class, or status. |
+| `redaction` | Policy, omitted field names, and whether retained values were sanitized. |
 | `safe_summary` | Short redacted summary suitable for governance review. |
 
 Artifact payloads must be schema-governed and allowlisted. Free-form bags may be
 used only at an external extension boundary; internal platform semantics must
 use typed fields.
+
+Lifecycle is scoped to the subject of each immutable record, not to a global
+product workflow. A boundary `2xx` receipt is `accepted` and nonterminal. It is
+never upgraded to execution success by the HTTP capture plane. Terminal command
+or run outcomes are emitted only by the committed producer that owns that fact.
+Event kinds without producer-owned lifecycle or execution-provenance semantics
+leave those fields unspecified rather than inventing identities or outcomes.
 
 ## 3. Capture Planes
 
@@ -101,8 +112,10 @@ The middleware is host glue only:
 
 1. Read endpoint audit metadata from the selected endpoint.
 2. Resolve the authenticated caller through `IAuditActorIdentityHasher`.
-3. Append `operation_name.attempted` plus exactly one terminal
-   `operation_name` record through `IAuditTrailAppender`.
+3. Append `operation_name.attempted` plus exactly one boundary-result
+   `operation_name` record through `IAuditTrailAppender`. A `2xx` result remains
+   nonterminal `accepted`; a boundary rejection, error, cancellation, or timeout
+   is terminal only for the HTTP request subject.
 4. Fail open for business responses if audit append fails, while logging the
    operational failure.
 
@@ -210,6 +223,10 @@ other's authority.
 Observability data may be sampled or aggregated. Audit artifacts are append-only
 and retention-governed.
 
+W3C Trace Context and OpenTelemetry identifiers are optional correlation data.
+Their absence never invalidates a durable audit fact, and sampled telemetry is
+never used to reconstruct the audit trail.
+
 ## 6. Forbidden Patterns
 
 Do not implement platform audit trail as:
@@ -247,6 +264,7 @@ readers, actor state, or event stores directly. Audit artifacts are queried thro
 | Route | Method | Authorization | Semantics |
 |---|---|---|---|
 | `/api/audit/trail` | `GET` | Authenticated caller; platform admin only when `scope` targets another scope | Query materialized audit artifacts. Missing `scope` means caller scope. |
+| `/api/audit/trail/cloudevents` | `GET` | Same as `/api/audit/trail` | Export the selected page as a CloudEvents 1.0 JSON batch. |
 | `/api/audit/actor-resolutions` | `POST` | Platform admin | Resolve an external actor identity to `auditActorId`. |
 
 The resolver accepts raw external identity only in the JSON request body. It must never
@@ -265,20 +283,57 @@ state reads, query-time replay, or event-store reconstruction. If platform-admin
 authorization is unavailable for an admin-only path, the endpoint returns
 `503 AUDIT_ADMIN_AUTH_UNAVAILABLE`.
 
-Audit query responses expose `readTimestampUtc`, `queryWatermark`, and `nextCursor`.
-Each record also exposes `occurredAtUtc` and `identityKeyId`. These fields describe
-artifact-store query freshness and must not imply strong consistency with writes that
-may still be in flight.
+Audit query responses expose requested and effective windows, continuation cursor,
+truncation, ingestion watermark, optional complete-through checkpoint, window
+completeness, schema compatibility, and read timestamp. Each record exposes all safe
+typed fields, including `occurredAtUtc`, `recordedAtUtc`, lifecycle, failure,
+provenance, correlation, redaction, and committed-fact reference.
 
 Audit queries return the newest matching artifacts first, ordered by
 `occurredAtUtc DESC` with `auditId ASC` as the deterministic tie-breaker. A
-`nextCursor` continues toward older artifacts. `queryWatermark` is the greatest
-`occurredAtUtc` across the full filtered result set, independent of the current cursor
-page; it is null when the filtered result set is empty.
+`continuationCursor` continues toward older artifacts. `truncated` is true only when
+another record exists. `ingestionWatermark` is the greatest durable `recorded_at`
+known to the artifact store across its ingestion stream; it is not derived from the
+maximum business occurrence time. `completeThrough` may be set only from a real source
+checkpoint that proves ingestion completeness. Without that checkpoint, a bounded
+window is honestly `unknown` or `behind_ingestion_watermark`, never guessed complete.
+`recorded_at` is the first successful capture time and is excluded from the semantic
+content hash, so redelivery with a later capture clock remains idempotent and preserves
+the first durable value.
 
 Admin-only resolver reads and cross-scope audit trail reads carry endpoint metadata with
 `AccessLevel = ADMIN`. That metadata is for the host self-audit pipeline; it does not
 replace the runtime admin gate.
+
+### 7.2 CloudEvents 1.0 Export
+
+CloudEvents is an HTTP/export representation, not an internal envelope. The export
+uses `application/cloudevents-batch+json` and maps durable fields as follows:
+
+| CloudEvents attribute | Audit source |
+|---|---|
+| `specversion` | Literal `1.0`. |
+| `id` | Stable `audit_id`; retries and repeated exports do not mint a new id. |
+| `source` | Stored producer `source` URI. |
+| `type` | Stored `event_kind`. |
+| `subject` | Stored audit `subject`. |
+| `time` | `occurred_at`. |
+| `dataschema` | URI for the stored `schema_version`. |
+| `data` | The same sanitized typed record returned by the normal query API. |
+
+Optional extension attributes are `traceparent`, `tracestate`, `correlationid`, and
+`causationid`. Export coverage is returned in `Aevatar-Audit-*` response headers.
+CloudEvents does not replace `EventEnvelope`, create a projection rail, or make audit
+artifacts authoritative business state.
+
+### 7.3 Stored-Record Compatibility
+
+Records written before explicit schema versioning remain readable. The query adapter
+marks them `legacy_mapped`, reports `schemaVersion = legacy-v0`, derives only the
+unambiguous lifecycle mapping (`Accepted` remains nonterminal; the old terminal status
+maps to one terminal outcome), and never writes that projection back to storage. A
+page containing such records reports `contains_legacy_records`. Unknown nonempty
+schema versions report `incompatible`; they are not silently claimed current.
 
 ## 8. Retention and Operations
 

--- a/src/Aevatar.AI.Core/Auditing/ToolAuditRecordFactory.cs
+++ b/src/Aevatar.AI.Core/Auditing/ToolAuditRecordFactory.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Audit;
 using Aevatar.Audit.Abstractions.Identity;
+using Aevatar.Audit.Abstractions.Models;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.AI.Core.Auditing;
@@ -31,65 +33,162 @@ public sealed class ToolAuditRecordFactory
         var actor = ResolveActor(executionContext);
         var identity = _identityHasher.Hash(actor.CanonicalKey);
         var receipt = finalizedReceipt.Receipt;
+        var record = BuildRecord(
+            context,
+            executionContext,
+            receipt,
+            actor.Kind,
+            identity.AuditActorId,
+            identity.IdentityKeyId,
+            _timeProvider.GetUtcNow());
+        AddAnnotations(record, executionContext, receipt, finalizedReceipt.IsSynthetic);
+        AddFailure(record, receipt);
+        return record;
+    }
+
+    private static AuditRecord BuildRecord(
+        ToolCallContext context,
+        AgentToolExecutionContext executionContext,
+        AgentToolReceipt receipt,
+        AuditActorKind actorKind,
+        string auditActorId,
+        string identityKeyId,
+        DateTimeOffset recordedAt)
+    {
+        var operationName = ResolveOperationName(receipt, context);
+        var targetKind = ResolveTargetKind(receipt);
+        var targetId = ResolveTargetId(receipt, context);
+        var scopeId = ResolveScopeId(executionContext);
+        var correlation = BuildCorrelation(context, executionContext, receipt);
 
         var record = new AuditRecord
         {
             AuditId = CreateAuditId(executionContext, context, receipt),
-            OccurredAt = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-            ScopeId = ResolveScopeId(executionContext),
-            AuditActorId = identity.AuditActorId,
-            IdentityKeyId = identity.IdentityKeyId,
-            ActorKind = actor.Kind,
+            OccurredAt = Timestamp.FromDateTimeOffset(recordedAt),
+            RecordedAt = Timestamp.FromDateTimeOffset(recordedAt),
+            EventKind = operationName,
+            Subject = $"{targetKind}/{targetId}",
+            SchemaVersion = AuditContractSemantics.CurrentSchemaVersion,
+            Source = "urn:aevatar:audit:tool-execution",
+            ScopeId = scopeId,
+            AuditActorId = auditActorId,
+            IdentityKeyId = identityKeyId,
+            ActorKind = actorKind,
             CredentialSource = MapCredentialSource(context.CredentialSource),
             OperationKind = AuditOperationKind.Tool,
-            OperationName = ResolveOperationName(receipt, context),
+            OperationName = operationName,
             SensitivityLevel = AuditSensitivityLevel.Internal,
             Outcome = MapOutcome(receipt.Status),
+            LifecyclePhase = MapLifecyclePhase(receipt.Status),
+            TerminalOutcome = MapTerminalOutcome(receipt),
             CapturePlane = AuditCapturePlane.ToolExecution,
             Target = new AuditTarget
             {
-                Kind = ResolveTargetKind(receipt),
-                Id = ResolveTargetId(receipt, context),
+                Kind = targetKind,
+                Id = targetId,
                 DisplayName = string.Empty,
             },
-            Correlation = new AuditCorrelation
+            Correlation = correlation,
+            Provenance = new AuditExecutionProvenance
             {
-                TraceId = string.Empty,
-                RequestId = executionContext.Request.RequestId ?? string.Empty,
-                CallId = string.IsNullOrWhiteSpace(receipt.CallId)
-                    ? context.ToolCallId ?? string.Empty
-                    : receipt.CallId,
-                SessionId = executionContext.Caller.ResponseId ?? string.Empty,
-                WorkflowRunId = executionContext.WorkflowRuntime.ParentRunId
-                                ?? executionContext.WorkflowRuntime.RootRunId
-                                ?? string.Empty,
-                ApprovalId = receipt.ApprovalRequestId ?? string.Empty,
+                ScopeId = scopeId,
+                RunId = correlation.WorkflowRunId,
+                CorrelationId = correlation.CorrelationId,
+            },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.tool-safe-fields.v1",
+                ValuesSanitized = true,
             },
         };
+        record.Redaction.OmittedFields.Add(["model.prompt", "tool.arguments", "tool.result"]);
+        return record;
+    }
 
-        record.Annotations.Add("tool_name", ResolveOperationName(receipt, context));
+    private static void AddAnnotations(
+        AuditRecord record,
+        AgentToolExecutionContext executionContext,
+        AgentToolReceipt receipt,
+        bool isSynthetic)
+    {
+        record.Annotations.Add("tool_name", record.OperationName);
         record.Annotations.Add("tool_receipt_status", receipt.Status.ToString());
         record.Annotations.Add("approval_mode", receipt.ApprovalMode.ToString());
         record.Annotations.Add("is_destructive", receipt.IsDestructive ? "true" : "false");
-        record.Annotations.Add("receipt_synthetic", finalizedReceipt.IsSynthetic ? "true" : "false");
+        record.Annotations.Add("receipt_synthetic", isSynthetic ? "true" : "false");
         AddIfPresent(record.Annotations, "side_effect_kind", receipt.SideEffectKind);
         AddIfPresent(record.Annotations, "subject_kind", receipt.SubjectKind);
         AddIfPresent(record.Annotations, "subject_version", receipt.SubjectVersion);
         AddIfPresent(record.Annotations, "subject_hash", receipt.SubjectHash);
         AddIfPresent(record.Annotations, "channel_platform", executionContext.Channel.Platform);
         AddIfPresent(record.Annotations, "schedule_id", executionContext.Schedule.ScheduleId);
+    }
 
+    private static void AddFailure(AuditRecord record, AgentToolReceipt receipt)
+    {
         if (record.Outcome == AuditOutcome.Error || record.Outcome == AuditOutcome.Denied)
         {
-            record.ErrorCode = string.IsNullOrWhiteSpace(receipt.ErrorCode)
-                ? DefaultErrorCode(receipt.Status)
-                : receipt.ErrorCode.Trim();
-            record.ErrorSummary = string.IsNullOrWhiteSpace(receipt.ErrorMessage)
-                ? record.ErrorCode
-                : receipt.ErrorMessage.Trim();
+            record.ErrorCode = ResolveFailureCode(receipt.ErrorCode, receipt.Status);
+            record.ErrorSummary = record.ErrorCode;
+            var timedOut = record.TerminalOutcome == AuditTerminalOutcome.TimedOut;
+            record.Failure = new AuditFailure
+            {
+                Code = record.ErrorCode,
+                Category = timedOut
+                    ? AuditFailureCategory.Timeout
+                    : receipt.Status == AgentToolReceiptStatus.Denied
+                        ? AuditFailureCategory.Authorization
+                        : AuditFailureCategory.Execution,
+                Retryability = receipt.Status == AgentToolReceiptStatus.Denied
+                    ? AuditRetryability.NotRetryable
+                    : AuditRetryability.Unknown,
+                FailedPhase = string.IsNullOrWhiteSpace(receipt.ApprovalRequestId)
+                    ? AuditLifecyclePhase.Running
+                    : AuditLifecyclePhase.WaitingApproval,
+                SanitizedMessage = record.ErrorCode,
+            };
         }
+    }
 
-        return record;
+    private static string ResolveFailureCode(string? value, AgentToolReceiptStatus status) =>
+        value?.Trim() switch
+        {
+            "approval_denied" => "approval_denied",
+            "approval_timeout" => "approval_timeout",
+            "credential_denied" => "credential_denied",
+            "middleware_terminated" => "middleware_terminated",
+            "tool_call_terminated" => "tool_call_terminated",
+            "tool_execution_exception" => "tool_execution_exception",
+            _ => DefaultErrorCode(status),
+        };
+
+    private static AuditCorrelation BuildCorrelation(
+        ToolCallContext context,
+        AgentToolExecutionContext executionContext,
+        AgentToolReceipt receipt)
+    {
+        var activity = Activity.Current;
+        var hasW3CContext = activity?.IdFormat == ActivityIdFormat.W3C;
+        return new AuditCorrelation
+        {
+            TraceId = activity?.TraceId.ToString() ?? string.Empty,
+            SpanId = activity?.SpanId.ToString() ?? string.Empty,
+            Traceparent = hasW3CContext ? activity?.Id ?? string.Empty : string.Empty,
+            Tracestate = hasW3CContext ? activity?.TraceStateString ?? string.Empty : string.Empty,
+            RequestId = executionContext.Request.RequestId ?? string.Empty,
+            CommandId = receipt.WorkflowRunDelivery?.WorkflowCommandId ?? string.Empty,
+            CallId = string.IsNullOrWhiteSpace(receipt.CallId)
+                ? context.ToolCallId ?? string.Empty
+                : receipt.CallId,
+            SessionId = executionContext.Caller.ResponseId ?? string.Empty,
+            WorkflowRunId = executionContext.WorkflowRuntime.ParentRunId
+                            ?? executionContext.WorkflowRuntime.RootRunId
+                            ?? string.Empty,
+            ApprovalId = receipt.ApprovalRequestId ?? string.Empty,
+            CorrelationId = receipt.WorkflowRunDelivery?.WorkflowCorrelationId
+                            ?? executionContext.Request.RequestId
+                            ?? string.Empty,
+        };
     }
 
     private static ToolAuditActor ResolveActor(AgentToolExecutionContext context)
@@ -157,6 +256,23 @@ public sealed class ToolAuditRecordFactory
             AgentToolReceiptStatus.Denied => AuditOutcome.Denied,
             AgentToolReceiptStatus.Error => AuditOutcome.Error,
             _ => AuditOutcome.Error,
+        };
+
+    private static AuditLifecyclePhase MapLifecyclePhase(AgentToolReceiptStatus status) =>
+        status == AgentToolReceiptStatus.ApprovalRequired
+            ? AuditLifecyclePhase.WaitingApproval
+            : AuditLifecyclePhase.Terminal;
+
+    private static AuditTerminalOutcome MapTerminalOutcome(AgentToolReceipt receipt) =>
+        ResolveFailureCode(receipt.ErrorCode, receipt.Status) switch
+        {
+            "approval_timeout" => AuditTerminalOutcome.TimedOut,
+            _ => receipt.Status switch
+            {
+                AgentToolReceiptStatus.Success => AuditTerminalOutcome.Succeeded,
+                AgentToolReceiptStatus.ApprovalRequired => AuditTerminalOutcome.Unspecified,
+                _ => AuditTerminalOutcome.Failed,
+            },
         };
 
     private static string ResolveOperationName(AgentToolReceipt receipt, ToolCallContext context) =>

--- a/src/Aevatar.Audit.Abstractions/CommittedFacts/CommittedAuditTranslationContext.cs
+++ b/src/Aevatar.Audit.Abstractions/CommittedFacts/CommittedAuditTranslationContext.cs
@@ -11,4 +11,9 @@ public sealed record CommittedAuditTranslationContext(
     DateTimeOffset ObservedAt,
     string CommandId,
     string RequestId,
-    string CorrelationId);
+    string CorrelationId,
+    string TraceId = "",
+    string SpanId = "",
+    string TraceFlags = "",
+    string CausationId = "",
+    DateTimeOffset? RecordedAt = null);

--- a/src/Aevatar.Audit.Abstractions/Models/AuditContractSemantics.cs
+++ b/src/Aevatar.Audit.Abstractions/Models/AuditContractSemantics.cs
@@ -1,0 +1,74 @@
+using Aevatar.Audit;
+
+namespace Aevatar.Audit.Abstractions.Models;
+
+public static class AuditContractSemantics
+{
+    public const string CurrentSchemaVersion = "1.0";
+    public const string LegacySchemaVersion = "legacy-v0";
+
+    public static AuditLifecyclePhase ResolveLifecyclePhase(AuditRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (record.LifecyclePhase != AuditLifecyclePhase.Unspecified)
+            return record.LifecyclePhase;
+
+        if (!string.IsNullOrWhiteSpace(record.SchemaVersion))
+            return AuditLifecyclePhase.Unspecified;
+
+        return record.Outcome switch
+        {
+            AuditOutcome.Accepted => AuditLifecyclePhase.Accepted,
+            AuditOutcome.Success or AuditOutcome.Denied or AuditOutcome.Error or AuditOutcome.Cancelled =>
+                AuditLifecyclePhase.Terminal,
+            _ => AuditLifecyclePhase.Unspecified,
+        };
+    }
+
+    public static AuditTerminalOutcome ResolveTerminalOutcome(AuditRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (record.TerminalOutcome != AuditTerminalOutcome.Unspecified)
+            return record.TerminalOutcome;
+
+        if (record.LifecyclePhase != AuditLifecyclePhase.Unspecified)
+            return AuditTerminalOutcome.Unspecified;
+
+        if (!string.IsNullOrWhiteSpace(record.SchemaVersion))
+            return AuditTerminalOutcome.Unspecified;
+
+        return record.Outcome switch
+        {
+            AuditOutcome.Success => AuditTerminalOutcome.Succeeded,
+            AuditOutcome.Denied or AuditOutcome.Error => AuditTerminalOutcome.Failed,
+            AuditOutcome.Cancelled => AuditTerminalOutcome.Cancelled,
+            _ => AuditTerminalOutcome.Unspecified,
+        };
+    }
+
+    public static AuditRecordSchemaCompatibility GetSchemaCompatibility(AuditRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (string.IsNullOrWhiteSpace(record.SchemaVersion))
+            return AuditRecordSchemaCompatibility.LegacyMapped;
+
+        return string.Equals(record.SchemaVersion, CurrentSchemaVersion, StringComparison.Ordinal)
+            ? AuditRecordSchemaCompatibility.Current
+            : AuditRecordSchemaCompatibility.Incompatible;
+    }
+
+    public static string ResolveSchemaVersion(AuditRecord record) =>
+        string.IsNullOrWhiteSpace(record.SchemaVersion)
+            ? LegacySchemaVersion
+            : record.SchemaVersion.Trim();
+}
+
+public enum AuditRecordSchemaCompatibility
+{
+    Current = 0,
+    LegacyMapped = 1,
+    Incompatible = 2,
+}

--- a/src/Aevatar.Audit.Abstractions/Models/AuditTrailPage.cs
+++ b/src/Aevatar.Audit.Abstractions/Models/AuditTrailPage.cs
@@ -6,4 +6,70 @@ public sealed record AuditTrailPage(
     IReadOnlyList<AuditRecord> Records,
     string? NextCursor,
     DateTimeOffset ReadAt,
-    DateTimeOffset? Watermark);
+    AuditQueryCoverage Coverage);
+
+public sealed record AuditQueryCoverage(
+    AuditQueryWindow RequestedWindow,
+    AuditQueryWindow EffectiveWindow,
+    bool Truncated,
+    DateTimeOffset? IngestionWatermark,
+    DateTimeOffset? CompleteThrough,
+    AuditWindowCompleteness WindowCompleteness,
+    AuditSchemaCompatibility SchemaCompatibility)
+{
+    public static AuditQueryCoverage Create(
+        AuditTrailQuery query,
+        bool truncated,
+        DateTimeOffset? ingestionWatermark,
+        DateTimeOffset? completeThrough,
+        AuditSchemaCompatibility schemaCompatibility)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var requested = new AuditQueryWindow(ToUtc(query.OccurredFrom), ToUtc(query.OccurredTo));
+        return new AuditQueryCoverage(
+            requested,
+            requested,
+            truncated,
+            ToUtc(ingestionWatermark),
+            ToUtc(completeThrough),
+            ResolveCompleteness(requested, ingestionWatermark, completeThrough),
+            schemaCompatibility);
+    }
+
+    private static AuditWindowCompleteness ResolveCompleteness(
+        AuditQueryWindow window,
+        DateTimeOffset? ingestionWatermark,
+        DateTimeOffset? completeThrough)
+    {
+        if (!window.From.HasValue || !window.To.HasValue)
+            return AuditWindowCompleteness.Unbounded;
+
+        if (completeThrough.HasValue && completeThrough.Value >= window.To.Value)
+            return AuditWindowCompleteness.Complete;
+
+        if (ingestionWatermark.HasValue && ingestionWatermark.Value < window.To.Value)
+            return AuditWindowCompleteness.BehindIngestionWatermark;
+
+        return AuditWindowCompleteness.Unknown;
+    }
+
+    private static DateTimeOffset? ToUtc(DateTimeOffset? value) => value?.ToUniversalTime();
+}
+
+public sealed record AuditQueryWindow(DateTimeOffset? From, DateTimeOffset? To);
+
+public enum AuditWindowCompleteness
+{
+    Unknown = 0,
+    Complete = 1,
+    BehindIngestionWatermark = 2,
+    Unbounded = 3,
+}
+
+public enum AuditSchemaCompatibility
+{
+    Current = 0,
+    ContainsLegacyRecords = 1,
+    Incompatible = 2,
+}

--- a/src/Aevatar.Audit.Abstractions/Models/AuditTrailQuery.cs
+++ b/src/Aevatar.Audit.Abstractions/Models/AuditTrailQuery.cs
@@ -22,6 +22,10 @@ public sealed record AuditTrailQuery
 
     public AuditOutcome? Outcome { get; init; }
 
+    public AuditLifecyclePhase? LifecyclePhase { get; init; }
+
+    public AuditTerminalOutcome? TerminalOutcome { get; init; }
+
     public AuditSensitivityLevel? SensitivityLevel { get; init; }
 
     public AuditCapturePlane? CapturePlane { get; init; }
@@ -31,6 +35,10 @@ public sealed record AuditTrailQuery
     public string? TargetId { get; init; }
 
     public string? TraceId { get; init; }
+
+    public string? CorrelationId { get; init; }
+
+    public string? CausationId { get; init; }
 
     public string? RequestId { get; init; }
 

--- a/src/Aevatar.Audit.Abstractions/audit_messages.proto
+++ b/src/Aevatar.Audit.Abstractions/audit_messages.proto
@@ -59,6 +59,40 @@ enum AuditCapturePlane {
   AUDIT_CAPTURE_PLANE_PROJECTION_ARTIFACT = 3;
 }
 
+enum AuditLifecyclePhase {
+  AUDIT_LIFECYCLE_PHASE_UNSPECIFIED = 0;
+  AUDIT_LIFECYCLE_PHASE_ACCEPTED = 1;
+  AUDIT_LIFECYCLE_PHASE_RUNNING = 2;
+  AUDIT_LIFECYCLE_PHASE_WAITING_APPROVAL = 3;
+  AUDIT_LIFECYCLE_PHASE_TERMINAL = 4;
+}
+
+enum AuditTerminalOutcome {
+  AUDIT_TERMINAL_OUTCOME_UNSPECIFIED = 0;
+  AUDIT_TERMINAL_OUTCOME_SUCCEEDED = 1;
+  AUDIT_TERMINAL_OUTCOME_FAILED = 2;
+  AUDIT_TERMINAL_OUTCOME_CANCELLED = 3;
+  AUDIT_TERMINAL_OUTCOME_TIMED_OUT = 4;
+}
+
+enum AuditFailureCategory {
+  AUDIT_FAILURE_CATEGORY_UNSPECIFIED = 0;
+  AUDIT_FAILURE_CATEGORY_AUTHORIZATION = 1;
+  AUDIT_FAILURE_CATEGORY_VALIDATION = 2;
+  AUDIT_FAILURE_CATEGORY_EXECUTION = 3;
+  AUDIT_FAILURE_CATEGORY_DEPENDENCY = 4;
+  AUDIT_FAILURE_CATEGORY_TIMEOUT = 5;
+  AUDIT_FAILURE_CATEGORY_CONFLICT = 6;
+  AUDIT_FAILURE_CATEGORY_INTERNAL = 7;
+}
+
+enum AuditRetryability {
+  AUDIT_RETRYABILITY_UNSPECIFIED = 0;
+  AUDIT_RETRYABILITY_UNKNOWN = 1;
+  AUDIT_RETRYABILITY_RETRYABLE = 2;
+  AUDIT_RETRYABILITY_NOT_RETRYABLE = 3;
+}
+
 message AuditTarget {
   string kind = 1;
   string id = 2;
@@ -73,6 +107,11 @@ message AuditCorrelation {
   string session_id = 5;
   string workflow_run_id = 6;
   string approval_id = 7;
+  string span_id = 8;
+  string traceparent = 9;
+  string tracestate = 10;
+  string correlation_id = 11;
+  string causation_id = 12;
 }
 
 message AuditCommittedFactReference {
@@ -81,6 +120,34 @@ message AuditCommittedFactReference {
   string actor_type = 3;
   string event_type_url = 4;
   int64 state_version = 5;
+}
+
+message AuditFailure {
+  string code = 1;
+  AuditFailureCategory category = 2;
+  AuditRetryability retryability = 3;
+  AuditLifecyclePhase failed_phase = 4;
+  string sanitized_message = 5;
+}
+
+message AuditExecutionProvenance {
+  string scope_id = 1;
+  string team_id = 2;
+  string member_id = 3;
+  string workflow_id = 4;
+  string published_service_id = 5;
+  string run_id = 6;
+  string causation_id = 7;
+  string correlation_id = 8;
+  string actor_id = 9;
+  int64 actor_state_version = 10;
+  string actor_event_id = 11;
+}
+
+message AuditRedaction {
+  string policy = 1;
+  repeated string omitted_fields = 2;
+  bool values_sanitized = 3;
 }
 
 message AuditRecord {
@@ -104,6 +171,16 @@ message AuditRecord {
   map<string, string> annotations = 18;
   AuditCapturePlane capture_plane = 19;
   AuditCommittedFactReference committed_fact_ref = 20;
+  string event_kind = 21;
+  string subject = 22;
+  google.protobuf.Timestamp recorded_at = 23;
+  string schema_version = 24;
+  string source = 25;
+  AuditLifecyclePhase lifecycle_phase = 26;
+  AuditTerminalOutcome terminal_outcome = 27;
+  AuditFailure failure = 28;
+  AuditExecutionProvenance provenance = 29;
+  AuditRedaction redaction = 30;
 }
 
 message AuditTrailDocument {
@@ -130,4 +207,12 @@ message AuditTrailDocument {
   string committed_actor_type = 21;
   string committed_event_type_url = 22;
   int64 committed_state_version = 23;
+  string event_kind = 24;
+  string schema_version = 25;
+  google.protobuf.Timestamp recorded_at = 26;
+  AuditLifecyclePhase lifecycle_phase = 27;
+  AuditTerminalOutcome terminal_outcome = 28;
+  string subject = 29;
+  string source = 30;
+  string trace_id = 31;
 }

--- a/src/Aevatar.Audit.Core/CommittedFacts/CommittedAuditArtifactMaterializer.cs
+++ b/src/Aevatar.Audit.Core/CommittedFacts/CommittedAuditArtifactMaterializer.cs
@@ -51,16 +51,22 @@ public sealed class CommittedAuditArtifactMaterializer<TContext>
         if (!_registry.TryGet(eventTypeUrl, out var translator))
             return;
 
+        var recordedAt = _clock.UtcNow;
         var translationContext = new CommittedAuditTranslationContext(
             envelope,
             published,
             stateEvent,
             string.IsNullOrWhiteSpace(stateEvent.AgentId) ? context.RootActorId : stateEvent.AgentId,
             eventTypeUrl,
-            CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow),
+            CommittedStateEventEnvelope.ResolveTimestamp(envelope, recordedAt),
             ResolveBaggage(envelope, CommandIdBaggageKey, CommandIdCamelBaggageKey),
             ResolveBaggage(envelope, RequestIdBaggageKey, RequestIdCamelBaggageKey),
-            envelope.Propagation?.CorrelationId ?? string.Empty);
+            envelope.Propagation?.CorrelationId ?? string.Empty,
+            envelope.Propagation?.Trace?.TraceId ?? string.Empty,
+            envelope.Propagation?.Trace?.SpanId ?? string.Empty,
+            envelope.Propagation?.Trace?.TraceFlags ?? string.Empty,
+            envelope.Propagation?.CausationEventId ?? string.Empty,
+            RecordedAt: recordedAt);
 
         IReadOnlyList<Audit.AuditRecord> records;
         try

--- a/src/Aevatar.Audit.Core/CommittedFacts/CommittedAuditRecordFactory.cs
+++ b/src/Aevatar.Audit.Core/CommittedFacts/CommittedAuditRecordFactory.cs
@@ -1,6 +1,7 @@
 using Aevatar.Audit;
 using Aevatar.Audit.Abstractions.CommittedFacts;
 using Aevatar.Audit.Abstractions.Identity;
+using Aevatar.Audit.Abstractions.Models;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Audit.Core.CommittedFacts;
@@ -22,7 +23,16 @@ public sealed record CommittedAuditSeed(
     // record factory then HMAC-hashes the origin actor id through
     // IAuditActorIdentityHasher before stamping it, so no raw subject can enter
     // the audit artifact (docs/canon/audit-trail.md §4 structural exclusion).
-    bool SubjectBearing = false);
+    bool SubjectBearing = false,
+    AuditLifecyclePhase LifecyclePhase = AuditLifecyclePhase.Terminal,
+    AuditTerminalOutcome TerminalOutcome = AuditTerminalOutcome.Succeeded,
+    AuditFailure? Failure = null,
+    string TeamId = "",
+    string MemberId = "",
+    string WorkflowId = "",
+    string PublishedServiceId = "",
+    string RunId = "",
+    IReadOnlyList<string>? OmittedFields = null);
 
 public static class CommittedAuditRecordFactory
 {
@@ -56,14 +66,23 @@ public static class CommittedAuditRecordFactory
         }
 
         var auditId = BuildAuditId(context, originActorId, seed.OperationName, seed.TargetKind, seed.TargetId);
+        var correlationId = FirstNonBlank(seed.CorrelationId, context.CorrelationId);
+        var causationId = FirstNonBlank(context.CausationId, context.StateEvent.EventId);
         var record = new AuditRecord
         {
             AuditId = auditId,
             OccurredAt = Timestamp.FromDateTimeOffset(context.ObservedAt),
+            RecordedAt = Timestamp.FromDateTimeOffset(context.RecordedAt ?? context.ObservedAt),
+            EventKind = seed.OperationName,
+            Subject = BuildSubject(seed.TargetKind, seed.TargetId),
+            SchemaVersion = AuditContractSemantics.CurrentSchemaVersion,
+            Source = "urn:aevatar:audit:projection-artifact",
             OperationName = seed.OperationName,
             OperationKind = AuditOperationKind.System,
             SensitivityLevel = seed.SensitivityLevel,
-            Outcome = AuditOutcome.Success,
+            Outcome = MapLegacyOutcome(seed.LifecyclePhase, seed.TerminalOutcome),
+            LifecyclePhase = seed.LifecyclePhase,
+            TerminalOutcome = seed.TerminalOutcome,
             ScopeId = seed.ScopeId ?? string.Empty,
             AuditActorId = "system",
             IdentityKeyId = "system",
@@ -78,7 +97,11 @@ public static class CommittedAuditRecordFactory
             {
                 RequestId = FirstNonBlank(seed.RequestId, context.RequestId),
                 CommandId = FirstNonBlank(seed.CommandId, context.CommandId, context.Envelope.Id),
-                TraceId = FirstNonBlank(seed.CorrelationId, context.CorrelationId),
+                TraceId = context.TraceId?.Trim().ToLowerInvariant() ?? string.Empty,
+                SpanId = context.SpanId?.Trim().ToLowerInvariant() ?? string.Empty,
+                Traceparent = BuildTraceparent(context.TraceId, context.SpanId, context.TraceFlags),
+                CorrelationId = correlationId,
+                CausationId = causationId,
             },
             CapturePlane = AuditCapturePlane.ProjectionArtifact,
             CommittedFactRef = new AuditCommittedFactReference
@@ -89,7 +112,33 @@ public static class CommittedAuditRecordFactory
                 StateVersion = context.StateEvent.Version,
             },
             ResultSummary = seed.ResultSummary ?? string.Empty,
+            Provenance = new AuditExecutionProvenance
+            {
+                ScopeId = seed.ScopeId ?? string.Empty,
+                TeamId = seed.TeamId ?? string.Empty,
+                MemberId = seed.MemberId ?? string.Empty,
+                WorkflowId = seed.WorkflowId ?? string.Empty,
+                PublishedServiceId = seed.PublishedServiceId ?? string.Empty,
+                RunId = FirstNonBlank(seed.RunId, seed.TargetKind == "workflow_run" ? seed.TargetId : string.Empty),
+                CausationId = causationId,
+                CorrelationId = correlationId,
+                ActorId = originActorId,
+                ActorStateVersion = context.StateEvent.Version,
+                ActorEventId = context.StateEvent.EventId ?? string.Empty,
+            },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.safe-fields.v1",
+                ValuesSanitized = true,
+            },
         };
+        record.Redaction.OmittedFields.Add(seed.OmittedFields ?? ["source_event.payload"]);
+        if (seed.Failure is not null)
+        {
+            record.Failure = seed.Failure.Clone();
+            record.ErrorCode = seed.Failure.Code;
+            record.ErrorSummary = seed.Failure.SanitizedMessage;
+        }
         if (seed.IsDestructive)
             record.Annotations.Add("is_destructive", "true");
         record.Annotations.Add("source_event_type_url", context.EventTypeUrl);
@@ -124,4 +173,36 @@ public static class CommittedAuditRecordFactory
 
     private static string FirstNonBlank(params string?[] values) =>
         values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value))?.Trim() ?? string.Empty;
+
+    private static string BuildSubject(string targetKind, string targetId) =>
+        $"{targetKind?.Trim()}/{targetId?.Trim()}";
+
+    private static AuditOutcome MapLegacyOutcome(
+        AuditLifecyclePhase lifecyclePhase,
+        AuditTerminalOutcome terminalOutcome)
+    {
+        if (lifecyclePhase != AuditLifecyclePhase.Terminal)
+            return AuditOutcome.Accepted;
+
+        return terminalOutcome switch
+        {
+            AuditTerminalOutcome.Succeeded => AuditOutcome.Success,
+            AuditTerminalOutcome.Cancelled => AuditOutcome.Cancelled,
+            _ => AuditOutcome.Error,
+        };
+    }
+
+    private static string BuildTraceparent(string? traceId, string? spanId, string? traceFlags)
+    {
+        var normalizedTraceId = traceId?.Trim().ToLowerInvariant() ?? string.Empty;
+        var normalizedSpanId = spanId?.Trim().ToLowerInvariant() ?? string.Empty;
+        if (normalizedTraceId.Length != 32 || normalizedSpanId.Length != 16)
+            return string.Empty;
+
+        var normalizedFlags = traceFlags?.Trim().ToLowerInvariant();
+        if (normalizedFlags is not { Length: 2 })
+            normalizedFlags = "00";
+
+        return $"00-{normalizedTraceId}-{normalizedSpanId}-{normalizedFlags}";
+    }
 }

--- a/src/Aevatar.Audit.Core/Projection/AuditRecordContentHasher.cs
+++ b/src/Aevatar.Audit.Core/Projection/AuditRecordContentHasher.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography;
+using Google.Protobuf;
+
+namespace Aevatar.Audit.Core.Projection;
+
+internal static class AuditRecordContentHasher
+{
+    public static string Compute(Audit.AuditRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var semanticRecord = record.Clone();
+        semanticRecord.RecordedAt = null;
+        return Convert.ToHexString(SHA256.HashData(semanticRecord.ToByteArray())).ToLowerInvariant();
+    }
+}

--- a/src/Aevatar.Audit.Core/Projection/AuditTrailDocumentFactory.cs
+++ b/src/Aevatar.Audit.Core/Projection/AuditTrailDocumentFactory.cs
@@ -16,7 +16,7 @@ internal static class AuditTrailDocumentFactory
             ContentHash = contentHash,
             Record = record.Clone(),
             OccurredAt = Timestamp.FromDateTimeOffset(observedAt),
-            UpdatedAt = Timestamp.FromDateTimeOffset(observedAt),
+            UpdatedAt = record.RecordedAt?.Clone() ?? Timestamp.FromDateTimeOffset(observedAt),
             AuditActorId = Text(record.AuditActorId),
             ScopeId = Text(record.ScopeId),
             OperationName = Text(record.OperationName),
@@ -34,6 +34,14 @@ internal static class AuditTrailDocumentFactory
             CommittedActorType = CommittedActorType(record),
             CommittedEventTypeUrl = CommittedEventTypeUrl(record),
             CommittedStateVersion = CommittedStateVersion(record),
+            EventKind = Text(record.EventKind),
+            SchemaVersion = Text(record.SchemaVersion),
+            RecordedAt = record.RecordedAt?.Clone(),
+            LifecyclePhase = record.LifecyclePhase,
+            TerminalOutcome = record.TerminalOutcome,
+            Subject = Text(record.Subject),
+            Source = Text(record.Source),
+            TraceId = Text(record.Correlation?.TraceId),
         };
 
     private static string Text(string? value) => value ?? string.Empty;
@@ -46,7 +54,7 @@ internal static class AuditTrailDocumentFactory
 
     private static string CommandId(Audit.AuditRecord record) => Text(record.Correlation?.CommandId);
 
-    private static string CorrelationId(Audit.AuditRecord record) => Text(record.Correlation?.TraceId);
+    private static string CorrelationId(Audit.AuditRecord record) => Text(record.Correlation?.CorrelationId);
 
     private static string SessionId(Audit.AuditRecord record) => Text(record.Correlation?.SessionId);
 

--- a/src/Aevatar.Audit.Core/Projection/ProjectionAuditTrailAppender.cs
+++ b/src/Aevatar.Audit.Core/Projection/ProjectionAuditTrailAppender.cs
@@ -1,7 +1,5 @@
-using System.Security.Cryptography;
 using Aevatar.Audit.Abstractions.Ports;
 using Aevatar.Audit.Core.Sanitization;
-using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -47,7 +45,7 @@ public sealed class ProjectionAuditTrailAppender : IAuditTrailAppender
 
         try
         {
-            var contentHash = ComputeContentHash(sanitized);
+            var contentHash = AuditRecordContentHasher.Compute(sanitized);
             var existing = await _store.GetAsync(auditId, ct);
             if (existing != null)
             {
@@ -70,13 +68,6 @@ public sealed class ProjectionAuditTrailAppender : IAuditTrailAppender
             _logger.LogError(ex, "Audit trail append failed. auditId={AuditId}", auditId);
             return AuditTrailAppendResult.StoreUnavailable(auditId, ex.Message);
         }
-    }
-
-    private static string ComputeContentHash(Audit.AuditRecord record)
-    {
-        var bytes = record.ToByteArray();
-        var hash = SHA256.HashData(bytes);
-        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 
     private static AuditTrailAppendResult ToAppendResult(

--- a/src/Aevatar.Audit.Core/Sanitization/AuditRecordSanitizer.cs
+++ b/src/Aevatar.Audit.Core/Sanitization/AuditRecordSanitizer.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using Aevatar.Audit;
+using Aevatar.Audit.Abstractions.Models;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Audit.Core.Sanitization;
@@ -42,10 +44,34 @@ public sealed class AuditRecordSanitizer
         Validate(record);
 
         var sanitized = record.Clone();
+        sanitized.EventKind = CleanText(record.EventKind, _options.MaxSummaryLength);
+        sanitized.Subject = CleanText(record.Subject, _options.MaxSummaryLength);
+        sanitized.Source = CleanText(record.Source, _options.MaxSummaryLength);
         sanitized.RequestSummary = CleanText(record.RequestSummary, _options.MaxSummaryLength);
         sanitized.ResultSummary = CleanText(record.ResultSummary, _options.MaxSummaryLength);
         sanitized.ErrorCode = CleanText(record.ErrorCode, _options.MaxSummaryLength);
         sanitized.ErrorSummary = CleanText(record.ErrorSummary, _options.MaxSummaryLength);
+
+        if (sanitized.Failure is not null)
+        {
+            RejectSecretCarrier("failure_code", record.Failure.Code);
+            RejectSecretCarrier("failure_message", record.Failure.SanitizedMessage);
+            sanitized.Failure.Code = CleanText(record.Failure.Code, _options.MaxSummaryLength);
+            sanitized.Failure.SanitizedMessage = CleanText(
+                record.Failure.SanitizedMessage,
+                _options.MaxSummaryLength);
+        }
+
+        if (sanitized.Redaction is not null)
+        {
+            sanitized.Redaction.Policy = CleanText(record.Redaction.Policy, _options.MaxSummaryLength);
+            sanitized.Redaction.OmittedFields.Clear();
+            sanitized.Redaction.OmittedFields.Add(record.Redaction.OmittedFields
+                .Select(field => CleanText(field, _options.MaxAnnotationKeyLength))
+                .Where(static field => field.Length > 0)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(static field => field, StringComparer.Ordinal));
+        }
 
         sanitized.Annotations.Clear();
         foreach (var annotation in record.Annotations.OrderBy(static item => item.Key, StringComparer.Ordinal))
@@ -65,36 +91,65 @@ public sealed class AuditRecordSanitizer
 
     private static void Validate(AuditRecord record)
     {
+        ValidateIdentity(record);
+        ValidateEventContract(record);
+        ValidateEnumFields(record);
+        ValidateLifecycle(record);
+        ValidateSupplementalContracts(record);
+        ValidateTraceContext(record.Correlation);
+    }
+
+    private static void ValidateIdentity(AuditRecord record)
+    {
         if (string.IsNullOrWhiteSpace(record.AuditId))
-        {
             throw new ArgumentException("AuditId is required.", nameof(record));
-        }
 
         if (record.OccurredAt is null || record.OccurredAt == Timestamp.FromDateTimeOffset(DateTimeOffset.UnixEpoch))
-        {
             throw new ArgumentException("OccurredAt is required.", nameof(record));
-        }
+
+        if (record.RecordedAt is null || record.RecordedAt == Timestamp.FromDateTimeOffset(DateTimeOffset.UnixEpoch))
+            throw new ArgumentException("RecordedAt is required.", nameof(record));
 
         if (string.IsNullOrWhiteSpace(record.ScopeId))
-        {
             throw new ArgumentException("ScopeId is required.", nameof(record));
-        }
 
         if (string.IsNullOrWhiteSpace(record.AuditActorId))
-        {
             throw new ArgumentException("AuditActorId is required.", nameof(record));
-        }
 
         if (string.IsNullOrWhiteSpace(record.IdentityKeyId))
-        {
             throw new ArgumentException("IdentityKeyId is required.", nameof(record));
-        }
 
         if (string.IsNullOrWhiteSpace(record.OperationName))
-        {
             throw new ArgumentException("OperationName is required.", nameof(record));
+    }
+
+    private static void ValidateEventContract(AuditRecord record)
+    {
+        if (string.IsNullOrWhiteSpace(record.EventKind) ||
+            string.IsNullOrWhiteSpace(record.Subject) ||
+            string.IsNullOrWhiteSpace(record.Source))
+        {
+            throw new ArgumentException("EventKind, Subject, and Source are required.", nameof(record));
         }
 
+        if (!Uri.IsWellFormedUriString(record.Source, UriKind.Absolute))
+        {
+            throw new ArgumentException("Source must be an absolute URI.", nameof(record));
+        }
+
+        if (!string.Equals(
+                record.SchemaVersion,
+                AuditContractSemantics.CurrentSchemaVersion,
+                StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"SchemaVersion must be '{AuditContractSemantics.CurrentSchemaVersion}'.",
+                nameof(record));
+        }
+    }
+
+    private static void ValidateEnumFields(AuditRecord record)
+    {
         if (record.ActorKind == AuditActorKind.Unspecified ||
             record.CredentialSource == AuditCredentialSource.Unspecified ||
             record.OperationKind == AuditOperationKind.Unspecified ||
@@ -103,6 +158,136 @@ public sealed class AuditRecordSanitizer
             record.Outcome == AuditOutcome.Unspecified)
         {
             throw new ArgumentException("Audit enum fields must be specified.", nameof(record));
+        }
+    }
+
+    private static void ValidateLifecycle(AuditRecord record)
+    {
+        var isTerminal = record.LifecyclePhase == AuditLifecyclePhase.Terminal;
+        if (isTerminal != (record.TerminalOutcome != AuditTerminalOutcome.Unspecified))
+        {
+            throw new ArgumentException(
+                "Terminal lifecycle records must carry exactly one terminal outcome; nonterminal records must carry none.",
+                nameof(record));
+        }
+
+        var needsFailure = record.TerminalOutcome is AuditTerminalOutcome.Failed or AuditTerminalOutcome.TimedOut;
+        if (needsFailure != (record.Failure is not null))
+        {
+            throw new ArgumentException(
+                "Failed and timed-out terminal records must carry structured failure data, and other outcomes must not.",
+                nameof(record));
+        }
+
+        if (record.Failure is { } failure &&
+            (string.IsNullOrWhiteSpace(failure.Code) ||
+             string.IsNullOrWhiteSpace(failure.SanitizedMessage) ||
+             failure.Category == AuditFailureCategory.Unspecified ||
+             failure.Retryability == AuditRetryability.Unspecified ||
+             failure.FailedPhase is AuditLifecyclePhase.Unspecified or AuditLifecyclePhase.Terminal))
+        {
+            throw new ArgumentException("Structured failure fields must be specified.", nameof(record));
+        }
+    }
+
+    private static void ValidateSupplementalContracts(AuditRecord record)
+    {
+        if (record.Provenance is { } provenance)
+        {
+            if (string.IsNullOrWhiteSpace(provenance.ScopeId))
+                throw new ArgumentException("Execution provenance ScopeId is required when provenance is present.", nameof(record));
+
+            if (!string.Equals(provenance.ScopeId, record.ScopeId, StringComparison.Ordinal))
+                throw new ArgumentException("Execution provenance ScopeId must match the audit scope.", nameof(record));
+
+            EnsureMatchingIfPresent(provenance.RunId, record.Correlation?.WorkflowRunId, "run identity", record);
+            EnsureMatchingIfPresent(
+                provenance.CorrelationId,
+                record.Correlation?.CorrelationId,
+                "correlation identity",
+                record);
+            EnsureMatchingIfPresent(
+                provenance.CausationId,
+                record.Correlation?.CausationId,
+                "causation identity",
+                record);
+            EnsureMatchingIfPresent(
+                provenance.ActorId,
+                record.CommittedFactRef?.ActorId,
+                "committed actor identity",
+                record);
+            EnsureMatchingIfPresent(
+                provenance.ActorEventId,
+                record.CommittedFactRef?.CommittedEventId,
+                "committed event identity",
+                record);
+            if (provenance.ActorStateVersion > 0 &&
+                record.CommittedFactRef?.StateVersion > 0 &&
+                provenance.ActorStateVersion != record.CommittedFactRef.StateVersion)
+            {
+                throw new ArgumentException(
+                    "Execution provenance state version must match the committed fact.",
+                    nameof(record));
+            }
+        }
+
+        if (record.Redaction is null ||
+            string.IsNullOrWhiteSpace(record.Redaction.Policy) ||
+            !record.Redaction.ValuesSanitized)
+        {
+            throw new ArgumentException("Redaction policy metadata is required.", nameof(record));
+        }
+    }
+
+    private static void EnsureMatchingIfPresent(
+        string? first,
+        string? second,
+        string fieldName,
+        AuditRecord record)
+    {
+        if (!string.IsNullOrWhiteSpace(first) &&
+            !string.IsNullOrWhiteSpace(second) &&
+            !string.Equals(first, second, StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"Execution provenance {fieldName} must match its canonical field.", nameof(record));
+        }
+    }
+
+    private static void ValidateTraceContext(AuditCorrelation? correlation)
+    {
+        if (correlation is null)
+            return;
+
+        if (string.IsNullOrWhiteSpace(correlation.Traceparent))
+        {
+            if (!string.IsNullOrWhiteSpace(correlation.Tracestate))
+                throw new ArgumentException("Tracestate requires a valid traceparent.", nameof(correlation));
+            return;
+        }
+
+        if (!ActivityContext.TryParse(
+                correlation.Traceparent.Trim(),
+                string.IsNullOrWhiteSpace(correlation.Tracestate) ? null : correlation.Tracestate,
+                isRemote: true,
+                out var activityContext))
+        {
+            throw new ArgumentException("Trace context is not a valid W3C Trace Context value.", nameof(correlation));
+        }
+
+        if ((!string.IsNullOrWhiteSpace(correlation.TraceId) &&
+             !string.Equals(
+                 correlation.TraceId.Trim(),
+                 activityContext.TraceId.ToString(),
+                 StringComparison.Ordinal)) ||
+            (!string.IsNullOrWhiteSpace(correlation.SpanId) &&
+             !string.Equals(
+                 correlation.SpanId.Trim(),
+                 activityContext.SpanId.ToString(),
+                 StringComparison.Ordinal)))
+        {
+            throw new ArgumentException(
+                "TraceId and SpanId must match traceparent when both are present.",
+                nameof(correlation));
         }
     }
 

--- a/src/Aevatar.Audit.Core/Stores/InMemoryAuditTrailStore.cs
+++ b/src/Aevatar.Audit.Core/Stores/InMemoryAuditTrailStore.cs
@@ -3,7 +3,6 @@ using Aevatar.Audit.Abstractions.Models;
 using Aevatar.Audit.Abstractions.Ports;
 using Aevatar.Audit.Core.Projection;
 using Aevatar.Audit.Core.Sanitization;
-using Google.Protobuf;
 
 namespace Aevatar.Audit.Core.Stores;
 
@@ -16,6 +15,7 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
     private readonly TimeProvider _timeProvider;
     private readonly List<AuditRecord> _records = [];
     private readonly List<AuditTrailDocument> _documents = [];
+    private DateTimeOffset? _ingestionWatermark;
 
     public InMemoryAuditTrailStore(
         AuditRecordSanitizer? sanitizer = null,
@@ -103,6 +103,9 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
 
             _records.Add(sanitizedRecord.Clone());
             _documents.Add(sanitizedDocument);
+            var recordedAt = sanitizedRecord.RecordedAt.ToDateTimeOffset();
+            if (!_ingestionWatermark.HasValue || recordedAt > _ingestionWatermark.Value)
+                _ingestionWatermark = recordedAt;
         }
 
         return Task.FromResult(AuditTrailArtifactWriteResult.Applied());
@@ -116,9 +119,11 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
         cancellationToken.ThrowIfCancellationRequested();
 
         List<AuditRecord> snapshot;
+        DateTimeOffset? ingestionWatermark;
         lock (_records)
         {
             snapshot = _records.Select(static record => record.Clone()).ToList();
+            ingestionWatermark = _ingestionWatermark;
         }
 
         var take = ClampTake(query.Take);
@@ -137,15 +142,18 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
 
         var nextOffset = offset + pageRecords.Count;
         var nextCursor = nextOffset < filtered.Count ? EncodeCursor(nextOffset) : null;
-        var watermark = filtered.Count == 0
-            ? (DateTimeOffset?)null
-            : filtered.Max(static record => record.OccurredAt.ToDateTimeOffset());
+        var coverage = AuditQueryCoverage.Create(
+            query,
+            nextCursor is not null,
+            ingestionWatermark,
+            completeThrough: null,
+            schemaCompatibility: ResolveSchemaCompatibility(filtered));
 
         return Task.FromResult(new AuditTrailPage(
             pageRecords,
             nextCursor,
             _timeProvider.GetUtcNow(),
-            watermark));
+            coverage));
     }
 
     private static bool Matches(AuditRecord record, AuditTrailQuery query)
@@ -178,6 +186,10 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
         return Matches(record.OperationName, query.OperationName) &&
                (!query.OperationKind.HasValue || record.OperationKind == query.OperationKind.Value) &&
                (!query.Outcome.HasValue || record.Outcome == query.Outcome.Value) &&
+               (!query.LifecyclePhase.HasValue ||
+                AuditContractSemantics.ResolveLifecyclePhase(record) == query.LifecyclePhase.Value) &&
+               (!query.TerminalOutcome.HasValue ||
+                AuditContractSemantics.ResolveTerminalOutcome(record) == query.TerminalOutcome.Value) &&
                (!query.SensitivityLevel.HasValue || record.SensitivityLevel == query.SensitivityLevel.Value) &&
                (!query.CapturePlane.HasValue || record.CapturePlane == query.CapturePlane.Value);
     }
@@ -191,6 +203,8 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
     private static bool MatchesCorrelation(AuditRecord record, AuditTrailQuery query)
     {
         return Matches(record.Correlation?.TraceId, query.TraceId) &&
+               Matches(record.Correlation?.CorrelationId, query.CorrelationId) &&
+               Matches(record.Correlation?.CausationId, query.CausationId) &&
                Matches(record.Correlation?.RequestId, query.RequestId) &&
                Matches(record.Correlation?.CommandId, query.CommandId) &&
                Matches(record.Correlation?.CallId, query.CallId) &&
@@ -219,6 +233,24 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
         return take <= 0 ? DefaultTake : Math.Min(take, MaxTake);
     }
 
+    private static AuditSchemaCompatibility ResolveSchemaCompatibility(IEnumerable<AuditRecord> records)
+    {
+        var compatibility = AuditSchemaCompatibility.Current;
+        foreach (var record in records)
+        {
+            switch (AuditContractSemantics.GetSchemaCompatibility(record))
+            {
+                case AuditRecordSchemaCompatibility.Incompatible:
+                    return AuditSchemaCompatibility.Incompatible;
+                case AuditRecordSchemaCompatibility.LegacyMapped:
+                    compatibility = AuditSchemaCompatibility.ContainsLegacyRecords;
+                    break;
+            }
+        }
+
+        return compatibility;
+    }
+
     private static string EncodeCursor(int offset)
     {
         return Convert.ToBase64String(BitConverter.GetBytes(offset));
@@ -244,8 +276,7 @@ public sealed class InMemoryAuditTrailStore : IAuditTrailAppender, IAuditTrailQu
 
     private static AuditTrailDocument ToDocument(AuditRecord record)
     {
-        var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(record.ToByteArray()))
-            .ToLowerInvariant();
+        var contentHash = AuditRecordContentHasher.Compute(record);
         var observedAt = record.OccurredAt?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow;
         return AuditTrailDocumentFactory.Create(record, record.AuditId, contentHash, observedAt);
     }

--- a/src/Aevatar.Audit.Hosting/AuditTrailCapabilityHostBuilderExtensions.cs
+++ b/src/Aevatar.Audit.Hosting/AuditTrailCapabilityHostBuilderExtensions.cs
@@ -19,6 +19,7 @@ public static class AuditTrailCapabilityHostBuilderExtensions
             RequiredRoutes =
             [
                 "/api/audit/trail",
+                "/api/audit/trail/cloudevents",
                 "/api/audit/actor-resolutions",
             ],
             Critical = false,

--- a/src/Aevatar.Audit.Hosting/AuditTrailContracts.cs
+++ b/src/Aevatar.Audit.Hosting/AuditTrailContracts.cs
@@ -1,22 +1,147 @@
+using System.Text.Json.Serialization;
+
 namespace Aevatar.Audit.Hosting;
 
 public sealed record AuditTrailReadResponse(
     IReadOnlyList<AuditTrailRecordResponse> Records,
-    DateTimeOffset ReadTimestampUtc,
-    DateTimeOffset? QueryWatermark,
-    string? NextCursor);
+    AuditQueryCoverageResponse Coverage);
+
+public sealed record AuditQueryCoverageResponse(
+    AuditQueryWindowResponse RequestedWindow,
+    AuditQueryWindowResponse EffectiveWindow,
+    string? ContinuationCursor,
+    bool Truncated,
+    DateTimeOffset? IngestionWatermark,
+    DateTimeOffset? CompleteThrough,
+    string WindowCompleteness,
+    string SchemaCompatibility,
+    DateTimeOffset ReadTimestampUtc);
+
+public sealed record AuditQueryWindowResponse(DateTimeOffset? From, DateTimeOffset? To);
 
 public sealed record AuditTrailRecordResponse(
     string Id,
+    string EventKind,
+    string Subject,
+    string Source,
+    string SchemaVersion,
+    string SchemaCompatibility,
+    DateTimeOffset OccurredAtUtc,
+    DateTimeOffset RecordedAtUtc,
+    string LifecyclePhase,
+    string? TerminalOutcome,
     string ScopeId,
     string AuditActorId,
     string IdentityKeyId,
-    string Action,
-    string Outcome,
-    DateTimeOffset OccurredAtUtc,
-    string? ResourceType,
-    string? ResourceId,
-    string? CorrelationId);
+    string ActorKind,
+    string CredentialSource,
+    string OperationKind,
+    string OperationName,
+    string SensitivityLevel,
+    string LegacyOutcome,
+    string CapturePlane,
+    AuditTargetResponse? Target,
+    AuditCorrelationResponse? Correlation,
+    AuditFailureResponse? Failure,
+    AuditExecutionProvenanceResponse? Provenance,
+    AuditRedactionResponse? Redaction,
+    AuditCommittedFactReferenceResponse? CommittedFact,
+    string? RequestSummary,
+    string? ResultSummary);
+
+public sealed record AuditTargetResponse(string Kind, string Id, string? DisplayName);
+
+public sealed record AuditCorrelationResponse(
+    string? TraceId,
+    string? SpanId,
+    string? Traceparent,
+    string? Tracestate,
+    string? CorrelationId,
+    string? CausationId,
+    string? RequestId,
+    string? CommandId,
+    string? CallId,
+    string? SessionId,
+    string? WorkflowRunId,
+    string? ApprovalId);
+
+public sealed record AuditFailureResponse(
+    string Code,
+    string Category,
+    string Retryability,
+    string FailedPhase,
+    string? SanitizedMessage);
+
+public sealed record AuditExecutionProvenanceResponse(
+    string? ScopeId,
+    string? TeamId,
+    string? MemberId,
+    string? WorkflowId,
+    string? PublishedServiceId,
+    string? RunId,
+    string? CausationId,
+    string? CorrelationId,
+    string? ActorId,
+    long? ActorStateVersion,
+    string? ActorEventId);
+
+public sealed record AuditRedactionResponse(
+    string Policy,
+    IReadOnlyList<string> OmittedFields,
+    bool ValuesSanitized);
+
+public sealed record AuditCommittedFactReferenceResponse(
+    string? CommittedEventId,
+    string? ActorId,
+    string? ActorType,
+    string? EventTypeUrl,
+    long? StateVersion);
+
+public sealed record AuditCloudEventResponse
+{
+    [JsonPropertyName("specversion")]
+    public required string SpecVersion { get; init; }
+
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("subject")]
+    public required string Subject { get; init; }
+
+    [JsonPropertyName("time")]
+    public required DateTimeOffset Time { get; init; }
+
+    [JsonPropertyName("dataschema")]
+    public required string DataSchema { get; init; }
+
+    [JsonPropertyName("datacontenttype")]
+    public string DataContentType { get; init; } = "application/json";
+
+    [JsonPropertyName("traceparent")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Traceparent { get; init; }
+
+    [JsonPropertyName("tracestate")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Tracestate { get; init; }
+
+    [JsonPropertyName("correlationid")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CorrelationId { get; init; }
+
+    [JsonPropertyName("causationid")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CausationId { get; init; }
+
+    [JsonPropertyName("data")]
+    public required AuditTrailRecordResponse Data { get; init; }
+}
 
 public sealed record AuditActorResolutionRequest(
     string Provider,

--- a/src/Aevatar.Audit.Hosting/AuditTrailEndpoints.cs
+++ b/src/Aevatar.Audit.Hosting/AuditTrailEndpoints.cs
@@ -4,7 +4,6 @@ using Aevatar.Audit.Abstractions.Models;
 using Aevatar.Audit.Abstractions.Ports;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.Capabilities;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -39,6 +38,12 @@ public static class AuditTrailEndpoints
             .RequireAuthorization()
             .WithMetadata(new AuditTrailEndpointAuditMetadata("audit-trail", "query-cross-scope", AdminAccessLevel));
 
+        data.MapGet("/trail/cloudevents", ExportAuditTrailCloudEvents)
+            .WithName("ExportAuditTrailCloudEvents")
+            .WithSummary("Export audit trail records as a CloudEvents 1.0 JSON batch.")
+            .RequireAuthorization()
+            .WithMetadata(new AuditTrailEndpointAuditMetadata("audit-trail", "export-cross-scope", AdminAccessLevel));
+
         data.MapPost("/actor-resolutions", ResolveAuditActor)
             .WithName("ResolveAuditActor")
             .WithSummary("Admin-only: resolve an external actor identity to its server-side audit actor id.")
@@ -59,7 +64,89 @@ public static class AuditTrailEndpoints
         DateTimeOffset? from = null,
         DateTimeOffset? to = null,
         int take = DefaultTake,
+        string? commandId = null,
+        string? workflowRunId = null,
+        AuditLifecyclePhase? lifecyclePhase = null,
+        AuditTerminalOutcome? terminalOutcome = null,
+        string? correlationId = null,
         CancellationToken ct = default)
+    {
+        return await QueryAuditTrailCore(
+            http,
+            dependencies,
+            loggerFactory,
+            scope,
+            auditActorId,
+            identityKeyId,
+            cursor,
+            from,
+            to,
+            take,
+            commandId,
+            workflowRunId,
+            lifecyclePhase,
+            terminalOutcome,
+            correlationId,
+            exportCloudEvents: false,
+            ct: ct);
+    }
+
+    internal static async Task<IResult> ExportAuditTrailCloudEvents(
+        HttpContext http,
+        [FromServices] AuditTrailEndpointDependencies dependencies,
+        [FromServices] ILoggerFactory loggerFactory,
+        string? scope = null,
+        string? auditActorId = null,
+        string? identityKeyId = null,
+        string? cursor = null,
+        DateTimeOffset? from = null,
+        DateTimeOffset? to = null,
+        int take = DefaultTake,
+        string? commandId = null,
+        string? workflowRunId = null,
+        AuditLifecyclePhase? lifecyclePhase = null,
+        AuditTerminalOutcome? terminalOutcome = null,
+        string? correlationId = null,
+        CancellationToken ct = default)
+    {
+        return await QueryAuditTrailCore(
+            http,
+            dependencies,
+            loggerFactory,
+            scope,
+            auditActorId,
+            identityKeyId,
+            cursor,
+            from,
+            to,
+            take,
+            commandId,
+            workflowRunId,
+            lifecyclePhase,
+            terminalOutcome,
+            correlationId,
+            exportCloudEvents: true,
+            ct: ct);
+    }
+
+    private static async Task<IResult> QueryAuditTrailCore(
+        HttpContext http,
+        AuditTrailEndpointDependencies dependencies,
+        ILoggerFactory loggerFactory,
+        string? scope,
+        string? auditActorId,
+        string? identityKeyId,
+        string? cursor,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        int take,
+        string? commandId,
+        string? workflowRunId,
+        AuditLifecyclePhase? lifecyclePhase,
+        AuditTerminalOutcome? terminalOutcome,
+        string? correlationId,
+        bool exportCloudEvents,
+        CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(http);
 
@@ -85,7 +172,7 @@ public static class AuditTrailEndpoints
                 logger,
                 callerScopeId,
                 targetScope,
-                "query-cross-scope",
+                exportCloudEvents ? "export-cross-scope" : "query-cross-scope",
                 ct);
             if (denied is not null)
                 return denied;
@@ -103,10 +190,21 @@ public static class AuditTrailEndpoints
             Cursor = NormalizeOptional(cursor),
             OccurredFrom = from,
             OccurredTo = to,
+            CommandId = NormalizeOptional(commandId),
+            WorkflowRunId = NormalizeOptional(workflowRunId),
+            LifecyclePhase = lifecyclePhase,
+            TerminalOutcome = terminalOutcome,
+            CorrelationId = NormalizeOptional(correlationId),
             Take = NormalizeTake(take),
         };
         var result = await queryPort.QueryAsync(query, ct);
-        return Results.Json(ToResponse(result));
+        if (!exportCloudEvents)
+            return Results.Json(AuditTrailResponseMapper.ToResponse(result));
+
+        SetExportCoverageHeaders(http, result);
+        return Results.Json(
+            AuditTrailResponseMapper.ToCloudEvents(result),
+            contentType: AuditTrailResponseMapper.CloudEventsBatchContentType);
     }
 
     internal static async Task<IResult> ResolveAuditActor(
@@ -190,25 +288,6 @@ public static class AuditTrailEndpoints
         return null;
     }
 
-    private static AuditTrailReadResponse ToResponse(AuditTrailPage result) =>
-        new(
-            result.Records.Select(static record => new AuditTrailRecordResponse(
-                    record.AuditId,
-                    record.ScopeId,
-                    record.AuditActorId,
-                    record.IdentityKeyId,
-                    record.OperationName,
-                    record.Outcome.ToString(),
-                    ToDateTimeOffset(record.OccurredAt),
-                    NormalizeOptional(record.Target?.Kind),
-                    NormalizeOptional(record.Target?.Id),
-                    NormalizeOptional(record.Correlation?.RequestId) ??
-                    NormalizeOptional(record.Correlation?.TraceId)))
-                .ToArray(),
-            result.ReadAt,
-            result.Watermark,
-            result.NextCursor);
-
     private static IResult QueryUnavailable() =>
         Results.Json(
             new { code = "AUDIT_QUERY_UNAVAILABLE", message = "Audit trail query port is not configured." },
@@ -238,8 +317,19 @@ public static class AuditTrailEndpoints
         return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
     }
 
-    private static DateTimeOffset ToDateTimeOffset(Timestamp? timestamp) =>
-        timestamp is null ? DateTimeOffset.UnixEpoch : timestamp.ToDateTimeOffset();
+    private static void SetExportCoverageHeaders(HttpContext http, AuditTrailPage page)
+    {
+        var coverage = AuditTrailResponseMapper.ToCoverageResponse(page);
+        http.Response.Headers["Aevatar-Audit-Truncated"] = coverage.Truncated ? "true" : "false";
+        http.Response.Headers["Aevatar-Audit-Window-Completeness"] = coverage.WindowCompleteness;
+        http.Response.Headers["Aevatar-Audit-Schema-Compatibility"] = coverage.SchemaCompatibility;
+        if (!string.IsNullOrWhiteSpace(page.NextCursor))
+            http.Response.Headers["Aevatar-Audit-Continuation-Cursor"] = page.NextCursor;
+        if (page.Coverage.IngestionWatermark.HasValue)
+            http.Response.Headers["Aevatar-Audit-Ingestion-Watermark"] = page.Coverage.IngestionWatermark.Value.ToString("O");
+        if (page.Coverage.CompleteThrough.HasValue)
+            http.Response.Headers["Aevatar-Audit-Complete-Through"] = page.Coverage.CompleteThrough.Value.ToString("O");
+    }
 
     private static bool TryBuildCanonicalActorKey(
         string provider,

--- a/src/Aevatar.Audit.Hosting/AuditTrailResponseMapper.cs
+++ b/src/Aevatar.Audit.Hosting/AuditTrailResponseMapper.cs
@@ -1,0 +1,286 @@
+using Aevatar.Audit;
+using Aevatar.Audit.Abstractions.Models;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Audit.Hosting;
+
+internal static class AuditTrailResponseMapper
+{
+    public const string CloudEventsSpecVersion = "1.0";
+    public const string CloudEventsBatchContentType = "application/cloudevents-batch+json";
+
+    public static AuditTrailReadResponse ToResponse(AuditTrailPage page) =>
+        new(
+            page.Records.Select(ToRecordResponse).ToArray(),
+            ToCoverageResponse(page));
+
+    public static IReadOnlyList<AuditCloudEventResponse> ToCloudEvents(AuditTrailPage page) =>
+        page.Records.Select(ToCloudEvent).ToArray();
+
+    public static AuditTrailRecordResponse ToRecordResponse(AuditRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var lifecyclePhase = AuditContractSemantics.ResolveLifecyclePhase(record);
+        var terminalOutcome = AuditContractSemantics.ResolveTerminalOutcome(record);
+        var compatibility = AuditContractSemantics.GetSchemaCompatibility(record);
+        var hasCurrentContract = compatibility == AuditRecordSchemaCompatibility.Current;
+        var eventKind = Optional(record.EventKind) ?? record.OperationName;
+        var subject = Optional(record.Subject) ?? BuildSubject(record.Target);
+        var source = ResolveSource(record);
+
+        return new AuditTrailRecordResponse(
+            record.AuditId,
+            eventKind,
+            subject,
+            source,
+            AuditContractSemantics.ResolveSchemaVersion(record),
+            SchemaCompatibilityName(compatibility),
+            ToDateTimeOffset(record.OccurredAt),
+            record.RecordedAt is null ? ToDateTimeOffset(record.OccurredAt) : ToDateTimeOffset(record.RecordedAt),
+            LifecyclePhaseName(lifecyclePhase),
+            terminalOutcome == AuditTerminalOutcome.Unspecified ? null : TerminalOutcomeName(terminalOutcome),
+            record.ScopeId,
+            record.AuditActorId,
+            record.IdentityKeyId,
+            record.ActorKind.ToString(),
+            record.CredentialSource.ToString(),
+            record.OperationKind.ToString(),
+            record.OperationName,
+            record.SensitivityLevel.ToString(),
+            record.Outcome.ToString(),
+            record.CapturePlane.ToString(),
+            ToTarget(record.Target, hasCurrentContract),
+            ToCorrelation(record.Correlation, hasCurrentContract),
+            ToFailure(record, terminalOutcome, hasCurrentContract),
+            hasCurrentContract ? ToProvenance(record) : null,
+            hasCurrentContract ? ToRedaction(record.Redaction) : null,
+            hasCurrentContract ? ToCommittedFact(record.CommittedFactRef) : null,
+            hasCurrentContract ? Optional(record.RequestSummary) : null,
+            hasCurrentContract ? Optional(record.ResultSummary) : null);
+    }
+
+    private static AuditCloudEventResponse ToCloudEvent(AuditRecord record)
+    {
+        var data = ToRecordResponse(record);
+        return new AuditCloudEventResponse
+        {
+            SpecVersion = CloudEventsSpecVersion,
+            Id = data.Id,
+            Source = data.Source,
+            Type = data.EventKind,
+            Subject = data.Subject,
+            Time = data.OccurredAtUtc,
+            DataSchema = BuildDataSchema(data.SchemaVersion),
+            Traceparent = data.Correlation?.Traceparent,
+            Tracestate = data.Correlation?.Tracestate,
+            CorrelationId = data.Correlation?.CorrelationId,
+            CausationId = data.Correlation?.CausationId,
+            Data = data,
+        };
+    }
+
+    internal static AuditQueryCoverageResponse ToCoverageResponse(AuditTrailPage page) =>
+        new(
+            new AuditQueryWindowResponse(page.Coverage.RequestedWindow.From, page.Coverage.RequestedWindow.To),
+            new AuditQueryWindowResponse(page.Coverage.EffectiveWindow.From, page.Coverage.EffectiveWindow.To),
+            page.NextCursor,
+            page.Coverage.Truncated,
+            page.Coverage.IngestionWatermark,
+            page.Coverage.CompleteThrough,
+            WindowCompletenessName(page.Coverage.WindowCompleteness),
+            SchemaCompatibilityName(page.Coverage.SchemaCompatibility),
+            page.ReadAt);
+
+    private static AuditTargetResponse? ToTarget(AuditTarget? target, bool hasCurrentContract) =>
+        target is null
+            ? null
+            : new AuditTargetResponse(
+                target.Kind,
+                target.Id,
+                hasCurrentContract ? Optional(target.DisplayName) : null);
+
+    private static AuditCorrelationResponse? ToCorrelation(
+        AuditCorrelation? correlation,
+        bool hasCurrentContract) =>
+        correlation is null
+            ? null
+            : new AuditCorrelationResponse(
+                Optional(correlation.TraceId),
+                hasCurrentContract ? Optional(correlation.SpanId) : null,
+                hasCurrentContract ? Optional(correlation.Traceparent) : null,
+                hasCurrentContract ? Optional(correlation.Tracestate) : null,
+                hasCurrentContract ? Optional(correlation.CorrelationId) : null,
+                hasCurrentContract ? Optional(correlation.CausationId) : null,
+                Optional(correlation.RequestId),
+                hasCurrentContract ? Optional(correlation.CommandId) : null,
+                hasCurrentContract ? Optional(correlation.CallId) : null,
+                hasCurrentContract ? Optional(correlation.SessionId) : null,
+                hasCurrentContract ? Optional(correlation.WorkflowRunId) : null,
+                hasCurrentContract ? Optional(correlation.ApprovalId) : null);
+
+    private static AuditFailureResponse? ToFailure(
+        AuditRecord record,
+        AuditTerminalOutcome terminalOutcome,
+        bool hasCurrentContract)
+    {
+        if (hasCurrentContract && record.Failure is { } failure)
+        {
+            return new AuditFailureResponse(
+                failure.Code,
+                FailureCategoryName(failure.Category),
+                RetryabilityName(failure.Retryability),
+                LifecyclePhaseName(failure.FailedPhase),
+                Optional(failure.SanitizedMessage));
+        }
+
+        if (terminalOutcome != AuditTerminalOutcome.Failed)
+            return null;
+
+        return new AuditFailureResponse(
+            "legacy_failure",
+            "legacy_unspecified",
+            "unknown",
+            "legacy_unspecified",
+            null);
+    }
+
+    private static AuditExecutionProvenanceResponse? ToProvenance(AuditRecord record)
+    {
+        var provenance = record.Provenance;
+        if (provenance is null && record.CommittedFactRef is null && record.Correlation is null)
+            return null;
+
+        return new AuditExecutionProvenanceResponse(
+            FirstOptional(provenance?.ScopeId, record.ScopeId),
+            Optional(provenance?.TeamId),
+            Optional(provenance?.MemberId),
+            Optional(provenance?.WorkflowId),
+            Optional(provenance?.PublishedServiceId),
+            FirstOptional(provenance?.RunId, record.Correlation?.WorkflowRunId),
+            FirstOptional(provenance?.CausationId, record.Correlation?.CausationId),
+            FirstOptional(provenance?.CorrelationId, record.Correlation?.CorrelationId),
+            FirstOptional(provenance?.ActorId, record.CommittedFactRef?.ActorId),
+            ResolveActorStateVersion(provenance, record.CommittedFactRef),
+            FirstOptional(provenance?.ActorEventId, record.CommittedFactRef?.CommittedEventId));
+    }
+
+    private static AuditRedactionResponse? ToRedaction(AuditRedaction? redaction) =>
+        redaction is null
+            ? null
+            : new AuditRedactionResponse(
+                redaction.Policy,
+                redaction.OmittedFields.ToArray(),
+                redaction.ValuesSanitized);
+
+    private static AuditCommittedFactReferenceResponse? ToCommittedFact(AuditCommittedFactReference? reference) =>
+        reference is null
+            ? null
+            : new AuditCommittedFactReferenceResponse(
+                Optional(reference.CommittedEventId),
+                Optional(reference.ActorId),
+                Optional(reference.ActorType),
+                Optional(reference.EventTypeUrl),
+                reference.StateVersion > 0 ? reference.StateVersion : null);
+
+    private static string ResolveSource(AuditRecord record)
+    {
+        var source = Optional(record.Source);
+        if (source is not null && Uri.IsWellFormedUriString(source, UriKind.Absolute))
+            return source;
+
+        return record.CapturePlane switch
+        {
+            AuditCapturePlane.BoundaryEndpoint => "urn:aevatar:audit:boundary-endpoint",
+            AuditCapturePlane.ToolExecution => "urn:aevatar:audit:tool-execution",
+            AuditCapturePlane.ProjectionArtifact => "urn:aevatar:audit:projection-artifact",
+            _ => "urn:aevatar:audit:legacy",
+        };
+    }
+
+    private static string BuildSubject(AuditTarget? target) =>
+        target is null ? "audit/unknown" : $"{target.Kind}/{target.Id}";
+
+    private static string BuildDataSchema(string schemaVersion) =>
+        $"https://schemas.aevatar.ai/audit/{Uri.EscapeDataString(schemaVersion)}";
+
+    private static string LifecyclePhaseName(AuditLifecyclePhase value) => value switch
+    {
+        AuditLifecyclePhase.Accepted => "accepted",
+        AuditLifecyclePhase.Running => "running",
+        AuditLifecyclePhase.WaitingApproval => "waiting_approval",
+        AuditLifecyclePhase.Terminal => "terminal",
+        _ => "unspecified",
+    };
+
+    private static string TerminalOutcomeName(AuditTerminalOutcome value) => value switch
+    {
+        AuditTerminalOutcome.Succeeded => "succeeded",
+        AuditTerminalOutcome.Failed => "failed",
+        AuditTerminalOutcome.Cancelled => "cancelled",
+        AuditTerminalOutcome.TimedOut => "timed_out",
+        _ => "unspecified",
+    };
+
+    private static string FailureCategoryName(AuditFailureCategory value) => value switch
+    {
+        AuditFailureCategory.Authorization => "authorization",
+        AuditFailureCategory.Validation => "validation",
+        AuditFailureCategory.Execution => "execution",
+        AuditFailureCategory.Dependency => "dependency",
+        AuditFailureCategory.Timeout => "timeout",
+        AuditFailureCategory.Conflict => "conflict",
+        AuditFailureCategory.Internal => "internal",
+        _ => "unspecified",
+    };
+
+    private static string RetryabilityName(AuditRetryability value) => value switch
+    {
+        AuditRetryability.Unknown => "unknown",
+        AuditRetryability.Retryable => "retryable",
+        AuditRetryability.NotRetryable => "not_retryable",
+        _ => "unspecified",
+    };
+
+    private static string WindowCompletenessName(AuditWindowCompleteness value) => value switch
+    {
+        AuditWindowCompleteness.Complete => "complete",
+        AuditWindowCompleteness.BehindIngestionWatermark => "behind_ingestion_watermark",
+        AuditWindowCompleteness.Unbounded => "unbounded",
+        _ => "unknown",
+    };
+
+    private static string SchemaCompatibilityName(AuditSchemaCompatibility value) => value switch
+    {
+        AuditSchemaCompatibility.Current => "current",
+        AuditSchemaCompatibility.ContainsLegacyRecords => "contains_legacy_records",
+        AuditSchemaCompatibility.Incompatible => "incompatible",
+        _ => "incompatible",
+    };
+
+    private static string SchemaCompatibilityName(AuditRecordSchemaCompatibility value) => value switch
+    {
+        AuditRecordSchemaCompatibility.Current => "current",
+        AuditRecordSchemaCompatibility.LegacyMapped => "legacy_mapped",
+        AuditRecordSchemaCompatibility.Incompatible => "incompatible",
+        _ => "incompatible",
+    };
+
+    private static string? Optional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? FirstOptional(params string?[] values) =>
+        values.Select(Optional).FirstOrDefault(static value => value is not null);
+
+    private static long? ResolveActorStateVersion(
+        AuditExecutionProvenance? provenance,
+        AuditCommittedFactReference? committedFact) =>
+        provenance is { ActorStateVersion: > 0 }
+            ? provenance.ActorStateVersion
+            : committedFact is { StateVersion: > 0 }
+                ? committedFact.StateVersion
+                : null;
+
+    private static DateTimeOffset ToDateTimeOffset(Timestamp? timestamp) =>
+        timestamp is null ? DateTimeOffset.UnixEpoch : timestamp.ToDateTimeOffset();
+}

--- a/src/Aevatar.Bootstrap/Hosting/EndpointAuditCaptureMiddleware.cs
+++ b/src/Aevatar.Bootstrap/Hosting/EndpointAuditCaptureMiddleware.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Aevatar.Audit;
 using Aevatar.Audit.Hosting.EndpointAudit;
 using Aevatar.Audit.Abstractions.Identity;
+using Aevatar.Audit.Abstractions.Models;
 using Aevatar.Audit.Abstractions.Ports;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
@@ -107,12 +108,25 @@ public sealed class EndpointAuditCaptureMiddleware
         var auditIdentity = identityHasher.Hash(ResolveCanonicalActorKey(context.User));
         var target = ResolveTarget(context, metadata);
         var isAttemptedRecord = operationName.EndsWith(AttemptedSuffix, StringComparison.Ordinal);
+        var recordedAt = _timeProvider.GetUtcNow();
+        var scopeId = SanitizeRecordText(ResolveScopeId(context.User, context));
+        var correlation = BuildCorrelation(context);
+        var lifecyclePhase = isAttemptedRecord || outcome == AuditOutcome.Accepted
+            ? AuditLifecyclePhase.Accepted
+            : AuditLifecyclePhase.Terminal;
+        var terminalOutcome = ResolveTerminalOutcome(context, lifecyclePhase, outcome);
+        var failure = BuildFailure(context, terminalOutcome);
 
-        return new AuditRecord
+        var record = new AuditRecord
         {
             AuditId = BuildAuditId(context, operationName, outcome),
-            OccurredAt = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-            ScopeId = SanitizeRecordText(ResolveScopeId(context.User, context)),
+            OccurredAt = Timestamp.FromDateTimeOffset(recordedAt),
+            RecordedAt = Timestamp.FromDateTimeOffset(recordedAt),
+            EventKind = operationName,
+            Subject = BuildSubject(target),
+            SchemaVersion = AuditContractSemantics.CurrentSchemaVersion,
+            Source = "urn:aevatar:audit:boundary-endpoint",
+            ScopeId = scopeId,
             AuditActorId = auditIdentity.AuditActorId,
             IdentityKeyId = auditIdentity.IdentityKeyId,
             ActorKind = ResolveActorKind(context.User),
@@ -121,19 +135,46 @@ public sealed class EndpointAuditCaptureMiddleware
             OperationName = operationName,
             SensitivityLevel = metadata.SensitivityLevel,
             Outcome = outcome,
+            LifecyclePhase = lifecyclePhase,
+            TerminalOutcome = terminalOutcome,
             Target = new AuditTarget
             {
                 Kind = SanitizeRecordText(target.Kind),
                 Id = SanitizeRecordText(target.Id),
                 DisplayName = SanitizeRecordText(target.DisplayName),
             },
-            Correlation = BuildCorrelation(context),
+            Correlation = correlation,
             RequestSummary = SanitizeRecordText(ResolveRequestSummary(context)),
             ResultSummary = isAttemptedRecord ? string.Empty : SanitizeRecordText(ResolveResultSummary(context, outcome)),
-            ErrorCode = isAttemptedRecord ? string.Empty : ResolveErrorCode(context, outcome),
-            ErrorSummary = isAttemptedRecord ? string.Empty : SanitizeRecordText(ResolveErrorSummary(context, outcome)),
+            ErrorCode = isAttemptedRecord
+                ? string.Empty
+                : failure?.Code ?? ResolveErrorCode(context, outcome),
+            ErrorSummary = isAttemptedRecord
+                ? string.Empty
+                : failure?.SanitizedMessage ?? SanitizeRecordText(ResolveErrorSummary(context, outcome)),
             CapturePlane = AuditCapturePlane.BoundaryEndpoint,
+            Provenance = new AuditExecutionProvenance
+            {
+                ScopeId = scopeId,
+                TeamId = SanitizeRecordText(ReadRouteValue(context, "teamId") ?? string.Empty),
+                MemberId = SanitizeRecordText(ReadRouteValue(context, "memberId") ?? string.Empty),
+                WorkflowId = SanitizeRecordText(ReadRouteValue(context, "workflowId") ?? string.Empty),
+                PublishedServiceId = SanitizeRecordText(ReadRouteValue(context, "publishedServiceId") ?? string.Empty),
+                RunId = correlation.WorkflowRunId,
+                CausationId = correlation.CausationId,
+                CorrelationId = correlation.CorrelationId,
+            },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.endpoint-safe-fields.v1",
+                ValuesSanitized = true,
+            },
         };
+        record.Redaction.OmittedFields.Add(["request.headers", "request.body", "response.body"]);
+        if (failure is not null)
+            record.Failure = failure;
+
+        return record;
     }
 
     private async Task AppendBestEffortAsync(
@@ -256,10 +297,16 @@ public sealed class EndpointAuditCaptureMiddleware
 
     private static AuditCorrelation BuildCorrelation(HttpContext context)
     {
+        var activity = Activity.Current;
+        var hasW3CContext = activity?.IdFormat == ActivityIdFormat.W3C;
         return new AuditCorrelation
         {
-            TraceId = Activity.Current?.TraceId.ToString() ?? string.Empty,
+            TraceId = activity?.TraceId.ToString() ?? string.Empty,
+            SpanId = activity?.SpanId.ToString() ?? string.Empty,
+            Traceparent = hasW3CContext ? activity?.Id ?? string.Empty : string.Empty,
+            Tracestate = hasW3CContext ? activity?.TraceStateString ?? string.Empty : string.Empty,
             RequestId = context.TraceIdentifier ?? string.Empty,
+            CorrelationId = context.TraceIdentifier ?? string.Empty,
             CommandId = SanitizeRecordText(ReadRouteValue(context, "commandId") ?? string.Empty),
             CallId = SanitizeRecordText(ReadRouteValue(context, "callId") ?? string.Empty),
             SessionId = SanitizeRecordText(ReadRouteValue(context, "sessionId") ?? string.Empty),
@@ -267,6 +314,60 @@ public sealed class EndpointAuditCaptureMiddleware
             ApprovalId = SanitizeRecordText(ReadRouteValue(context, "approvalId") ?? string.Empty),
         };
     }
+
+    private static AuditTerminalOutcome ResolveTerminalOutcome(
+        HttpContext context,
+        AuditLifecyclePhase lifecyclePhase,
+        AuditOutcome outcome)
+    {
+        if (lifecyclePhase != AuditLifecyclePhase.Terminal)
+            return AuditTerminalOutcome.Unspecified;
+
+        if (context.Response.StatusCode is StatusCodes.Status408RequestTimeout or StatusCodes.Status504GatewayTimeout)
+            return AuditTerminalOutcome.TimedOut;
+
+        return outcome switch
+        {
+            AuditOutcome.Success => AuditTerminalOutcome.Succeeded,
+            AuditOutcome.Cancelled => AuditTerminalOutcome.Cancelled,
+            _ => AuditTerminalOutcome.Failed,
+        };
+    }
+
+    private static AuditFailure? BuildFailure(HttpContext context, AuditTerminalOutcome terminalOutcome)
+    {
+        if (terminalOutcome is not (AuditTerminalOutcome.Failed or AuditTerminalOutcome.TimedOut))
+            return null;
+
+        var statusCode = context.Response.StatusCode;
+        var category = terminalOutcome == AuditTerminalOutcome.TimedOut
+            ? AuditFailureCategory.Timeout
+            : statusCode switch
+            {
+                StatusCodes.Status401Unauthorized or StatusCodes.Status403Forbidden => AuditFailureCategory.Authorization,
+                StatusCodes.Status409Conflict => AuditFailureCategory.Conflict,
+                >= 400 and < 500 => AuditFailureCategory.Validation,
+                _ => AuditFailureCategory.Internal,
+            };
+        return new AuditFailure
+        {
+            Code = terminalOutcome == AuditTerminalOutcome.TimedOut
+                ? "endpoint_timeout"
+                : ResolveErrorCode(context, EndpointAuditOutcomeClassifier.Classify(context)),
+            Category = category,
+            Retryability = statusCode >= 500
+                ? AuditRetryability.Retryable
+                : AuditRetryability.NotRetryable,
+            FailedPhase = category is AuditFailureCategory.Authorization or AuditFailureCategory.Validation
+                ? AuditLifecyclePhase.Accepted
+                : AuditLifecyclePhase.Running,
+            SanitizedMessage = SanitizeRecordText(
+                ResolveErrorSummary(context, EndpointAuditOutcomeClassifier.Classify(context))),
+        };
+    }
+
+    private static string BuildSubject(EndpointAuditTarget target) =>
+        $"{SanitizeRecordText(target.Kind)}/{SanitizeRecordText(target.Id)}";
 
     private static string ResolveScopeId(ClaimsPrincipal user, HttpContext context)
     {

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetAgentProjectionDocumentStoresExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetAgentProjectionDocumentStoresExtensions.cs
@@ -382,21 +382,39 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
                         $"Elasticsearch audit artifact index '{_indexName}' was not found.");
                 }
 
-                return new AuditTrailPage([], null, DateTimeOffset.UtcNow, null);
+                return new AuditTrailPage(
+                    [],
+                    null,
+                    DateTimeOffset.UtcNow,
+                    AuditQueryCoverage.Create(
+                        query,
+                        truncated: false,
+                        ingestionWatermark: null,
+                        completeThrough: null,
+                        schemaCompatibility: AuditSchemaCompatibility.Current));
             }
 
             await EnsureSuccessAsync(response, "audit artifact query", cancellationToken);
             var payload = await response.Content.ReadAsStringAsync(cancellationToken);
             using var jsonDocument = JsonDocument.Parse(payload);
-            var watermark = ParseAuditQueryWatermark(jsonDocument.RootElement);
+            var ingestionWatermark = ParseAuditIngestionWatermark(jsonDocument.RootElement);
+            var schemaCompatibility = ParseAuditSchemaCompatibility(jsonDocument.RootElement);
             if (!jsonDocument.RootElement.TryGetProperty("hits", out var hitsNode) ||
                 !hitsNode.TryGetProperty("hits", out var hitItems))
             {
-                return new AuditTrailPage([], null, DateTimeOffset.UtcNow, watermark);
+                return new AuditTrailPage(
+                    [],
+                    null,
+                    DateTimeOffset.UtcNow,
+                    AuditQueryCoverage.Create(
+                        query,
+                        truncated: false,
+                        ingestionWatermark: ingestionWatermark,
+                        completeThrough: null,
+                        schemaCompatibility: schemaCompatibility));
             }
 
-            var records = new List<AuditRecord>();
-            string? nextCursor = null;
+            var recordsWithCursors = new List<(AuditRecord Record, string? Cursor)>();
             foreach (var hit in hitItems.EnumerateArray())
             {
                 if (!hit.TryGetProperty("_source", out var sourceNode))
@@ -406,15 +424,24 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
                 if (storageDocument.Artifact?.Record is not { } record)
                     continue;
 
-                records.Add(record.Clone());
-                nextCursor = BuildSearchAfterCursor(hit);
+                recordsWithCursors.Add((record.Clone(), BuildSearchAfterCursor(hit)));
             }
+
+            var truncated = recordsWithCursors.Count > boundedTake;
+            var pageItems = recordsWithCursors.Take(boundedTake).ToArray();
+            var records = pageItems.Select(static item => item.Record).ToArray();
+            var nextCursor = truncated ? pageItems.LastOrDefault().Cursor : null;
 
             return new AuditTrailPage(
                 records,
-                records.Count == boundedTake ? nextCursor : null,
+                nextCursor,
                 DateTimeOffset.UtcNow,
-                watermark);
+                AuditQueryCoverage.Create(
+                    query,
+                    truncated,
+                    ingestionWatermark,
+                    completeThrough: null,
+                    schemaCompatibility: schemaCompatibility));
         }
 
         public async Task<AuditTrailArtifactWriteResult> UpsertAsync(
@@ -549,7 +576,7 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
             var filters = BuildAuditQueryFilters(query);
             var root = new Dictionary<string, object?>(StringComparer.Ordinal)
             {
-                ["size"] = boundedTake,
+                ["size"] = boundedTake + 1,
                 ["sort"] = new object[]
                 {
                     new Dictionary<string, object?>
@@ -571,11 +598,55 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
                 },
                 ["aggs"] = new Dictionary<string, object?>
                 {
-                    ["query_watermark"] = new Dictionary<string, object?>
+                    ["ingestion"] = new Dictionary<string, object?>
                     {
-                        ["max"] = new Dictionary<string, object?>
+                        ["global"] = new Dictionary<string, object?>(),
+                        ["aggs"] = new Dictionary<string, object?>
                         {
-                            ["field"] = "artifact.occurred_at",
+                            ["watermark"] = new Dictionary<string, object?>
+                            {
+                                ["max"] = new Dictionary<string, object?>
+                                {
+                                    ["field"] = "artifact.recorded_at",
+                                },
+                            },
+                        },
+                    },
+                    ["incompatible_schema_records"] = new Dictionary<string, object?>
+                    {
+                        ["filter"] = new Dictionary<string, object?>
+                        {
+                            ["bool"] = new Dictionary<string, object?>
+                            {
+                                ["filter"] = new object[]
+                                {
+                                    new Dictionary<string, object?>
+                                    {
+                                        ["exists"] = new Dictionary<string, object?>
+                                        {
+                                            ["field"] = "artifact.schema_version",
+                                        },
+                                    },
+                                },
+                                ["must_not"] = new object[]
+                                {
+                                    new Dictionary<string, object?>
+                                    {
+                                        ["term"] = new Dictionary<string, object?>
+                                        {
+                                            ["artifact.schema_version.keyword"] =
+                                                AuditContractSemantics.CurrentSchemaVersion,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    ["legacy_schema_records"] = new Dictionary<string, object?>
+                    {
+                        ["missing"] = new Dictionary<string, object?>
+                        {
+                            ["field"] = "artifact.schema_version",
                         },
                     },
                 },
@@ -611,7 +682,9 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
             AddTerm(filters, "artifact.operation_name.keyword", query.OperationName);
             AddTerm(filters, "artifact.target_kind.keyword", query.TargetKind);
             AddTerm(filters, "artifact.target_id.keyword", query.TargetId);
-            AddTerm(filters, "artifact.correlation_id.keyword", query.TraceId);
+            AddTerm(filters, "artifact.trace_id.keyword", query.TraceId);
+            AddTerm(filters, "artifact.correlation_id.keyword", query.CorrelationId);
+            AddTerm(filters, "artifact.record.correlation.causation_id.keyword", query.CausationId);
             AddTerm(filters, "artifact.request_id.keyword", query.RequestId);
             AddTerm(filters, "artifact.command_id.keyword", query.CommandId);
             AddTerm(filters, "artifact.record.correlation.call_id.keyword", query.CallId);
@@ -625,6 +698,8 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
             AddEnumTerm(filters, "artifact.record.actor_kind.keyword", query.ActorKind);
             AddEnumTerm(filters, "artifact.record.operation_kind.keyword", query.OperationKind);
             AddEnumTerm(filters, "artifact.outcome.keyword", query.Outcome);
+            AddEnumTerm(filters, "artifact.lifecycle_phase.keyword", query.LifecyclePhase);
+            AddEnumTerm(filters, "artifact.terminal_outcome.keyword", query.TerminalOutcome);
             AddEnumTerm(filters, "artifact.sensitivity_level.keyword", query.SensitivityLevel);
             AddEnumTerm(filters, "artifact.record.capture_plane.keyword", query.CapturePlane);
             if (query.CommittedStateVersion.HasValue)
@@ -751,10 +826,11 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(sortNode.GetRawText()));
         }
 
-        private static DateTimeOffset? ParseAuditQueryWatermark(JsonElement root)
+        private static DateTimeOffset? ParseAuditIngestionWatermark(JsonElement root)
         {
             if (!root.TryGetProperty("aggregations", out var aggregations) ||
-                !aggregations.TryGetProperty("query_watermark", out var watermark) ||
+                !aggregations.TryGetProperty("ingestion", out var ingestion) ||
+                !ingestion.TryGetProperty("watermark", out var watermark) ||
                 !watermark.TryGetProperty("value_as_string", out var value) ||
                 value.ValueKind != JsonValueKind.String)
             {
@@ -768,6 +844,36 @@ public static class MainnetAgentProjectionDocumentStoresExtensions
                 out var parsed)
                 ? parsed
                 : null;
+        }
+
+        private static AuditSchemaCompatibility ParseAuditSchemaCompatibility(JsonElement root)
+        {
+            if (!root.TryGetProperty("aggregations", out var aggregations))
+                return AuditSchemaCompatibility.Incompatible;
+
+            if (!aggregations.TryGetProperty("incompatible_schema_records", out var incompatible) ||
+                !incompatible.TryGetProperty("doc_count", out var incompatibleCountNode) ||
+                !incompatibleCountNode.TryGetInt64(out var incompatibleCount))
+            {
+                return AuditSchemaCompatibility.Incompatible;
+            }
+
+            if (incompatibleCount > 0)
+                return AuditSchemaCompatibility.Incompatible;
+
+            if (!aggregations.TryGetProperty("legacy_schema_records", out var legacy) ||
+                !legacy.TryGetProperty("doc_count", out var count) ||
+                !count.TryGetInt64(out var legacyCount))
+            {
+                return AuditSchemaCompatibility.Incompatible;
+            }
+
+            if (legacyCount > 0)
+            {
+                return AuditSchemaCompatibility.ContainsLegacyRecords;
+            }
+
+            return AuditSchemaCompatibility.Current;
         }
 
         private static AuditTrailArtifactWriteResult EvaluateExisting(

--- a/src/Aevatar.Scripting.Projection/Audit/ScriptAuditCommittedEventTranslators.cs
+++ b/src/Aevatar.Scripting.Projection/Audit/ScriptAuditCommittedEventTranslators.cs
@@ -91,7 +91,9 @@ public sealed class ScriptCatalogRollbackRequestedAuditTranslator
                 ["target_revision"] = evt.TargetRevision ?? string.Empty,
                 ["proposal_id"] = evt.ProposalId ?? string.Empty,
                 ["reason"] = evt.Reason ?? string.Empty,
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Accepted,
+            terminalOutcome: AuditTerminalOutcome.Unspecified);
 }
 
 public sealed class ScriptCatalogRolledBackAuditTranslator
@@ -185,7 +187,22 @@ public sealed class ScriptRunOutcomeRecordedAuditTranslator
                 ["script_revision"] = evt.ScriptRevision ?? string.Empty,
                 ["command_id"] = evt.CommandId ?? string.Empty,
                 ["correlation_id"] = evt.CorrelationId ?? string.Empty,
-            });
+            },
+            terminalOutcome: succeeded
+                ? AuditTerminalOutcome.Succeeded
+                : AuditTerminalOutcome.Failed,
+            failure: succeeded
+                ? null
+                : new AuditFailure
+                {
+                    Code = "script_run_failed",
+                    Category = AuditFailureCategory.Execution,
+                    Retryability = AuditRetryability.Unknown,
+                    FailedPhase = AuditLifecyclePhase.Running,
+                    SanitizedMessage = "Script run failed.",
+                },
+            runId: evt.ScriptRunId,
+            omittedFields: ["script_run.result", "script_run.error"]);
     }
 }
 
@@ -213,7 +230,12 @@ public abstract class ScriptAuditTranslatorBase<TEvent> : IAuditCommittedEventTr
         string resultSummary,
         AuditSensitivityLevel sensitivityLevel = AuditSensitivityLevel.Confidential,
         bool isDestructive = false,
-        IReadOnlyDictionary<string, string>? annotations = null) =>
+        IReadOnlyDictionary<string, string>? annotations = null,
+        AuditLifecyclePhase lifecyclePhase = AuditLifecyclePhase.Terminal,
+        AuditTerminalOutcome terminalOutcome = AuditTerminalOutcome.Succeeded,
+        AuditFailure? failure = null,
+        string runId = "",
+        IReadOnlyList<string>? omittedFields = null) =>
         new(
             operationName,
             targetKind,
@@ -222,5 +244,10 @@ public abstract class ScriptAuditTranslatorBase<TEvent> : IAuditCommittedEventTr
             sensitivityLevel,
             isDestructive,
             ResultSummary: resultSummary,
-            Annotations: annotations);
+            Annotations: annotations,
+            LifecyclePhase: lifecyclePhase,
+            TerminalOutcome: terminalOutcome,
+            Failure: failure,
+            RunId: runId,
+            OmittedFields: omittedFields);
 }

--- a/src/Aevatar.Studio.Projection/Audit/StudioLifecycleAuditTranslators.cs
+++ b/src/Aevatar.Studio.Projection/Audit/StudioLifecycleAuditTranslators.cs
@@ -186,9 +186,12 @@ public sealed class StudioMemberBindingFailedAuditTranslator
             Annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["binding_run_id"] = evt.BindingRunId,
-                ["failure_code"] = evt.Failure?.Code ?? string.Empty,
-                ["failure_message"] = evt.Failure?.Message ?? string.Empty,
-            });
+            },
+            TerminalOutcome: AuditTerminalOutcome.Failed,
+            Failure: BindingFailure(
+                "studio_member_binding_failed",
+                AuditFailureCategory.Execution,
+                "Studio member binding failed."));
 }
 
 public sealed class StudioMemberBindingRejectedAuditTranslator
@@ -209,9 +212,12 @@ public sealed class StudioMemberBindingRejectedAuditTranslator
             Annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["binding_run_id"] = evt.BindingRunId,
-                ["failure_code"] = evt.Failure?.Code ?? string.Empty,
-                ["failure_message"] = evt.Failure?.Message ?? string.Empty,
-            });
+            },
+            TerminalOutcome: AuditTerminalOutcome.Failed,
+            Failure: BindingFailure(
+                "studio_member_binding_rejected",
+                AuditFailureCategory.Validation,
+                "Studio member binding was rejected."));
 }
 
 public sealed class StudioTeamEntryMemberChangedAuditTranslator
@@ -259,7 +265,10 @@ public abstract class StudioAuditTranslatorBase<TEvent> : IAuditCommittedEventTr
         string resultSummary,
         AuditSensitivityLevel sensitivityLevel = AuditSensitivityLevel.Confidential,
         bool isDestructive = false,
-        IReadOnlyDictionary<string, string>? Annotations = null) =>
+        IReadOnlyDictionary<string, string>? Annotations = null,
+        AuditLifecyclePhase LifecyclePhase = AuditLifecyclePhase.Terminal,
+        AuditTerminalOutcome TerminalOutcome = AuditTerminalOutcome.Succeeded,
+        AuditFailure? Failure = null) =>
         new(
             operationName,
             targetKind,
@@ -268,5 +277,21 @@ public abstract class StudioAuditTranslatorBase<TEvent> : IAuditCommittedEventTr
             sensitivityLevel,
             isDestructive,
             ResultSummary: resultSummary,
-            Annotations: Annotations);
+            Annotations: Annotations,
+            LifecyclePhase: LifecyclePhase,
+            TerminalOutcome: TerminalOutcome,
+            Failure: Failure);
+
+    protected static AuditFailure BindingFailure(
+        string? code,
+        AuditFailureCategory category,
+        string sanitizedMessage) =>
+        new()
+        {
+            Code = code,
+            Category = category,
+            Retryability = AuditRetryability.Unknown,
+            FailedPhase = AuditLifecyclePhase.Running,
+            SanitizedMessage = sanitizedMessage,
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Audit/ServiceAuditCommittedEventTranslators.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Audit/ServiceAuditCommittedEventTranslators.cs
@@ -41,11 +41,12 @@ public sealed class ServiceRegistrationFailedAuditTranslator
             evt.Identity?.ServiceId ?? string.Empty,
             evt.CredentialKid,
             $"Service registration failed for {evt.Identity?.ServiceId ?? string.Empty}.",
-            AuditSensitivityLevel.Confidential,
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["error_summary"] = evt.LastError ?? string.Empty,
-            });
+            sensitivityLevel: AuditSensitivityLevel.Confidential,
+            terminalOutcome: AuditTerminalOutcome.Failed,
+            failure: Failure(
+                "service_registration_failed",
+                AuditFailureCategory.Dependency,
+                AuditLifecyclePhase.Running));
 }
 
 public sealed class ServiceRegistrationRetiredAuditTranslator
@@ -305,7 +306,13 @@ public sealed class ServiceRunRegisteredAuditTranslator
             CommandId: record?.CommandId ?? string.Empty,
             CorrelationId: record?.CorrelationId ?? string.Empty,
             ResultSummary: $"Service run {runId} registered for service {serviceId} (status {status}).",
-            Annotations: annotations);
+            Annotations: annotations,
+            LifecyclePhase: LifecyclePhase(record?.Status ?? ServiceRunStatus.Unspecified),
+            TerminalOutcome: TerminalOutcome(record?.Status ?? ServiceRunStatus.Unspecified),
+            Failure: BuildRunFailure(record?.Status ?? ServiceRunStatus.Unspecified),
+            PublishedServiceId: serviceId,
+            RunId: runId,
+            OmittedFields: ["service_run.last_output", "service_run.last_error"]);
     }
 }
 
@@ -316,9 +323,7 @@ public sealed class ServiceRunStatusUpdatedAuditTranslator
         AuditCommittedEventTypeUrl.FromDescriptor(ServiceRunStatusUpdatedEvent.Descriptor);
 
     // The event carries only run id, status and the free-text last_output /
-    // last_error terminal bodies. Only the run id, status and a bounded safe
-    // error class are recorded — never the last_output / last_error body, which
-    // may embed business payload.
+    // last_error terminal bodies. Only the run id and status are recorded.
     protected override CommittedAuditSeed BuildSeed(
         CommittedAuditTranslationContext context,
         ServiceRunStatusUpdatedEvent evt)
@@ -328,9 +333,6 @@ public sealed class ServiceRunStatusUpdatedAuditTranslator
         {
             ["status"] = status,
         };
-        var errorClass = RunAuditAnnotations.SafeErrorClass(evt.LastError);
-        if (!string.IsNullOrWhiteSpace(errorClass))
-            annotations["error_class"] = errorClass;
 
         return new CommittedAuditSeed(
             "service.run.status-updated",
@@ -338,7 +340,12 @@ public sealed class ServiceRunStatusUpdatedAuditTranslator
             evt.RunId ?? string.Empty,
             SensitivityLevel: AuditSensitivityLevel.Confidential,
             ResultSummary: $"Service run {evt.RunId} status updated to {status}.",
-            Annotations: annotations);
+            Annotations: annotations,
+            LifecyclePhase: LifecyclePhase(evt.Status),
+            TerminalOutcome: TerminalOutcome(evt.Status),
+            Failure: BuildRunFailure(evt.Status),
+            RunId: evt.RunId ?? string.Empty,
+            OmittedFields: ["service_run.last_output", "service_run.last_error"]);
     }
 }
 
@@ -369,7 +376,9 @@ public sealed class ScheduledDispatchFireDispatchedAuditTranslator
                 ["target_actor_id"] = evt.TargetActorId ?? string.Empty,
                 ["idempotency_key"] = evt.IdempotencyKey ?? string.Empty,
                 ["manual"] = evt.Manual ? "true" : "false",
-            });
+            },
+            LifecyclePhase: AuditLifecyclePhase.Accepted,
+            TerminalOutcome: AuditTerminalOutcome.Unspecified);
 }
 
 public sealed class ScheduledDispatchFireFailedAuditTranslator
@@ -378,9 +387,8 @@ public sealed class ScheduledDispatchFireFailedAuditTranslator
     public override string EventTypeUrl =>
         AuditCommittedEventTypeUrl.FromDescriptor(ScheduledDispatchFireFailedEvent.Descriptor);
 
-    // Only a bounded safe error class is recorded, never the free-text error
-    // body which may embed dispatch payload detail. Fire failure is a terminal
-    // outcome, not a delete/retire, so it is not marked destructive.
+    // The free-text error body is omitted because it may embed dispatch payload
+    // detail. Fire failure is terminal but is not a delete/retire operation.
     protected override CommittedAuditSeed BuildSeed(
         CommittedAuditTranslationContext context,
         ScheduledDispatchFireFailedEvent evt)
@@ -390,17 +398,19 @@ public sealed class ScheduledDispatchFireFailedAuditTranslator
             ["idempotency_key"] = evt.IdempotencyKey ?? string.Empty,
             ["manual"] = evt.Manual ? "true" : "false",
         };
-        var errorClass = RunAuditAnnotations.SafeErrorClass(evt.Error);
-        if (!string.IsNullOrWhiteSpace(errorClass))
-            annotations["error_class"] = errorClass;
 
         return new CommittedAuditSeed(
             "scheduled.dispatch.fire.failed",
             "scheduled_dispatch",
             context.OriginActorId,
             SensitivityLevel: AuditSensitivityLevel.Confidential,
-            ResultSummary: $"Scheduled dispatch {context.OriginActorId} fire failed ({errorClass}).",
-            Annotations: annotations);
+            ResultSummary: $"Scheduled dispatch {context.OriginActorId} fire failed.",
+            Annotations: annotations,
+            TerminalOutcome: AuditTerminalOutcome.Failed,
+            Failure: Failure(
+                "scheduled_dispatch_failed",
+                AuditFailureCategory.Execution,
+                AuditLifecyclePhase.Running));
     }
 }
 
@@ -416,21 +426,6 @@ internal static class RunAuditAnnotations
             _ => "unspecified",
         };
 
-    // Reduces a free-text error to a bounded, safe class token: the exception
-    // type-like head before the first ':' or newline, capped in length so no
-    // full error body (which may embed business payload) can enter the audit
-    // artifact.
-    public static string SafeErrorClass(string? error)
-    {
-        if (string.IsNullOrWhiteSpace(error))
-            return string.Empty;
-
-        var trimmed = error.Trim();
-        var separatorIndex = trimmed.IndexOfAny([':', '\n', '\r']);
-        var head = (separatorIndex >= 0 ? trimmed[..separatorIndex] : trimmed).Trim();
-        const int maxLength = 80;
-        return head.Length <= maxLength ? head : head[..maxLength];
-    }
 }
 
 public abstract class AuditTranslatorBase<TEvent> : IAuditCommittedEventTranslator
@@ -457,7 +452,10 @@ public abstract class AuditTranslatorBase<TEvent> : IAuditCommittedEventTranslat
         string resultSummary,
         AuditSensitivityLevel sensitivityLevel = AuditSensitivityLevel.Confidential,
         IReadOnlyDictionary<string, string>? annotations = null,
-        bool isDestructive = false)
+        bool isDestructive = false,
+        AuditLifecyclePhase lifecyclePhase = AuditLifecyclePhase.Terminal,
+        AuditTerminalOutcome terminalOutcome = AuditTerminalOutcome.Succeeded,
+        AuditFailure? failure = null)
     {
         var merged = new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -482,7 +480,11 @@ public abstract class AuditTranslatorBase<TEvent> : IAuditCommittedEventTranslat
             sensitivityLevel,
             isDestructive,
             ResultSummary: resultSummary,
-            Annotations: merged);
+            Annotations: merged,
+            LifecyclePhase: lifecyclePhase,
+            TerminalOutcome: terminalOutcome,
+            Failure: failure,
+            PublishedServiceId: identity?.ServiceId ?? string.Empty);
     }
 
     protected static CommittedAuditSeed ScheduleSeed(
@@ -530,4 +532,41 @@ public abstract class AuditTranslatorBase<TEvent> : IAuditCommittedEventTranslat
 
         return string.Empty;
     }
+
+    protected static AuditLifecyclePhase LifecyclePhase(ServiceRunStatus status) => status switch
+    {
+        ServiceRunStatus.Accepted => AuditLifecyclePhase.Accepted,
+        ServiceRunStatus.Completed or ServiceRunStatus.Failed or ServiceRunStatus.Stopped =>
+            AuditLifecyclePhase.Terminal,
+        _ => AuditLifecyclePhase.Running,
+    };
+
+    protected static AuditTerminalOutcome TerminalOutcome(ServiceRunStatus status) => status switch
+    {
+        ServiceRunStatus.Completed => AuditTerminalOutcome.Succeeded,
+        ServiceRunStatus.Failed => AuditTerminalOutcome.Failed,
+        ServiceRunStatus.Stopped => AuditTerminalOutcome.Cancelled,
+        _ => AuditTerminalOutcome.Unspecified,
+    };
+
+    protected static AuditFailure? BuildRunFailure(ServiceRunStatus status) =>
+        status == ServiceRunStatus.Failed
+            ? Failure(
+                "service_run_failed",
+                AuditFailureCategory.Execution,
+                AuditLifecyclePhase.Running)
+            : null;
+
+    protected static AuditFailure Failure(
+        string code,
+        AuditFailureCategory category,
+        AuditLifecyclePhase failedPhase) =>
+        new()
+        {
+            Code = code,
+            Category = category,
+            Retryability = AuditRetryability.Unknown,
+            FailedPhase = failedPhase,
+            SanitizedMessage = code,
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Audit/ServiceServingAuditCommittedEventTranslators.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Audit/ServiceServingAuditCommittedEventTranslators.cs
@@ -50,7 +50,9 @@ public sealed class ServiceRolloutStartedAuditTranslator
             {
                 ["rollout_id"] = evt.Plan?.RolloutId ?? string.Empty,
                 ["stage_count"] = (evt.Plan?.Stages.Count ?? 0).ToString(),
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Running,
+            terminalOutcome: AuditTerminalOutcome.Unspecified);
 }
 
 public sealed class ServiceRolloutStageAdvancedAuditTranslator
@@ -74,7 +76,9 @@ public sealed class ServiceRolloutStageAdvancedAuditTranslator
                 ["rollout_id"] = evt.RolloutId ?? string.Empty,
                 ["stage_index"] = evt.StageIndex.ToString(),
                 ["stage_id"] = evt.StageId ?? string.Empty,
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Running,
+            terminalOutcome: AuditTerminalOutcome.Unspecified);
 }
 
 public sealed class ServiceRolloutPausedAuditTranslator
@@ -97,7 +101,9 @@ public sealed class ServiceRolloutPausedAuditTranslator
             {
                 ["rollout_id"] = evt.RolloutId ?? string.Empty,
                 ["reason"] = evt.Reason ?? string.Empty,
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Running,
+            terminalOutcome: AuditTerminalOutcome.Unspecified);
 }
 
 public sealed class ServiceRolloutResumedAuditTranslator
@@ -119,7 +125,9 @@ public sealed class ServiceRolloutResumedAuditTranslator
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["rollout_id"] = evt.RolloutId ?? string.Empty,
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Running,
+            terminalOutcome: AuditTerminalOutcome.Unspecified);
 }
 
 public sealed class ServiceRolloutCompletedAuditTranslator
@@ -188,6 +196,10 @@ public sealed class ServiceRolloutFailedAuditTranslator
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["rollout_id"] = evt.RolloutId ?? string.Empty,
-                ["failure_reason"] = evt.FailureReason ?? string.Empty,
-            });
+            },
+            terminalOutcome: AuditTerminalOutcome.Failed,
+            failure: Failure(
+                "service_rollout_failed",
+                AuditFailureCategory.Execution,
+                AuditLifecyclePhase.Running));
 }

--- a/src/workflow/Aevatar.Workflow.Projection/Audit/WorkflowAuditScopeResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Audit/WorkflowAuditScopeResolver.cs
@@ -1,0 +1,21 @@
+using Aevatar.Audit.Abstractions.CommittedFacts;
+using Aevatar.Workflow.Core;
+
+namespace Aevatar.Workflow.Projection.Audit;
+
+internal static class WorkflowAuditScopeResolver
+{
+    public static string Resolve(
+        CommittedAuditTranslationContext context,
+        string? eventScopeId = null)
+    {
+        if (!string.IsNullOrWhiteSpace(eventScopeId))
+            return eventScopeId;
+
+        var stateRoot = context.Published.StateRoot;
+        if (stateRoot?.Is(WorkflowRunState.Descriptor) != true)
+            return string.Empty;
+
+        return stateRoot.Unpack<WorkflowRunState>().ScopeId ?? string.Empty;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Audit/WorkflowHumanApprovalResolvedAuditTranslator.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Audit/WorkflowHumanApprovalResolvedAuditTranslator.cs
@@ -51,11 +51,19 @@ public sealed class WorkflowHumanApprovalResolvedAuditTranslator : IAuditCommitt
             "workflow.human-approval.resolved",
             "workflow_run",
             runId,
+            ScopeId: WorkflowAuditScopeResolver.Resolve(context),
             SensitivityLevel: AuditSensitivityLevel.Restricted,
             ResultSummary: evt.Approved
                 ? $"Human approval granted for run {runId} ({resolutionSource})."
                 : $"Human approval denied for run {runId} ({resolutionSource}).",
-            Annotations: annotations);
+            Annotations: annotations,
+            RunId: runId,
+            OmittedFields: [
+                "approval.user_input",
+                "approval.edited_content",
+                "approval.feedback",
+                "approval.resolved_content",
+            ]);
     }
 
     private static string ResolutionSourceLabel(WorkflowHumanApprovalResolutionSource source) =>

--- a/src/workflow/Aevatar.Workflow.Projection/Audit/WorkflowRunAuditCommittedEventTranslators.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Audit/WorkflowRunAuditCommittedEventTranslators.cs
@@ -46,18 +46,23 @@ public sealed class WorkflowRunExecutionStartedAuditTranslator
         WorkflowRunExecutionStartedEvent evt)
     {
         var runId = string.IsNullOrWhiteSpace(evt.RunId) ? context.OriginActorId : evt.RunId;
+        var scopeId = WorkflowAuditScopeResolver.Resolve(context, evt.ScopeId);
         return WorkflowSeed(
             "workflow.run.started",
             "workflow_run",
             runId,
-            evt.ScopeId,
+            scopeId,
             $"Workflow run {runId} execution started.",
             annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["workflow_name"] = evt.WorkflowName ?? string.Empty,
                 ["definition_actor_id"] = evt.DefinitionActorId ?? string.Empty,
                 ["attempt"] = evt.Attempt.ToString(),
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Running,
+            terminalOutcome: AuditTerminalOutcome.Unspecified,
+            runId: runId,
+            omittedFields: ["workflow.input"]);
     }
 }
 
@@ -72,6 +77,7 @@ public sealed class WorkflowCompletedAuditTranslator
         WorkflowCompletedEvent evt)
     {
         var runId = string.IsNullOrWhiteSpace(evt.RunId) ? context.OriginActorId : evt.RunId;
+        var scopeId = WorkflowAuditScopeResolver.Resolve(context);
         var outcome = evt.Success ? "succeeded" : "failed";
         // `output` and `error` are free-text and may embed business payload — record
         // only the terminal outcome and whether an error was present, never the body.
@@ -80,14 +86,29 @@ public sealed class WorkflowCompletedAuditTranslator
             "workflow.run.completed",
             "workflow_run",
             runId,
-            string.Empty,
+            scopeId,
             $"Workflow run {runId} completed ({outcome}).",
             annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["workflow_name"] = evt.WorkflowName ?? string.Empty,
                 ["outcome"] = outcome,
                 ["error_present"] = errorPresent ? "true" : "false",
-            });
+            },
+            terminalOutcome: evt.Success
+                ? AuditTerminalOutcome.Succeeded
+                : AuditTerminalOutcome.Failed,
+            failure: evt.Success
+                ? null
+                : new AuditFailure
+                {
+                    Code = "workflow_failed",
+                    Category = AuditFailureCategory.Execution,
+                    Retryability = AuditRetryability.Unknown,
+                    FailedPhase = AuditLifecyclePhase.Running,
+                    SanitizedMessage = "Workflow execution failed.",
+                },
+            runId: runId,
+            omittedFields: ["workflow.output", "workflow.error"]);
     }
 }
 
@@ -102,17 +123,20 @@ public sealed class WorkflowStoppedAuditTranslator
         WorkflowStoppedEvent evt)
     {
         var runId = string.IsNullOrWhiteSpace(evt.RunId) ? context.OriginActorId : evt.RunId;
+        var scopeId = WorkflowAuditScopeResolver.Resolve(context);
         return WorkflowSeed(
             "workflow.run.stopped",
             "workflow_run",
             runId,
-            string.Empty,
+            scopeId,
             $"Workflow run {runId} stopped.",
             annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["workflow_name"] = evt.WorkflowName ?? string.Empty,
                 ["reason"] = evt.Reason ?? string.Empty,
-            });
+            },
+            terminalOutcome: AuditTerminalOutcome.Cancelled,
+            runId: runId);
     }
 }
 
@@ -127,16 +151,19 @@ public sealed class WorkflowRunStoppedAuditTranslator
         WorkflowRunStoppedEvent evt)
     {
         var runId = string.IsNullOrWhiteSpace(evt.RunId) ? context.OriginActorId : evt.RunId;
+        var scopeId = WorkflowAuditScopeResolver.Resolve(context);
         return WorkflowSeed(
             "workflow.run.stopped-run",
             "workflow_run",
             runId,
-            string.Empty,
+            scopeId,
             $"Workflow run {runId} stopped.",
             annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["reason"] = evt.Reason ?? string.Empty,
-            });
+            },
+            terminalOutcome: AuditTerminalOutcome.Cancelled,
+            runId: runId);
     }
 }
 
@@ -151,17 +178,21 @@ public sealed class WorkflowRunForkRequestedAuditTranslator
         WorkflowRunForkRequestedEvent evt)
     {
         var sourceRunId = string.IsNullOrWhiteSpace(evt.SourceRunId) ? context.OriginActorId : evt.SourceRunId;
+        var scopeId = WorkflowAuditScopeResolver.Resolve(context, evt.ScopeId);
         return WorkflowSeed(
             "workflow.run.fork-requested",
             "workflow_run",
             sourceRunId,
-            evt.ScopeId,
+            scopeId,
             $"Workflow run {sourceRunId} requested a fork (attempt {evt.Attempt}).",
             annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["start_at_step_id"] = evt.StartAtStepId ?? string.Empty,
                 ["attempt"] = evt.Attempt.ToString(),
-            });
+            },
+            lifecyclePhase: AuditLifecyclePhase.Accepted,
+            terminalOutcome: AuditTerminalOutcome.Unspecified,
+            runId: sourceRunId);
     }
 }
 
@@ -176,12 +207,13 @@ public sealed class BindWorkflowRunDefinitionAuditTranslator
         BindWorkflowRunDefinitionEvent evt)
     {
         var runId = string.IsNullOrWhiteSpace(evt.RunId) ? context.OriginActorId : evt.RunId;
+        var scopeId = WorkflowAuditScopeResolver.Resolve(context, evt.ScopeId);
         // workflow_yaml / inline_workflow_yamls are the definition body — never recorded.
         return WorkflowSeed(
             "workflow.run.definition-bound",
             "workflow_run",
             runId,
-            evt.ScopeId,
+            scopeId,
             $"Workflow run {runId} bound to definition `{evt.WorkflowName}`.",
             annotations: new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -248,7 +280,12 @@ public abstract class WorkflowAuditTranslatorBase<TEvent> : IAuditCommittedEvent
         string resultSummary,
         AuditSensitivityLevel sensitivityLevel = AuditSensitivityLevel.Confidential,
         bool isDestructive = false,
-        IReadOnlyDictionary<string, string>? annotations = null) =>
+        IReadOnlyDictionary<string, string>? annotations = null,
+        AuditLifecyclePhase lifecyclePhase = AuditLifecyclePhase.Terminal,
+        AuditTerminalOutcome terminalOutcome = AuditTerminalOutcome.Succeeded,
+        AuditFailure? failure = null,
+        string runId = "",
+        IReadOnlyList<string>? omittedFields = null) =>
         new(
             operationName,
             targetKind,
@@ -257,5 +294,10 @@ public abstract class WorkflowAuditTranslatorBase<TEvent> : IAuditCommittedEvent
             sensitivityLevel,
             isDestructive,
             ResultSummary: resultSummary,
-            Annotations: annotations);
+            Annotations: annotations,
+            LifecyclePhase: lifecyclePhase,
+            TerminalOutcome: terminalOutcome,
+            Failure: failure,
+            RunId: runId,
+            OmittedFields: omittedFields);
 }

--- a/test/Aevatar.AI.Core.Tests/Middleware/ToolExecutionAuditMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/ToolExecutionAuditMiddlewareTests.cs
@@ -55,6 +55,8 @@ public sealed class ToolExecutionAuditMiddlewareTests
         record.OperationKind.Should().Be(AuditOperationKind.Tool);
         record.OperationName.Should().Be("delete_record");
         record.Outcome.Should().Be(AuditOutcome.Success);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Succeeded);
         record.CapturePlane.Should().Be(AuditCapturePlane.ToolExecution);
         record.Target.Kind.Should().Be("record");
         record.Target.Id.Should().Be("record-1");
@@ -198,6 +200,8 @@ public sealed class ToolExecutionAuditMiddlewareTests
 
         var record = appender.Records.Should().ContainSingle().Subject;
         record.Outcome.Should().Be(AuditOutcome.Accepted);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.WaitingApproval);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
         record.Correlation.ApprovalId.Should().Be("approval-1");
         record.Annotations.Should().Contain("tool_receipt_status", AgentToolReceiptStatus.ApprovalRequired.ToString());
     }
@@ -220,7 +224,7 @@ public sealed class ToolExecutionAuditMiddlewareTests
             context.CredentialSource = AgentToolCredentialSource.ChannelRegistration;
             context.Terminate = true;
             context.TerminationKind = ToolCallTerminationKind.MiddlewareTerminated;
-            context.TerminationReason = "sender is not bound";
+            context.TerminationReason = "sender is not bound: Bearer secret-token";
             context.Result = """{"error":"credential_denied","code":"credential_denied","token":"secret-token"}""";
             return Task.CompletedTask;
         });
@@ -228,9 +232,120 @@ public sealed class ToolExecutionAuditMiddlewareTests
         var record = appender.Records.Should().ContainSingle().Subject;
         record.Outcome.Should().Be(AuditOutcome.Denied);
         record.ErrorCode.Should().Be("credential_denied");
-        record.ErrorSummary.Should().Be("sender is not bound");
+        record.ErrorSummary.Should().Be("credential_denied");
+        record.Failure.SanitizedMessage.Should().Be("credential_denied");
         record.Annotations.Should().Contain("receipt_synthetic", "true");
         AuditText(record).Should().NotContain("secret-token");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenApprovalIsDenied_ShouldRecordWaitingApprovalAsFailedPhase()
+    {
+        var appender = new RecordingAuditTrailAppender();
+        var middleware = NewMiddleware(appender);
+        var context = NewContext(
+            new FakeAgentTool("danger", ToolApprovalMode.AlwaysRequire, isDestructive: true),
+            AgentToolExecutionContext.Empty with
+            {
+                Caller = new AgentToolCallerContext("scope-approval", "owner-approval", null),
+            });
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            context.Receipt = new AgentToolReceipt
+            {
+                CallId = "call-approval",
+                ToolName = "danger",
+                Status = AgentToolReceiptStatus.Denied,
+                ApprovalMode = AgentToolReceiptApprovalMode.AlwaysRequire,
+                ApprovalRequestId = "approval-denied-1",
+                ErrorCode = "approval_denied",
+                ErrorMessage = "approval_denied",
+                IsDestructive = true,
+            };
+            return Task.CompletedTask;
+        });
+
+        var record = appender.Records.Should().ContainSingle().Subject;
+        record.Outcome.Should().Be(AuditOutcome.Denied);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+        record.Failure.FailedPhase.Should().Be(AuditLifecyclePhase.WaitingApproval);
+        record.Correlation.ApprovalId.Should().Be("approval-denied-1");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenApprovalTimesOut_ShouldRecordTimedOutTerminalOutcome()
+    {
+        const string secret = "must-not-be-recorded";
+        var appender = new RecordingAuditTrailAppender();
+        var middleware = NewMiddleware(appender);
+        var context = NewContext(
+            new FakeAgentTool("danger", ToolApprovalMode.AlwaysRequire, isDestructive: true),
+            AgentToolExecutionContext.Empty with
+            {
+                Caller = new AgentToolCallerContext("scope-timeout", "owner-timeout", null),
+            });
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            context.Terminate = true;
+            context.TerminationKind = ToolCallTerminationKind.ApprovalTimedOut;
+            context.TerminationReason = $"Approval timed out: {secret}";
+            context.PendingApproval = new ToolApprovalPendingContext(
+                "approval-timeout-1",
+                "danger",
+                "call-timeout",
+                "{}",
+                ToolApprovalMode.AlwaysRequire,
+                IsReadOnly: false,
+                IsDestructive: true);
+            return Task.CompletedTask;
+        });
+
+        var record = appender.Records.Should().ContainSingle().Subject;
+        record.Outcome.Should().Be(AuditOutcome.Error);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.TimedOut);
+        record.Failure.Code.Should().Be("approval_timeout");
+        record.Failure.Category.Should().Be(AuditFailureCategory.Timeout);
+        record.Failure.FailedPhase.Should().Be(AuditLifecyclePhase.WaitingApproval);
+        record.Correlation.ApprovalId.Should().Be("approval-timeout-1");
+        AuditText(record).Should().NotContain(secret);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenReceiptErrorFieldsContainCompactSecrets_ShouldUseOwnedFailureCode()
+    {
+        const string compactSecret = "compactSecretToken123";
+        var appender = new RecordingAuditTrailAppender();
+        var middleware = NewMiddleware(appender);
+        var context = NewContext(
+            new FakeAgentTool("failing_tool"),
+            AgentToolExecutionContext.Empty with
+            {
+                Caller = new AgentToolCallerContext("scope-error", "owner-error", null),
+            });
+
+        await middleware.InvokeAsync(context, () =>
+        {
+            context.Receipt = new AgentToolReceipt
+            {
+                CallId = "call-error",
+                ToolName = "failing_tool",
+                Status = AgentToolReceiptStatus.Error,
+                ErrorCode = compactSecret,
+                ErrorMessage = compactSecret,
+            };
+            return Task.CompletedTask;
+        });
+
+        var record = appender.Records.Should().ContainSingle().Subject;
+        record.ErrorCode.Should().Be("tool_error");
+        record.ErrorSummary.Should().Be("tool_error");
+        record.Failure.Code.Should().Be("tool_error");
+        record.Failure.SanitizedMessage.Should().Be("tool_error");
+        AuditText(record).Should().NotContain(compactSecret);
     }
 
     [Fact]
@@ -322,8 +437,11 @@ public sealed class ToolExecutionAuditMiddlewareTests
         thrown.Which.Should().BeSameAs(exception);
         var record = appender.Records.Should().ContainSingle().Subject;
         record.Outcome.Should().Be(AuditOutcome.Error);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+        record.Failure.Category.Should().Be(AuditFailureCategory.Execution);
         record.ErrorCode.Should().Be("tool_execution_exception");
-        record.ErrorSummary.Should().Be(nameof(InvalidOperationException));
+        record.ErrorSummary.Should().Be("tool_execution_exception");
         AuditText(record).Should().NotContain(secret);
         record.CredentialSource.Should().Be(AuditCredentialSource.BearerToken);
         record.Target.Kind.Should().Be("tool");

--- a/test/Aevatar.Audit.Abstractions.Tests/AuditContractSemanticsTests.cs
+++ b/test/Aevatar.Audit.Abstractions.Tests/AuditContractSemanticsTests.cs
@@ -1,0 +1,53 @@
+using Aevatar.Audit;
+using Aevatar.Audit.Abstractions.Models;
+using Shouldly;
+
+namespace Aevatar.Audit.Abstractions.Tests;
+
+public sealed class AuditContractSemanticsTests
+{
+    [Theory]
+    [InlineData(AuditOutcome.Accepted, AuditLifecyclePhase.Accepted, AuditTerminalOutcome.Unspecified)]
+    [InlineData(AuditOutcome.Success, AuditLifecyclePhase.Terminal, AuditTerminalOutcome.Succeeded)]
+    [InlineData(AuditOutcome.Denied, AuditLifecyclePhase.Terminal, AuditTerminalOutcome.Failed)]
+    [InlineData(AuditOutcome.Error, AuditLifecyclePhase.Terminal, AuditTerminalOutcome.Failed)]
+    [InlineData(AuditOutcome.Cancelled, AuditLifecyclePhase.Terminal, AuditTerminalOutcome.Cancelled)]
+    [InlineData(AuditOutcome.Unspecified, AuditLifecyclePhase.Unspecified, AuditTerminalOutcome.Unspecified)]
+    public void LegacyRecords_MapOnlyUnambiguousLifecycleFacts(
+        AuditOutcome outcome,
+        AuditLifecyclePhase expectedPhase,
+        AuditTerminalOutcome expectedTerminalOutcome)
+    {
+        var record = new AuditRecord { Outcome = outcome };
+
+        AuditContractSemantics.ResolveLifecyclePhase(record).ShouldBe(expectedPhase);
+        AuditContractSemantics.ResolveTerminalOutcome(record).ShouldBe(expectedTerminalOutcome);
+    }
+
+    [Fact]
+    public void ExplicitLifecycleFields_RemainAuthoritative()
+    {
+        var record = new AuditRecord
+        {
+            Outcome = AuditOutcome.Success,
+            LifecyclePhase = AuditLifecyclePhase.WaitingApproval,
+            TerminalOutcome = AuditTerminalOutcome.Unspecified,
+        };
+
+        AuditContractSemantics.ResolveLifecyclePhase(record).ShouldBe(AuditLifecyclePhase.WaitingApproval);
+        AuditContractSemantics.ResolveTerminalOutcome(record).ShouldBe(AuditTerminalOutcome.Unspecified);
+    }
+
+    [Fact]
+    public void CurrentRecordWithoutApplicableLifecycle_DoesNotInferLegacySemantics()
+    {
+        var record = new AuditRecord
+        {
+            SchemaVersion = AuditContractSemantics.CurrentSchemaVersion,
+            Outcome = AuditOutcome.Success,
+        };
+
+        AuditContractSemantics.ResolveLifecyclePhase(record).ShouldBe(AuditLifecyclePhase.Unspecified);
+        AuditContractSemantics.ResolveTerminalOutcome(record).ShouldBe(AuditTerminalOutcome.Unspecified);
+    }
+}

--- a/test/Aevatar.Audit.Abstractions.Tests/AuditRecordProtoTests.cs
+++ b/test/Aevatar.Audit.Abstractions.Tests/AuditRecordProtoTests.cs
@@ -21,8 +21,12 @@ public sealed class AuditRecordProtoTests
         parsed.SensitivityLevel.ShouldBe(AuditSensitivityLevel.Confidential);
         parsed.Outcome.ShouldBe(AuditOutcome.Success);
         parsed.CapturePlane.ShouldBe(AuditCapturePlane.ToolExecution);
+        parsed.LifecyclePhase.ShouldBe(AuditLifecyclePhase.Terminal);
+        parsed.TerminalOutcome.ShouldBe(AuditTerminalOutcome.Succeeded);
+        parsed.SchemaVersion.ShouldBe("1.0");
         parsed.Target.Kind.ShouldBe("workflow");
         parsed.Correlation.RequestId.ShouldBe("req-1");
+        parsed.Correlation.Traceparent.ShouldBe("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
         parsed.CommittedFactRef.CommittedEventId.ShouldBe("event-1");
         parsed.CommittedFactRef.StateVersion.ShouldBe(42);
         parsed.Annotations["risk"].ShouldBe("low");
@@ -70,6 +74,11 @@ public sealed class AuditRecordProtoTests
 
         auditRecordFields.ShouldContain("capture_plane");
         auditRecordFields.ShouldContain("committed_fact_ref");
+        auditRecordFields.ShouldContain("lifecycle_phase");
+        auditRecordFields.ShouldContain("terminal_outcome");
+        auditRecordFields.ShouldContain("failure");
+        auditRecordFields.ShouldContain("provenance");
+        auditRecordFields.ShouldContain("redaction");
         committedFactFields.ShouldBe(
         [
             "committed_event_id",
@@ -86,6 +95,11 @@ public sealed class AuditRecordProtoTests
         {
             AuditId = "audit-1",
             OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:05Z")),
+            RecordedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:06Z")),
+            EventKind = "tools.invoke",
+            Subject = "workflow/wf-1",
+            SchemaVersion = "1.0",
+            Source = "urn:aevatar:audit:tool-execution",
             ScopeId = "scope-1",
             AuditActorId = "audit_actor:hmac-sha256:abc",
             IdentityKeyId = "key-1",
@@ -95,9 +109,18 @@ public sealed class AuditRecordProtoTests
             OperationName = "tools.invoke",
             SensitivityLevel = AuditSensitivityLevel.Confidential,
             Outcome = AuditOutcome.Success,
+            LifecyclePhase = AuditLifecyclePhase.Terminal,
+            TerminalOutcome = AuditTerminalOutcome.Succeeded,
             CapturePlane = AuditCapturePlane.ToolExecution,
             Target = new AuditTarget { Kind = "workflow", Id = "wf-1", DisplayName = "Workflow One" },
-            Correlation = new AuditCorrelation { TraceId = "trace-1", RequestId = "req-1" },
+            Correlation = new AuditCorrelation
+            {
+                TraceId = "0123456789abcdef0123456789abcdef",
+                SpanId = "0123456789abcdef",
+                Traceparent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                RequestId = "req-1",
+                CorrelationId = "corr-1",
+            },
             CommittedFactRef = new AuditCommittedFactReference
             {
                 CommittedEventId = "event-1",
@@ -107,8 +130,22 @@ public sealed class AuditRecordProtoTests
                 StateVersion = 42
             },
             RequestSummary = "started workflow",
-            ResultSummary = "accepted"
+            ResultSummary = "accepted",
+            Provenance = new AuditExecutionProvenance
+            {
+                ScopeId = "scope-1",
+                WorkflowId = "wf-1",
+                ActorId = "actor-1",
+                ActorStateVersion = 42,
+                ActorEventId = "event-1",
+            },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.safe-fields.v1",
+                ValuesSanitized = true,
+            },
         };
+        record.Redaction.OmittedFields.Add("tool.arguments");
         record.Annotations.Add("risk", "low");
         return record;
     }

--- a/test/Aevatar.Audit.Core.Tests/AuditRecordSanitizerTests.cs
+++ b/test/Aevatar.Audit.Core.Tests/AuditRecordSanitizerTests.cs
@@ -70,12 +70,139 @@ public sealed class AuditRecordSanitizerTests
         Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
     }
 
+    [Fact]
+    public void Sanitize_RejectsTerminalLifecycleWithoutExactlyOneTerminalOutcome()
+    {
+        var record = CreateRecord();
+        record.TerminalOutcome = AuditTerminalOutcome.Unspecified;
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+
+        record.LifecyclePhase = AuditLifecyclePhase.Running;
+        record.TerminalOutcome = AuditTerminalOutcome.Succeeded;
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
+    [Fact]
+    public void Sanitize_RequiresStructuredFailureForFailedTerminalRecord()
+    {
+        var record = CreateRecord();
+        record.Outcome = AuditOutcome.Error;
+        record.TerminalOutcome = AuditTerminalOutcome.Failed;
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+
+        record.Failure = new AuditFailure
+        {
+            Code = "execution_failed",
+            Category = AuditFailureCategory.Execution,
+            Retryability = AuditRetryability.Unknown,
+            FailedPhase = AuditLifecyclePhase.Running,
+            SanitizedMessage = "Execution failed.",
+        };
+        new AuditRecordSanitizer().Sanitize(record).Failure.Code.ShouldBe("execution_failed");
+    }
+
+    [Fact]
+    public void Sanitize_RejectsStructuredFailureWithoutSanitizedMessage()
+    {
+        var record = CreateRecord();
+        record.Outcome = AuditOutcome.Error;
+        record.TerminalOutcome = AuditTerminalOutcome.Failed;
+        record.Failure = new AuditFailure
+        {
+            Code = "execution_failed",
+            Category = AuditFailureCategory.Execution,
+            Retryability = AuditRetryability.Unknown,
+            FailedPhase = AuditLifecyclePhase.Running,
+        };
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
+    [Fact]
+    public void Sanitize_AllowsLifecycleAndProvenanceToBeAbsentWhenNotApplicable()
+    {
+        var record = CreateRecord();
+        record.LifecyclePhase = AuditLifecyclePhase.Unspecified;
+        record.TerminalOutcome = AuditTerminalOutcome.Unspecified;
+        record.Provenance = null;
+
+        var sanitized = new AuditRecordSanitizer().Sanitize(record);
+
+        sanitized.LifecyclePhase.ShouldBe(AuditLifecyclePhase.Unspecified);
+        sanitized.Provenance.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Sanitize_RejectsInvalidW3CTraceparent()
+    {
+        var record = CreateRecord();
+        record.Correlation.Traceparent = "not-a-traceparent";
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
+    [Fact]
+    public void Sanitize_RejectsTracestateWithoutTraceparent()
+    {
+        var record = CreateRecord();
+        record.Correlation.Tracestate = "vendor=value";
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
+    [Fact]
+    public void Sanitize_RejectsTraceIdentifiersThatContradictTraceparent()
+    {
+        var record = CreateRecord();
+        record.Correlation.TraceId = "fedcba9876543210fedcba9876543210";
+        record.Correlation.SpanId = "0123456789abcdef";
+        record.Correlation.Traceparent =
+            "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01";
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
+    [Fact]
+    public void Sanitize_RejectsContradictoryExecutionProvenance()
+    {
+        var record = CreateRecord();
+        record.Correlation.CorrelationId = "correlation-1";
+        record.Provenance.CorrelationId = "correlation-2";
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
+    [Fact]
+    public void Sanitize_RejectsSecretBearingStructuredFailure()
+    {
+        var record = CreateRecord();
+        record.Outcome = AuditOutcome.Error;
+        record.TerminalOutcome = AuditTerminalOutcome.Failed;
+        record.Failure = new AuditFailure
+        {
+            Code = "execution_failed",
+            Category = AuditFailureCategory.Execution,
+            Retryability = AuditRetryability.Unknown,
+            FailedPhase = AuditLifecyclePhase.Running,
+            SanitizedMessage = "Bearer must-not-be-stored",
+        };
+
+        Should.Throw<ArgumentException>(() => new AuditRecordSanitizer().Sanitize(record));
+    }
+
     private static AuditRecord CreateRecord()
     {
         return new AuditRecord
         {
             AuditId = "audit-1",
             OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:05Z")),
+            RecordedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:06Z")),
+            EventKind = "api.call",
+            Subject = "service/svc-1",
+            SchemaVersion = "1.0",
+            Source = "urn:aevatar:audit:boundary-endpoint",
             ScopeId = "scope-1",
             AuditActorId = "audit_actor:hmac-sha256:abc",
             IdentityKeyId = "key-1",
@@ -85,9 +212,17 @@ public sealed class AuditRecordSanitizerTests
             OperationName = "api.call",
             SensitivityLevel = AuditSensitivityLevel.Internal,
             Outcome = AuditOutcome.Success,
+            LifecyclePhase = AuditLifecyclePhase.Terminal,
+            TerminalOutcome = AuditTerminalOutcome.Succeeded,
             CapturePlane = AuditCapturePlane.BoundaryEndpoint,
             Target = new AuditTarget { Kind = "service", Id = "svc-1" },
-            Correlation = new AuditCorrelation { RequestId = "req-1" }
+            Correlation = new AuditCorrelation { RequestId = "req-1" },
+            Provenance = new AuditExecutionProvenance { ScopeId = "scope-1" },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.endpoint-safe-fields.v1",
+                ValuesSanitized = true,
+            },
         };
     }
 }

--- a/test/Aevatar.Audit.Core.Tests/InMemoryAuditTrailStoreTests.cs
+++ b/test/Aevatar.Audit.Core.Tests/InMemoryAuditTrailStoreTests.cs
@@ -32,14 +32,18 @@ public sealed class InMemoryAuditTrailStoreTests
     {
         var store = new InMemoryAuditTrailStore();
         var record = CreateRecord("audit-1", "scope-a", "actor-a", "api.call", AuditOutcome.Success);
+        var retry = record.Clone();
+        retry.RecordedAt = Timestamp.FromDateTimeOffset(
+            record.RecordedAt.ToDateTimeOffset().AddMinutes(1));
 
         var first = await store.AppendAsync(record);
-        var second = await store.AppendAsync(record.Clone());
+        var second = await store.AppendAsync(retry);
         var page = await store.QueryAsync(new AuditTrailQuery { Take = 10 });
 
         first.Status.ShouldBe(AuditTrailAppendStatus.Appended);
         second.Status.ShouldBe(AuditTrailAppendStatus.Duplicate);
         page.Records.Select(static item => item.AuditId).ShouldBe(["audit-1"]);
+        page.Records.Single().RecordedAt.ShouldBe(record.RecordedAt);
     }
 
     [Fact]
@@ -92,7 +96,8 @@ public sealed class InMemoryAuditTrailStoreTests
 
         page.Records.Select(static record => record.AuditId).ShouldBe(["audit-2"]);
         page.NextCursor.ShouldBeNull();
-        page.Watermark.ShouldNotBeNull();
+        page.Coverage.IngestionWatermark.ShouldNotBeNull();
+        page.Coverage.SchemaCompatibility.ShouldBe(AuditSchemaCompatibility.Current);
     }
 
     [Theory]
@@ -105,11 +110,15 @@ public sealed class InMemoryAuditTrailStoreTests
     [InlineData("operation_name")]
     [InlineData("operation_kind")]
     [InlineData("outcome")]
+    [InlineData("lifecycle_phase")]
+    [InlineData("terminal_outcome")]
     [InlineData("sensitivity_level")]
     [InlineData("capture_plane")]
     [InlineData("target_kind")]
     [InlineData("target_id")]
     [InlineData("trace_id")]
+    [InlineData("correlation_id")]
+    [InlineData("causation_id")]
     [InlineData("request_id")]
     [InlineData("command_id")]
     [InlineData("call_id")]
@@ -154,10 +163,35 @@ public sealed class InMemoryAuditTrailStoreTests
 
         first.Records.Select(static record => record.AuditId).ShouldBe(["audit-3", "audit-2"]);
         first.NextCursor.ShouldNotBeNull();
-        first.Watermark.ShouldBe(DateTimeOffset.Parse("2026-01-02T03:04:08Z"));
+        first.Coverage.IngestionWatermark.ShouldBe(DateTimeOffset.Parse("2026-01-02T03:04:15Z"));
+        first.Coverage.Truncated.ShouldBeTrue();
         second.Records.Select(static record => record.AuditId).ShouldBe(["audit-1"]);
         second.NextCursor.ShouldBeNull();
-        second.Watermark.ShouldBe(first.Watermark);
+        second.Coverage.IngestionWatermark.ShouldBe(first.Coverage.IngestionWatermark);
+        second.Coverage.Truncated.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task QueryAsync_WhenBoundedWindowExtendsPastIngestionWatermark_ReportsBehindWatermark()
+    {
+        var store = new InMemoryAuditTrailStore();
+        await store.AppendAsync(
+            CreateRecord("audit-1", "scope-a", "actor-a", "api.call", AuditOutcome.Success));
+        var from = DateTimeOffset.Parse("2026-01-02T03:04:00Z");
+        var to = DateTimeOffset.Parse("2026-01-02T03:04:10Z");
+
+        var page = await store.QueryAsync(new AuditTrailQuery
+        {
+            OccurredFrom = from,
+            OccurredTo = to,
+            Take = 10,
+        });
+
+        page.Coverage.RequestedWindow.ShouldBe(new AuditQueryWindow(from, to));
+        page.Coverage.EffectiveWindow.ShouldBe(new AuditQueryWindow(from, to));
+        page.Coverage.IngestionWatermark.ShouldBe(DateTimeOffset.Parse("2026-01-02T03:04:05Z"));
+        page.Coverage.CompleteThrough.ShouldBeNull();
+        page.Coverage.WindowCompleteness.ShouldBe(AuditWindowCompleteness.BehindIngestionWatermark);
     }
 
     [Fact]
@@ -239,10 +273,23 @@ public sealed class InMemoryAuditTrailStoreTests
         AuditOutcome outcome,
         int seconds = 0)
     {
-        return new AuditRecord
+        var occurredAt = DateTimeOffset.Parse("2026-01-02T03:04:05Z").AddSeconds(seconds);
+        var terminalOutcome = outcome switch
+        {
+            AuditOutcome.Success => AuditTerminalOutcome.Succeeded,
+            AuditOutcome.Cancelled => AuditTerminalOutcome.Cancelled,
+            AuditOutcome.Accepted => AuditTerminalOutcome.Unspecified,
+            _ => AuditTerminalOutcome.Failed,
+        };
+        var record = new AuditRecord
         {
             AuditId = auditId,
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:05Z").AddSeconds(seconds)),
+            OccurredAt = Timestamp.FromDateTimeOffset(occurredAt),
+            RecordedAt = Timestamp.FromDateTimeOffset(occurredAt),
+            EventKind = operationName,
+            Subject = $"workflow/wf-{auditId}",
+            SchemaVersion = "1.0",
+            Source = "urn:aevatar:audit:test",
             ScopeId = scopeId,
             AuditActorId = auditActorId,
             IdentityKeyId = "key-1",
@@ -252,6 +299,10 @@ public sealed class InMemoryAuditTrailStoreTests
             OperationName = operationName,
             SensitivityLevel = AuditSensitivityLevel.Confidential,
             Outcome = outcome,
+            LifecyclePhase = outcome == AuditOutcome.Accepted
+                ? AuditLifecyclePhase.Accepted
+                : AuditLifecyclePhase.Terminal,
+            TerminalOutcome = terminalOutcome,
             CapturePlane = operationName.StartsWith("tool.", StringComparison.Ordinal)
                 ? AuditCapturePlane.ToolExecution
                 : AuditCapturePlane.BoundaryEndpoint,
@@ -259,6 +310,8 @@ public sealed class InMemoryAuditTrailStoreTests
             Correlation = new AuditCorrelation
             {
                 TraceId = $"trace-{auditId}",
+                CorrelationId = $"correlation-{auditId}",
+                CausationId = $"causation-{auditId}",
                 RequestId = $"req-{auditId}",
                 CommandId = $"cmd-{auditId}",
                 CallId = $"call-{auditId}",
@@ -275,8 +328,34 @@ public sealed class InMemoryAuditTrailStoreTests
                 StateVersion = seconds == 0 ? 20 : seconds
             },
             RequestSummary = "request summary",
-            ResultSummary = "result summary"
+            ResultSummary = "result summary",
+            Provenance = new AuditExecutionProvenance
+            {
+                ScopeId = scopeId,
+                RunId = $"run-{auditId}",
+                ActorId = $"actor-ref-{auditId}",
+                ActorStateVersion = seconds == 0 ? 20 : seconds,
+                ActorEventId = $"event-{auditId}",
+            },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.test.v1",
+                ValuesSanitized = true,
+            },
         };
+        if (terminalOutcome == AuditTerminalOutcome.Failed)
+        {
+            record.Failure = new AuditFailure
+            {
+                Code = "test_failed",
+                Category = AuditFailureCategory.Execution,
+                Retryability = AuditRetryability.Unknown,
+                FailedPhase = AuditLifecyclePhase.Running,
+                SanitizedMessage = "Test execution failed.",
+            };
+        }
+
+        return record;
     }
 
     private static AuditTrailDocument CreateDocument(string auditId, string contentHash = "content-a") =>
@@ -297,7 +376,7 @@ public sealed class InMemoryAuditTrailStoreTests
             TargetId = $"wf-{auditId}",
             RequestId = $"req-{auditId}",
             CommandId = $"cmd-{auditId}",
-            CorrelationId = $"trace-{auditId}",
+            CorrelationId = $"correlation-{auditId}",
             SessionId = $"session-{auditId}",
             WorkflowRunId = $"run-{auditId}",
             CommittedEventId = $"event-{auditId}",
@@ -309,42 +388,41 @@ public sealed class InMemoryAuditTrailStoreTests
 
     private static AuditRecord CreateFocusedRecord(string auditId)
     {
-        return new AuditRecord
+        var record = CreateRecord(auditId, "scope-match", "actor-match", "tool.match", AuditOutcome.Denied);
+        record.IdentityKeyId = "key-match";
+        record.Target = new AuditTarget { Kind = "workflow", Id = "workflow-match" };
+        record.Subject = "workflow/workflow-match";
+        record.Correlation = new AuditCorrelation
         {
-            AuditId = auditId,
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:05Z")),
-            ScopeId = "scope-match",
-            AuditActorId = "actor-match",
-            IdentityKeyId = "key-match",
-            ActorKind = AuditActorKind.NyxidUser,
-            CredentialSource = AuditCredentialSource.NyxidAssertion,
-            OperationKind = AuditOperationKind.Tool,
-            OperationName = "tool.match",
-            SensitivityLevel = AuditSensitivityLevel.Confidential,
-            Outcome = AuditOutcome.Denied,
-            CapturePlane = AuditCapturePlane.ToolExecution,
-            Target = new AuditTarget { Kind = "workflow", Id = "workflow-match" },
-            Correlation = new AuditCorrelation
-            {
-                TraceId = "trace-match",
-                RequestId = "request-match",
-                CommandId = "command-match",
-                CallId = "call-match",
-                SessionId = "session-match",
-                WorkflowRunId = "workflow-run-match",
-                ApprovalId = "approval-match"
-            },
-            CommittedFactRef = new AuditCommittedFactReference
-            {
-                CommittedEventId = "event-match",
-                ActorId = "committed-actor-match",
-                ActorType = "CommittedActorTypeMatch",
-                EventTypeUrl = "type.googleapis.com/aevatar.audit.MatchEvent",
-                StateVersion = 42
-            },
-            RequestSummary = "request summary",
-            ResultSummary = "result summary"
+            TraceId = "trace-match",
+            CorrelationId = "correlation-match",
+            CausationId = "causation-match",
+            RequestId = "request-match",
+            CommandId = "command-match",
+            CallId = "call-match",
+            SessionId = "session-match",
+            WorkflowRunId = "workflow-run-match",
+            ApprovalId = "approval-match",
         };
+        record.CommittedFactRef = new AuditCommittedFactReference
+        {
+            CommittedEventId = "event-match",
+            ActorId = "committed-actor-match",
+            ActorType = "CommittedActorTypeMatch",
+            EventTypeUrl = "type.googleapis.com/aevatar.audit.MatchEvent",
+            StateVersion = 42,
+        };
+        record.Provenance = new AuditExecutionProvenance
+        {
+            ScopeId = "scope-match",
+            RunId = "workflow-run-match",
+            CorrelationId = "correlation-match",
+            CausationId = "causation-match",
+            ActorId = "committed-actor-match",
+            ActorStateVersion = 42,
+            ActorEventId = "event-match",
+        };
+        return record;
     }
 
     private static AuditTrailQuery BuildSingleFilterQuery(string filterName, AuditRecord decoyRecord)
@@ -361,7 +439,11 @@ public sealed class InMemoryAuditTrailStoreTests
                 new AuditTrailQuery { OccurredTo = DateTimeOffset.Parse("2026-01-02T03:04:05Z"), Take = 10 }),
             "scope_id" => ChangeDecoyAndQuery(
                 decoyRecord,
-                static record => record.ScopeId = "scope-decoy",
+                static record =>
+                {
+                    record.ScopeId = "scope-decoy";
+                    record.Provenance.ScopeId = "scope-decoy";
+                },
                 new AuditTrailQuery { ScopeId = "scope-match", Take = 10 }),
             "audit_actor_id" => ChangeDecoyAndQuery(
                 decoyRecord,
@@ -387,6 +469,25 @@ public sealed class InMemoryAuditTrailStoreTests
                 decoyRecord,
                 static record => record.Outcome = AuditOutcome.Success,
                 new AuditTrailQuery { Outcome = AuditOutcome.Denied, Take = 10 }),
+            "lifecycle_phase" => ChangeDecoyAndQuery(
+                decoyRecord,
+                static record =>
+                {
+                    record.Outcome = AuditOutcome.Accepted;
+                    record.LifecyclePhase = AuditLifecyclePhase.Accepted;
+                    record.TerminalOutcome = AuditTerminalOutcome.Unspecified;
+                    record.Failure = null;
+                },
+                new AuditTrailQuery { LifecyclePhase = AuditLifecyclePhase.Terminal, Take = 10 }),
+            "terminal_outcome" => ChangeDecoyAndQuery(
+                decoyRecord,
+                static record =>
+                {
+                    record.Outcome = AuditOutcome.Cancelled;
+                    record.TerminalOutcome = AuditTerminalOutcome.Cancelled;
+                    record.Failure = null;
+                },
+                new AuditTrailQuery { TerminalOutcome = AuditTerminalOutcome.Failed, Take = 10 }),
             "sensitivity_level" => ChangeDecoyAndQuery(
                 decoyRecord,
                 static record => record.SensitivityLevel = AuditSensitivityLevel.Internal,
@@ -407,6 +508,22 @@ public sealed class InMemoryAuditTrailStoreTests
                 decoyRecord,
                 static record => record.Correlation.TraceId = "trace-decoy",
                 new AuditTrailQuery { TraceId = "trace-match", Take = 10 }),
+            "correlation_id" => ChangeDecoyAndQuery(
+                decoyRecord,
+                static record =>
+                {
+                    record.Correlation.CorrelationId = "correlation-decoy";
+                    record.Provenance.CorrelationId = "correlation-decoy";
+                },
+                new AuditTrailQuery { CorrelationId = "correlation-match", Take = 10 }),
+            "causation_id" => ChangeDecoyAndQuery(
+                decoyRecord,
+                static record =>
+                {
+                    record.Correlation.CausationId = "causation-decoy";
+                    record.Provenance.CausationId = "causation-decoy";
+                },
+                new AuditTrailQuery { CausationId = "causation-match", Take = 10 }),
             "request_id" => ChangeDecoyAndQuery(
                 decoyRecord,
                 static record => record.Correlation.RequestId = "request-decoy",
@@ -425,7 +542,11 @@ public sealed class InMemoryAuditTrailStoreTests
                 new AuditTrailQuery { SessionId = "session-match", Take = 10 }),
             "workflow_run_id" => ChangeDecoyAndQuery(
                 decoyRecord,
-                static record => record.Correlation.WorkflowRunId = "workflow-run-decoy",
+                static record =>
+                {
+                    record.Correlation.WorkflowRunId = "workflow-run-decoy";
+                    record.Provenance.RunId = "workflow-run-decoy";
+                },
                 new AuditTrailQuery { WorkflowRunId = "workflow-run-match", Take = 10 }),
             "approval_id" => ChangeDecoyAndQuery(
                 decoyRecord,
@@ -433,11 +554,19 @@ public sealed class InMemoryAuditTrailStoreTests
                 new AuditTrailQuery { ApprovalId = "approval-match", Take = 10 }),
             "committed_event_id" => ChangeDecoyAndQuery(
                 decoyRecord,
-                static record => record.CommittedFactRef.CommittedEventId = "event-decoy",
+                static record =>
+                {
+                    record.CommittedFactRef.CommittedEventId = "event-decoy";
+                    record.Provenance.ActorEventId = "event-decoy";
+                },
                 new AuditTrailQuery { CommittedEventId = "event-match", Take = 10 }),
             "committed_actor_id" => ChangeDecoyAndQuery(
                 decoyRecord,
-                static record => record.CommittedFactRef.ActorId = "committed-actor-decoy",
+                static record =>
+                {
+                    record.CommittedFactRef.ActorId = "committed-actor-decoy";
+                    record.Provenance.ActorId = "committed-actor-decoy";
+                },
                 new AuditTrailQuery { CommittedActorId = "committed-actor-match", Take = 10 }),
             "committed_actor_type" => ChangeDecoyAndQuery(
                 decoyRecord,
@@ -449,7 +578,11 @@ public sealed class InMemoryAuditTrailStoreTests
                 new AuditTrailQuery { CommittedEventTypeUrl = "type.googleapis.com/aevatar.audit.MatchEvent", Take = 10 }),
             "committed_state_version" => ChangeDecoyAndQuery(
                 decoyRecord,
-                static record => record.CommittedFactRef.StateVersion = 43,
+                static record =>
+                {
+                    record.CommittedFactRef.StateVersion = 43;
+                    record.Provenance.ActorStateVersion = 43;
+                },
                 new AuditTrailQuery { CommittedStateVersion = 42, Take = 10 }),
             _ => throw new ArgumentOutOfRangeException(nameof(filterName), filterName, "Unknown audit query filter.")
         };

--- a/test/Aevatar.Audit.Hosting.Tests/AuditTrailEndpointsTests.cs
+++ b/test/Aevatar.Audit.Hosting.Tests/AuditTrailEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Security.Claims;
+using System.Text.Json;
 using Aevatar.Audit;
 using Aevatar.Audit.Abstractions.Identity;
 using Aevatar.Audit.Abstractions.Models;
@@ -54,8 +55,8 @@ public sealed class AuditTrailEndpointsTests
         query.OccurredTo.Should().BeNull();
         query.Take.Should().Be(500);
         authorizer.Calls.Should().Be(0);
-        body.Should().Contain("queryWatermark").And.Contain("readTimestampUtc").And.Contain("identityKeyId");
-        body.Should().Contain("nextCursor");
+        body.Should().Contain("coverage").And.Contain("ingestionWatermark").And.Contain("identityKeyId");
+        body.Should().Contain("continuationCursor").And.Contain("lifecyclePhase").And.Contain("terminalOutcome");
     }
 
     [Fact]
@@ -260,7 +261,12 @@ public sealed class AuditTrailEndpointsTests
             cursor: " cursor-1 ",
             from: from,
             to: to,
-            take: 25);
+            take: 25,
+            commandId: " command-1 ",
+            workflowRunId: " run-1 ",
+            lifecyclePhase: AuditLifecyclePhase.Terminal,
+            terminalOutcome: AuditTerminalOutcome.Succeeded,
+            correlationId: " correlation-1 ");
         var status = await ExecuteAsync(result, http);
 
         status.Should().Be(StatusCodes.Status200OK);
@@ -271,7 +277,103 @@ public sealed class AuditTrailEndpointsTests
         query.Cursor.Should().Be("cursor-1");
         query.OccurredFrom.Should().Be(from);
         query.OccurredTo.Should().Be(to);
+        query.CommandId.Should().Be("command-1");
+        query.WorkflowRunId.Should().Be("run-1");
+        query.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        query.TerminalOutcome.Should().Be(AuditTerminalOutcome.Succeeded);
+        query.CorrelationId.Should().Be("correlation-1");
         query.Take.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task ExportAuditTrailCloudEvents_ShouldReturnCloudEvents10BatchWithStableAuditData()
+    {
+        var queryPort = new RecordingAuditTrailQueryPort();
+        var http = BuildHttpContext(CallerScope, bearer: "token", queryPort);
+
+        var result = await AuditTrailEndpoints.ExportAuditTrailCloudEvents(
+            http,
+            BuildEndpointDependencies(queryPort),
+            NullLoggerFactory.Instance,
+            commandId: "command-1",
+            lifecyclePhase: AuditLifecyclePhase.Terminal);
+        var (status, body) = await ExecuteWithBodyAsync(result, http);
+
+        status.Should().Be(StatusCodes.Status200OK);
+        http.Response.ContentType.Should().StartWith("application/cloudevents-batch+json");
+        http.Response.Headers["Aevatar-Audit-Truncated"].ToString().Should().Be("true");
+        http.Response.Headers["Aevatar-Audit-Window-Completeness"].ToString().Should().Be("unbounded");
+        http.Response.Headers["Aevatar-Audit-Schema-Compatibility"].ToString().Should().Be("current");
+
+        using var json = JsonDocument.Parse(body);
+        var cloudEvent = json.RootElement.EnumerateArray().Should().ContainSingle().Subject;
+        cloudEvent.GetProperty("specversion").GetString().Should().Be("1.0");
+        cloudEvent.GetProperty("id").GetString().Should().Be("audit-1");
+        cloudEvent.GetProperty("source").GetString().Should().Be("urn:aevatar:audit:projection-artifact");
+        cloudEvent.GetProperty("type").GetString().Should().Be("workflow.run.completed");
+        cloudEvent.GetProperty("subject").GetString().Should().Be("workflow_run/run-1");
+        cloudEvent.GetProperty("dataschema").GetString().Should().Be("https://schemas.aevatar.ai/audit/1.0");
+        cloudEvent.GetProperty("datacontenttype").GetString().Should().Be("application/json");
+        cloudEvent.GetProperty("traceparent").GetString()
+            .Should().Be("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
+        cloudEvent.GetProperty("correlationid").GetString().Should().Be("correlation-1");
+        cloudEvent.GetProperty("data").GetProperty("lifecyclePhase").GetString().Should().Be("terminal");
+        cloudEvent.GetProperty("data").GetProperty("terminalOutcome").GetString().Should().Be("succeeded");
+        Uri.TryCreate(cloudEvent.GetProperty("source").GetString(), UriKind.Absolute, out _).Should().BeTrue();
+        Uri.TryCreate(cloudEvent.GetProperty("dataschema").GetString(), UriKind.Absolute, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task QueryAuditTrail_WhenRecordUsesLegacyContract_ReportsExplicitCompatibilityProjection()
+    {
+        var queryPort = new RecordingAuditTrailQueryPort { ReturnLegacyRecord = true };
+        var http = BuildHttpContext(CallerScope, bearer: "token", queryPort);
+
+        var result = await AuditTrailEndpoints.QueryAuditTrail(
+            http,
+            BuildEndpointDependencies(queryPort),
+            NullLoggerFactory.Instance);
+        var (status, body) = await ExecuteWithBodyAsync(result, http);
+
+        status.Should().Be(StatusCodes.Status200OK);
+        using var json = JsonDocument.Parse(body);
+        var root = json.RootElement;
+        root.GetProperty("coverage").GetProperty("schemaCompatibility").GetString()
+            .Should().Be("contains_legacy_records");
+        var record = root.GetProperty("records").EnumerateArray().Should().ContainSingle().Subject;
+        record.GetProperty("schemaVersion").GetString().Should().Be("legacy-v0");
+        record.GetProperty("schemaCompatibility").GetString().Should().Be("legacy_mapped");
+        record.GetProperty("eventKind").GetString().Should().Be("READ");
+        record.GetProperty("source").GetString().Should().Be("urn:aevatar:audit:legacy");
+        record.GetProperty("lifecyclePhase").GetString().Should().Be("terminal");
+        record.GetProperty("terminalOutcome").GetString().Should().Be("succeeded");
+    }
+
+    [Fact]
+    public async Task QueryAuditTrail_WhenLegacyFailureContainsFreeText_DoesNotExposeUntrustedFields()
+    {
+        var queryPort = new RecordingAuditTrailQueryPort
+        {
+            ReturnLegacyRecord = true,
+            ReturnLegacyFailure = true,
+        };
+        var http = BuildHttpContext(CallerScope, bearer: "token", queryPort);
+
+        var result = await AuditTrailEndpoints.QueryAuditTrail(
+            http,
+            BuildEndpointDependencies(queryPort),
+            NullLoggerFactory.Instance);
+        var (status, body) = await ExecuteWithBodyAsync(result, http);
+
+        status.Should().Be(StatusCodes.Status200OK);
+        body.Should().NotContain("legacy-sensitive");
+        using var json = JsonDocument.Parse(body);
+        var record = json.RootElement.GetProperty("records").EnumerateArray().Should().ContainSingle().Subject;
+        record.TryGetProperty("annotations", out _).Should().BeFalse();
+        record.GetProperty("provenance").ValueKind.Should().Be(JsonValueKind.Null);
+        record.GetProperty("committedFact").ValueKind.Should().Be(JsonValueKind.Null);
+        record.GetProperty("failure").GetProperty("code").GetString().Should().Be("legacy_failure");
+        record.GetProperty("failure").GetProperty("sanitizedMessage").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
     [Fact]
@@ -470,12 +572,17 @@ public sealed class AuditTrailEndpointsTests
             .ToArray();
         routeEndpoints.Select(static endpoint => endpoint.RoutePattern.RawText)
             .Should()
-            .Contain(["/api/audit/trail", "/api/audit/actor-resolutions"]);
+            .Contain(["/api/audit/trail", "/api/audit/trail/cloudevents", "/api/audit/actor-resolutions"]);
         routeEndpoints.Single(static endpoint => endpoint.RoutePattern.RawText == "/api/audit/trail")
             .Metadata
             .GetMetadata<AuditTrailEndpointAuditMetadata>()
             .Should()
             .BeEquivalentTo(new AuditTrailEndpointAuditMetadata("audit-trail", "query-cross-scope", "ADMIN"));
+        routeEndpoints.Single(static endpoint => endpoint.RoutePattern.RawText == "/api/audit/trail/cloudevents")
+            .Metadata
+            .GetMetadata<AuditTrailEndpointAuditMetadata>()
+            .Should()
+            .BeEquivalentTo(new AuditTrailEndpointAuditMetadata("audit-trail", "export-cross-scope", "ADMIN"));
         routeEndpoints.Single(static endpoint => endpoint.RoutePattern.RawText == "/api/audit/actor-resolutions")
             .Metadata
             .GetMetadata<AuditTrailEndpointAuditMetadata>()
@@ -574,29 +681,95 @@ public sealed class AuditTrailEndpointsTests
     {
         public List<AuditTrailQuery> Queries { get; } = [];
 
+        public bool ReturnLegacyRecord { get; init; }
+
+        public bool ReturnLegacyFailure { get; init; }
+
         public Task<AuditTrailPage> QueryAsync(
             AuditTrailQuery query,
             CancellationToken cancellationToken = default)
         {
             Queries.Add(query);
+            var record = new AuditRecord
+            {
+                AuditId = "audit-1",
+                EventKind = "workflow.run.completed",
+                Subject = "workflow_run/run-1",
+                Source = "urn:aevatar:audit:projection-artifact",
+                SchemaVersion = "1.0",
+                ScopeId = query.ScopeId ?? "scope-from-store",
+                AuditActorId = query.AuditActorId ?? "audit_actor:default",
+                IdentityKeyId = "key-1",
+                OperationName = "READ",
+                Outcome = AuditOutcome.Success,
+                LifecyclePhase = AuditLifecyclePhase.Terminal,
+                TerminalOutcome = AuditTerminalOutcome.Succeeded,
+                OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:05Z")),
+                RecordedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:06Z")),
+                Target = new AuditTarget { Kind = "workflow", Id = "wf-1" },
+                Correlation = new AuditCorrelation
+                {
+                    TraceId = "0123456789abcdef0123456789abcdef",
+                    SpanId = "0123456789abcdef",
+                    Traceparent = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
+                    RequestId = "request-1",
+                    CommandId = "command-1",
+                    WorkflowRunId = "run-1",
+                    CorrelationId = "correlation-1",
+                    CausationId = "event-0",
+                },
+                Provenance = new AuditExecutionProvenance
+                {
+                    ScopeId = query.ScopeId ?? "scope-from-store",
+                    RunId = "run-1",
+                    CorrelationId = "correlation-1",
+                },
+                Redaction = new AuditRedaction
+                {
+                    Policy = "aevatar.audit.safe-fields.v1",
+                    ValuesSanitized = true,
+                },
+            };
+            if (ReturnLegacyRecord)
+            {
+                record.EventKind = string.Empty;
+                record.Subject = string.Empty;
+                record.Source = string.Empty;
+                record.SchemaVersion = string.Empty;
+                record.LifecyclePhase = AuditLifecyclePhase.Unspecified;
+                record.TerminalOutcome = AuditTerminalOutcome.Unspecified;
+                record.RecordedAt = null;
+                record.CapturePlane = AuditCapturePlane.Unspecified;
+                record.RequestSummary = "legacy-sensitive-request";
+                record.ResultSummary = "legacy-sensitive-result";
+                record.ErrorSummary = "Bearer legacy-sensitive-token";
+                record.Annotations["raw_body"] = "legacy-sensitive-body";
+                record.Provenance.ActorId = "legacy-sensitive-external-subject";
+                record.CommittedFactRef = new AuditCommittedFactReference
+                {
+                    CommittedEventId = "legacy-event-1",
+                    ActorId = "legacy-sensitive-external-subject",
+                    StateVersion = 1,
+                };
+                if (ReturnLegacyFailure)
+                {
+                    record.Outcome = AuditOutcome.Error;
+                    record.ErrorCode = "legacy-sensitive-error-code";
+                }
+            }
+
             return Task.FromResult(new AuditTrailPage(
-                [
-                    new AuditRecord
-                    {
-                        AuditId = "audit-1",
-                        ScopeId = query.ScopeId ?? "scope-from-store",
-                        AuditActorId = query.AuditActorId ?? "audit_actor:default",
-                        IdentityKeyId = "key-1",
-                        OperationName = "READ",
-                        Outcome = AuditOutcome.Success,
-                        OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-01-02T03:04:05Z")),
-                        Target = new AuditTarget { Kind = "workflow", Id = "wf-1" },
-                        Correlation = new AuditCorrelation { RequestId = "corr-1" },
-                    }
-                ],
+                [record],
                 "cursor-2",
                 DateTimeOffset.Parse("2026-01-02T03:04:07Z"),
-                DateTimeOffset.Parse("2026-01-02T03:04:05Z")));
+                AuditQueryCoverage.Create(
+                    query,
+                    truncated: true,
+                    ingestionWatermark: DateTimeOffset.Parse("2026-01-02T03:04:06Z"),
+                    completeThrough: null,
+                    schemaCompatibility: ReturnLegacyRecord
+                        ? AuditSchemaCompatibility.ContainsLegacyRecords
+                        : AuditSchemaCompatibility.Current)));
         }
     }
 

--- a/test/Aevatar.Bootstrap.Tests/EndpointAuditCaptureMiddlewareTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/EndpointAuditCaptureMiddlewareTests.cs
@@ -40,9 +40,13 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         appender.Records.Should().HaveCount(2);
         appender.Records[0].OperationName.Should().Be("test.widget.create.attempted");
         appender.Records[0].Outcome.Should().Be(AuditOutcome.Accepted);
+        appender.Records[0].LifecyclePhase.Should().Be(AuditLifecyclePhase.Accepted);
+        appender.Records[0].TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
         appender.Records[0].ResultSummary.Should().BeEmpty();
         appender.Records[1].OperationName.Should().Be("test.widget.create");
         appender.Records[1].Outcome.Should().Be(AuditOutcome.Accepted);
+        appender.Records[1].LifecyclePhase.Should().Be(AuditLifecyclePhase.Accepted);
+        appender.Records[1].TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
         appender.Records[1].ResultSummary.Should().Be("status=202");
         appender.Records.Should().OnlyContain(record =>
             record.CapturePlane == AuditCapturePlane.BoundaryEndpoint &&
@@ -53,7 +57,7 @@ public sealed class EndpointAuditCaptureMiddlewareTests
     }
 
     [Fact]
-    public async Task AnnotatedEndpoint_WhenOk_ShouldAppendAcceptedTerminalRecord()
+    public async Task AnnotatedEndpoint_WhenOk_ShouldAppendAcceptedNonterminalRecord()
     {
         var appender = new RecordingAuditTrailAppender();
         await using var app = await CreateHostAsync(appender);
@@ -65,6 +69,8 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         appender.Records.Should().HaveCount(2);
         appender.Records[1].OperationName.Should().Be("test.widget.read");
         appender.Records[1].Outcome.Should().Be(AuditOutcome.Accepted);
+        appender.Records[1].LifecyclePhase.Should().Be(AuditLifecyclePhase.Accepted);
+        appender.Records[1].TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
     }
 
     [Fact]
@@ -81,6 +87,9 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         appender.Records[0].OperationName.Should().Be("test.widget.admin.attempted");
         appender.Records[1].OperationName.Should().Be("test.widget.admin");
         appender.Records[1].Outcome.Should().Be(AuditOutcome.Denied);
+        appender.Records[1].LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        appender.Records[1].TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+        appender.Records[1].Failure.Category.Should().Be(AuditFailureCategory.Authorization);
         appender.Records[1].ErrorCode.Should().Be("authorization_denied");
     }
 
@@ -99,6 +108,9 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         appender.Records[0].Outcome.Should().Be(AuditOutcome.Accepted);
         appender.Records[1].OperationName.Should().Be("test.widget.throw");
         appender.Records[1].Outcome.Should().Be(AuditOutcome.Error);
+        appender.Records[1].LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        appender.Records[1].TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+        appender.Records[1].Failure.Code.Should().Be("endpoint_error");
         appender.Records[1].ErrorCode.Should().Be("endpoint_error");
         appender.Records[1].ErrorSummary.Should().Be(nameof(InvalidOperationException));
     }
@@ -118,6 +130,25 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         appender.Records[1].Outcome.Should().Be(AuditOutcome.Error);
         appender.Records[1].ErrorCode.Should().Be("endpoint_error");
         appender.Records[1].ErrorSummary.Should().Be("status=500");
+    }
+
+    [Fact]
+    public async Task AnnotatedEndpoint_WhenStatusCodeIs504_ShouldRecordConsistentTimeoutFailure()
+    {
+        var appender = new RecordingAuditTrailAppender();
+        await using var app = await CreateHostAsync(appender);
+
+        using var request = AuthenticatedRequest(HttpMethod.Post, "/audited/widgets/widget-1/timeout");
+        var response = await app.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.GatewayTimeout);
+        appender.Records.Should().HaveCount(2);
+        var record = appender.Records[1];
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.TimedOut);
+        record.Failure.Code.Should().Be("endpoint_timeout");
+        record.Failure.Category.Should().Be(AuditFailureCategory.Timeout);
+        record.ErrorCode.Should().Be(record.Failure.Code);
+        record.ErrorSummary.Should().Be(record.Failure.SanitizedMessage);
     }
 
     [Fact]
@@ -299,6 +330,9 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         appender.Records[0].OperationName.Should().Be("test.widget.cancel.attempted");
         appender.Records[1].OperationName.Should().Be("test.widget.cancel");
         appender.Records[1].Outcome.Should().Be(AuditOutcome.Cancelled);
+        appender.Records[1].LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        appender.Records[1].TerminalOutcome.Should().Be(AuditTerminalOutcome.Cancelled);
+        appender.Records[1].Failure.Should().BeNull();
         appender.CancellationStates.Should().Equal(false, false);
     }
 
@@ -454,6 +488,14 @@ public sealed class EndpointAuditCaptureMiddlewareTests
         app.MapPost("/audited/widgets/{widgetId}/fail", () => Results.StatusCode(StatusCodes.Status500InternalServerError))
             .WithEndpointAudit(
                 "test.widget.fail",
+                AuditSensitivityLevel.Confidential,
+                "widget",
+                EndpointAuditTargetResolvers.FromRouteValue("widget", "widgetId"),
+                EndpointAuditSanitizers.WithRouteValues("widgetId"))
+            .RequireAuthorization();
+        app.MapPost("/audited/widgets/{widgetId}/timeout", () => Results.StatusCode(StatusCodes.Status504GatewayTimeout))
+            .WithEndpointAudit(
+                "test.widget.timeout",
                 AuditSensitivityLevel.Confidential,
                 "widget",
                 EndpointAuditTargetResolvers.FromRouteValue("widget", "widgetId"),

--- a/test/Aevatar.CQRS.Projection.Core.Tests/CommittedAuditArtifactMaterializerTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/CommittedAuditArtifactMaterializerTests.cs
@@ -19,7 +19,7 @@ public sealed class CommittedAuditArtifactMaterializerTests
         var materializer = new CommittedAuditArtifactMaterializer<TestContext>(
             new AuditCommittedEventTranslatorRegistry([translator]),
             appender,
-            new FixedClock(DateTimeOffset.Parse("2026-07-03T08:00:00+00:00")));
+            new FixedClock(DateTimeOffset.Parse("2026-07-03T08:02:00+00:00")));
 
         await materializer.ProjectAsync(
             new TestContext(),
@@ -30,7 +30,11 @@ public sealed class CommittedAuditArtifactMaterializerTests
                 new StringValue { Value = "payload" },
                 commandId: "cmd-from-baggage",
                 requestId: "req-from-baggage",
-                correlationId: "corr-1"));
+                correlationId: "corr-1",
+                traceId: "0123456789abcdef0123456789abcdef",
+                spanId: "0123456789abcdef",
+                traceFlags: "01",
+                causationId: "cause-1"));
 
         appender.Records.Should().ContainSingle();
         var record = appender.Records[0];
@@ -38,9 +42,15 @@ public sealed class CommittedAuditArtifactMaterializerTests
         record.OperationKind.Should().Be(AuditOperationKind.System);
         record.CapturePlane.Should().Be(AuditCapturePlane.ProjectionArtifact);
         record.CommittedFactRef.StateVersion.Should().Be(42);
+        record.OccurredAt.ToDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-07-03T08:01:00+00:00"));
+        record.RecordedAt.ToDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-07-03T08:02:00+00:00"));
         record.Correlation.CommandId.Should().Be("cmd-from-baggage");
         record.Correlation.RequestId.Should().Be("req-from-baggage");
-        record.Correlation.TraceId.Should().Be("corr-1");
+        record.Correlation.CorrelationId.Should().Be("corr-1");
+        record.Correlation.TraceId.Should().Be("0123456789abcdef0123456789abcdef");
+        record.Correlation.SpanId.Should().Be("0123456789abcdef");
+        record.Correlation.Traceparent.Should().Be("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
+        record.Correlation.CausationId.Should().Be("cause-1");
         record.ActorKind.Should().Be(AuditActorKind.System);
         record.Annotations["source_event_type_url"].Should().Be(StringValueAuditTranslator.TypeUrl);
     }
@@ -106,7 +116,11 @@ public sealed class CommittedAuditArtifactMaterializerTests
         IMessage payload,
         string commandId = "",
         string requestId = "",
-        string correlationId = "")
+        string correlationId = "",
+        string traceId = "",
+        string spanId = "",
+        string traceFlags = "",
+        string causationId = "")
     {
         var envelope = new EventEnvelope
         {
@@ -115,6 +129,13 @@ public sealed class CommittedAuditArtifactMaterializerTests
             Propagation = new EnvelopePropagation
             {
                 CorrelationId = correlationId,
+                CausationEventId = causationId,
+                Trace = new TraceContext
+                {
+                    TraceId = traceId,
+                    SpanId = spanId,
+                    TraceFlags = traceFlags,
+                },
             },
             Payload = Any.Pack(new CommittedStateEventPublished
             {

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionAuditTrailAppenderTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionAuditTrailAppenderTests.cs
@@ -31,7 +31,7 @@ public sealed class ProjectionAuditTrailAppenderTests
         document.Record.Should().NotBeSameAs(record);
         document.Record.Should().Be(record);
         document.OccurredAt.ToDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-07-03T08:09:10+00:00"));
-        document.UpdatedAt.ToDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-07-03T08:09:10+00:00"));
+        document.UpdatedAt.ToDateTimeOffset().Should().Be(DateTimeOffset.Parse("2026-07-03T08:09:11+00:00"));
         document.AuditActorId.Should().Be("actor-audit-1");
         document.ScopeId.Should().Be("scope-audit-1");
         document.OperationName.Should().Be("audit.operation");
@@ -41,7 +41,8 @@ public sealed class ProjectionAuditTrailAppenderTests
         document.TargetId.Should().Be("target-audit-1");
         document.RequestId.Should().Be("request-audit-1");
         document.CommandId.Should().Be("command-audit-1");
-        document.CorrelationId.Should().Be("trace-audit-1");
+        document.CorrelationId.Should().Be("correlation-audit-1");
+        document.TraceId.Should().Be("trace-audit-1");
         document.SessionId.Should().Be("session-audit-1");
         document.WorkflowRunId.Should().Be("run-audit-1");
         document.CommittedEventId.Should().Be("event-audit-1");
@@ -110,6 +111,29 @@ public sealed class ProjectionAuditTrailAppenderTests
 
         result.Status.Should().Be(AuditTrailAppendStatus.Duplicate);
         result.AuditId.Should().Be("audit-1");
+        store.Documents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AppendAsync_WhenRetryHasLaterRecordedAt_ShouldRemainDuplicate()
+    {
+        var original = CreateRecord("audit-1");
+        var retry = original.Clone();
+        retry.RecordedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-03T08:10:11+00:00"));
+        var store = new RecordingAuditTrailArtifactStore
+        {
+            Existing = new AuditTrailDocument
+            {
+                AuditId = "audit-1",
+                ContentHash = ComputeContentHash(original),
+                Record = original,
+            },
+        };
+        var appender = new ProjectionAuditTrailAppender([store]);
+
+        var result = await appender.AppendAsync(retry);
+
+        result.Status.Should().Be(AuditTrailAppendStatus.Duplicate);
         store.Documents.Should().BeEmpty();
     }
 
@@ -198,6 +222,11 @@ public sealed class ProjectionAuditTrailAppenderTests
         {
             AuditId = auditId,
             OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-03T08:09:10+00:00")),
+            RecordedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-03T08:09:11+00:00")),
+            EventKind = "audit.operation",
+            Subject = $"workflow/target-{auditId}",
+            SchemaVersion = "1.0",
+            Source = "urn:aevatar:audit:projection-artifact",
             ScopeId = $"scope-{auditId}",
             AuditActorId = $"actor-{auditId}",
             IdentityKeyId = "identity-key-1",
@@ -206,6 +235,8 @@ public sealed class ProjectionAuditTrailAppenderTests
             OperationKind = AuditOperationKind.Api,
             OperationName = "audit.operation",
             Outcome = AuditOutcome.Success,
+            LifecyclePhase = AuditLifecyclePhase.Terminal,
+            TerminalOutcome = AuditTerminalOutcome.Succeeded,
             SensitivityLevel = AuditSensitivityLevel.Confidential,
             CapturePlane = AuditCapturePlane.ProjectionArtifact,
             Target = new AuditTarget
@@ -216,6 +247,7 @@ public sealed class ProjectionAuditTrailAppenderTests
             Correlation = new AuditCorrelation
             {
                 TraceId = $"trace-{auditId}",
+                CorrelationId = $"correlation-{auditId}",
                 RequestId = $"request-{auditId}",
                 CommandId = $"command-{auditId}",
                 SessionId = $"session-{auditId}",
@@ -229,10 +261,27 @@ public sealed class ProjectionAuditTrailAppenderTests
                 EventTypeUrl = "type.googleapis.com/aevatar.audit.TestEvent",
                 StateVersion = 42,
             },
+            Provenance = new AuditExecutionProvenance
+            {
+                ScopeId = $"scope-{auditId}",
+                RunId = $"run-{auditId}",
+                ActorId = $"committed-actor-{auditId}",
+                ActorStateVersion = 42,
+                ActorEventId = $"event-{auditId}",
+            },
+            Redaction = new AuditRedaction
+            {
+                Policy = "aevatar.audit.safe-fields.v1",
+                ValuesSanitized = true,
+            },
         };
 
-    private static string ComputeContentHash(AuditRecord record) =>
-        Convert.ToHexString(SHA256.HashData(record.ToByteArray())).ToLowerInvariant();
+    private static string ComputeContentHash(AuditRecord record)
+    {
+        var semanticRecord = record.Clone();
+        semanticRecord.RecordedAt = null;
+        return Convert.ToHexString(SHA256.HashData(semanticRecord.ToByteArray())).ToLowerInvariant();
+    }
 
     private sealed class RecordingAuditTrailArtifactStore : IAuditTrailArtifactStore
     {

--- a/test/Aevatar.Capabilities.Tests/ElasticsearchAuditTrailArtifactStoreTests.cs
+++ b/test/Aevatar.Capabilities.Tests/ElasticsearchAuditTrailArtifactStoreTests.cs
@@ -9,6 +9,7 @@ using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.Mainnet.Host.Api.Hosting;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Capabilities.Tests;
 
@@ -108,14 +109,16 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
     }
 
     [Fact]
-    public async Task QueryAsync_ShouldSearchNewestAuditArtifactsAndReturnCursorAndWatermark()
+    public async Task QueryAsync_ShouldSearchNewestAuditArtifactsAndReturnCursorAndCoverage()
     {
         var handler = new ScriptedHttpMessageHandler();
         handler.EnqueueResponse(_ => CreateJsonResponse(
             HttpStatusCode.OK,
             BuildSearchPayload(
                 BuildDocument("audit-1", "hash-1"),
-                """["2026-07-03T09:00:00Z","audit-1"]""")));
+                """["2026-07-03T09:00:00Z","audit-1"]""",
+                BuildDocument("audit-2", "hash-2"),
+                """["2026-07-03T08:00:00Z","audit-2"]""")));
         using var store = CreateStore(new ElasticsearchProjectionDocumentStoreOptions(), handler);
 
         var page = await ((IAuditTrailQueryPort)store).QueryAsync(new AuditTrailQuery
@@ -125,6 +128,10 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
             IdentityKeyId = "identity-key-1",
             OperationName = "audit.test",
             Outcome = AuditOutcome.Success,
+            LifecyclePhase = AuditLifecyclePhase.Terminal,
+            TerminalOutcome = AuditTerminalOutcome.Succeeded,
+            TraceId = "trace-1",
+            CorrelationId = "correlation-1",
             OccurredFrom = DateTimeOffset.Parse("2026-07-03T00:00:00+00:00"),
             OccurredTo = DateTimeOffset.Parse("2026-07-04T00:00:00+00:00"),
             Take = 1,
@@ -133,7 +140,9 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
         page.Records.Should().ContainSingle()
             .Which.AuditId.Should().Be("audit-1");
         page.NextCursor.Should().NotBeNullOrWhiteSpace();
-        page.Watermark.Should().Be(DateTimeOffset.Parse("2026-07-03T09:00:00Z"));
+        page.Coverage.IngestionWatermark.Should().Be(DateTimeOffset.Parse("2026-07-03T09:01:00Z"));
+        page.Coverage.Truncated.Should().BeTrue();
+        page.Coverage.SchemaCompatibility.Should().Be(AuditSchemaCompatibility.Current);
         handler.CapturedRequests.Should().ContainSingle()
             .Which.PathAndQuery.Should().Be("/audit-tests-audit-trail/_search");
         using var requestBody = JsonDocument.Parse(handler.CapturedRequests[0].Body);
@@ -152,19 +161,34 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
         filterJson.Should().Contain("audit.test");
         filterJson.Should().Contain("artifact.outcome.keyword");
         filterJson.Should().Contain("AUDIT_OUTCOME_SUCCESS");
+        filterJson.Should().Contain("artifact.lifecycle_phase.keyword");
+        filterJson.Should().Contain("AUDIT_LIFECYCLE_PHASE_TERMINAL");
+        filterJson.Should().Contain("artifact.terminal_outcome.keyword");
+        filterJson.Should().Contain("AUDIT_TERMINAL_OUTCOME_SUCCEEDED");
+        filterJson.Should().Contain("artifact.trace_id.keyword");
+        filterJson.Should().Contain("artifact.correlation_id.keyword");
         filterJson.Should().Contain("artifact.occurred_at");
-        requestBody.RootElement.GetProperty("size").GetInt32().Should().Be(1);
+        requestBody.RootElement.GetProperty("size").GetInt32().Should().Be(2);
         var sort = requestBody.RootElement.GetProperty("sort");
         sort[0].GetProperty("artifact.occurred_at").GetProperty("order").GetString().Should().Be("desc");
         sort[1].GetProperty("id.keyword").GetProperty("order").GetString().Should().Be("asc");
         requestBody.RootElement
             .GetProperty("aggs")
-            .GetProperty("query_watermark")
+            .GetProperty("ingestion")
+            .GetProperty("aggs")
+            .GetProperty("watermark")
             .GetProperty("max")
             .GetProperty("field")
             .GetString()
             .Should()
-            .Be("artifact.occurred_at");
+            .Be("artifact.recorded_at");
+        requestBody.RootElement
+            .GetProperty("aggs")
+            .GetProperty("incompatible_schema_records")
+            .GetProperty("filter")
+            .GetRawText()
+            .Should()
+            .Contain(AuditContractSemantics.CurrentSchemaVersion);
     }
 
     [Fact]
@@ -186,6 +210,29 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
             .Should().Be("2026-07-03T09:00:00Z");
         requestBody.RootElement.GetProperty("search_after")[1].GetString()
             .Should().Be("audit-1");
+    }
+
+    [Fact]
+    public async Task QueryAsync_WhenAnyNonCurrentSchemaExists_ShouldReportIncompatible()
+    {
+        var handler = new ScriptedHttpMessageHandler();
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """
+            {
+              "aggregations": {
+                "ingestion": { "watermark": { "value": null } },
+                "incompatible_schema_records": { "doc_count": 1 },
+                "legacy_schema_records": { "doc_count": 0 }
+              },
+              "hits": { "hits": [] }
+            }
+            """));
+        using var store = CreateStore(new ElasticsearchProjectionDocumentStoreOptions(), handler);
+
+        var page = await ((IAuditTrailQueryPort)store).QueryAsync(new AuditTrailQuery());
+
+        page.Coverage.SchemaCompatibility.Should().Be(AuditSchemaCompatibility.Incompatible);
     }
 
     [Fact]
@@ -222,24 +269,38 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
             AuditId = auditId,
             ContentHash = contentHash,
             OperationName = "audit.test",
+            EventKind = "audit.test",
+            SchemaVersion = "1.0",
+            LifecyclePhase = AuditLifecyclePhase.Terminal,
+            TerminalOutcome = AuditTerminalOutcome.Succeeded,
+            Subject = "test-target/target-1",
+            Source = "urn:aevatar:audit:test",
             ScopeId = "scope-1",
             TargetKind = "test-target",
             TargetId = "target-1",
             Record = new AuditRecord
             {
                 AuditId = auditId,
+                EventKind = "audit.test",
+                Subject = "test-target/target-1",
+                SchemaVersion = "1.0",
+                Source = "urn:aevatar:audit:test",
                 OperationName = "audit.test",
                 ScopeId = "scope-1",
                 AuditActorId = "audit_actor:abc",
                 IdentityKeyId = "identity-key-1",
                 Outcome = AuditOutcome.Success,
+                LifecyclePhase = AuditLifecyclePhase.Terminal,
+                TerminalOutcome = AuditTerminalOutcome.Succeeded,
                 Target = new AuditTarget
                 {
                     Kind = "test-target",
                     Id = "target-1",
                 },
+                Correlation = new AuditCorrelation { CorrelationId = "correlation-1" },
             },
             OccurredAtDateTimeOffset = DateTimeOffset.Parse("2026-07-03T09:00:00+00:00"),
+            RecordedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-03T09:01:00+00:00")),
             UpdatedAtDateTimeOffset = DateTimeOffset.Parse("2026-07-03T09:01:00+00:00"),
         };
     }
@@ -255,18 +316,27 @@ public sealed class ElasticsearchAuditTrailArtifactStoreTests
         return "{\"_source\":" + formatter.Format(storageDocument) + "}";
     }
 
-    private static string BuildSearchPayload(AuditTrailDocument document, string sortJson)
+    private static string BuildSearchPayload(
+        AuditTrailDocument firstDocument,
+        string firstSortJson,
+        AuditTrailDocument secondDocument,
+        string secondSortJson)
     {
-        var storageDocument = AuditTrailArtifactStorageDocument.FromArtifact(document);
+        var firstStorageDocument = AuditTrailArtifactStorageDocument.FromArtifact(firstDocument);
+        var secondStorageDocument = AuditTrailArtifactStorageDocument.FromArtifact(secondDocument);
         var formatter = new JsonFormatter(
             JsonFormatter.Settings.Default
                 .WithPreserveProtoFieldNames(true)
                 .WithFormatDefaultValues(true));
 
-        return "{\"aggregations\":{\"query_watermark\":{\"value\":1783069200000,\"value_as_string\":\"2026-07-03T09:00:00.000Z\"}},\"hits\":{\"hits\":[{\"_source\":"
-            + formatter.Format(storageDocument)
+        return "{\"aggregations\":{\"ingestion\":{\"watermark\":{\"value\":1783069260000,\"value_as_string\":\"2026-07-03T09:01:00.000Z\"}},\"incompatible_schema_records\":{\"doc_count\":0},\"legacy_schema_records\":{\"doc_count\":0}},\"hits\":{\"hits\":[{\"_source\":"
+            + formatter.Format(firstStorageDocument)
             + ",\"sort\":"
-            + sortJson
+            + firstSortJson
+            + "},{\"_source\":"
+            + formatter.Format(secondStorageDocument)
+            + ",\"sort\":"
+            + secondSortJson
             + "}]}}";
     }
 

--- a/test/Aevatar.Capabilities.Tests/MainnetHealthEndpointsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHealthEndpointsTests.cs
@@ -173,7 +173,12 @@ public sealed class MainnetHealthEndpointsTests
                 [],
                 null,
                 DateTimeOffset.UnixEpoch,
-                DateTimeOffset.UnixEpoch));
+                AuditQueryCoverage.Create(
+                    query,
+                    truncated: false,
+                    ingestionWatermark: null,
+                    completeThrough: null,
+                    schemaCompatibility: AuditSchemaCompatibility.Current)));
         }
     }
 

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCommittedAuditTranslatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCommittedAuditTranslatorTests.cs
@@ -87,7 +87,7 @@ public sealed class ServiceCommittedAuditTranslatorTests
         var record = Translate(translator, evt);
 
         record.OperationName.Should().Be(operationName);
-        record.Outcome.Should().Be(AuditOutcome.Success);
+        AssertLifecycle(record, translator);
         record.ActorKind.Should().Be(AuditActorKind.System);
         record.Target.Kind.Should().Be(targetKind);
         record.Target.Id.Should().Be(targetId);
@@ -95,7 +95,8 @@ public sealed class ServiceCommittedAuditTranslatorTests
         record.SensitivityLevel.Should().Be(expected.SensitivityLevel);
         record.Correlation.CommandId.Should().Be(expected.CommandId);
         record.Correlation.RequestId.Should().Be(expected.RequestId);
-        record.Correlation.TraceId.Should().Be("corr-1");
+        record.Correlation.TraceId.Should().BeEmpty();
+        record.Correlation.CorrelationId.Should().Be("corr-1");
         record.CommittedFactRef.StateVersion.Should().Be(17);
         AssertDestructiveAnnotation(record, expected.IsDestructive);
         AssertAnnotations(record, expected.Annotations);
@@ -136,7 +137,9 @@ public sealed class ServiceCommittedAuditTranslatorTests
         record.ScopeId.Should().Be("scope-1");
         record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Confidential);
         record.Correlation.CommandId.Should().Be("cmd-run");
-        record.Correlation.TraceId.Should().Be("corr-run");
+        record.Correlation.CorrelationId.Should().Be("corr-run");
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Succeeded);
         record.Annotations.Should().Contain("service_id", "svc-a");
         record.Annotations.Should().Contain("status", "completed");
         record.Annotations.Should().Contain("target_actor_id", "target-1");
@@ -144,14 +147,14 @@ public sealed class ServiceCommittedAuditTranslatorTests
     }
 
     [Fact]
-    public void ServiceRunStatusUpdatedTranslator_ShouldRecordStatusAndSafeErrorClassWithoutBody()
+    public void ServiceRunStatusUpdatedTranslator_ShouldRecordStatusWithoutErrorBody()
     {
         var evt = new ServiceRunStatusUpdatedEvent
         {
             RunId = "run-1",
             Status = ServiceRunStatus.Failed,
             LastOutput = "sensitive business output body",
-            LastError = "System.InvalidOperationException: secret detail must not leak",
+            LastError = "compactSecretToken123",
         };
 
         var record = Translate(new ServiceRunStatusUpdatedAuditTranslator(), evt);
@@ -161,10 +164,14 @@ public sealed class ServiceCommittedAuditTranslatorTests
         record.Target.Id.Should().Be("run-1");
         record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Confidential);
         record.Annotations.Should().Contain("status", "failed");
-        record.Annotations.Should().Contain("error_class", "System.InvalidOperationException");
+        record.Outcome.Should().Be(AuditOutcome.Error);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+        record.Failure.Code.Should().Be("service_run_failed");
+        record.Annotations.Should().NotContainKey("error_class");
         record.Annotations.Should().NotContainKey("last_output");
         record.Annotations.Should().NotContainKey("last_error");
-        record.Annotations.Values.Should().NotContain(value => value.Contains("secret detail", StringComparison.Ordinal));
+        record.ToString().Should().NotContain("compactSecretToken123");
         record.Annotations.Values.Should().NotContain(value => value.Contains("business output", StringComparison.Ordinal));
         record.ResultSummary.Should().NotContain("business output");
     }
@@ -188,19 +195,21 @@ public sealed class ServiceCommittedAuditTranslatorTests
         record.Target.Id.Should().Be("actor-1");
         record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Confidential);
         record.Correlation.CommandId.Should().Be("cmd-fire");
-        record.Correlation.TraceId.Should().Be("corr-fire");
+        record.Correlation.CorrelationId.Should().Be("corr-fire");
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Accepted);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
         record.Annotations.Should().Contain("target_actor_id", "target-1");
         record.Annotations.Should().Contain("idempotency_key", "idem-1");
         record.Annotations.Should().Contain("manual", "true");
     }
 
     [Fact]
-    public void ScheduledDispatchFireFailedTranslator_ShouldRecordSafeErrorClassWithoutBody()
+    public void ScheduledDispatchFireFailedTranslator_ShouldOmitErrorBody()
     {
         var evt = new ScheduledDispatchFireFailedEvent
         {
             IdempotencyKey = "idem-1",
-            Error = "System.TimeoutException: downstream secret payload should not leak",
+            Error = "compactSecretToken123",
             Manual = false,
         };
 
@@ -210,10 +219,13 @@ public sealed class ServiceCommittedAuditTranslatorTests
         record.Target.Kind.Should().Be("scheduled_dispatch");
         record.Target.Id.Should().Be("actor-1");
         record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Confidential);
-        record.Annotations.Should().Contain("error_class", "System.TimeoutException");
+        record.Annotations.Should().NotContainKey("error_class");
         record.Annotations.Should().Contain("idempotency_key", "idem-1");
         record.Annotations.Should().Contain("manual", "false");
-        record.Annotations.Values.Should().NotContain(value => value.Contains("secret payload", StringComparison.Ordinal));
+        record.Outcome.Should().Be(AuditOutcome.Error);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+        record.Failure.Code.Should().Be("scheduled_dispatch_failed");
+        record.ToString().Should().NotContain("compactSecretToken123");
     }
 
     [Fact]
@@ -319,7 +331,6 @@ public sealed class ServiceCommittedAuditTranslatorTests
                     new Dictionary<string, string>(StringComparer.Ordinal)
                     {
                         ["credential_kid"] = "kid-1",
-                        ["error_summary"] = "provider rejected",
                     })),
         ];
         yield return
@@ -636,7 +647,6 @@ public sealed class ServiceCommittedAuditTranslatorTests
                     new Dictionary<string, string>(StringComparer.Ordinal)
                     {
                         ["rollout_id"] = "rollout-1",
-                        ["failure_reason"] = "activation error",
                     })),
         ];
         yield return
@@ -772,6 +782,36 @@ public sealed class ServiceCommittedAuditTranslatorTests
     {
         foreach (var annotation in expectedAnnotations)
             record.Annotations.Should().Contain(annotation.Key, annotation.Value);
+    }
+
+    private static void AssertLifecycle(AuditRecord record, IAuditCommittedEventTranslator translator)
+    {
+        if (translator is ServiceRegistrationFailedAuditTranslator or ServiceRolloutFailedAuditTranslator)
+        {
+            record.Outcome.Should().Be(AuditOutcome.Error);
+            record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+            record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+            record.Failure.Should().NotBeNull();
+            record.Failure.SanitizedMessage.Should().Be(record.Failure.Code);
+            record.Annotations.Should().NotContainKey("error_summary");
+            record.Annotations.Should().NotContainKey("failure_reason");
+            return;
+        }
+
+        if (translator is ServiceRolloutStartedAuditTranslator or
+            ServiceRolloutStageAdvancedAuditTranslator or
+            ServiceRolloutPausedAuditTranslator or
+            ServiceRolloutResumedAuditTranslator)
+        {
+            record.Outcome.Should().Be(AuditOutcome.Accepted);
+            record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Running);
+            record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
+            return;
+        }
+
+        record.Outcome.Should().Be(AuditOutcome.Success);
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Succeeded);
     }
 
     private static AuditRecord Translate(IAuditCommittedEventTranslator translator, IMessage evt)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationAuditTranslatorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationAuditTranslatorTests.cs
@@ -62,7 +62,8 @@ public sealed class ChannelRegistrationAuditTranslatorTests
         record.SensitivityLevel.Should().Be(expected.SensitivityLevel);
         record.Correlation.CommandId.Should().Be("cmd-1");
         record.Correlation.RequestId.Should().Be("req-1");
-        record.Correlation.TraceId.Should().Be("corr-1");
+        record.Correlation.TraceId.Should().BeEmpty();
+        record.Correlation.CorrelationId.Should().Be("corr-1");
         record.CommittedFactRef.StateVersion.Should().Be(5);
         AssertDestructiveAnnotation(record, expected.IsDestructive);
         foreach (var annotation in expected.Annotations)

--- a/test/Aevatar.Studio.Tests/StudioAuditTranslatorTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioAuditTranslatorTests.cs
@@ -85,7 +85,24 @@ public sealed class StudioAuditTranslatorTests
         var record = translator.Translate(Context(), Any.Pack(evt)).Should().ContainSingle().Subject;
 
         record.OperationName.Should().Be(operationName);
-        record.Outcome.Should().Be(AuditOutcome.Success);
+        if (translator is StudioMemberBindingFailedAuditTranslator or StudioMemberBindingRejectedAuditTranslator)
+        {
+            record.Outcome.Should().Be(AuditOutcome.Error);
+            record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Failed);
+            record.Failure.Should().NotBeNull();
+            record.Annotations.Should().NotContainKey("failure_code");
+            record.Annotations.Should().NotContainKey("failure_message");
+            record.Failure.Code.Should().Be(translator is StudioMemberBindingFailedAuditTranslator
+                ? "studio_member_binding_failed"
+                : "studio_member_binding_rejected");
+            record.ToString().Should().NotContain("compactSecretToken123");
+        }
+        else
+        {
+            record.Outcome.Should().Be(AuditOutcome.Success);
+            record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Succeeded);
+        }
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
         record.ActorKind.Should().Be(AuditActorKind.System);
         record.Target.Kind.Should().Be(targetKind);
         record.Target.Id.Should().Be(targetId);
@@ -93,7 +110,8 @@ public sealed class StudioAuditTranslatorTests
         record.SensitivityLevel.Should().Be(expected.SensitivityLevel);
         record.Correlation.CommandId.Should().Be("cmd-1");
         record.Correlation.RequestId.Should().Be("req-1");
-        record.Correlation.TraceId.Should().Be("corr-1");
+        record.Correlation.TraceId.Should().BeEmpty();
+        record.Correlation.CorrelationId.Should().Be("corr-1");
         record.CommittedFactRef.StateVersion.Should().Be(9);
         AssertDestructiveAnnotation(record, expected.IsDestructive);
         foreach (var annotation in expected.Annotations)
@@ -300,7 +318,11 @@ public sealed class StudioAuditTranslatorTests
             new StudioMemberBindingFailedEvent
             {
                 BindingRunId = "run-1",
-                Failure = new StudioMemberBindingFailure { Code = "ERR", Message = "boom" },
+                Failure = new StudioMemberBindingFailure
+                {
+                    Code = "compactSecretToken123",
+                    Message = "compactSecretToken123",
+                },
             },
             "studio.member.binding.failed",
             "studio_member",
@@ -312,8 +334,6 @@ public sealed class StudioAuditTranslatorTests
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     ["binding_run_id"] = "run-1",
-                    ["failure_code"] = "ERR",
-                    ["failure_message"] = "boom",
                 }),
         ];
         yield return
@@ -324,7 +344,11 @@ public sealed class StudioAuditTranslatorTests
                 BindingRunId = "run-1",
                 ScopeId = "scope-alpha",
                 MemberId = "m-alpha",
-                Failure = new StudioMemberBindingFailure { Code = "STALE", Message = "rejected" },
+                Failure = new StudioMemberBindingFailure
+                {
+                    Code = "compactSecretToken123",
+                    Message = "compactSecretToken123",
+                },
             },
             "studio.member.binding.rejected",
             "studio_member",
@@ -336,8 +360,6 @@ public sealed class StudioAuditTranslatorTests
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     ["binding_run_id"] = "run-1",
-                    ["failure_code"] = "STALE",
-                    ["failure_message"] = "rejected",
                 }),
         ];
         yield return

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanApprovalResolvedAuditTranslatorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanApprovalResolvedAuditTranslatorTests.cs
@@ -1,9 +1,11 @@
 using Aevatar.Audit;
 using Aevatar.Audit.Abstractions.CommittedFacts;
 using Aevatar.Audit.Core.CommittedFacts;
+using Aevatar.Audit.Core.Sanitization;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Projection;
 using Aevatar.Workflow.Projection.Audit;
 using Aevatar.Workflow.Projection.DependencyInjection;
@@ -65,6 +67,7 @@ public sealed class WorkflowHumanApprovalResolvedAuditTranslatorTests
         record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Restricted);
         record.Target.Kind.Should().Be("workflow_run");
         record.Target.Id.Should().Be("run-1");
+        record.ScopeId.Should().Be("scope-context");
         record.Annotations.Should().Contain("approved", approved ? "true" : "false");
         record.Annotations.Should().Contain("resolution_source", expectedSourceLabel);
         record.Annotations.Should().Contain("step_id", "step-7");
@@ -73,6 +76,7 @@ public sealed class WorkflowHumanApprovalResolvedAuditTranslatorTests
         // The approval payload must never enter the audit artifact.
         var serialized = record.ToString();
         serialized.Should().NotContain("SENSITIVE");
+        new AuditRecordSanitizer().Sanitize(record).Should().NotBeNull();
     }
 
     [Fact]
@@ -118,7 +122,13 @@ public sealed class WorkflowHumanApprovalResolvedAuditTranslatorTests
                     CorrelationId = "corr-1",
                 },
             },
-            new CommittedStateEventPublished(),
+            new CommittedStateEventPublished
+            {
+                StateRoot = Any.Pack(new WorkflowRunState
+                {
+                    ScopeId = "scope-context",
+                }),
+            },
             new StateEvent
             {
                 AgentId = "workflow-run-actor-1",

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunAuditCommittedEventTranslatorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunAuditCommittedEventTranslatorTests.cs
@@ -1,9 +1,11 @@
 using Aevatar.Audit;
 using Aevatar.Audit.Abstractions.CommittedFacts;
 using Aevatar.Audit.Core.CommittedFacts;
+using Aevatar.Audit.Core.Sanitization;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Projection;
 using Aevatar.Workflow.Projection.Audit;
 using Aevatar.Workflow.Projection.DependencyInjection;
@@ -71,6 +73,8 @@ public sealed class WorkflowRunAuditCommittedEventTranslatorTests
         record.Target.Kind.Should().Be("workflow_run");
         record.Target.Id.Should().Be("run-1");
         record.ScopeId.Should().Be("scope-1");
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Running);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
         record.Annotations.Should().Contain("workflow_name", "daily-report");
         record.Annotations.Should().Contain("definition_actor_id", "def-actor-1");
         record.Annotations.Should().Contain("attempt", "2");
@@ -96,11 +100,21 @@ public sealed class WorkflowRunAuditCommittedEventTranslatorTests
         record.OperationName.Should().Be("workflow.run.completed");
         record.SensitivityLevel.Should().Be(AuditSensitivityLevel.Confidential);
         record.Target.Id.Should().Be("run-2");
+        record.ScopeId.Should().Be("scope-context");
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(success
+            ? AuditTerminalOutcome.Succeeded
+            : AuditTerminalOutcome.Failed);
+        if (success)
+            record.Failure.Should().BeNull();
+        else
+            record.Failure.Code.Should().Be("workflow_failed");
         record.Annotations.Should().Contain("outcome", expectedOutcome);
         record.Annotations.Should().Contain("error_present", expectedErrorPresent);
         record.Annotations.Should().NotContainKey("output");
         record.Annotations.Should().NotContainKey("error");
         record.ToString().Should().NotContain("SENSITIVE");
+        new AuditRecordSanitizer().Sanitize(record).Should().NotBeNull();
     }
 
     [Fact]
@@ -117,6 +131,9 @@ public sealed class WorkflowRunAuditCommittedEventTranslatorTests
 
         record.OperationName.Should().Be("workflow.run.stopped");
         record.Target.Id.Should().Be("run-3");
+        record.ScopeId.Should().Be("scope-context");
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Terminal);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Cancelled);
         record.Annotations.Should().Contain("reason", "cancelled-by-user");
         record.Annotations.Should().NotContainKey("is_destructive");
     }
@@ -134,6 +151,7 @@ public sealed class WorkflowRunAuditCommittedEventTranslatorTests
 
         record.OperationName.Should().Be("workflow.run.stopped-run");
         record.Target.Id.Should().Be("run-4");
+        record.ScopeId.Should().Be("scope-context");
         record.Annotations.Should().Contain("reason", "superseded");
     }
 
@@ -152,6 +170,8 @@ public sealed class WorkflowRunAuditCommittedEventTranslatorTests
 
         record.OperationName.Should().Be("workflow.run.fork-requested");
         record.Target.Id.Should().Be("run-5");
+        record.LifecyclePhase.Should().Be(AuditLifecyclePhase.Accepted);
+        record.TerminalOutcome.Should().Be(AuditTerminalOutcome.Unspecified);
         record.ScopeId.Should().Be("scope-5");
         record.Annotations.Should().Contain("start_at_step_id", "step-9");
         record.Annotations.Should().Contain("attempt", "3");
@@ -230,7 +250,13 @@ public sealed class WorkflowRunAuditCommittedEventTranslatorTests
                     CorrelationId = "corr-1",
                 },
             },
-            new CommittedStateEventPublished(),
+            new CommittedStateEventPublished
+            {
+                StateRoot = Any.Pack(new WorkflowRunState
+                {
+                    ScopeId = "scope-context",
+                }),
+            },
             new StateEvent
             {
                 AgentId = "workflow-run-actor-1",


### PR DESCRIPTION
## Problem

Audit consumers could not reliably distinguish accepted work, active execution, approval waits, terminal outcomes, and failures without interpreting legacy status fields or free-form text. Query responses also lacked explicit bounded-window coverage and an interoperable export representation.

## Solution

- Extend the versioned Protobuf audit contract with lifecycle phase, terminal outcome, structured failure, execution provenance, W3C Trace Context correlation, redaction metadata, stable source/subject identities, and separate occurrence/recording timestamps.
- Map endpoint, tool, workflow, scripting, Studio, and service producers to producer-owned lifecycle facts while excluding raw prompts, payloads, tool results, third-party responses, and free-form error bodies.
- Add bounded query coverage, schema compatibility reporting, lifecycle/correlation filters, stable duplicate hashing, and Elasticsearch ingestion-watermark semantics.
- Add a CloudEvents 1.0 JSON batch export at `/api/audit/trail/cloudevents` while retaining the durable audit artifact as the authority.
- Keep pre-versioned records readable through an explicit, read-only legacy projection without writing compatibility data back to storage.

## Impact

The change updates audit abstractions, sanitization and materialization, producer translators, the audit HTTP capability, Elasticsearch query behavior, existing canon documentation, and focused contract/integration tests. It does not add a second projection rail or make telemetry authoritative.

## Verification

- `bash tools/ci/architecture_guards.sh` - passed, including 15/15 architecture tests.
- `bash tools/ci/query_projection_priming_guard.sh` - passed.
- `bash tools/ci/test_stability_guards.sh` - passed.
- `bash tools/docs/lint.sh` - passed, 76 files checked.
- `git diff --check origin/feature/integrate...HEAD` - passed.
- `dotnet test aevatar.slnx --nologo --no-restore` - passed with exit code 0; environment-gated external integration tests retained their existing skips.

Fixes #2787

⟦AI:FKST⟧
