### PR TITLE
为 Ornn 技能发布增加精确版本校验

### DIFF
--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -164,6 +164,16 @@ chat-route policy 指定 `tool_set_ref` 或 `tool_choice_hint` 时，三条直�
 
 直连工具的失败语义按边界分层处理。客户端声明但不属于 Aevatar substitute 或 additive 的 forwarded tools 仍然由客户端执行；这类工具不会在 Aevatar 内被降级。只要某个工具名来自 Aevatar-owned substitute/additive discovery，即使客户端也声明了同名工具，该名称也会作为 `owned_tool_names` 写入 run command，并由运行时作为 deny-forward 边界处理，不能被转成 forwarded tool call。Aevatar 本地 direct tools 执行失败时，actor 会把失败转成合法 JSON tool output，并继续把结果送回模型，避免一个可选本地工具异常终止整次 response。该 JSON 只暴露稳定错误码、工具名和异常类型，不透出 token、请求头或内部路径。调用方取消仍然取消整次 run，不会被转成 tool output。chat-route `tool_set_ref` 解析错误仍然 fail closed 返回配置错误；但已经解析出的 tool source、全局 provider、skills/Ornn discovery 如果单个 source 失败，会记录 warning 并跳过该 source，其他可用工具继续进入本次计划。
 
+### 5.1 Ordinary discovery 与 curated exact read
+
+`use_skill`、skill recovery、搜索和系统 overlay 继续使用 ordinary name-or-ID 读取。这条路径服务发现与普通执行，允许按名称读取当前版本，属于 normal trust；它不会因为名称、`@1.1` member 文本或当前 overlay 配置自动获得 curated trust。
+
+需要审核不可变发布证据的调用方必须使用独立的 exact port，并提交 Protobuf `ExactRemoteSkillRef` 或 `ExactRemoteSkillsetRef`。两种引用都只有 GUID 和 literal `major.minor` version，没有 name、dist-tag、latest 或 hash fallback。Exact skill 固定并发读取 versioned package、versioned detail 和 GUID-scoped versions；exact skillset 固定并发读取 versioned detail、versioned closure 和 GUID-scoped versions。三份响应必须在同一个 30 秒预算内完成并互相一致，任何缺失、重复、解析失败或身份/版本/名称/closure 差异都会失败关闭，不追加第四个 name/latest 请求。
+
+读取在反序列化前受限：skill package 原始 JSON 最大 100 MiB，其余五类证据各最大 25 MiB，同时检查 `Content-Length` 与实际流字节。解码后的 skill package 最多 1000 个文件、规范相对路径最多 512 UTF-8 bytes、单文件最多 25 MiB、文件总量最多 50 MiB、声明工具最多 50 个；skillset direct members 最多 100 个，closure 最多 500 个节点。调用方审核的 bounds 只能进一步收紧这些上限。
+
+Version row 的 publisher snapshot 完整保留 `createdBy`、可选 `createdByEmail`、可选 `createdByDisplayName` 与 `createdOn`。只有稳定 subject id 表示发布者身份；email 和 display name 只是该 immutable version 的展示快照，参与完整性比较但不授予权限。`metadata.tools` 同样只是待审核的 package 声明，不会注册或授权工具。Ornn 的 `skillHash/integrity` 覆盖原始 ZIP，而 exact package 返回解包后的 JSON files，因此二者只在 adapter 内用于跨响应一致性检查，不作为调用方的 JSON 内容 hash pin。
+
 ## 6. 显式 Skill 触发
 
 直连入口支持同一套显式 skill 触发语法：

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -392,6 +392,16 @@ message SystemSkillOverlay {
   int64 materialized_at = 3;
 }
 
+message ExactRemoteSkillRef {
+  string guid = 1;
+  string literal_version = 2;
+}
+
+message ExactRemoteSkillsetRef {
+  string guid = 1;
+  string literal_version = 2;
+}
+
 // Retired (issue #2498): no longer emitted — the overlay is sourced by the host-level provider, not
 // materialized per-actor. Kept defined so historical journals / queued durable timeouts still
 // deserialize and replay through their no-op handlers. Remove in a later release once no grain journal

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
@@ -10,7 +10,7 @@ namespace Aevatar.AI.ToolProviders.Ornn;
 /// <summary>
 /// Ornn 远程技能拉取器。通过 OrnnSkillClient 从 Ornn 平台获取技能。
 /// </summary>
-public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
+public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher, IExactRemoteSkillFetcher
 {
     private readonly OrnnSkillClient _client;
     private static readonly char[] PathSeparators = ['/', '\\'];
@@ -23,6 +23,44 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         var skill = await _client.GetSkillJsonAsync(accessToken, nameOrId, ct);
         if (skill == null)
             return null;
+
+        return MapSkill(skill, nameOrId);
+    }
+
+    public async Task<ExactRemoteSkillRelease> FetchExactSkillAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        var evidence = await _client.GetExactSkillAsync(accessToken, reference, ct);
+        return new ExactRemoteSkillRelease(
+            reference.Clone(),
+            evidence.PublishedName,
+            evidence.Provenance,
+            evidence.ExactPackage,
+            evidence.DeclaredTools,
+            MapSkill(evidence.Package, reference.Guid));
+    }
+
+    public async Task<ExactRemoteSkillsetRelease> FetchExactSkillsetAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        var evidence = await _client.GetExactSkillsetAsync(accessToken, reference, ct);
+        return new ExactRemoteSkillsetRelease(
+            reference.Clone(),
+            evidence.PublishedName,
+            evidence.Provenance,
+            evidence.Instructions,
+            evidence.DirectMembers.Select(static member => member.Clone()).ToArray(),
+            evidence.FullClosure.Select(static member => member.Clone()).ToArray());
+    }
+
+    private static SkillDefinition MapSkill(OrnnSkillJson skill, string remoteId)
+    {
 
         // 从 SKILL.md 文件内容中提取 instructions
         var instructions = "";
@@ -54,17 +92,17 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         if (workflows.Count == 0)
             workflows = extraction.Workflows;
         var scriptExtraction = new SkillScriptExtractor().ExtractFromFiles(
-            parsed.Name ?? skill.Name ?? nameOrId,
+            parsed.Name ?? skill.Name ?? remoteId,
             parsed.ScriptEntry,
             extraction.RemainingFiles);
 
         return new SkillDefinition
         {
-            Name = parsed.Name ?? skill.Name ?? nameOrId,
+            Name = parsed.Name ?? skill.Name ?? remoteId,
             Description = parsed.Description ?? skill.Description ?? "",
             Instructions = parsed.Body,
             Source = SkillSource.Remote,
-            RemoteId = nameOrId,
+            RemoteId = remoteId,
             Arguments = parsed.Arguments,
             WhenToUse = parsed.WhenToUse,
             IsModelInvocable = parsed.IsModelInvocable,

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -1,5 +1,8 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Collections.ObjectModel;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.Publishing;
 using Aevatar.AI.ToolProviders.Skills;
@@ -17,6 +20,10 @@ namespace Aevatar.AI.ToolProviders.Ornn;
 /// </summary>
 public sealed class OrnnSkillClient
 {
+    private const int MaximumDeclaredTools = 50;
+    private const int MaximumDirectMembers = 100;
+    private const int MaximumClosureNodes = 500;
+    private const long EvidenceResponseMaximumBytes = NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes;
     private readonly NyxIdApiClient _nyxApi;
     private readonly OrnnOptions _options;
     private readonly ILogger _logger;
@@ -26,6 +33,10 @@ public sealed class OrnnSkillClient
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    private static readonly Regex LiteralVersionPattern = new(
+        "^[0-9]+\\.[0-9]+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     /// <summary>
     /// Default per-call timeout for Ornn HTTP fetches through the NyxID proxy. Without this, a
@@ -260,6 +271,124 @@ public sealed class OrnnSkillClient
         }
     }
 
+    internal async Task<OrnnExactSkillEvidence> GetExactSkillAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
+        CancellationToken ct = default)
+    {
+        ValidateExactReference(
+            reference.Guid,
+            reference.LiteralVersion,
+            ExactRemoteResourceKind.Skill);
+        var encodedGuid = Uri.EscapeDataString(reference.Guid);
+        var encodedVersion = Uri.EscapeDataString(reference.LiteralVersion);
+        var resourceKind = ExactRemoteResourceKind.Skill;
+
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        try
+        {
+            var packageTask = ReadExactDataAsync<OrnnSkillJson>(
+                accessToken,
+                $"/api/v1/skills/{encodedGuid}/json?version={encodedVersion}",
+                NyxIdToolOptions.HardProxyFileArtifactMaxBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var detailTask = ReadExactDataAsync<OrnnExactSkillDetail>(
+                accessToken,
+                $"/api/v1/skills/{encodedGuid}?version={encodedVersion}",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var versionsTask = ReadExactDataAsync<OrnnExactVersionItems<OrnnExactSkillVersionRow>>(
+                accessToken,
+                $"/api/v1/skills/{encodedGuid}/versions",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+
+            await Task.WhenAll(packageTask, detailTask, versionsTask);
+            return BuildExactSkillEvidence(reference, packageTask.Result, detailTask.Result, versionsTask.Result.Items);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw ExactRemoteFetchException.Unavailable(
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"the shared {_perCallTimeout.TotalSeconds:0.###} second request budget expired");
+        }
+    }
+
+    internal async Task<OrnnExactSkillsetEvidence> GetExactSkillsetAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
+        CancellationToken ct = default)
+    {
+        ValidateExactReference(
+            reference.Guid,
+            reference.LiteralVersion,
+            ExactRemoteResourceKind.Skillset);
+        var encodedGuid = Uri.EscapeDataString(reference.Guid);
+        var encodedVersion = Uri.EscapeDataString(reference.LiteralVersion);
+        var resourceKind = ExactRemoteResourceKind.Skillset;
+
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        try
+        {
+            var detailTask = ReadExactDataAsync<OrnnSkillSet>(
+                accessToken,
+                $"/api/v1/skillsets/{encodedGuid}?version={encodedVersion}",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var closureTask = ReadExactDataAsync<OrnnExactSkillsetClosure>(
+                accessToken,
+                $"/api/v1/skillsets/{encodedGuid}/closure?version={encodedVersion}",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var versionsTask = ReadExactDataAsync<OrnnExactVersionItems<OrnnExactSkillsetVersionRow>>(
+                accessToken,
+                $"/api/v1/skillsets/{encodedGuid}/versions",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+
+            await Task.WhenAll(detailTask, closureTask, versionsTask);
+            return BuildExactSkillsetEvidence(reference, detailTask.Result, closureTask.Result, versionsTask.Result.Items);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw ExactRemoteFetchException.Unavailable(
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"the shared {_perCallTimeout.TotalSeconds:0.###} second request budget expired");
+        }
+    }
+
     public async Task<OrnnSkillPublishResponse> PublishSkillAsync(
         string accessToken,
         byte[] zipBytes,
@@ -454,7 +583,635 @@ public sealed class OrnnSkillClient
             ? prop.GetString()
             : null;
 
+    private async Task<T> ReadExactDataAsync<T>(
+        string accessToken,
+        string path,
+        long maximumBytes,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        CancellationToken ct)
+        where T : class
+    {
+        var response = await _nyxApi.ProxyGetBinaryResponseAsync(
+            accessToken,
+            _options.NyxIdSlug,
+            path,
+            extraHeaders: null,
+            maximumBytes,
+            ct);
+        if (!response.Succeeded)
+        {
+            if (response.Detail is "content_length_exceeds_max_bytes" or "content_exceeds_max_bytes")
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    resourceKind,
+                    guid,
+                    literalVersion,
+                    $"response '{path}' exceeded {maximumBytes} bytes");
+            }
+
+            throw ExactRemoteFetchException.Unavailable(
+                resourceKind,
+                guid,
+                literalVersion,
+                string.IsNullOrWhiteSpace(response.Detail) ? $"request '{path}' failed" : response.Detail,
+                response.HttpStatus == 0 ? null : response.HttpStatus);
+        }
+
+        try
+        {
+            var envelope = JsonSerializer.Deserialize<OrnnApiResponse<T>>(response.Content, JsonOptions);
+            return envelope?.Data ?? throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                $"response '{path}' omitted data");
+        }
+        catch (ExactRemoteFetchException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                $"response '{path}' was not valid JSON",
+                ex);
+        }
+    }
+
+    private static OrnnExactSkillEvidence BuildExactSkillEvidence(
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
+        OrnnSkillJson package,
+        OrnnExactSkillDetail detail,
+        IReadOnlyList<OrnnExactSkillVersionRow> versionRows)
+    {
+        RequireGuidMatch(detail.Guid, reference.Guid, ExactRemoteResourceKind.Skill, reference.LiteralVersion);
+        RequireText(package.Name, "package name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireText(detail.Name, "detail name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(package.Name!, detail.Name!, "package/detail name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(package.Version, reference.LiteralVersion, "package version", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.Version, reference.LiteralVersion, "detail version", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        if (package.Metadata is null || detail.Metadata is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                "package and detail metadata must both be present");
+        }
+
+        var versionRow = SelectExactVersionRow(
+            versionRows,
+            reference.LiteralVersion,
+            static row => row.Version,
+            ExactRemoteResourceKind.Skill,
+            reference.Guid);
+        RequireText(detail.SkillHash, "detail skill hash", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireText(versionRow.SkillHash, "version skill hash", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireText(versionRow.Integrity, "version integrity", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.SkillHash!, versionRow.SkillHash!, "detail/version skill hash", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        VerifyIntegrity(versionRow.SkillHash!, versionRow.Integrity, reference.Guid, reference.LiteralVersion);
+
+        var packageTools = NormalizeTools(package.Metadata?.Tools, reference.Guid, reference.LiteralVersion);
+        var detailTools = NormalizeTools(detail.Metadata?.Tools, reference.Guid, reference.LiteralVersion);
+        RequireToolSetsEqual(packageTools, detailTools, reference.Guid, reference.LiteralVersion);
+        var exactPackage = ValidatePackage(package.Files, reference.Guid, reference.LiteralVersion);
+        package.Files = exactPackage.Files.ToDictionary(static file => file.Key, static file => file.Value, StringComparer.Ordinal);
+
+        return new OrnnExactSkillEvidence(
+            package,
+            detail.Name!,
+            BuildProvenance(versionRow, reference.Guid, reference.LiteralVersion, ExactRemoteResourceKind.Skill),
+            exactPackage,
+            packageTools);
+    }
+
+    private static OrnnExactSkillsetEvidence BuildExactSkillsetEvidence(
+        Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
+        OrnnSkillSet detail,
+        OrnnExactSkillsetClosure closure,
+        IReadOnlyList<OrnnExactSkillsetVersionRow> versionRows)
+    {
+        RequireGuidMatch(detail.Guid, reference.Guid, ExactRemoteResourceKind.Skillset, reference.LiteralVersion);
+        RequireText(detail.Name, "detail name", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.Version, reference.LiteralVersion, "detail version", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireText(detail.Instructions, "detail instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireText(closure.Instructions, "closure instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.Instructions!, closure.Instructions!, "detail/closure instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+
+        if (detail.Members.Count > MaximumDirectMembers)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"direct member count exceeded {MaximumDirectMembers}");
+        }
+        if (detail.Members.Count == 0)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "direct members were missing or empty");
+        }
+        if (closure.Items is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "closure items were missing");
+        }
+        if (closure.Items.Count > MaximumClosureNodes)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"closure node count exceeded {MaximumClosureNodes}");
+        }
+
+        var versionRow = SelectExactVersionRow(
+            versionRows,
+            reference.LiteralVersion,
+            static row => row.Version,
+            ExactRemoteResourceKind.Skillset,
+            reference.Guid);
+        if (versionRow.MemberCount is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "version member count was missing");
+        }
+        if (versionRow.MemberCount.Value != detail.Members.Count)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "version member count differs from detail members");
+        }
+
+        var closureItems = ValidateClosureItems(closure.Items, reference.Guid, reference.LiteralVersion);
+        var directMembers = ResolveDirectMembers(detail.Members, closureItems, reference.Guid, reference.LiteralVersion);
+        return new OrnnExactSkillsetEvidence(
+            detail.Name!,
+            BuildProvenance(versionRow, reference.Guid, reference.LiteralVersion, ExactRemoteResourceKind.Skillset),
+            detail.Instructions!,
+            directMembers,
+            closureItems.Select(static item => item.Reference).ToArray());
+    }
+
+    private static ExactRemotePackage ValidatePackage(
+        IReadOnlyDictionary<string, string>? files,
+        string guid,
+        string literalVersion)
+    {
+        if (files is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "package files were missing");
+        }
+
+        var maximum = ExactRemotePackageBounds.AdapterMaximum;
+        if (files.Count > maximum.MaximumFileCount)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                $"package file count exceeded {maximum.MaximumFileCount}");
+        }
+
+        var normalizedFiles = new Dictionary<string, string>(StringComparer.Ordinal);
+        var maximumPathBytes = 0;
+        long maximumFileBytes = 0;
+        long totalFileBytes = 0;
+        foreach (var (path, content) in files)
+        {
+            var normalizedPath = NormalizePackagePath(path, guid, literalVersion);
+            if (content is null)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    $"package file '{normalizedPath}' had null content");
+            }
+            if (!normalizedFiles.TryAdd(normalizedPath, content))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    $"package contains duplicate normalized path '{normalizedPath}'");
+            }
+
+            var pathBytes = Encoding.UTF8.GetByteCount(normalizedPath);
+            var fileBytes = Encoding.UTF8.GetByteCount(content);
+            if (pathBytes > maximum.MaximumPathUtf8Bytes || fileBytes > maximum.MaximumFileUtf8Bytes)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    $"package path or file '{normalizedPath}' exceeded adapter bounds");
+            }
+
+            maximumPathBytes = Math.Max(maximumPathBytes, pathBytes);
+            maximumFileBytes = Math.Max(maximumFileBytes, fileBytes);
+            totalFileBytes += fileBytes;
+            if (totalFileBytes > maximum.MaximumTotalFileUtf8Bytes)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    "package total file bytes exceeded adapter bounds");
+            }
+        }
+
+        return new ExactRemotePackage(
+            new ReadOnlyDictionary<string, string>(normalizedFiles),
+            new ExactRemotePackageShape(files.Count, maximumPathBytes, maximumFileBytes, totalFileBytes));
+    }
+
+    private static string NormalizePackagePath(string path, string guid, string literalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(path) || path.Contains('\0'))
+            throw InvalidPackagePath(guid, literalVersion, path);
+
+        var replaced = path.Replace('\\', '/');
+        if (replaced.StartsWith('/') || Regex.IsMatch(replaced, "^[A-Za-z]:/", RegexOptions.CultureInvariant))
+            throw InvalidPackagePath(guid, literalVersion, path);
+
+        var segments = replaced.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0 || segments.Any(static segment => segment is "." or ".."))
+            throw InvalidPackagePath(guid, literalVersion, path);
+        return string.Join('/', segments);
+    }
+
+    private static ExactRemoteFetchException InvalidPackagePath(string guid, string literalVersion, string? path) =>
+        ExactRemoteFetchException.InvalidResponse(
+            ExactRemoteResourceKind.Skill,
+            guid,
+            literalVersion,
+            $"package path '{path}' is not a normalized relative path");
+
+    private static IReadOnlyList<ExactRemoteToolDeclaration> NormalizeTools(
+        IReadOnlyList<OrnnSkillToolDeclaration>? tools,
+        string guid,
+        string literalVersion)
+    {
+        if (tools is null)
+            return [];
+        if (tools.Count > MaximumDeclaredTools)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                $"declared tool count exceeded {MaximumDeclaredTools}");
+        }
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var normalized = new List<ExactRemoteToolDeclaration>(tools.Count);
+        foreach (var tool in tools)
+        {
+            if (string.IsNullOrWhiteSpace(tool.Tool) || string.IsNullOrWhiteSpace(tool.Type) ||
+                !names.Add(tool.Tool))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    "declared tools contain a blank or duplicate identity");
+            }
+
+            var mcpServers = new List<ExactRemoteMcpServerDeclaration>();
+            var mcpKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var server in tool.McpServers ?? [])
+            {
+                var key = $"{server.Mcp}\u001f{server.Version}";
+                if (string.IsNullOrWhiteSpace(server.Mcp) || string.IsNullOrWhiteSpace(server.Version) ||
+                    !mcpKeys.Add(key))
+                {
+                    throw ExactRemoteFetchException.InvalidResponse(
+                        ExactRemoteResourceKind.Skill,
+                        guid,
+                        literalVersion,
+                        $"declared tool '{tool.Tool}' contains a blank or duplicate MCP server");
+                }
+                mcpServers.Add(new ExactRemoteMcpServerDeclaration(server.Mcp, server.Version));
+            }
+
+            normalized.Add(new ExactRemoteToolDeclaration(
+                tool.Tool,
+                tool.Type,
+                mcpServers.OrderBy(static server => server.Mcp, StringComparer.Ordinal)
+                    .ThenBy(static server => server.Version, StringComparer.Ordinal)
+                    .ToArray()));
+        }
+
+        return normalized.OrderBy(static tool => tool.Tool, StringComparer.Ordinal).ToArray();
+    }
+
+    private static void RequireToolSetsEqual(
+        IReadOnlyList<ExactRemoteToolDeclaration> packageTools,
+        IReadOnlyList<ExactRemoteToolDeclaration> detailTools,
+        string guid,
+        string literalVersion)
+    {
+        var packageKeys = packageTools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
+        var detailKeys = detailTools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
+        if (!packageKeys.SetEquals(detailKeys))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "package/detail declared tools differ");
+        }
+    }
+
+    private static string ToolKey(ExactRemoteToolDeclaration tool) =>
+        $"{tool.Tool}\u001f{tool.Type}\u001f{string.Join('\u001e', tool.McpServers.Select(static server => $"{server.Mcp}\u001d{server.Version}"))}";
+
+    private static void VerifyIntegrity(string skillHash, string? integrity, string guid, string literalVersion)
+    {
+        byte[] digest;
+        try
+        {
+            digest = Convert.FromHexString(skillHash);
+        }
+        catch (FormatException ex)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "version skill hash is not hexadecimal",
+                ex);
+        }
+
+        if (digest.Length != 32)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "version skill hash is not a SHA-256 digest");
+        }
+
+        var expected = $"sha256-{Convert.ToBase64String(digest)}";
+        if (!string.Equals(integrity, expected, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "version integrity does not match the skill hash");
+        }
+    }
+
+    private static ExactRemoteVersionProvenance BuildProvenance(
+        IOrnnExactVersionRow row,
+        string guid,
+        string literalVersion,
+        ExactRemoteResourceKind resourceKind)
+    {
+        RequireText(row.CreatedBy, "version publisher subject", resourceKind, guid, literalVersion);
+        ValidateOptionalSnapshot(row.CreatedByEmail, "publisher email snapshot", resourceKind, guid, literalVersion);
+        ValidateOptionalSnapshot(row.CreatedByDisplayName, "publisher display name snapshot", resourceKind, guid, literalVersion);
+        if (!DateTimeOffset.TryParse(
+                row.CreatedOn,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind,
+                out var publishedAt))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                "version published timestamp is missing or invalid");
+        }
+
+        return new ExactRemoteVersionProvenance(
+            row.CreatedBy!,
+            row.CreatedByEmail,
+            row.CreatedByDisplayName,
+            publishedAt.ToUniversalTime());
+    }
+
+    private static void ValidateOptionalSnapshot(
+        string? value,
+        string field,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        if (value is not null && string.IsNullOrWhiteSpace(value))
+            throw ExactRemoteFetchException.InvalidResponse(resourceKind, guid, literalVersion, $"{field} was blank");
+    }
+
+    private static T SelectExactVersionRow<T>(
+        IReadOnlyList<T> rows,
+        string literalVersion,
+        Func<T, string?> versionSelector,
+        ExactRemoteResourceKind resourceKind,
+        string guid)
+    {
+        var matches = rows.Where(row => string.Equals(versionSelector(row), literalVersion, StringComparison.Ordinal)).ToArray();
+        if (matches.Length != 1)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                "versions response must contain the requested literal version exactly once");
+        }
+        return matches[0];
+    }
+
+    private static IReadOnlyList<ValidatedClosureItem> ValidateClosureItems(
+        IReadOnlyList<OrnnExactSkillsetClosureItem> items,
+        string guid,
+        string literalVersion)
+    {
+        var identities = new HashSet<string>(StringComparer.Ordinal);
+        var validated = new List<ValidatedClosureItem>(items.Count);
+        foreach (var item in items)
+        {
+            RequireText(item.Ref, "closure ref", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            RequireText(item.Name, "closure name", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            ValidateExactReference(item.Guid, item.Version, ExactRemoteResourceKind.Skillset);
+            if (item.Depth is null || item.Depth.Value < 0)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "closure depth must be non-negative");
+            }
+
+            var normalizedGuid = System.Guid.Parse(item.Guid!).ToString("D");
+            if (!identities.Add(normalizedGuid))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "closure contains a duplicate or conflicting GUID");
+            }
+
+            validated.Add(new ValidatedClosureItem(
+                item.Ref!,
+                item.Name!,
+                item.Depth.Value,
+                new Aevatar.AI.Abstractions.ExactRemoteSkillRef
+                {
+                    Guid = item.Guid!,
+                    LiteralVersion = item.Version!,
+                }));
+        }
+        return validated;
+    }
+
+    private static IReadOnlyList<Aevatar.AI.Abstractions.ExactRemoteSkillRef> ResolveDirectMembers(
+        IReadOnlyList<OrnnSkillSetMember> members,
+        IReadOnlyList<ValidatedClosureItem> closureItems,
+        string guid,
+        string literalVersion)
+    {
+        var roots = closureItems.Where(static item => item.Depth == 0).ToArray();
+        if (roots.Length != members.Count)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                guid,
+                literalVersion,
+                "closure root count differs from direct member count");
+        }
+
+        var usedRootGuids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var resolved = new List<Aevatar.AI.Abstractions.ExactRemoteSkillRef>(members.Count);
+        foreach (var member in members)
+        {
+            RequireText(member.Name, "direct member name", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            RequireText(member.Version, "direct member version", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            if (member.Guid is not null && !System.Guid.TryParse(member.Guid, out _))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "direct member GUID was invalid");
+            }
+            var matches = roots.Where(root => MemberMatches(member, root)).ToArray();
+            if (matches.Length != 1 || !usedRootGuids.Add(matches[0].Reference.Guid))
+            {
+                throw ExactRemoteFetchException.IntegrityMismatch(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "each direct member must resolve to one unique closure root");
+            }
+            resolved.Add(matches[0].Reference.Clone());
+        }
+        return resolved;
+    }
+
+    private static bool MemberMatches(OrnnSkillSetMember member, ValidatedClosureItem root)
+    {
+        if (!string.IsNullOrWhiteSpace(member.Guid) &&
+            System.Guid.TryParse(member.Guid, out var memberGuid) &&
+            System.Guid.TryParse(root.Reference.Guid, out var rootGuid))
+        {
+            return memberGuid == rootGuid;
+        }
+
+        if (!string.Equals(member.Name, root.Name, StringComparison.Ordinal))
+            return false;
+        return !IsLiteralVersion(member.Version) ||
+               string.Equals(member.Version, root.Reference.LiteralVersion, StringComparison.Ordinal);
+    }
+
+    private static void RequireGuidMatch(
+        string? actual,
+        string expected,
+        ExactRemoteResourceKind resourceKind,
+        string literalVersion)
+    {
+        if (!System.Guid.TryParse(actual, out var actualGuid) ||
+            !System.Guid.TryParse(expected, out var expectedGuid) ||
+            actualGuid != expectedGuid)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                expected,
+                literalVersion,
+                "returned GUID differs from the requested GUID");
+        }
+    }
+
+    private static void RequireText(
+        string? value,
+        string field,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw ExactRemoteFetchException.InvalidResponse(resourceKind, guid, literalVersion, $"{field} was missing or blank");
+    }
+
+    private static void RequireEqual(
+        string? actual,
+        string expected,
+        string field,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            throw ExactRemoteFetchException.IntegrityMismatch(resourceKind, guid, literalVersion, $"{field} mismatch");
+    }
+
+    private static void ValidateExactReference(
+        string? guid,
+        string? literalVersion,
+        ExactRemoteResourceKind resourceKind)
+    {
+        if (!System.Guid.TryParseExact(guid, "D", out _) || !IsLiteralVersion(literalVersion))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid ?? string.Empty,
+                literalVersion ?? string.Empty,
+                "reference must contain a D-format GUID and a literal major.minor version");
+        }
+    }
+
+    private static bool IsLiteralVersion(string? version) =>
+        version is not null && LiteralVersionPattern.IsMatch(version);
+
     private sealed record NyxIdProxyError(int Status, string Detail);
+
+    private sealed record ValidatedClosureItem(
+        string Ref,
+        string Name,
+        int Depth,
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef Reference);
 }
 
 // DTOs
@@ -492,12 +1249,28 @@ public sealed class OrnnSkillMetadata
     public string? Category { get; set; }
     [JsonPropertyName("tag")]
     public List<string>? Tags { get; set; }
+    public List<OrnnSkillToolDeclaration>? Tools { get; set; }
+}
+
+public sealed class OrnnSkillToolDeclaration
+{
+    public string? Tool { get; set; }
+    public string? Type { get; set; }
+    [JsonPropertyName("mcp-servers")]
+    public List<OrnnMcpServerDeclaration>? McpServers { get; set; }
+}
+
+public sealed class OrnnMcpServerDeclaration
+{
+    public string? Mcp { get; set; }
+    public string? Version { get; set; }
 }
 
 public sealed class OrnnSkillJson
 {
     public string? Name { get; set; }
     public string? Description { get; set; }
+    public string? Version { get; set; }
     public OrnnSkillMetadata? Metadata { get; set; }
     public Dictionary<string, string>? Files { get; set; }
 }
@@ -508,10 +1281,83 @@ public sealed class OrnnSkillSet
 {
     public string? Guid { get; set; }
     public string? Name { get; set; }
+    public string? Version { get; set; }
     /// <summary>Set-level master prompt authored on the skillset itself.</summary>
     public string? Instructions { get; set; }
     public bool IsPrivate { get; set; }
     public List<OrnnSkillSetMember> Members { get; set; } = [];
+}
+
+internal sealed record OrnnExactSkillEvidence(
+    OrnnSkillJson Package,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    ExactRemotePackage ExactPackage,
+    IReadOnlyList<ExactRemoteToolDeclaration> DeclaredTools);
+
+internal sealed record OrnnExactSkillsetEvidence(
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    string Instructions,
+    IReadOnlyList<Aevatar.AI.Abstractions.ExactRemoteSkillRef> DirectMembers,
+    IReadOnlyList<Aevatar.AI.Abstractions.ExactRemoteSkillRef> FullClosure);
+
+internal sealed class OrnnExactSkillDetail
+{
+    public string? Guid { get; set; }
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+    public string? SkillHash { get; set; }
+    public OrnnSkillMetadata? Metadata { get; set; }
+}
+
+internal sealed class OrnnExactVersionItems<T>
+{
+    public List<T> Items { get; set; } = [];
+}
+
+internal interface IOrnnExactVersionRow
+{
+    string? CreatedBy { get; }
+    string? CreatedByEmail { get; }
+    string? CreatedByDisplayName { get; }
+    string? CreatedOn { get; }
+}
+
+internal sealed class OrnnExactSkillVersionRow : IOrnnExactVersionRow
+{
+    public string? Version { get; set; }
+    public string? SkillHash { get; set; }
+    public string? Integrity { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? CreatedByEmail { get; set; }
+    public string? CreatedByDisplayName { get; set; }
+    public string? CreatedOn { get; set; }
+}
+
+internal sealed class OrnnExactSkillsetVersionRow : IOrnnExactVersionRow
+{
+    public string? Version { get; set; }
+    public int? MemberCount { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? CreatedByEmail { get; set; }
+    public string? CreatedByDisplayName { get; set; }
+    public string? CreatedOn { get; set; }
+}
+
+internal sealed class OrnnExactSkillsetClosure
+{
+    public string? Instructions { get; set; }
+    public List<OrnnExactSkillsetClosureItem>? Items { get; set; }
+}
+
+internal sealed class OrnnExactSkillsetClosureItem
+{
+    public string? Ref { get; set; }
+    public string? Guid { get; set; }
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+    public int? Depth { get; set; }
 }
 
 /// <summary>
@@ -526,6 +1372,7 @@ public sealed class OrnnSkillSetMember
     public string? Guid { get; init; }
     public string? Name { get; init; }
     public string? Version { get; init; }
+    internal string? RawReference { get; init; }
 
     /// <summary>The id or name to fetch this member's full skill JSON with (guid preferred).</summary>
     public string? Reference =>
@@ -576,8 +1423,13 @@ internal sealed class OrnnSkillSetMemberJsonConverter : JsonConverter<OrnnSkillS
         var trimmed = raw.Trim();
         var at = trimmed.LastIndexOf('@');
         return at > 0
-            ? new OrnnSkillSetMember { Name = trimmed[..at], Version = trimmed[(at + 1)..] }
-            : new OrnnSkillSetMember { Name = trimmed };
+            ? new OrnnSkillSetMember
+            {
+                Name = trimmed[..at],
+                Version = trimmed[(at + 1)..],
+                RawReference = trimmed,
+            }
+            : new OrnnSkillSetMember { Name = trimmed, RawReference = trimmed };
     }
 
     private static string? ReadString(JsonElement root, string propertyName)

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -31,7 +31,10 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<OrnnSkillPackageFormatValidator>();
         services.TryAddSingleton<OrnnPublishSkillTool>();
         services.TryAddSingleton<OrnnUpdateSkillTool>();
-        services.TryAddSingleton<IRemoteSkillFetcher, OrnnRemoteSkillFetcher>();
+        services.TryAddSingleton<OrnnRemoteSkillFetcher>();
+        services.TryAddSingleton<IRemoteSkillFetcher>(sp => sp.GetRequiredService<OrnnRemoteSkillFetcher>());
+        services.TryAddSingleton<IExactRemoteSkillFetcher>(sp => sp.GetRequiredService<OrnnRemoteSkillFetcher>());
+        services.TryAddSingleton<ExactRemoteReleaseVerifier>();
         services.TryAddSingleton<OrnnAgentToolSource>();
         services.TryAddAgentToolSourceAlias<OrnnAgentToolSource>(GetOrnnAgentToolSource);
         return services;

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteFetchException.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteFetchException.cs
@@ -1,0 +1,83 @@
+namespace Aevatar.AI.ToolProviders.Skills;
+
+public enum ExactRemoteFetchFailureKind
+{
+    Unavailable,
+    InvalidResponse,
+    IntegrityMismatch,
+}
+
+public enum ExactRemoteResourceKind
+{
+    Skill,
+    Skillset,
+}
+
+public sealed class ExactRemoteFetchException : Exception
+{
+    public ExactRemoteFetchFailureKind FailureKind { get; }
+    public ExactRemoteResourceKind ResourceKind { get; }
+    public string Guid { get; }
+    public string LiteralVersion { get; }
+    public int? HttpStatus { get; }
+
+    public ExactRemoteFetchException(
+        ExactRemoteFetchFailureKind failureKind,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string message,
+        int? httpStatus = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        FailureKind = failureKind;
+        ResourceKind = resourceKind;
+        Guid = guid;
+        LiteralVersion = literalVersion;
+        HttpStatus = httpStatus;
+    }
+
+    public static ExactRemoteFetchException Unavailable(
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string detail,
+        int? httpStatus = null) =>
+        new(
+            ExactRemoteFetchFailureKind.Unavailable,
+            resourceKind,
+            guid,
+            literalVersion,
+            $"Exact remote {ResourceName(resourceKind)} '{guid}@{literalVersion}' is unavailable: {detail}",
+            httpStatus);
+
+    public static ExactRemoteFetchException InvalidResponse(
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string detail,
+        Exception? innerException = null) =>
+        new(
+            ExactRemoteFetchFailureKind.InvalidResponse,
+            resourceKind,
+            guid,
+            literalVersion,
+            $"Exact remote {ResourceName(resourceKind)} '{guid}@{literalVersion}' returned an invalid response: {detail}",
+            innerException: innerException);
+
+    public static ExactRemoteFetchException IntegrityMismatch(
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string detail) =>
+        new(
+            ExactRemoteFetchFailureKind.IntegrityMismatch,
+            resourceKind,
+            guid,
+            literalVersion,
+            $"Exact remote {ResourceName(resourceKind)} '{guid}@{literalVersion}' failed integrity verification: {detail}");
+
+    private static string ResourceName(ExactRemoteResourceKind resourceKind) =>
+        resourceKind == ExactRemoteResourceKind.Skill ? "skill" : "skillset";
+}

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseModels.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseModels.cs
@@ -1,0 +1,69 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Skills;
+
+public sealed record ExactRemoteVersionProvenance(
+    string PublisherSubjectId,
+    string? PublisherEmailSnapshot,
+    string? PublisherDisplayNameSnapshot,
+    DateTimeOffset PublishedAt);
+
+public sealed record ExactRemoteMcpServerDeclaration(string Mcp, string Version);
+
+public sealed record ExactRemoteToolDeclaration(
+    string Tool,
+    string Type,
+    IReadOnlyList<ExactRemoteMcpServerDeclaration> McpServers);
+
+public sealed record ExactRemotePackageShape(
+    int FileCount,
+    int MaximumPathUtf8Bytes,
+    long MaximumFileUtf8Bytes,
+    long TotalFileUtf8Bytes);
+
+public sealed record ExactRemotePackage(
+    IReadOnlyDictionary<string, string> Files,
+    ExactRemotePackageShape Shape);
+
+public sealed record ExactRemotePackageBounds(
+    int MaximumFileCount,
+    int MaximumPathUtf8Bytes,
+    long MaximumFileUtf8Bytes,
+    long MaximumTotalFileUtf8Bytes)
+{
+    public static ExactRemotePackageBounds AdapterMaximum { get; } = new(
+        MaximumFileCount: 1000,
+        MaximumPathUtf8Bytes: 512,
+        MaximumFileUtf8Bytes: 25L * 1024 * 1024,
+        MaximumTotalFileUtf8Bytes: 50L * 1024 * 1024);
+}
+
+public sealed record ExactRemoteSkillRelease(
+    ExactRemoteSkillRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    ExactRemotePackage Package,
+    IReadOnlyList<ExactRemoteToolDeclaration> DeclaredTools,
+    SkillDefinition Definition);
+
+public sealed record ExactRemoteSkillsetRelease(
+    ExactRemoteSkillsetRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    string Instructions,
+    IReadOnlyList<ExactRemoteSkillRef> DirectMembers,
+    IReadOnlyList<ExactRemoteSkillRef> FullClosure);
+
+public sealed record ReviewedExactRemoteSkillExpectation(
+    ExactRemoteSkillRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    ExactRemotePackageBounds PackageBounds,
+    IReadOnlyList<ExactRemoteToolDeclaration> DeclaredTools);
+
+public sealed record ReviewedExactRemoteSkillsetExpectation(
+    ExactRemoteSkillsetRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    IReadOnlyList<ExactRemoteSkillRef> DirectMembers,
+    IReadOnlyList<ExactRemoteSkillRef> FullClosure);

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseVerifier.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseVerifier.cs
@@ -1,0 +1,207 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Skills;
+
+/// <summary>Verifies fetched releases against caller-reviewed immutable expectations.</summary>
+public sealed class ExactRemoteReleaseVerifier
+{
+    public ExactRemoteSkillRelease VerifySkill(
+        ExactRemoteSkillRelease release,
+        ReviewedExactRemoteSkillExpectation expectation)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(expectation);
+
+        var reference = expectation.Reference;
+        VerifyReference(release.Reference, reference, ExactRemoteResourceKind.Skill);
+        VerifyText(release.PublishedName, expectation.PublishedName, "published name", reference);
+        VerifyProvenance(release.Provenance, expectation.Provenance, ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        VerifyBounds(release.Package.Shape, expectation.PackageBounds, reference);
+        VerifyTools(release.DeclaredTools, expectation.DeclaredTools, reference);
+        return release;
+    }
+
+    public ExactRemoteSkillsetRelease VerifySkillset(
+        ExactRemoteSkillsetRelease release,
+        ReviewedExactRemoteSkillsetExpectation expectation)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(expectation);
+
+        var reference = expectation.Reference;
+        VerifyReference(release.Reference, reference, ExactRemoteResourceKind.Skillset);
+        VerifyText(release.PublishedName, expectation.PublishedName, "published name", reference);
+        VerifyProvenance(release.Provenance, expectation.Provenance, ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        VerifyExactRefs(release.DirectMembers, expectation.DirectMembers, "direct members", reference);
+        VerifyExactRefs(release.FullClosure, expectation.FullClosure, "full closure", reference);
+        return release;
+    }
+
+    private static void VerifyReference(
+        ExactRemoteSkillRef actual,
+        ExactRemoteSkillRef expected,
+        ExactRemoteResourceKind resourceKind)
+    {
+        if (!string.Equals(actual.Guid, expected.Guid, StringComparison.Ordinal) ||
+            !string.Equals(actual.LiteralVersion, expected.LiteralVersion, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                expected.Guid,
+                expected.LiteralVersion,
+                "exact reference differs from the reviewed reference");
+        }
+    }
+
+    private static void VerifyReference(
+        ExactRemoteSkillsetRef actual,
+        ExactRemoteSkillsetRef expected,
+        ExactRemoteResourceKind resourceKind)
+    {
+        if (!string.Equals(actual.Guid, expected.Guid, StringComparison.Ordinal) ||
+            !string.Equals(actual.LiteralVersion, expected.LiteralVersion, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                expected.Guid,
+                expected.LiteralVersion,
+                "exact reference differs from the reviewed reference");
+        }
+    }
+
+    private static void VerifyText(
+        string actual,
+        string expected,
+        string field,
+        ExactRemoteSkillRef reference)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"{field} differs from the reviewed value");
+        }
+    }
+
+    private static void VerifyText(
+        string actual,
+        string expected,
+        string field,
+        ExactRemoteSkillsetRef reference)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"{field} differs from the reviewed value");
+        }
+    }
+
+    private static void VerifyProvenance(
+        ExactRemoteVersionProvenance actual,
+        ExactRemoteVersionProvenance expected,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        var matches = string.Equals(actual.PublisherSubjectId, expected.PublisherSubjectId, StringComparison.Ordinal) &&
+                      string.Equals(actual.PublisherEmailSnapshot, expected.PublisherEmailSnapshot, StringComparison.Ordinal) &&
+                      string.Equals(actual.PublisherDisplayNameSnapshot, expected.PublisherDisplayNameSnapshot, StringComparison.Ordinal) &&
+                      actual.PublishedAt.ToUniversalTime() == expected.PublishedAt.ToUniversalTime();
+        if (!matches)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                guid,
+                literalVersion,
+                "version publisher provenance differs from the reviewed snapshot");
+        }
+    }
+
+    private static void VerifyBounds(
+        ExactRemotePackageShape shape,
+        ExactRemotePackageBounds bounds,
+        ExactRemoteSkillRef reference)
+    {
+        var maximum = ExactRemotePackageBounds.AdapterMaximum;
+        var boundsArePositive = bounds.MaximumFileCount > 0 &&
+                                bounds.MaximumPathUtf8Bytes > 0 &&
+                                bounds.MaximumFileUtf8Bytes > 0 &&
+                                bounds.MaximumTotalFileUtf8Bytes > 0;
+        var boundsDoNotExpandAdapterCeilings = bounds.MaximumFileCount <= maximum.MaximumFileCount &&
+                                              bounds.MaximumPathUtf8Bytes <= maximum.MaximumPathUtf8Bytes &&
+                                              bounds.MaximumFileUtf8Bytes <= maximum.MaximumFileUtf8Bytes &&
+                                              bounds.MaximumTotalFileUtf8Bytes <= maximum.MaximumTotalFileUtf8Bytes;
+        var shapeFits = shape.FileCount <= bounds.MaximumFileCount &&
+                        shape.MaximumPathUtf8Bytes <= bounds.MaximumPathUtf8Bytes &&
+                        shape.MaximumFileUtf8Bytes <= bounds.MaximumFileUtf8Bytes &&
+                        shape.TotalFileUtf8Bytes <= bounds.MaximumTotalFileUtf8Bytes;
+        if (!boundsArePositive || !boundsDoNotExpandAdapterCeilings || !shapeFits)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                "package shape exceeds the reviewed bounds or the reviewed bounds expand adapter ceilings");
+        }
+    }
+
+    private static void VerifyTools(
+        IReadOnlyList<ExactRemoteToolDeclaration> actual,
+        IReadOnlyList<ExactRemoteToolDeclaration> expected,
+        ExactRemoteSkillRef reference)
+    {
+        var actualKeys = ToolKeys(actual);
+        var expectedKeys = ToolKeys(expected);
+        if (actualKeys.Count != actual.Count || expectedKeys.Count != expected.Count ||
+            !actualKeys.SetEquals(expectedKeys))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                "declared tools differ from the reviewed set");
+        }
+    }
+
+    private static HashSet<string> ToolKeys(IReadOnlyList<ExactRemoteToolDeclaration> tools) =>
+        tools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
+
+    private static string ToolKey(ExactRemoteToolDeclaration tool) =>
+        string.Join(
+            '\u001f',
+            tool.Tool,
+            tool.Type,
+            string.Join(
+                '\u001e',
+                tool.McpServers
+                    .Select(static server => $"{server.Mcp}\u001d{server.Version}")
+                    .OrderBy(static server => server, StringComparer.Ordinal)));
+
+    private static void VerifyExactRefs(
+        IReadOnlyList<ExactRemoteSkillRef> actual,
+        IReadOnlyList<ExactRemoteSkillRef> expected,
+        string field,
+        ExactRemoteSkillsetRef reference)
+    {
+        var actualKeys = RefKeys(actual);
+        var expectedKeys = RefKeys(expected);
+        if (actualKeys.Count != actual.Count || expectedKeys.Count != expected.Count ||
+            !actualKeys.SetEquals(expectedKeys))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"{field} differ from the reviewed set");
+        }
+    }
+
+    private static HashSet<string> RefKeys(IReadOnlyList<ExactRemoteSkillRef> references) =>
+        references.Select(static reference => $"{reference.Guid}\u001f{reference.LiteralVersion}")
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/src/Aevatar.AI.ToolProviders.Skills/IExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/IExactRemoteSkillFetcher.cs
@@ -1,0 +1,17 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Skills;
+
+/// <summary>Fetches immutable remote releases by stable GUID and literal version.</summary>
+public interface IExactRemoteSkillFetcher
+{
+    Task<ExactRemoteSkillRelease> FetchExactSkillAsync(
+        string accessToken,
+        ExactRemoteSkillRef reference,
+        CancellationToken ct = default);
+
+    Task<ExactRemoteSkillsetRelease> FetchExactSkillsetAsync(
+        string accessToken,
+        ExactRemoteSkillsetRef reference,
+        CancellationToken ct = default);
+}

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -582,28 +582,25 @@ public sealed class AIAbstractionsProtoCoverageTests
             Headers = { ["k1"] = "v1" },
         });
 
-        target.Prompt.Should().Be("p1");
-        target.SessionId.Should().Be("s1");
-        target.Headers["k1"].Should().Be("v1");
+        (target.Prompt, target.SessionId, target.Headers["k1"]).Should().Be(("p1", "s1", "v1"));
 
         target.Clone().Should().BeEquivalentTo(target);
         target.ToString().Should().Contain("prompt");
 
         AiMessagesReflection.Descriptor.Should().NotBeNull();
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ChatRequestEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ChatResponseEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageStartEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageContentEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageReasoningEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageEndEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ToolCallEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ToolResultEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleChatSessionStartedEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleChatSessionCompletedEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(InitializeRoleAgentEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(AIAgentConfigOverrides));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleChatSessionState));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleGAgentState));
+        AiMessagesReflection.Descriptor.MessageTypes.Select(static type => type.Name).Should().Contain(
+            [nameof(ChatRequestEvent), nameof(ChatResponseEvent), nameof(TextMessageStartEvent), nameof(TextMessageContentEvent), nameof(TextMessageReasoningEvent), nameof(TextMessageEndEvent), nameof(ToolCallEvent), nameof(ToolResultEvent), nameof(RoleChatSessionStartedEvent), nameof(RoleChatSessionCompletedEvent), nameof(InitializeRoleAgentEvent), nameof(AIAgentConfigOverrides), nameof(RoleChatSessionState), nameof(RoleGAgentState)]);
+
+        var skillRef = RoundTrip(new ExactRemoteSkillRef { Guid = "11111111-1111-1111-1111-111111111111", LiteralVersion = "1.2" }, ExactRemoteSkillRef.Parser);
+        var skillsetRef = RoundTrip(new ExactRemoteSkillsetRef { Guid = "22222222-2222-2222-2222-222222222222", LiteralVersion = "3.4" }, ExactRemoteSkillsetRef.Parser);
+        (skillRef.Guid, skillRef.LiteralVersion).Should().Be(("11111111-1111-1111-1111-111111111111", "1.2"));
+        (skillsetRef.Guid, skillsetRef.LiteralVersion).Should().Be(("22222222-2222-2222-2222-222222222222", "3.4"));
+        foreach (var descriptor in new[] { ExactRemoteSkillRef.Descriptor, ExactRemoteSkillsetRef.Descriptor })
+        {
+            descriptor.Fields.InFieldNumberOrder().Select(static field => (field.FieldNumber, field.Name))
+                .Should().Equal((1, "guid"), (2, "literal_version"));
+            descriptor.Oneofs.Should().BeEmpty();
+        }
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
@@ -1,0 +1,213 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.ToolProviders.Skills;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class ExactRemoteReleaseVerifierTests
+{
+    private const string SkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string SkillsetGuid = "22222222-2222-2222-2222-222222222222";
+    private const string MemberGuid = "33333333-3333-3333-3333-333333333333";
+    private static readonly DateTimeOffset PublishedAt = DateTimeOffset.Parse("2026-07-10T12:30:00Z");
+    private readonly ExactRemoteReleaseVerifier _verifier = new();
+
+    [Fact]
+    public void VerifySkill_WhenEveryReviewedFieldMatches_ReturnsFetchedRelease()
+    {
+        var release = SkillRelease();
+        var expectation = SkillExpectation();
+
+        var verified = _verifier.VerifySkill(release, expectation);
+
+        verified.Should().BeSameAs(release);
+    }
+
+    [Fact]
+    public void VerifySkill_WhenReferenceOrNameDiffers_RejectsRelease()
+    {
+        var wrongReference = SkillExpectation() with
+        {
+            Reference = new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.3" },
+        };
+        var wrongName = SkillExpectation() with { PublishedName = "different" };
+
+        Action referenceAct = () => _verifier.VerifySkill(SkillRelease(), wrongReference);
+        Action nameAct = () => _verifier.VerifySkill(SkillRelease(), wrongName);
+
+        referenceAct.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        nameAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Theory]
+    [InlineData("subject")]
+    [InlineData("email-absence")]
+    [InlineData("email-value")]
+    [InlineData("display-absence")]
+    [InlineData("display-value")]
+    [InlineData("published-at")]
+    public void VerifySkill_WhenAnyPublisherSnapshotFieldDiffers_RejectsRelease(string mismatch)
+    {
+        var provenance = mismatch switch
+        {
+            "subject" => Provenance() with { PublisherSubjectId = "other-subject" },
+            "email-absence" => Provenance() with { PublisherEmailSnapshot = null },
+            "email-value" => Provenance() with { PublisherEmailSnapshot = "other@example.test" },
+            "display-absence" => Provenance() with { PublisherDisplayNameSnapshot = null },
+            "display-value" => Provenance() with { PublisherDisplayNameSnapshot = "Other Publisher" },
+            "published-at" => Provenance() with { PublishedAt = PublishedAt.AddSeconds(1) },
+            _ => throw new ArgumentOutOfRangeException(nameof(mismatch)),
+        };
+        var expectation = SkillExpectation() with { Provenance = provenance };
+
+        Action act = () => _verifier.VerifySkill(SkillRelease(), expectation);
+
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.Message.Should().Contain("provenance");
+    }
+
+    [Fact]
+    public void VerifySkill_WhenPackageExceedsReviewedBoundsOrBoundsExpandAdapterCeiling_RejectsRelease()
+    {
+        var tooTight = SkillExpectation() with
+        {
+            PackageBounds = new ExactRemotePackageBounds(1, 10, 3, 3),
+        };
+        var expanded = SkillExpectation() with
+        {
+            PackageBounds = ExactRemotePackageBounds.AdapterMaximum with
+            {
+                MaximumFileCount = ExactRemotePackageBounds.AdapterMaximum.MaximumFileCount + 1,
+            },
+        };
+
+        Action tightAct = () => _verifier.VerifySkill(SkillRelease(), tooTight);
+        Action expandedAct = () => _verifier.VerifySkill(SkillRelease(), expanded);
+
+        tightAct.Should().Throw<ExactRemoteFetchException>();
+        expandedAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Fact]
+    public void VerifySkill_WhenToolSetDiffersOrContainsDuplicates_RejectsRelease()
+    {
+        var different = SkillExpectation() with
+        {
+            DeclaredTools = [new ExactRemoteToolDeclaration("different", "builtin", [])],
+        };
+        var duplicateTool = Tool();
+        var duplicates = SkillExpectation() with { DeclaredTools = [duplicateTool, duplicateTool] };
+
+        Action differentAct = () => _verifier.VerifySkill(SkillRelease(), different);
+        Action duplicatesAct = () => _verifier.VerifySkill(SkillRelease(), duplicates);
+
+        differentAct.Should().Throw<ExactRemoteFetchException>();
+        duplicatesAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Fact]
+    public void VerifySkillset_WhenDirectMembersOrClosureDiffer_RejectsRelease()
+    {
+        var differentDirect = SkillsetExpectation() with
+        {
+            DirectMembers = [Member("1.1")],
+        };
+        var differentClosure = SkillsetExpectation() with
+        {
+            FullClosure = [Member("1.0"), Member("1.0")],
+        };
+
+        Action directAct = () => _verifier.VerifySkillset(SkillsetRelease(), differentDirect);
+        Action closureAct = () => _verifier.VerifySkillset(SkillsetRelease(), differentClosure);
+
+        directAct.Should().Throw<ExactRemoteFetchException>();
+        closureAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Fact]
+    public void ReleaseEvidence_ContainsNoAuthorizationFields()
+    {
+        typeof(ExactRemoteVersionProvenance).GetProperties().Select(static property => property.Name)
+            .Should().BeEquivalentTo(
+                nameof(ExactRemoteVersionProvenance.PublisherSubjectId),
+                nameof(ExactRemoteVersionProvenance.PublisherEmailSnapshot),
+                nameof(ExactRemoteVersionProvenance.PublisherDisplayNameSnapshot),
+                nameof(ExactRemoteVersionProvenance.PublishedAt));
+        typeof(ExactRemoteToolDeclaration).GetProperties().Select(static property => property.Name)
+            .Should().BeEquivalentTo(
+                nameof(ExactRemoteToolDeclaration.Tool),
+                nameof(ExactRemoteToolDeclaration.Type),
+                nameof(ExactRemoteToolDeclaration.McpServers));
+
+        _verifier.VerifySkill(SkillRelease(), SkillExpectation()).Should().NotBeNull();
+    }
+
+    private static ExactRemoteSkillRelease SkillRelease() => new(
+        SkillReference(),
+        "curated-skill",
+        Provenance(),
+        new ExactRemotePackage(
+            new Dictionary<string, string> { ["SKILL.md"] = "Run it." },
+            new ExactRemotePackageShape(1, 8, 7, 7)),
+        [Tool()],
+        new SkillDefinition
+        {
+            Name = "curated-skill",
+            Description = "Reviewed",
+            Instructions = "Run it.",
+            Source = SkillSource.Remote,
+            RemoteId = SkillGuid,
+        });
+
+    private static ReviewedExactRemoteSkillExpectation SkillExpectation() => new(
+        SkillReference(),
+        "curated-skill",
+        Provenance(),
+        new ExactRemotePackageBounds(10, 64, 1024, 2048),
+        [Tool()]);
+
+    private static ExactRemoteSkillsetRelease SkillsetRelease() => new(
+        SkillsetReference(),
+        "reviewed-set",
+        Provenance(),
+        "Use reviewed skills.",
+        [Member("1.0")],
+        [Member("1.0")]);
+
+    private static ReviewedExactRemoteSkillsetExpectation SkillsetExpectation() => new(
+        SkillsetReference(),
+        "reviewed-set",
+        Provenance(),
+        [Member("1.0")],
+        [Member("1.0")]);
+
+    private static ExactRemoteVersionProvenance Provenance() => new(
+        "publisher-subject",
+        "publisher@example.test",
+        "Publisher Name",
+        PublishedAt);
+
+    private static ExactRemoteToolDeclaration Tool() => new(
+        "workspace.read",
+        "mcp",
+        [new ExactRemoteMcpServerDeclaration("workspace-mcp", "2.0")]);
+
+    private static ExactRemoteSkillRef SkillReference() => new()
+    {
+        Guid = SkillGuid,
+        LiteralVersion = "1.2",
+    };
+
+    private static ExactRemoteSkillsetRef SkillsetReference() => new()
+    {
+        Guid = SkillsetGuid,
+        LiteralVersion = "2.0",
+    };
+
+    private static ExactRemoteSkillRef Member(string version) => new()
+    {
+        Guid = MemberGuid,
+        LiteralVersion = version,
+    };
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -1,0 +1,391 @@
+using System.Net;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.Skills;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class OrnnExactRemoteSkillFetcherTests
+{
+    private const string SkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string SkillsetGuid = "22222222-2222-2222-2222-222222222222";
+    private const string MemberAGuid = "33333333-3333-3333-3333-333333333333";
+    private const string MemberBGuid = "44444444-4444-4444-4444-444444444444";
+    private const string DependencyGuid = "55555555-5555-5555-5555-555555555555";
+    private static readonly string SkillHash = new('a', 64);
+
+    [Fact]
+    public async Task FetchExactSkillAsync_UsesThreeGuidScopedReadsAndReturnsReviewedEvidence()
+    {
+        var handler = ExactSkillHandler();
+        var fetcher = CreateFetcher(handler);
+
+        var release = await fetcher.FetchExactSkillAsync(
+            "access-token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        release.Reference.Guid.Should().Be(SkillGuid);
+        release.Reference.LiteralVersion.Should().Be("1.2");
+        release.PublishedName.Should().Be("curated-skill");
+        release.Provenance.Should().Be(new ExactRemoteVersionProvenance(
+            "publisher-subject",
+            "publisher@example.test",
+            "Publisher Name",
+            DateTimeOffset.Parse("2026-07-10T12:30:00Z")));
+        release.Package.Files.Should().ContainKey("SKILL.md");
+        release.Package.Shape.FileCount.Should().Be(2);
+        release.DeclaredTools.Should().ContainSingle();
+        release.DeclaredTools[0].Tool.Should().Be("workspace.read");
+        release.DeclaredTools[0].McpServers.Should().ContainSingle()
+            .Which.Should().Be(new ExactRemoteMcpServerDeclaration("workspace-mcp", "2.0"));
+        release.Definition.Name.Should().Be("curated-skill");
+        release.Definition.RemoteId.Should().Be(SkillGuid);
+
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+        handler.Requests.Should().OnlyContain(request => request.Authorization!.Parameter == "access-token");
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_UsesThreeGuidScopedReadsAndResolvesLiteralMemberVersions()
+    {
+        var handler = ExactSkillsetHandler();
+        var fetcher = CreateFetcher(handler);
+
+        var release = await fetcher.FetchExactSkillsetAsync(
+            "access-token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        release.PublishedName.Should().Be("reviewed-set");
+        release.Instructions.Should().Be("Use both reviewed skills.");
+        release.Provenance.PublisherSubjectId.Should().Be("set-publisher");
+        release.Provenance.PublisherEmailSnapshot.Should().BeNull();
+        release.Provenance.PublisherDisplayNameSnapshot.Should().Be("Set Publisher");
+        release.DirectMembers.Select(member => (member.Guid, member.LiteralVersion)).Should().Equal(
+            (MemberAGuid, "1.0"),
+            (MemberBGuid, "2.0"));
+        release.FullClosure.Select(member => (member.Guid, member.LiteralVersion)).Should().Equal(
+            (DependencyGuid, "3.0"),
+            (MemberAGuid, "1.0"),
+            (MemberBGuid, "2.0"));
+
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenEvidenceMismatches_FailsClosedWithoutFallback()
+    {
+        var handler = ExactSkillHandler(detailJson: SkillDetail(name: "different-name"));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenOneResponseIsUnavailable_StillMakesOnlyTheFixedReads()
+    {
+        var handler = ExactSkillHandler(
+            packageResponse: () => OrnnTestHttpMessageHandler.JsonResponse(
+                """{"error":"missing"}""",
+                HttpStatusCode.NotFound));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
+        assertion.Which.HttpStatus.Should().Be(404);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_UsesOneSharedTimeoutForAllThreeReads()
+    {
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled();
+        var fetcher = CreateFetcher(handler, TimeSpan.FromMilliseconds(100));
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
+        handler.Requests.Should().HaveCount(3);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_RejectsDeclaredContentLengthBeforeDeserialization()
+    {
+        var handler = ExactSkillHandler(
+            packageResponse: () => OrnnTestHttpMessageHandler.JsonResponse(
+                SkillPackage(),
+                contentLength: NyxIdToolOptions.HardProxyFileArtifactMaxBytes + 1));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain("exceeded");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_RejectsOversizedEvidenceStreamWithoutContentLength()
+    {
+        var handler = ExactSkillHandler(
+            detailResponse: () => OrnnTestHttpMessageHandler.OversizedStreamResponse(
+                NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes + 1));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_RejectsDecodedPackagePathBeyondAdapterBound()
+    {
+        var oversizedPath = new string('p', 513);
+        var files = $$"""{"{{oversizedPath}}":"content"}""";
+        var handler = ExactSkillHandler(packageJson: SkillPackage(filesJson: files));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_WhenClosureContainsConflictingIdentity_FailsClosed()
+    {
+        var duplicateClosure = $$"""
+            {
+              "data": {
+                "instructions": "Use both reviewed skills.",
+                "items": [
+                  { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
+                  { "ref": "member-a@2.0", "guid": "{{MemberAGuid}}", "name": "member-b", "version": "2.0", "depth": 0 }
+                ]
+              }
+            }
+            """;
+        var handler = ExactSkillsetHandler(closureJson: duplicateClosure);
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillsetAsync(
+            "token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    private static OrnnRemoteSkillFetcher CreateFetcher(
+        OrnnTestHttpMessageHandler handler,
+        TimeSpan? timeout = null)
+    {
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+        var client = new OrnnSkillClient(
+            new OrnnOptions { NyxIdSlug = "ornn-api" },
+            nyxClient,
+            timeout ?? TimeSpan.FromSeconds(30));
+        return new OrnnRemoteSkillFetcher(client);
+    }
+
+    private static OrnnTestHttpMessageHandler ExactSkillHandler(
+        string? packageJson = null,
+        string? detailJson = null,
+        string? versionsJson = null,
+        Func<HttpResponseMessage>? packageResponse = null,
+        Func<HttpResponseMessage>? detailResponse = null)
+    {
+        return OrnnTestHttpMessageHandler.Routing(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith($"/skills/{SkillGuid}/json", StringComparison.Ordinal))
+                return packageResponse?.Invoke() ?? OrnnTestHttpMessageHandler.JsonResponse(packageJson ?? SkillPackage());
+            if (path.EndsWith($"/skills/{SkillGuid}/versions", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(versionsJson ?? SkillVersions());
+            if (path.EndsWith($"/skills/{SkillGuid}", StringComparison.Ordinal))
+                return detailResponse?.Invoke() ?? OrnnTestHttpMessageHandler.JsonResponse(detailJson ?? SkillDetail());
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+    }
+
+    private static OrnnTestHttpMessageHandler ExactSkillsetHandler(
+        string? detailJson = null,
+        string? closureJson = null,
+        string? versionsJson = null)
+    {
+        return OrnnTestHttpMessageHandler.Routing(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith($"/skillsets/{SkillsetGuid}/closure", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(closureJson ?? SkillsetClosure());
+            if (path.EndsWith($"/skillsets/{SkillsetGuid}/versions", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(versionsJson ?? SkillsetVersions());
+            if (path.EndsWith($"/skillsets/{SkillsetGuid}", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(detailJson ?? SkillsetDetail());
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+    }
+
+    private static void AssertOnlyExactRequests(
+        OrnnTestHttpMessageHandler handler,
+        string guid,
+        string version,
+        bool isSkillset)
+    {
+        var resource = isSkillset ? "skillsets" : "skills";
+        var expected = isSkillset
+            ? new[]
+            {
+                $"/api/v1/{resource}/{guid}?version={version}",
+                $"/api/v1/{resource}/{guid}/closure?version={version}",
+                $"/api/v1/{resource}/{guid}/versions",
+            }
+            : new[]
+            {
+                $"/api/v1/{resource}/{guid}/json?version={version}",
+                $"/api/v1/{resource}/{guid}?version={version}",
+                $"/api/v1/{resource}/{guid}/versions",
+            };
+
+        handler.Requests.Should().HaveCount(3);
+        handler.Requests.Select(request => request.RequestUri!.PathAndQuery)
+            .Should().BeEquivalentTo(expected.Select(path => $"/api/v1/proxy/s/ornn-api{path}"));
+        handler.Requests.Should().OnlyContain(request =>
+            request.RequestUri!.AbsolutePath.Contains($"/{resource}/{guid}", StringComparison.Ordinal));
+        handler.Requests.Select(request => request.RequestUri!.PathAndQuery)
+            .Should().NotContain(path => path.Contains("latest", StringComparison.OrdinalIgnoreCase) ||
+                                         path.Contains("search", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string SkillPackage(
+        string name = "curated-skill",
+        string version = "1.2",
+        string? filesJson = null) => $$"""
+        {
+          "data": {
+            "name": "{{name}}",
+            "description": "A reviewed skill",
+            "version": "{{version}}",
+            "metadata": {
+              "tools": [
+                {
+                  "tool": "workspace.read",
+                  "type": "mcp",
+                  "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
+                }
+              ]
+            },
+            "files": {{filesJson ?? "{\"SKILL.md\":\"---\\nname: curated-skill\\ndescription: Reviewed\\n---\\nRun it.\",\"docs/readme.md\":\"Reference\"}"}}
+          }
+        }
+        """;
+
+    private static string SkillDetail(string name = "curated-skill") => $$"""
+        {
+          "data": {
+            "guid": "{{SkillGuid}}",
+            "name": "{{name}}",
+            "version": "1.2",
+            "skillHash": "{{SkillHash}}",
+            "metadata": {
+              "tools": [
+                {
+                  "tool": "workspace.read",
+                  "type": "mcp",
+                  "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
+                }
+              ]
+            }
+          }
+        }
+        """;
+
+    private static string SkillVersions() => $$"""
+        {
+          "data": {
+            "items": [
+              {
+                "version": "1.2",
+                "skillHash": "{{SkillHash}}",
+                "integrity": "{{Integrity(SkillHash)}}",
+                "createdBy": "publisher-subject",
+                "createdByEmail": "publisher@example.test",
+                "createdByDisplayName": "Publisher Name",
+                "createdOn": "2026-07-10T12:30:00Z"
+              }
+            ]
+          }
+        }
+        """;
+
+    private static string SkillsetDetail() => $$"""
+        {
+          "data": {
+            "guid": "{{SkillsetGuid}}",
+            "name": "reviewed-set",
+            "version": "2.0",
+            "instructions": "Use both reviewed skills.",
+            "members": ["member-a@1.0", "member-b@beta"]
+          }
+        }
+        """;
+
+    private static string SkillsetClosure() => $$"""
+        {
+          "data": {
+            "instructions": "Use both reviewed skills.",
+            "items": [
+              { "ref": "dependency@3.0", "guid": "{{DependencyGuid}}", "name": "dependency", "version": "3.0", "depth": 1 },
+              { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
+              { "ref": "member-b@2.0", "guid": "{{MemberBGuid}}", "name": "member-b", "version": "2.0", "depth": 0 }
+            ]
+          }
+        }
+        """;
+
+    private static string SkillsetVersions() => """
+        {
+          "data": {
+            "items": [
+              {
+                "version": "2.0",
+                "memberCount": 2,
+                "createdBy": "set-publisher",
+                "createdByDisplayName": "Set Publisher",
+                "createdOn": "2026-07-11T08:00:00+00:00"
+              }
+            ]
+          }
+        }
+        """;
+
+    private static string Integrity(string hex) =>
+        $"sha256-{Convert.ToBase64String(Convert.FromHexString(hex))}";
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
@@ -1,23 +1,30 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Collections.Concurrent;
 
 namespace Aevatar.AI.ToolProviders.Ornn.Tests;
 
 internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
 {
-    private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+    private readonly ConcurrentQueue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+    private readonly Func<HttpRequestMessage, HttpResponseMessage>? _responseRouter;
     private readonly bool _hangUntilCanceled;
+    private readonly ConcurrentQueue<CapturedHttpRequest> _requests = new();
 
-    public List<CapturedHttpRequest> Requests { get; } = [];
+    public IReadOnlyList<CapturedHttpRequest> Requests => _requests.ToArray();
 
     public OrnnTestHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
-        : this(hangUntilCanceled: false, responses)
+        : this(hangUntilCanceled: false, responseRouter: null, responses)
     {
     }
 
-    private OrnnTestHttpMessageHandler(bool hangUntilCanceled, params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
+    private OrnnTestHttpMessageHandler(
+        bool hangUntilCanceled,
+        Func<HttpRequestMessage, HttpResponseMessage>? responseRouter,
+        params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
     {
         _hangUntilCanceled = hangUntilCanceled;
+        _responseRouter = responseRouter;
         foreach (var response in responses)
             _responses.Enqueue(response);
     }
@@ -35,12 +42,17 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
     /// </summary>
     public static OrnnTestHttpMessageHandler HangingUntilCanceled()
     {
-        return new OrnnTestHttpMessageHandler(hangUntilCanceled: true);
+        return new OrnnTestHttpMessageHandler(hangUntilCanceled: true, responseRouter: null);
+    }
+
+    public static OrnnTestHttpMessageHandler Routing(Func<HttpRequestMessage, HttpResponseMessage> responseRouter)
+    {
+        return new OrnnTestHttpMessageHandler(hangUntilCanceled: false, responseRouter);
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        Requests.Add(CapturedHttpRequest.From(request));
+        _requests.Enqueue(CapturedHttpRequest.From(request));
 
         if (_hangUntilCanceled)
         {
@@ -54,20 +66,78 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        var responseFactory = _responses.Count > 0
-            ? _responses.Dequeue()
+        if (_responseRouter is not null)
+            return _responseRouter(request);
+
+        var responseFactory = _responses.TryDequeue(out var queuedResponse)
+            ? queuedResponse
             : _ => new HttpResponseMessage(HttpStatusCode.NotFound);
 
         return responseFactory(request);
     }
 
-    public static HttpResponseMessage JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
+    public static HttpResponseMessage JsonResponse(
+        string json,
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        long? contentLength = null)
     {
-        return new HttpResponseMessage(statusCode)
+        var response = new HttpResponseMessage(statusCode)
         {
             Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
         };
+        if (contentLength is not null)
+            response.Content.Headers.ContentLength = contentLength;
+        return response;
     }
+
+    public static HttpResponseMessage OversizedStreamResponse(long byteCount)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new RepeatedByteStream(byteCount)),
+        };
+    }
+}
+
+internal sealed class RepeatedByteStream(long length) : Stream
+{
+    private long _position;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => length;
+    public override long Position { get => _position; set => throw new NotSupportedException(); }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var remaining = length - _position;
+        if (remaining <= 0)
+            return 0;
+        var read = (int)Math.Min(count, remaining);
+        Array.Fill(buffer, (byte)'x', offset, read);
+        _position += read;
+        return read;
+    }
+
+    public override ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var remaining = length - _position;
+        if (remaining <= 0)
+            return ValueTask.FromResult(0);
+        var read = (int)Math.Min(buffer.Length, remaining);
+        buffer.Span[..read].Fill((byte)'x');
+        _position += read;
+        return ValueTask.FromResult(read);
+    }
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 }
 
 internal sealed record CapturedHttpRequest(

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+using Aevatar.AI.ToolProviders.Skills;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -115,6 +116,31 @@ public sealed class ServiceCollectionExtensionsTests
         sources.Count(x => x is OrnnAgentToolSource).Should().Be(1);
         sources.OfType<OrnnAgentToolSource>().Should().ContainSingle()
             .Which.Should().BeSameAs(provider.GetRequiredService<OrnnAgentToolSource>());
+    }
+
+    [Fact]
+    public void AddOrnnSkills_ShouldAliasOrdinaryAndExactPortsToOneFetcherWithoutExposingItAsToolSource()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(new NotFoundHttpMessageHandler())));
+
+        services.AddOrnnSkills();
+        services.AddOrnnSkills();
+
+        using var provider = services.BuildServiceProvider();
+        var concrete = provider.GetRequiredService<OrnnRemoteSkillFetcher>();
+        var ordinary = provider.GetRequiredService<IRemoteSkillFetcher>();
+        var exact = provider.GetRequiredService<IExactRemoteSkillFetcher>();
+
+        ordinary.Should().BeSameAs(concrete);
+        exact.Should().BeSameAs(concrete);
+        provider.GetServices<IRemoteSkillFetcher>().Should().ContainSingle();
+        provider.GetServices<IExactRemoteSkillFetcher>().Should().ContainSingle();
+        provider.GetRequiredService<ExactRemoteReleaseVerifier>().Should().NotBeNull();
+        provider.GetServices<IAgentToolSource>().Should()
+            .NotContain(source => ReferenceEquals(source, exact));
     }
 
     private sealed class StubOverlayProvider : ISystemSkillOverlayProvider, ISystemSkillOverlayFallback


### PR DESCRIPTION
## Changed files

- 新增仅包含 GUID 和字面版本的 skill/skillset Protobuf 引用，以及独立的精确读取端口。
- 由 Ornn 适配器并发获取 skill 和 skillset 各三类 GUID 证据，严格比较四字段发布者快照、成员版本和包完整性，任何不一致均封闭失败。
- 将 exact 和 ordinary fetcher 注册为同一 singleton，并补充信任边界文档与快速、隔离的行为测试。

## Test results

- 解决方案构建通过，0 errors。
- Ornn 定向测试 29/29 通过；AI Protobuf/recovery 定向测试 29/29 通过。
- 全量解决方案测试 0 failures；架构门禁、测试稳定性门禁与 diff 格式检查全部通过。

## Deviations

- 无实现偏差，无授权范围扩展。
- `HOST_REFACTOR_COMMENT_POLICY` 未设置，按 `none` 处理，没有增加重构历史源码注释。

Closes #2813

⟦AI:AUTO-LOOP⟧
