### PR TITLE
为 Ornn 技能发布增加精确版本校验

### DIFF
--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -164,6 +164,16 @@ chat-route policy 指定 `tool_set_ref` 或 `tool_choice_hint` 时，三条直�
 
 直连工具的失败语义按边界分层处理。客户端声明但不属于 Aevatar substitute 或 additive 的 forwarded tools 仍然由客户端执行；这类工具不会在 Aevatar 内被降级。只要某个工具名来自 Aevatar-owned substitute/additive discovery，即使客户端也声明了同名工具，该名称也会作为 `owned_tool_names` 写入 run command，并由运行时作为 deny-forward 边界处理，不能被转成 forwarded tool call。Aevatar 本地 direct tools 执行失败时，actor 会把失败转成合法 JSON tool output，并继续把结果送回模型，避免一个可选本地工具异常终止整次 response。该 JSON 只暴露稳定错误码、工具名和异常类型，不透出 token、请求头或内部路径。调用方取消仍然取消整次 run，不会被转成 tool output。chat-route `tool_set_ref` 解析错误仍然 fail closed 返回配置错误；但已经解析出的 tool source、全局 provider、skills/Ornn discovery 如果单个 source 失败，会记录 warning 并跳过该 source，其他可用工具继续进入本次计划。
 
+### 5.1 Ordinary discovery 与 curated exact read
+
+`use_skill`、skill recovery、搜索和系统 overlay 继续使用 ordinary name-or-ID 读取。这条路径服务发现与普通执行，允许按名称读取当前版本，属于 normal trust；它不会因为名称、`@1.1` member 文本或当前 overlay 配置自动获得 curated trust。
+
+需要审核不可变发布证据的调用方必须使用独立的 exact port，并提交 Protobuf `ExactRemoteSkillRef` 或 `ExactRemoteSkillsetRef`。两种引用都只有 GUID 和 literal `major.minor` version，没有 name、dist-tag、latest 或 hash fallback。Exact skill 固定并发读取 versioned package、versioned detail 和 GUID-scoped versions；exact skillset 固定并发读取 versioned detail、versioned closure 和 GUID-scoped versions。三份响应必须在同一个 30 秒预算内完成并互相一致，任何缺失、重复、解析失败或身份/版本/名称/closure 差异都会失败关闭，不追加第四个 name/latest 请求。
+
+读取在反序列化前受限：skill package 原始 JSON 最大 100 MiB，其余五类证据各最大 25 MiB，同时检查 `Content-Length` 与实际流字节。解码后的 skill package 最多 1000 个文件、规范相对路径最多 512 UTF-8 bytes、单文件最多 25 MiB、文件总量最多 50 MiB、声明工具最多 50 个；skillset direct members 最多 100 个，closure 最多 500 个节点。调用方审核的 bounds 只能进一步收紧这些上限。
+
+Version row 的 publisher snapshot 完整保留 `createdBy`、可选 `createdByEmail`、可选 `createdByDisplayName` 与 `createdOn`。只有稳定 subject id 表示发布者身份；email 和 display name 只是该 immutable version 的展示快照，参与完整性比较但不授予权限。`metadata.tools` 同样只是待审核的 package 声明，不会注册或授权工具。Ornn 的 `skillHash/integrity` 覆盖原始 ZIP，而 exact package 返回解包后的 JSON files，因此二者只在 adapter 内用于跨响应一致性检查，不作为调用方的 JSON 内容 hash pin。
+
 ## 6. 显式 Skill 触发
 
 直连入口支持同一套显式 skill 触发语法：

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -392,6 +392,16 @@ message SystemSkillOverlay {
   int64 materialized_at = 3;
 }
 
+message ExactRemoteSkillRef {
+  string guid = 1;
+  string literal_version = 2;
+}
+
+message ExactRemoteSkillsetRef {
+  string guid = 1;
+  string literal_version = 2;
+}
+
 // Retired (issue #2498): no longer emitted — the overlay is sourced by the host-level provider, not
 // materialized per-actor. Kept defined so historical journals / queued durable timeouts still
 // deserialize and replay through their no-op handlers. Remove in a later release once no grain journal

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnRemoteSkillFetcher.cs
@@ -10,7 +10,7 @@ namespace Aevatar.AI.ToolProviders.Ornn;
 /// <summary>
 /// Ornn 远程技能拉取器。通过 OrnnSkillClient 从 Ornn 平台获取技能。
 /// </summary>
-public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
+public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher, IExactRemoteSkillFetcher
 {
     private readonly OrnnSkillClient _client;
     private static readonly char[] PathSeparators = ['/', '\\'];
@@ -23,6 +23,44 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         var skill = await _client.GetSkillJsonAsync(accessToken, nameOrId, ct);
         if (skill == null)
             return null;
+
+        return MapSkill(skill, nameOrId);
+    }
+
+    public async Task<ExactRemoteSkillRelease> FetchExactSkillAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        var evidence = await _client.GetExactSkillAsync(accessToken, reference, ct);
+        return new ExactRemoteSkillRelease(
+            reference.Clone(),
+            evidence.PublishedName,
+            evidence.Provenance,
+            evidence.ExactPackage,
+            evidence.DeclaredTools,
+            MapSkill(evidence.Package, reference.Guid));
+    }
+
+    public async Task<ExactRemoteSkillsetRelease> FetchExactSkillsetAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        var evidence = await _client.GetExactSkillsetAsync(accessToken, reference, ct);
+        return new ExactRemoteSkillsetRelease(
+            reference.Clone(),
+            evidence.PublishedName,
+            evidence.Provenance,
+            evidence.Instructions,
+            evidence.DirectMembers.Select(static member => member.Clone()).ToArray(),
+            evidence.FullClosure.Select(static member => member.Clone()).ToArray());
+    }
+
+    private static SkillDefinition MapSkill(OrnnSkillJson skill, string remoteId)
+    {
 
         // 从 SKILL.md 文件内容中提取 instructions
         var instructions = "";
@@ -54,17 +92,17 @@ public sealed class OrnnRemoteSkillFetcher : IRemoteSkillFetcher
         if (workflows.Count == 0)
             workflows = extraction.Workflows;
         var scriptExtraction = new SkillScriptExtractor().ExtractFromFiles(
-            parsed.Name ?? skill.Name ?? nameOrId,
+            parsed.Name ?? skill.Name ?? remoteId,
             parsed.ScriptEntry,
             extraction.RemainingFiles);
 
         return new SkillDefinition
         {
-            Name = parsed.Name ?? skill.Name ?? nameOrId,
+            Name = parsed.Name ?? skill.Name ?? remoteId,
             Description = parsed.Description ?? skill.Description ?? "",
             Instructions = parsed.Body,
             Source = SkillSource.Remote,
-            RemoteId = nameOrId,
+            RemoteId = remoteId,
             Arguments = parsed.Arguments,
             WhenToUse = parsed.WhenToUse,
             IsModelInvocable = parsed.IsModelInvocable,

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -1,5 +1,8 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Collections.ObjectModel;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.Publishing;
 using Aevatar.AI.ToolProviders.Skills;
@@ -17,6 +20,10 @@ namespace Aevatar.AI.ToolProviders.Ornn;
 /// </summary>
 public sealed class OrnnSkillClient
 {
+    private const int MaximumDeclaredTools = 50;
+    private const int MaximumDirectMembers = 100;
+    private const int MaximumClosureNodes = 500;
+    private const long EvidenceResponseMaximumBytes = NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes;
     private readonly NyxIdApiClient _nyxApi;
     private readonly OrnnOptions _options;
     private readonly ILogger _logger;
@@ -26,6 +33,10 @@ public sealed class OrnnSkillClient
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    private static readonly Regex LiteralVersionPattern = new(
+        "^[0-9]+\\.[0-9]+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
     /// <summary>
     /// Default per-call timeout for Ornn HTTP fetches through the NyxID proxy. Without this, a
@@ -260,6 +271,124 @@ public sealed class OrnnSkillClient
         }
     }
 
+    internal async Task<OrnnExactSkillEvidence> GetExactSkillAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
+        CancellationToken ct = default)
+    {
+        ValidateExactReference(
+            reference.Guid,
+            reference.LiteralVersion,
+            ExactRemoteResourceKind.Skill);
+        var encodedGuid = Uri.EscapeDataString(reference.Guid);
+        var encodedVersion = Uri.EscapeDataString(reference.LiteralVersion);
+        var resourceKind = ExactRemoteResourceKind.Skill;
+
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        try
+        {
+            var packageTask = ReadExactDataAsync<OrnnSkillJson>(
+                accessToken,
+                $"/api/v1/skills/{encodedGuid}/json?version={encodedVersion}",
+                NyxIdToolOptions.HardProxyFileArtifactMaxBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var detailTask = ReadExactDataAsync<OrnnExactSkillDetail>(
+                accessToken,
+                $"/api/v1/skills/{encodedGuid}?version={encodedVersion}",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var versionsTask = ReadExactDataAsync<OrnnExactVersionItems<OrnnExactSkillVersionRow>>(
+                accessToken,
+                $"/api/v1/skills/{encodedGuid}/versions",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+
+            await Task.WhenAll(packageTask, detailTask, versionsTask);
+            return BuildExactSkillEvidence(reference, packageTask.Result, detailTask.Result, versionsTask.Result.Items);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw ExactRemoteFetchException.Unavailable(
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"the shared {_perCallTimeout.TotalSeconds:0.###} second request budget expired");
+        }
+    }
+
+    internal async Task<OrnnExactSkillsetEvidence> GetExactSkillsetAsync(
+        string accessToken,
+        Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
+        CancellationToken ct = default)
+    {
+        ValidateExactReference(
+            reference.Guid,
+            reference.LiteralVersion,
+            ExactRemoteResourceKind.Skillset);
+        var encodedGuid = Uri.EscapeDataString(reference.Guid);
+        var encodedVersion = Uri.EscapeDataString(reference.LiteralVersion);
+        var resourceKind = ExactRemoteResourceKind.Skillset;
+
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        try
+        {
+            var detailTask = ReadExactDataAsync<OrnnSkillSet>(
+                accessToken,
+                $"/api/v1/skillsets/{encodedGuid}?version={encodedVersion}",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var closureTask = ReadExactDataAsync<OrnnExactSkillsetClosure>(
+                accessToken,
+                $"/api/v1/skillsets/{encodedGuid}/closure?version={encodedVersion}",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+            var versionsTask = ReadExactDataAsync<OrnnExactVersionItems<OrnnExactSkillsetVersionRow>>(
+                accessToken,
+                $"/api/v1/skillsets/{encodedGuid}/versions",
+                EvidenceResponseMaximumBytes,
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                linkedCts.Token);
+
+            await Task.WhenAll(detailTask, closureTask, versionsTask);
+            return BuildExactSkillsetEvidence(reference, detailTask.Result, closureTask.Result, versionsTask.Result.Items);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            throw ExactRemoteFetchException.Unavailable(
+                resourceKind,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"the shared {_perCallTimeout.TotalSeconds:0.###} second request budget expired");
+        }
+    }
+
     public async Task<OrnnSkillPublishResponse> PublishSkillAsync(
         string accessToken,
         byte[] zipBytes,
@@ -454,7 +583,635 @@ public sealed class OrnnSkillClient
             ? prop.GetString()
             : null;
 
+    private async Task<T> ReadExactDataAsync<T>(
+        string accessToken,
+        string path,
+        long maximumBytes,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        CancellationToken ct)
+        where T : class
+    {
+        var response = await _nyxApi.ProxyGetBinaryResponseAsync(
+            accessToken,
+            _options.NyxIdSlug,
+            path,
+            extraHeaders: null,
+            maximumBytes,
+            ct);
+        if (!response.Succeeded)
+        {
+            if (response.Detail is "content_length_exceeds_max_bytes" or "content_exceeds_max_bytes")
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    resourceKind,
+                    guid,
+                    literalVersion,
+                    $"response '{path}' exceeded {maximumBytes} bytes");
+            }
+
+            throw ExactRemoteFetchException.Unavailable(
+                resourceKind,
+                guid,
+                literalVersion,
+                string.IsNullOrWhiteSpace(response.Detail) ? $"request '{path}' failed" : response.Detail,
+                response.HttpStatus == 0 ? null : response.HttpStatus);
+        }
+
+        try
+        {
+            var envelope = JsonSerializer.Deserialize<OrnnApiResponse<T>>(response.Content, JsonOptions);
+            return envelope?.Data ?? throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                $"response '{path}' omitted data");
+        }
+        catch (ExactRemoteFetchException)
+        {
+            throw;
+        }
+        catch (JsonException ex)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                $"response '{path}' was not valid JSON",
+                ex);
+        }
+    }
+
+    private static OrnnExactSkillEvidence BuildExactSkillEvidence(
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
+        OrnnSkillJson package,
+        OrnnExactSkillDetail detail,
+        IReadOnlyList<OrnnExactSkillVersionRow> versionRows)
+    {
+        RequireGuidMatch(detail.Guid, reference.Guid, ExactRemoteResourceKind.Skill, reference.LiteralVersion);
+        RequireText(package.Name, "package name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireText(detail.Name, "detail name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(package.Name!, detail.Name!, "package/detail name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(package.Version, reference.LiteralVersion, "package version", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.Version, reference.LiteralVersion, "detail version", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        if (package.Metadata is null || detail.Metadata is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                "package and detail metadata must both be present");
+        }
+
+        var versionRow = SelectExactVersionRow(
+            versionRows,
+            reference.LiteralVersion,
+            static row => row.Version,
+            ExactRemoteResourceKind.Skill,
+            reference.Guid);
+        RequireText(detail.SkillHash, "detail skill hash", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireText(versionRow.SkillHash, "version skill hash", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireText(versionRow.Integrity, "version integrity", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.SkillHash!, versionRow.SkillHash!, "detail/version skill hash", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        VerifyIntegrity(versionRow.SkillHash!, versionRow.Integrity, reference.Guid, reference.LiteralVersion);
+
+        var packageTools = NormalizeTools(package.Metadata?.Tools, reference.Guid, reference.LiteralVersion);
+        var detailTools = NormalizeTools(detail.Metadata?.Tools, reference.Guid, reference.LiteralVersion);
+        RequireToolSetsEqual(packageTools, detailTools, reference.Guid, reference.LiteralVersion);
+        var exactPackage = ValidatePackage(package.Files, reference.Guid, reference.LiteralVersion);
+        package.Files = exactPackage.Files.ToDictionary(static file => file.Key, static file => file.Value, StringComparer.Ordinal);
+
+        return new OrnnExactSkillEvidence(
+            package,
+            detail.Name!,
+            BuildProvenance(versionRow, reference.Guid, reference.LiteralVersion, ExactRemoteResourceKind.Skill),
+            exactPackage,
+            packageTools);
+    }
+
+    private static OrnnExactSkillsetEvidence BuildExactSkillsetEvidence(
+        Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
+        OrnnSkillSet detail,
+        OrnnExactSkillsetClosure closure,
+        IReadOnlyList<OrnnExactSkillsetVersionRow> versionRows)
+    {
+        RequireGuidMatch(detail.Guid, reference.Guid, ExactRemoteResourceKind.Skillset, reference.LiteralVersion);
+        RequireText(detail.Name, "detail name", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.Version, reference.LiteralVersion, "detail version", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireText(detail.Instructions, "detail instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireText(closure.Instructions, "closure instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        RequireEqual(detail.Instructions!, closure.Instructions!, "detail/closure instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+
+        if (detail.Members.Count > MaximumDirectMembers)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"direct member count exceeded {MaximumDirectMembers}");
+        }
+        if (detail.Members.Count == 0)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "direct members were missing or empty");
+        }
+        if (closure.Items is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "closure items were missing");
+        }
+        if (closure.Items.Count > MaximumClosureNodes)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"closure node count exceeded {MaximumClosureNodes}");
+        }
+
+        var versionRow = SelectExactVersionRow(
+            versionRows,
+            reference.LiteralVersion,
+            static row => row.Version,
+            ExactRemoteResourceKind.Skillset,
+            reference.Guid);
+        if (versionRow.MemberCount is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "version member count was missing");
+        }
+        if (versionRow.MemberCount.Value != detail.Members.Count)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "version member count differs from detail members");
+        }
+
+        var closureItems = ValidateClosureItems(closure.Items, reference.Guid, reference.LiteralVersion);
+        var directMembers = ResolveDirectMembers(detail.Members, closureItems, reference.Guid, reference.LiteralVersion);
+        return new OrnnExactSkillsetEvidence(
+            detail.Name!,
+            BuildProvenance(versionRow, reference.Guid, reference.LiteralVersion, ExactRemoteResourceKind.Skillset),
+            detail.Instructions!,
+            directMembers,
+            closureItems.Select(static item => item.Reference).ToArray());
+    }
+
+    private static ExactRemotePackage ValidatePackage(
+        IReadOnlyDictionary<string, string>? files,
+        string guid,
+        string literalVersion)
+    {
+        if (files is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "package files were missing");
+        }
+
+        var maximum = ExactRemotePackageBounds.AdapterMaximum;
+        if (files.Count > maximum.MaximumFileCount)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                $"package file count exceeded {maximum.MaximumFileCount}");
+        }
+
+        var normalizedFiles = new Dictionary<string, string>(StringComparer.Ordinal);
+        var maximumPathBytes = 0;
+        long maximumFileBytes = 0;
+        long totalFileBytes = 0;
+        foreach (var (path, content) in files)
+        {
+            var normalizedPath = NormalizePackagePath(path, guid, literalVersion);
+            if (content is null)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    $"package file '{normalizedPath}' had null content");
+            }
+            if (!normalizedFiles.TryAdd(normalizedPath, content))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    $"package contains duplicate normalized path '{normalizedPath}'");
+            }
+
+            var pathBytes = Encoding.UTF8.GetByteCount(normalizedPath);
+            var fileBytes = Encoding.UTF8.GetByteCount(content);
+            if (pathBytes > maximum.MaximumPathUtf8Bytes || fileBytes > maximum.MaximumFileUtf8Bytes)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    $"package path or file '{normalizedPath}' exceeded adapter bounds");
+            }
+
+            maximumPathBytes = Math.Max(maximumPathBytes, pathBytes);
+            maximumFileBytes = Math.Max(maximumFileBytes, fileBytes);
+            totalFileBytes += fileBytes;
+            if (totalFileBytes > maximum.MaximumTotalFileUtf8Bytes)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    "package total file bytes exceeded adapter bounds");
+            }
+        }
+
+        return new ExactRemotePackage(
+            new ReadOnlyDictionary<string, string>(normalizedFiles),
+            new ExactRemotePackageShape(files.Count, maximumPathBytes, maximumFileBytes, totalFileBytes));
+    }
+
+    private static string NormalizePackagePath(string path, string guid, string literalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(path) || path.Contains('\0'))
+            throw InvalidPackagePath(guid, literalVersion, path);
+
+        var replaced = path.Replace('\\', '/');
+        if (replaced.StartsWith('/') || Regex.IsMatch(replaced, "^[A-Za-z]:/", RegexOptions.CultureInvariant))
+            throw InvalidPackagePath(guid, literalVersion, path);
+
+        var segments = replaced.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length == 0 || segments.Any(static segment => segment is "." or ".."))
+            throw InvalidPackagePath(guid, literalVersion, path);
+        return string.Join('/', segments);
+    }
+
+    private static ExactRemoteFetchException InvalidPackagePath(string guid, string literalVersion, string? path) =>
+        ExactRemoteFetchException.InvalidResponse(
+            ExactRemoteResourceKind.Skill,
+            guid,
+            literalVersion,
+            $"package path '{path}' is not a normalized relative path");
+
+    private static IReadOnlyList<ExactRemoteToolDeclaration> NormalizeTools(
+        IReadOnlyList<OrnnSkillToolDeclaration>? tools,
+        string guid,
+        string literalVersion)
+    {
+        if (tools is null)
+            return [];
+        if (tools.Count > MaximumDeclaredTools)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                $"declared tool count exceeded {MaximumDeclaredTools}");
+        }
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var normalized = new List<ExactRemoteToolDeclaration>(tools.Count);
+        foreach (var tool in tools)
+        {
+            if (string.IsNullOrWhiteSpace(tool.Tool) || string.IsNullOrWhiteSpace(tool.Type) ||
+                !names.Add(tool.Tool))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skill,
+                    guid,
+                    literalVersion,
+                    "declared tools contain a blank or duplicate identity");
+            }
+
+            var mcpServers = new List<ExactRemoteMcpServerDeclaration>();
+            var mcpKeys = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var server in tool.McpServers ?? [])
+            {
+                var key = $"{server.Mcp}\u001f{server.Version}";
+                if (string.IsNullOrWhiteSpace(server.Mcp) || string.IsNullOrWhiteSpace(server.Version) ||
+                    !mcpKeys.Add(key))
+                {
+                    throw ExactRemoteFetchException.InvalidResponse(
+                        ExactRemoteResourceKind.Skill,
+                        guid,
+                        literalVersion,
+                        $"declared tool '{tool.Tool}' contains a blank or duplicate MCP server");
+                }
+                mcpServers.Add(new ExactRemoteMcpServerDeclaration(server.Mcp, server.Version));
+            }
+
+            normalized.Add(new ExactRemoteToolDeclaration(
+                tool.Tool,
+                tool.Type,
+                mcpServers.OrderBy(static server => server.Mcp, StringComparer.Ordinal)
+                    .ThenBy(static server => server.Version, StringComparer.Ordinal)
+                    .ToArray()));
+        }
+
+        return normalized.OrderBy(static tool => tool.Tool, StringComparer.Ordinal).ToArray();
+    }
+
+    private static void RequireToolSetsEqual(
+        IReadOnlyList<ExactRemoteToolDeclaration> packageTools,
+        IReadOnlyList<ExactRemoteToolDeclaration> detailTools,
+        string guid,
+        string literalVersion)
+    {
+        var packageKeys = packageTools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
+        var detailKeys = detailTools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
+        if (!packageKeys.SetEquals(detailKeys))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "package/detail declared tools differ");
+        }
+    }
+
+    private static string ToolKey(ExactRemoteToolDeclaration tool) =>
+        $"{tool.Tool}\u001f{tool.Type}\u001f{string.Join('\u001e', tool.McpServers.Select(static server => $"{server.Mcp}\u001d{server.Version}"))}";
+
+    private static void VerifyIntegrity(string skillHash, string? integrity, string guid, string literalVersion)
+    {
+        byte[] digest;
+        try
+        {
+            digest = Convert.FromHexString(skillHash);
+        }
+        catch (FormatException ex)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "version skill hash is not hexadecimal",
+                ex);
+        }
+
+        if (digest.Length != 32)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "version skill hash is not a SHA-256 digest");
+        }
+
+        var expected = $"sha256-{Convert.ToBase64String(digest)}";
+        if (!string.Equals(integrity, expected, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                guid,
+                literalVersion,
+                "version integrity does not match the skill hash");
+        }
+    }
+
+    private static ExactRemoteVersionProvenance BuildProvenance(
+        IOrnnExactVersionRow row,
+        string guid,
+        string literalVersion,
+        ExactRemoteResourceKind resourceKind)
+    {
+        RequireText(row.CreatedBy, "version publisher subject", resourceKind, guid, literalVersion);
+        ValidateOptionalSnapshot(row.CreatedByEmail, "publisher email snapshot", resourceKind, guid, literalVersion);
+        ValidateOptionalSnapshot(row.CreatedByDisplayName, "publisher display name snapshot", resourceKind, guid, literalVersion);
+        if (!DateTimeOffset.TryParse(
+                row.CreatedOn,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind,
+                out var publishedAt))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                "version published timestamp is missing or invalid");
+        }
+
+        return new ExactRemoteVersionProvenance(
+            row.CreatedBy!,
+            row.CreatedByEmail,
+            row.CreatedByDisplayName,
+            publishedAt.ToUniversalTime());
+    }
+
+    private static void ValidateOptionalSnapshot(
+        string? value,
+        string field,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        if (value is not null && string.IsNullOrWhiteSpace(value))
+            throw ExactRemoteFetchException.InvalidResponse(resourceKind, guid, literalVersion, $"{field} was blank");
+    }
+
+    private static T SelectExactVersionRow<T>(
+        IReadOnlyList<T> rows,
+        string literalVersion,
+        Func<T, string?> versionSelector,
+        ExactRemoteResourceKind resourceKind,
+        string guid)
+    {
+        var matches = rows.Where(row => string.Equals(versionSelector(row), literalVersion, StringComparison.Ordinal)).ToArray();
+        if (matches.Length != 1)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                "versions response must contain the requested literal version exactly once");
+        }
+        return matches[0];
+    }
+
+    private static IReadOnlyList<ValidatedClosureItem> ValidateClosureItems(
+        IReadOnlyList<OrnnExactSkillsetClosureItem> items,
+        string guid,
+        string literalVersion)
+    {
+        var identities = new HashSet<string>(StringComparer.Ordinal);
+        var validated = new List<ValidatedClosureItem>(items.Count);
+        foreach (var item in items)
+        {
+            RequireText(item.Ref, "closure ref", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            RequireText(item.Name, "closure name", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            ValidateExactReference(item.Guid, item.Version, ExactRemoteResourceKind.Skillset);
+            if (item.Depth is null || item.Depth.Value < 0)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "closure depth must be non-negative");
+            }
+
+            var normalizedGuid = System.Guid.Parse(item.Guid!).ToString("D");
+            if (!identities.Add(normalizedGuid))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "closure contains a duplicate or conflicting GUID");
+            }
+
+            validated.Add(new ValidatedClosureItem(
+                item.Ref!,
+                item.Name!,
+                item.Depth.Value,
+                new Aevatar.AI.Abstractions.ExactRemoteSkillRef
+                {
+                    Guid = item.Guid!,
+                    LiteralVersion = item.Version!,
+                }));
+        }
+        return validated;
+    }
+
+    private static IReadOnlyList<Aevatar.AI.Abstractions.ExactRemoteSkillRef> ResolveDirectMembers(
+        IReadOnlyList<OrnnSkillSetMember> members,
+        IReadOnlyList<ValidatedClosureItem> closureItems,
+        string guid,
+        string literalVersion)
+    {
+        var roots = closureItems.Where(static item => item.Depth == 0).ToArray();
+        if (roots.Length != members.Count)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                guid,
+                literalVersion,
+                "closure root count differs from direct member count");
+        }
+
+        var usedRootGuids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var resolved = new List<Aevatar.AI.Abstractions.ExactRemoteSkillRef>(members.Count);
+        foreach (var member in members)
+        {
+            RequireText(member.Name, "direct member name", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            RequireText(member.Version, "direct member version", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            if (member.Guid is not null && !System.Guid.TryParse(member.Guid, out _))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "direct member GUID was invalid");
+            }
+            var matches = roots.Where(root => MemberMatches(member, root)).ToArray();
+            if (matches.Length != 1 || !usedRootGuids.Add(matches[0].Reference.Guid))
+            {
+                throw ExactRemoteFetchException.IntegrityMismatch(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "each direct member must resolve to one unique closure root");
+            }
+            resolved.Add(matches[0].Reference.Clone());
+        }
+        return resolved;
+    }
+
+    private static bool MemberMatches(OrnnSkillSetMember member, ValidatedClosureItem root)
+    {
+        if (!string.IsNullOrWhiteSpace(member.Guid) &&
+            System.Guid.TryParse(member.Guid, out var memberGuid) &&
+            System.Guid.TryParse(root.Reference.Guid, out var rootGuid))
+        {
+            return memberGuid == rootGuid;
+        }
+
+        if (!string.Equals(member.Name, root.Name, StringComparison.Ordinal))
+            return false;
+        return !IsLiteralVersion(member.Version) ||
+               string.Equals(member.Version, root.Reference.LiteralVersion, StringComparison.Ordinal);
+    }
+
+    private static void RequireGuidMatch(
+        string? actual,
+        string expected,
+        ExactRemoteResourceKind resourceKind,
+        string literalVersion)
+    {
+        if (!System.Guid.TryParse(actual, out var actualGuid) ||
+            !System.Guid.TryParse(expected, out var expectedGuid) ||
+            actualGuid != expectedGuid)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                expected,
+                literalVersion,
+                "returned GUID differs from the requested GUID");
+        }
+    }
+
+    private static void RequireText(
+        string? value,
+        string field,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw ExactRemoteFetchException.InvalidResponse(resourceKind, guid, literalVersion, $"{field} was missing or blank");
+    }
+
+    private static void RequireEqual(
+        string? actual,
+        string expected,
+        string field,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            throw ExactRemoteFetchException.IntegrityMismatch(resourceKind, guid, literalVersion, $"{field} mismatch");
+    }
+
+    private static void ValidateExactReference(
+        string? guid,
+        string? literalVersion,
+        ExactRemoteResourceKind resourceKind)
+    {
+        if (!System.Guid.TryParseExact(guid, "D", out _) || !IsLiteralVersion(literalVersion))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid ?? string.Empty,
+                literalVersion ?? string.Empty,
+                "reference must contain a D-format GUID and a literal major.minor version");
+        }
+    }
+
+    private static bool IsLiteralVersion(string? version) =>
+        version is not null && LiteralVersionPattern.IsMatch(version);
+
     private sealed record NyxIdProxyError(int Status, string Detail);
+
+    private sealed record ValidatedClosureItem(
+        string Ref,
+        string Name,
+        int Depth,
+        Aevatar.AI.Abstractions.ExactRemoteSkillRef Reference);
 }
 
 // DTOs
@@ -492,12 +1249,28 @@ public sealed class OrnnSkillMetadata
     public string? Category { get; set; }
     [JsonPropertyName("tag")]
     public List<string>? Tags { get; set; }
+    public List<OrnnSkillToolDeclaration>? Tools { get; set; }
+}
+
+public sealed class OrnnSkillToolDeclaration
+{
+    public string? Tool { get; set; }
+    public string? Type { get; set; }
+    [JsonPropertyName("mcp-servers")]
+    public List<OrnnMcpServerDeclaration>? McpServers { get; set; }
+}
+
+public sealed class OrnnMcpServerDeclaration
+{
+    public string? Mcp { get; set; }
+    public string? Version { get; set; }
 }
 
 public sealed class OrnnSkillJson
 {
     public string? Name { get; set; }
     public string? Description { get; set; }
+    public string? Version { get; set; }
     public OrnnSkillMetadata? Metadata { get; set; }
     public Dictionary<string, string>? Files { get; set; }
 }
@@ -508,10 +1281,83 @@ public sealed class OrnnSkillSet
 {
     public string? Guid { get; set; }
     public string? Name { get; set; }
+    public string? Version { get; set; }
     /// <summary>Set-level master prompt authored on the skillset itself.</summary>
     public string? Instructions { get; set; }
     public bool IsPrivate { get; set; }
     public List<OrnnSkillSetMember> Members { get; set; } = [];
+}
+
+internal sealed record OrnnExactSkillEvidence(
+    OrnnSkillJson Package,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    ExactRemotePackage ExactPackage,
+    IReadOnlyList<ExactRemoteToolDeclaration> DeclaredTools);
+
+internal sealed record OrnnExactSkillsetEvidence(
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    string Instructions,
+    IReadOnlyList<Aevatar.AI.Abstractions.ExactRemoteSkillRef> DirectMembers,
+    IReadOnlyList<Aevatar.AI.Abstractions.ExactRemoteSkillRef> FullClosure);
+
+internal sealed class OrnnExactSkillDetail
+{
+    public string? Guid { get; set; }
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+    public string? SkillHash { get; set; }
+    public OrnnSkillMetadata? Metadata { get; set; }
+}
+
+internal sealed class OrnnExactVersionItems<T>
+{
+    public List<T> Items { get; set; } = [];
+}
+
+internal interface IOrnnExactVersionRow
+{
+    string? CreatedBy { get; }
+    string? CreatedByEmail { get; }
+    string? CreatedByDisplayName { get; }
+    string? CreatedOn { get; }
+}
+
+internal sealed class OrnnExactSkillVersionRow : IOrnnExactVersionRow
+{
+    public string? Version { get; set; }
+    public string? SkillHash { get; set; }
+    public string? Integrity { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? CreatedByEmail { get; set; }
+    public string? CreatedByDisplayName { get; set; }
+    public string? CreatedOn { get; set; }
+}
+
+internal sealed class OrnnExactSkillsetVersionRow : IOrnnExactVersionRow
+{
+    public string? Version { get; set; }
+    public int? MemberCount { get; set; }
+    public string? CreatedBy { get; set; }
+    public string? CreatedByEmail { get; set; }
+    public string? CreatedByDisplayName { get; set; }
+    public string? CreatedOn { get; set; }
+}
+
+internal sealed class OrnnExactSkillsetClosure
+{
+    public string? Instructions { get; set; }
+    public List<OrnnExactSkillsetClosureItem>? Items { get; set; }
+}
+
+internal sealed class OrnnExactSkillsetClosureItem
+{
+    public string? Ref { get; set; }
+    public string? Guid { get; set; }
+    public string? Name { get; set; }
+    public string? Version { get; set; }
+    public int? Depth { get; set; }
 }
 
 /// <summary>
@@ -526,6 +1372,7 @@ public sealed class OrnnSkillSetMember
     public string? Guid { get; init; }
     public string? Name { get; init; }
     public string? Version { get; init; }
+    internal string? RawReference { get; init; }
 
     /// <summary>The id or name to fetch this member's full skill JSON with (guid preferred).</summary>
     public string? Reference =>
@@ -576,8 +1423,13 @@ internal sealed class OrnnSkillSetMemberJsonConverter : JsonConverter<OrnnSkillS
         var trimmed = raw.Trim();
         var at = trimmed.LastIndexOf('@');
         return at > 0
-            ? new OrnnSkillSetMember { Name = trimmed[..at], Version = trimmed[(at + 1)..] }
-            : new OrnnSkillSetMember { Name = trimmed };
+            ? new OrnnSkillSetMember
+            {
+                Name = trimmed[..at],
+                Version = trimmed[(at + 1)..],
+                RawReference = trimmed,
+            }
+            : new OrnnSkillSetMember { Name = trimmed, RawReference = trimmed };
     }
 
     private static string? ReadString(JsonElement root, string propertyName)

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -659,7 +659,7 @@ public sealed class OrnnSkillClient
         Aevatar.AI.Abstractions.ExactRemoteSkillRef reference,
         OrnnSkillJson package,
         OrnnExactSkillDetail detail,
-        IReadOnlyList<OrnnExactSkillVersionRow> versionRows)
+        IReadOnlyList<OrnnExactSkillVersionRow?>? versionRows)
     {
         RequireGuidMatch(detail.Guid, reference.Guid, ExactRemoteResourceKind.Skill, reference.LiteralVersion);
         RequireText(package.Name, "package name", ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
@@ -706,7 +706,7 @@ public sealed class OrnnSkillClient
         Aevatar.AI.Abstractions.ExactRemoteSkillsetRef reference,
         OrnnSkillSet detail,
         OrnnExactSkillsetClosure closure,
-        IReadOnlyList<OrnnExactSkillsetVersionRow> versionRows)
+        IReadOnlyList<OrnnExactSkillsetVersionRow?>? versionRows)
     {
         RequireGuidMatch(detail.Guid, reference.Guid, ExactRemoteResourceKind.Skillset, reference.LiteralVersion);
         RequireText(detail.Name, "detail name", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
@@ -715,6 +715,14 @@ public sealed class OrnnSkillClient
         RequireText(closure.Instructions, "closure instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
         RequireEqual(detail.Instructions!, closure.Instructions!, "detail/closure instructions", ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
 
+        if (detail.Members is null)
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "direct members were missing or empty");
+        }
         if (detail.Members.Count > MaximumDirectMembers)
         {
             throw ExactRemoteFetchException.InvalidResponse(
@@ -730,6 +738,14 @@ public sealed class OrnnSkillClient
                 reference.Guid,
                 reference.LiteralVersion,
                 "direct members were missing or empty");
+        }
+        if (detail.Members.Any(static member => member is null))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                "direct members contained null");
         }
         if (closure.Items is null)
         {
@@ -881,7 +897,7 @@ public sealed class OrnnSkillClient
             $"package path '{path}' is not a normalized relative path");
 
     private static IReadOnlyList<ExactRemoteToolDeclaration> NormalizeTools(
-        IReadOnlyList<OrnnSkillToolDeclaration>? tools,
+        IReadOnlyList<OrnnSkillToolDeclaration?>? tools,
         string guid,
         string literalVersion)
     {
@@ -900,7 +916,7 @@ public sealed class OrnnSkillClient
         var normalized = new List<ExactRemoteToolDeclaration>(tools.Count);
         foreach (var tool in tools)
         {
-            if (string.IsNullOrWhiteSpace(tool.Tool) || string.IsNullOrWhiteSpace(tool.Type) ||
+            if (tool is null || string.IsNullOrWhiteSpace(tool.Tool) || string.IsNullOrWhiteSpace(tool.Type) ||
                 !names.Add(tool.Tool))
             {
                 throw ExactRemoteFetchException.InvalidResponse(
@@ -914,7 +930,7 @@ public sealed class OrnnSkillClient
             var mcpIdentities = new HashSet<(string Mcp, string Version)>();
             foreach (var server in tool.McpServers ?? [])
             {
-                if (string.IsNullOrWhiteSpace(server.Mcp) || string.IsNullOrWhiteSpace(server.Version) ||
+                if (server is null || string.IsNullOrWhiteSpace(server.Mcp) || string.IsNullOrWhiteSpace(server.Version) ||
                     !mcpIdentities.Add((server.Mcp, server.Version)))
                 {
                     throw ExactRemoteFetchException.InvalidResponse(
@@ -1035,13 +1051,26 @@ public sealed class OrnnSkillClient
     }
 
     private static T SelectExactVersionRow<T>(
-        IReadOnlyList<T> rows,
+        IReadOnlyList<T?>? rows,
         string literalVersion,
         Func<T, string?> versionSelector,
         ExactRemoteResourceKind resourceKind,
         string guid)
+        where T : class
     {
-        var matches = rows.Where(row => string.Equals(versionSelector(row), literalVersion, StringComparison.Ordinal)).ToArray();
+        if (rows is null || rows.Any(static row => row is null))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                resourceKind,
+                guid,
+                literalVersion,
+                "versions response items were missing or contained null");
+        }
+
+        var matches = rows
+            .Select(static row => row!)
+            .Where(row => string.Equals(versionSelector(row), literalVersion, StringComparison.Ordinal))
+            .ToArray();
         if (matches.Length != 1)
         {
             throw ExactRemoteFetchException.InvalidResponse(
@@ -1054,7 +1083,7 @@ public sealed class OrnnSkillClient
     }
 
     private static IReadOnlyList<ValidatedClosureItem> ValidateClosureItems(
-        IReadOnlyList<OrnnExactSkillsetClosureItem> items,
+        IReadOnlyList<OrnnExactSkillsetClosureItem?> items,
         string guid,
         string literalVersion)
     {
@@ -1062,6 +1091,14 @@ public sealed class OrnnSkillClient
         var validated = new List<ValidatedClosureItem>(items.Count);
         foreach (var item in items)
         {
+            if (item is null)
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "closure items contained null");
+            }
             RequireText(item.Ref, "closure ref", ExactRemoteResourceKind.Skillset, guid, literalVersion);
             RequireText(item.Name, "closure name", ExactRemoteResourceKind.Skillset, guid, literalVersion);
             ValidateExactReference(item.Guid, item.Version, ExactRemoteResourceKind.Skillset);
@@ -1103,6 +1140,15 @@ public sealed class OrnnSkillClient
         string guid,
         string literalVersion)
     {
+        if (members.Any(static member => member is null))
+        {
+            throw ExactRemoteFetchException.InvalidResponse(
+                ExactRemoteResourceKind.Skillset,
+                guid,
+                literalVersion,
+                "direct members contained null");
+        }
+
         var roots = closureItems.Where(static item => item.Depth == 0).ToArray();
         if (roots.Length != members.Count)
         {
@@ -1267,7 +1313,7 @@ public sealed class OrnnSkillMetadata
     public string? Category { get; set; }
     [JsonPropertyName("tag")]
     public List<string>? Tags { get; set; }
-    public List<OrnnSkillToolDeclaration>? Tools { get; set; }
+    public List<OrnnSkillToolDeclaration?>? Tools { get; set; }
 }
 
 public sealed class OrnnSkillToolDeclaration
@@ -1275,7 +1321,7 @@ public sealed class OrnnSkillToolDeclaration
     public string? Tool { get; set; }
     public string? Type { get; set; }
     [JsonPropertyName("mcp-servers")]
-    public List<OrnnMcpServerDeclaration>? McpServers { get; set; }
+    public List<OrnnMcpServerDeclaration?>? McpServers { get; set; }
 }
 
 public sealed class OrnnMcpServerDeclaration
@@ -1329,9 +1375,9 @@ internal sealed class OrnnExactSkillDetail
     public OrnnSkillMetadata? Metadata { get; set; }
 }
 
-internal sealed class OrnnExactVersionItems<T>
+internal sealed class OrnnExactVersionItems<T> where T : class
 {
-    public List<T> Items { get; set; } = [];
+    public List<T?>? Items { get; set; } = [];
 }
 
 internal interface IOrnnExactVersionRow
@@ -1366,7 +1412,7 @@ internal sealed class OrnnExactSkillsetVersionRow : IOrnnExactVersionRow
 internal sealed class OrnnExactSkillsetClosure
 {
     public string? Instructions { get; set; }
-    public List<OrnnExactSkillsetClosureItem>? Items { get; set; }
+    public List<OrnnExactSkillsetClosureItem?>? Items { get; set; }
 }
 
 internal sealed class OrnnExactSkillsetClosureItem

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -27,6 +27,7 @@ public sealed class OrnnSkillClient
     private readonly NyxIdApiClient _nyxApi;
     private readonly OrnnOptions _options;
     private readonly ILogger _logger;
+    private readonly TimeProvider _timeProvider;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -64,12 +65,23 @@ public sealed class OrnnSkillClient
         NyxIdApiClient nyxApi,
         TimeSpan perCallTimeout,
         ILogger<OrnnSkillClient>? logger = null)
+        : this(options, nyxApi, perCallTimeout, TimeProvider.System, logger)
+    {
+    }
+
+    public OrnnSkillClient(
+        OrnnOptions options,
+        NyxIdApiClient nyxApi,
+        TimeSpan perCallTimeout,
+        TimeProvider timeProvider,
+        ILogger<OrnnSkillClient>? logger = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _nyxApi = nyxApi ?? throw new ArgumentNullException(nameof(nyxApi));
         if (perCallTimeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(perCallTimeout), "Per-call timeout must be positive.");
         _perCallTimeout = perCallTimeout;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _logger = logger ?? NullLogger<OrnnSkillClient>.Instance;
     }
 
@@ -102,7 +114,7 @@ public sealed class OrnnSkillClient
 
         var path = $"/api/v1/skill-search?query={Uri.EscapeDataString(query)}&mode={normalizedMode}&scope={Uri.EscapeDataString(normalizedScope)}&page={page}&pageSize={pageSize}";
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try
@@ -157,7 +169,7 @@ public sealed class OrnnSkillClient
     {
         var path = $"/api/v1/skills/{Uri.EscapeDataString(idOrName)}/json";
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try
@@ -223,7 +235,7 @@ public sealed class OrnnSkillClient
     {
         var path = $"/api/v1/skillsets/{Uri.EscapeDataString(idOrName)}";
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try
@@ -284,7 +296,7 @@ public sealed class OrnnSkillClient
         var encodedVersion = Uri.EscapeDataString(reference.LiteralVersion);
         var resourceKind = ExactRemoteResourceKind.Skill;
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
         try
         {
@@ -343,7 +355,7 @@ public sealed class OrnnSkillClient
         var encodedVersion = Uri.EscapeDataString(reference.LiteralVersion);
         var resourceKind = ExactRemoteResourceKind.Skillset;
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
         try
         {
@@ -394,7 +406,7 @@ public sealed class OrnnSkillClient
         byte[] zipBytes,
         CancellationToken ct = default)
     {
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try
@@ -442,7 +454,7 @@ public sealed class OrnnSkillClient
         CancellationToken ct = default)
     {
         var path = $"/api/v1/skills/{Uri.EscapeDataString(skillId)}";
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try
@@ -899,12 +911,11 @@ public sealed class OrnnSkillClient
             }
 
             var mcpServers = new List<ExactRemoteMcpServerDeclaration>();
-            var mcpKeys = new HashSet<string>(StringComparer.Ordinal);
+            var mcpIdentities = new HashSet<(string Mcp, string Version)>();
             foreach (var server in tool.McpServers ?? [])
             {
-                var key = $"{server.Mcp}\u001f{server.Version}";
                 if (string.IsNullOrWhiteSpace(server.Mcp) || string.IsNullOrWhiteSpace(server.Version) ||
-                    !mcpKeys.Add(key))
+                    !mcpIdentities.Add((server.Mcp, server.Version)))
                 {
                     throw ExactRemoteFetchException.InvalidResponse(
                         ExactRemoteResourceKind.Skill,
@@ -932,9 +943,11 @@ public sealed class OrnnSkillClient
         string guid,
         string literalVersion)
     {
-        var packageKeys = packageTools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
-        var detailKeys = detailTools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
-        if (!packageKeys.SetEquals(detailKeys))
+        var packageDeclarations = packageTools.ToHashSet(ExactRemoteToolDeclarationComparer.Instance);
+        var detailDeclarations = detailTools.ToHashSet(ExactRemoteToolDeclarationComparer.Instance);
+        if (packageDeclarations.Count != packageTools.Count ||
+            detailDeclarations.Count != detailTools.Count ||
+            !packageDeclarations.SetEquals(detailDeclarations))
         {
             throw ExactRemoteFetchException.IntegrityMismatch(
                 ExactRemoteResourceKind.Skill,
@@ -943,9 +956,6 @@ public sealed class OrnnSkillClient
                 "package/detail declared tools differ");
         }
     }
-
-    private static string ToolKey(ExactRemoteToolDeclaration tool) =>
-        $"{tool.Tool}\u001f{tool.Type}\u001f{string.Join('\u001e', tool.McpServers.Select(static server => $"{server.Mcp}\u001d{server.Version}"))}";
 
     private static void VerifyIntegrity(string skillHash, string? integrity, string guid, string literalVersion)
     {
@@ -1107,9 +1117,16 @@ public sealed class OrnnSkillClient
         var resolved = new List<Aevatar.AI.Abstractions.ExactRemoteSkillRef>(members.Count);
         foreach (var member in members)
         {
-            RequireText(member.Name, "direct member name", ExactRemoteResourceKind.Skillset, guid, literalVersion);
+            if (string.IsNullOrWhiteSpace(member.Guid) && string.IsNullOrWhiteSpace(member.Name))
+            {
+                throw ExactRemoteFetchException.InvalidResponse(
+                    ExactRemoteResourceKind.Skillset,
+                    guid,
+                    literalVersion,
+                    "direct member identifier was missing");
+            }
             RequireText(member.Version, "direct member version", ExactRemoteResourceKind.Skillset, guid, literalVersion);
-            if (member.Guid is not null && !System.Guid.TryParse(member.Guid, out _))
+            if (member.Guid is not null && !System.Guid.TryParseExact(member.Guid, "D", out _))
             {
                 throw ExactRemoteFetchException.InvalidResponse(
                     ExactRemoteResourceKind.Skillset,
@@ -1133,15 +1150,16 @@ public sealed class OrnnSkillClient
 
     private static bool MemberMatches(OrnnSkillSetMember member, ValidatedClosureItem root)
     {
-        if (!string.IsNullOrWhiteSpace(member.Guid) &&
-            System.Guid.TryParse(member.Guid, out var memberGuid) &&
-            System.Guid.TryParse(root.Reference.Guid, out var rootGuid))
-        {
-            return memberGuid == rootGuid;
-        }
-
-        if (!string.Equals(member.Name, root.Name, StringComparison.Ordinal))
+        var identityMatches = !string.IsNullOrWhiteSpace(member.Guid)
+            ? System.Guid.TryParse(member.Guid, out var memberGuid) &&
+              System.Guid.TryParse(root.Reference.Guid, out var rootGuid) &&
+              memberGuid == rootGuid &&
+              (string.IsNullOrWhiteSpace(member.Name) ||
+               string.Equals(member.Name, root.Name, StringComparison.Ordinal))
+            : string.Equals(member.Name, root.Name, StringComparison.Ordinal);
+        if (!identityMatches)
             return false;
+
         return !IsLiteralVersion(member.Version) ||
                string.Equals(member.Version, root.Reference.LiteralVersion, StringComparison.Ordinal);
     }
@@ -1422,14 +1440,24 @@ internal sealed class OrnnSkillSetMemberJsonConverter : JsonConverter<OrnnSkillS
 
         var trimmed = raw.Trim();
         var at = trimmed.LastIndexOf('@');
-        return at > 0
+        if (at <= 0)
+            return new OrnnSkillSetMember { Name = trimmed, RawReference = trimmed };
+
+        var identifier = trimmed[..at];
+        var version = trimmed[(at + 1)..];
+        return System.Guid.TryParseExact(identifier, "D", out var parsedGuid)
             ? new OrnnSkillSetMember
             {
-                Name = trimmed[..at],
-                Version = trimmed[(at + 1)..],
+                Guid = parsedGuid.ToString("D"),
+                Version = version,
                 RawReference = trimmed,
             }
-            : new OrnnSkillSetMember { Name = trimmed, RawReference = trimmed };
+            : new OrnnSkillSetMember
+            {
+                Name = identifier,
+                Version = version,
+                RawReference = trimmed,
+            };
     }
 
     private static string? ReadString(JsonElement root, string propertyName)

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -31,7 +31,10 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<OrnnSkillPackageFormatValidator>();
         services.TryAddSingleton<OrnnPublishSkillTool>();
         services.TryAddSingleton<OrnnUpdateSkillTool>();
-        services.TryAddSingleton<IRemoteSkillFetcher, OrnnRemoteSkillFetcher>();
+        services.TryAddSingleton<OrnnRemoteSkillFetcher>();
+        services.TryAddSingleton<IRemoteSkillFetcher>(sp => sp.GetRequiredService<OrnnRemoteSkillFetcher>());
+        services.TryAddSingleton<IExactRemoteSkillFetcher>(sp => sp.GetRequiredService<OrnnRemoteSkillFetcher>());
+        services.TryAddSingleton<ExactRemoteReleaseVerifier>();
         services.TryAddSingleton<OrnnAgentToolSource>();
         services.TryAddAgentToolSourceAlias<OrnnAgentToolSource>(GetOrnnAgentToolSource);
         return services;

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteFetchException.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteFetchException.cs
@@ -1,0 +1,83 @@
+namespace Aevatar.AI.ToolProviders.Skills;
+
+public enum ExactRemoteFetchFailureKind
+{
+    Unavailable,
+    InvalidResponse,
+    IntegrityMismatch,
+}
+
+public enum ExactRemoteResourceKind
+{
+    Skill,
+    Skillset,
+}
+
+public sealed class ExactRemoteFetchException : Exception
+{
+    public ExactRemoteFetchFailureKind FailureKind { get; }
+    public ExactRemoteResourceKind ResourceKind { get; }
+    public string Guid { get; }
+    public string LiteralVersion { get; }
+    public int? HttpStatus { get; }
+
+    public ExactRemoteFetchException(
+        ExactRemoteFetchFailureKind failureKind,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string message,
+        int? httpStatus = null,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        FailureKind = failureKind;
+        ResourceKind = resourceKind;
+        Guid = guid;
+        LiteralVersion = literalVersion;
+        HttpStatus = httpStatus;
+    }
+
+    public static ExactRemoteFetchException Unavailable(
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string detail,
+        int? httpStatus = null) =>
+        new(
+            ExactRemoteFetchFailureKind.Unavailable,
+            resourceKind,
+            guid,
+            literalVersion,
+            $"Exact remote {ResourceName(resourceKind)} '{guid}@{literalVersion}' is unavailable: {detail}",
+            httpStatus);
+
+    public static ExactRemoteFetchException InvalidResponse(
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string detail,
+        Exception? innerException = null) =>
+        new(
+            ExactRemoteFetchFailureKind.InvalidResponse,
+            resourceKind,
+            guid,
+            literalVersion,
+            $"Exact remote {ResourceName(resourceKind)} '{guid}@{literalVersion}' returned an invalid response: {detail}",
+            innerException: innerException);
+
+    public static ExactRemoteFetchException IntegrityMismatch(
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion,
+        string detail) =>
+        new(
+            ExactRemoteFetchFailureKind.IntegrityMismatch,
+            resourceKind,
+            guid,
+            literalVersion,
+            $"Exact remote {ResourceName(resourceKind)} '{guid}@{literalVersion}' failed integrity verification: {detail}");
+
+    private static string ResourceName(ExactRemoteResourceKind resourceKind) =>
+        resourceKind == ExactRemoteResourceKind.Skill ? "skill" : "skillset";
+}

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseModels.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseModels.cs
@@ -15,6 +15,49 @@ public sealed record ExactRemoteToolDeclaration(
     string Type,
     IReadOnlyList<ExactRemoteMcpServerDeclaration> McpServers);
 
+public sealed class ExactRemoteToolDeclarationComparer : IEqualityComparer<ExactRemoteToolDeclaration>
+{
+    public static ExactRemoteToolDeclarationComparer Instance { get; } = new();
+
+    private ExactRemoteToolDeclarationComparer()
+    {
+    }
+
+    public bool Equals(ExactRemoteToolDeclaration? x, ExactRemoteToolDeclaration? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || y is null ||
+            !string.Equals(x.Tool, y.Tool, StringComparison.Ordinal) ||
+            !string.Equals(x.Type, y.Type, StringComparison.Ordinal) ||
+            x.McpServers.Count != y.McpServers.Count)
+        {
+            return false;
+        }
+
+        return OrderedServers(x).SequenceEqual(OrderedServers(y));
+    }
+
+    public int GetHashCode(ExactRemoteToolDeclaration declaration)
+    {
+        var hashCode = new HashCode();
+        hashCode.Add(declaration.Tool, StringComparer.Ordinal);
+        hashCode.Add(declaration.Type, StringComparer.Ordinal);
+        foreach (var server in OrderedServers(declaration))
+        {
+            hashCode.Add(server.Mcp, StringComparer.Ordinal);
+            hashCode.Add(server.Version, StringComparer.Ordinal);
+        }
+        return hashCode.ToHashCode();
+    }
+
+    private static IOrderedEnumerable<ExactRemoteMcpServerDeclaration> OrderedServers(
+        ExactRemoteToolDeclaration declaration) =>
+        declaration.McpServers
+            .OrderBy(static server => server.Mcp, StringComparer.Ordinal)
+            .ThenBy(static server => server.Version, StringComparer.Ordinal);
+}
+
 public sealed record ExactRemotePackageShape(
     int FileCount,
     int MaximumPathUtf8Bytes,

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseModels.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseModels.cs
@@ -1,0 +1,69 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Skills;
+
+public sealed record ExactRemoteVersionProvenance(
+    string PublisherSubjectId,
+    string? PublisherEmailSnapshot,
+    string? PublisherDisplayNameSnapshot,
+    DateTimeOffset PublishedAt);
+
+public sealed record ExactRemoteMcpServerDeclaration(string Mcp, string Version);
+
+public sealed record ExactRemoteToolDeclaration(
+    string Tool,
+    string Type,
+    IReadOnlyList<ExactRemoteMcpServerDeclaration> McpServers);
+
+public sealed record ExactRemotePackageShape(
+    int FileCount,
+    int MaximumPathUtf8Bytes,
+    long MaximumFileUtf8Bytes,
+    long TotalFileUtf8Bytes);
+
+public sealed record ExactRemotePackage(
+    IReadOnlyDictionary<string, string> Files,
+    ExactRemotePackageShape Shape);
+
+public sealed record ExactRemotePackageBounds(
+    int MaximumFileCount,
+    int MaximumPathUtf8Bytes,
+    long MaximumFileUtf8Bytes,
+    long MaximumTotalFileUtf8Bytes)
+{
+    public static ExactRemotePackageBounds AdapterMaximum { get; } = new(
+        MaximumFileCount: 1000,
+        MaximumPathUtf8Bytes: 512,
+        MaximumFileUtf8Bytes: 25L * 1024 * 1024,
+        MaximumTotalFileUtf8Bytes: 50L * 1024 * 1024);
+}
+
+public sealed record ExactRemoteSkillRelease(
+    ExactRemoteSkillRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    ExactRemotePackage Package,
+    IReadOnlyList<ExactRemoteToolDeclaration> DeclaredTools,
+    SkillDefinition Definition);
+
+public sealed record ExactRemoteSkillsetRelease(
+    ExactRemoteSkillsetRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    string Instructions,
+    IReadOnlyList<ExactRemoteSkillRef> DirectMembers,
+    IReadOnlyList<ExactRemoteSkillRef> FullClosure);
+
+public sealed record ReviewedExactRemoteSkillExpectation(
+    ExactRemoteSkillRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    ExactRemotePackageBounds PackageBounds,
+    IReadOnlyList<ExactRemoteToolDeclaration> DeclaredTools);
+
+public sealed record ReviewedExactRemoteSkillsetExpectation(
+    ExactRemoteSkillsetRef Reference,
+    string PublishedName,
+    ExactRemoteVersionProvenance Provenance,
+    IReadOnlyList<ExactRemoteSkillRef> DirectMembers,
+    IReadOnlyList<ExactRemoteSkillRef> FullClosure);

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseVerifier.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseVerifier.cs
@@ -1,0 +1,207 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Skills;
+
+/// <summary>Verifies fetched releases against caller-reviewed immutable expectations.</summary>
+public sealed class ExactRemoteReleaseVerifier
+{
+    public ExactRemoteSkillRelease VerifySkill(
+        ExactRemoteSkillRelease release,
+        ReviewedExactRemoteSkillExpectation expectation)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(expectation);
+
+        var reference = expectation.Reference;
+        VerifyReference(release.Reference, reference, ExactRemoteResourceKind.Skill);
+        VerifyText(release.PublishedName, expectation.PublishedName, "published name", reference);
+        VerifyProvenance(release.Provenance, expectation.Provenance, ExactRemoteResourceKind.Skill, reference.Guid, reference.LiteralVersion);
+        VerifyBounds(release.Package.Shape, expectation.PackageBounds, reference);
+        VerifyTools(release.DeclaredTools, expectation.DeclaredTools, reference);
+        return release;
+    }
+
+    public ExactRemoteSkillsetRelease VerifySkillset(
+        ExactRemoteSkillsetRelease release,
+        ReviewedExactRemoteSkillsetExpectation expectation)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(expectation);
+
+        var reference = expectation.Reference;
+        VerifyReference(release.Reference, reference, ExactRemoteResourceKind.Skillset);
+        VerifyText(release.PublishedName, expectation.PublishedName, "published name", reference);
+        VerifyProvenance(release.Provenance, expectation.Provenance, ExactRemoteResourceKind.Skillset, reference.Guid, reference.LiteralVersion);
+        VerifyExactRefs(release.DirectMembers, expectation.DirectMembers, "direct members", reference);
+        VerifyExactRefs(release.FullClosure, expectation.FullClosure, "full closure", reference);
+        return release;
+    }
+
+    private static void VerifyReference(
+        ExactRemoteSkillRef actual,
+        ExactRemoteSkillRef expected,
+        ExactRemoteResourceKind resourceKind)
+    {
+        if (!string.Equals(actual.Guid, expected.Guid, StringComparison.Ordinal) ||
+            !string.Equals(actual.LiteralVersion, expected.LiteralVersion, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                expected.Guid,
+                expected.LiteralVersion,
+                "exact reference differs from the reviewed reference");
+        }
+    }
+
+    private static void VerifyReference(
+        ExactRemoteSkillsetRef actual,
+        ExactRemoteSkillsetRef expected,
+        ExactRemoteResourceKind resourceKind)
+    {
+        if (!string.Equals(actual.Guid, expected.Guid, StringComparison.Ordinal) ||
+            !string.Equals(actual.LiteralVersion, expected.LiteralVersion, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                expected.Guid,
+                expected.LiteralVersion,
+                "exact reference differs from the reviewed reference");
+        }
+    }
+
+    private static void VerifyText(
+        string actual,
+        string expected,
+        string field,
+        ExactRemoteSkillRef reference)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"{field} differs from the reviewed value");
+        }
+    }
+
+    private static void VerifyText(
+        string actual,
+        string expected,
+        string field,
+        ExactRemoteSkillsetRef reference)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"{field} differs from the reviewed value");
+        }
+    }
+
+    private static void VerifyProvenance(
+        ExactRemoteVersionProvenance actual,
+        ExactRemoteVersionProvenance expected,
+        ExactRemoteResourceKind resourceKind,
+        string guid,
+        string literalVersion)
+    {
+        var matches = string.Equals(actual.PublisherSubjectId, expected.PublisherSubjectId, StringComparison.Ordinal) &&
+                      string.Equals(actual.PublisherEmailSnapshot, expected.PublisherEmailSnapshot, StringComparison.Ordinal) &&
+                      string.Equals(actual.PublisherDisplayNameSnapshot, expected.PublisherDisplayNameSnapshot, StringComparison.Ordinal) &&
+                      actual.PublishedAt.ToUniversalTime() == expected.PublishedAt.ToUniversalTime();
+        if (!matches)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                resourceKind,
+                guid,
+                literalVersion,
+                "version publisher provenance differs from the reviewed snapshot");
+        }
+    }
+
+    private static void VerifyBounds(
+        ExactRemotePackageShape shape,
+        ExactRemotePackageBounds bounds,
+        ExactRemoteSkillRef reference)
+    {
+        var maximum = ExactRemotePackageBounds.AdapterMaximum;
+        var boundsArePositive = bounds.MaximumFileCount > 0 &&
+                                bounds.MaximumPathUtf8Bytes > 0 &&
+                                bounds.MaximumFileUtf8Bytes > 0 &&
+                                bounds.MaximumTotalFileUtf8Bytes > 0;
+        var boundsDoNotExpandAdapterCeilings = bounds.MaximumFileCount <= maximum.MaximumFileCount &&
+                                              bounds.MaximumPathUtf8Bytes <= maximum.MaximumPathUtf8Bytes &&
+                                              bounds.MaximumFileUtf8Bytes <= maximum.MaximumFileUtf8Bytes &&
+                                              bounds.MaximumTotalFileUtf8Bytes <= maximum.MaximumTotalFileUtf8Bytes;
+        var shapeFits = shape.FileCount <= bounds.MaximumFileCount &&
+                        shape.MaximumPathUtf8Bytes <= bounds.MaximumPathUtf8Bytes &&
+                        shape.MaximumFileUtf8Bytes <= bounds.MaximumFileUtf8Bytes &&
+                        shape.TotalFileUtf8Bytes <= bounds.MaximumTotalFileUtf8Bytes;
+        if (!boundsArePositive || !boundsDoNotExpandAdapterCeilings || !shapeFits)
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                "package shape exceeds the reviewed bounds or the reviewed bounds expand adapter ceilings");
+        }
+    }
+
+    private static void VerifyTools(
+        IReadOnlyList<ExactRemoteToolDeclaration> actual,
+        IReadOnlyList<ExactRemoteToolDeclaration> expected,
+        ExactRemoteSkillRef reference)
+    {
+        var actualKeys = ToolKeys(actual);
+        var expectedKeys = ToolKeys(expected);
+        if (actualKeys.Count != actual.Count || expectedKeys.Count != expected.Count ||
+            !actualKeys.SetEquals(expectedKeys))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skill,
+                reference.Guid,
+                reference.LiteralVersion,
+                "declared tools differ from the reviewed set");
+        }
+    }
+
+    private static HashSet<string> ToolKeys(IReadOnlyList<ExactRemoteToolDeclaration> tools) =>
+        tools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
+
+    private static string ToolKey(ExactRemoteToolDeclaration tool) =>
+        string.Join(
+            '\u001f',
+            tool.Tool,
+            tool.Type,
+            string.Join(
+                '\u001e',
+                tool.McpServers
+                    .Select(static server => $"{server.Mcp}\u001d{server.Version}")
+                    .OrderBy(static server => server, StringComparer.Ordinal)));
+
+    private static void VerifyExactRefs(
+        IReadOnlyList<ExactRemoteSkillRef> actual,
+        IReadOnlyList<ExactRemoteSkillRef> expected,
+        string field,
+        ExactRemoteSkillsetRef reference)
+    {
+        var actualKeys = RefKeys(actual);
+        var expectedKeys = RefKeys(expected);
+        if (actualKeys.Count != actual.Count || expectedKeys.Count != expected.Count ||
+            !actualKeys.SetEquals(expectedKeys))
+        {
+            throw ExactRemoteFetchException.IntegrityMismatch(
+                ExactRemoteResourceKind.Skillset,
+                reference.Guid,
+                reference.LiteralVersion,
+                $"{field} differ from the reviewed set");
+        }
+    }
+
+    private static HashSet<string> RefKeys(IReadOnlyList<ExactRemoteSkillRef> references) =>
+        references.Select(static reference => $"{reference.Guid}\u001f{reference.LiteralVersion}")
+            .ToHashSet(StringComparer.Ordinal);
+}

--- a/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseVerifier.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/ExactRemoteReleaseVerifier.cs
@@ -155,10 +155,10 @@ public sealed class ExactRemoteReleaseVerifier
         IReadOnlyList<ExactRemoteToolDeclaration> expected,
         ExactRemoteSkillRef reference)
     {
-        var actualKeys = ToolKeys(actual);
-        var expectedKeys = ToolKeys(expected);
-        if (actualKeys.Count != actual.Count || expectedKeys.Count != expected.Count ||
-            !actualKeys.SetEquals(expectedKeys))
+        var actualDeclarations = ToolDeclarations(actual);
+        var expectedDeclarations = ToolDeclarations(expected);
+        if (actualDeclarations.Count != actual.Count || expectedDeclarations.Count != expected.Count ||
+            !actualDeclarations.SetEquals(expectedDeclarations))
         {
             throw ExactRemoteFetchException.IntegrityMismatch(
                 ExactRemoteResourceKind.Skill,
@@ -168,19 +168,9 @@ public sealed class ExactRemoteReleaseVerifier
         }
     }
 
-    private static HashSet<string> ToolKeys(IReadOnlyList<ExactRemoteToolDeclaration> tools) =>
-        tools.Select(ToolKey).ToHashSet(StringComparer.Ordinal);
-
-    private static string ToolKey(ExactRemoteToolDeclaration tool) =>
-        string.Join(
-            '\u001f',
-            tool.Tool,
-            tool.Type,
-            string.Join(
-                '\u001e',
-                tool.McpServers
-                    .Select(static server => $"{server.Mcp}\u001d{server.Version}")
-                    .OrderBy(static server => server, StringComparer.Ordinal)));
+    private static HashSet<ExactRemoteToolDeclaration> ToolDeclarations(
+        IReadOnlyList<ExactRemoteToolDeclaration> tools) =>
+        tools.ToHashSet(ExactRemoteToolDeclarationComparer.Instance);
 
     private static void VerifyExactRefs(
         IReadOnlyList<ExactRemoteSkillRef> actual,
@@ -201,7 +191,7 @@ public sealed class ExactRemoteReleaseVerifier
         }
     }
 
-    private static HashSet<string> RefKeys(IReadOnlyList<ExactRemoteSkillRef> references) =>
-        references.Select(static reference => $"{reference.Guid}\u001f{reference.LiteralVersion}")
-            .ToHashSet(StringComparer.Ordinal);
+    private static HashSet<(string Guid, string LiteralVersion)> RefKeys(
+        IReadOnlyList<ExactRemoteSkillRef> references) =>
+        references.Select(static reference => (reference.Guid, reference.LiteralVersion)).ToHashSet();
 }

--- a/src/Aevatar.AI.ToolProviders.Skills/IExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Skills/IExactRemoteSkillFetcher.cs
@@ -1,0 +1,17 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.Skills;
+
+/// <summary>Fetches immutable remote releases by stable GUID and literal version.</summary>
+public interface IExactRemoteSkillFetcher
+{
+    Task<ExactRemoteSkillRelease> FetchExactSkillAsync(
+        string accessToken,
+        ExactRemoteSkillRef reference,
+        CancellationToken ct = default);
+
+    Task<ExactRemoteSkillsetRelease> FetchExactSkillsetAsync(
+        string accessToken,
+        ExactRemoteSkillsetRef reference,
+        CancellationToken ct = default);
+}

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -572,7 +572,7 @@ public sealed class AIAbstractionsProtoCoverageTests
     }
 
     [Fact]
-    public void ProtoMessages_ShouldSupportMergeAndDescriptors()
+    public void ProtoMessages_ShouldSupportMerge()
     {
         var target = new ChatRequestEvent();
         target.MergeFrom(new ChatRequestEvent
@@ -586,36 +586,6 @@ public sealed class AIAbstractionsProtoCoverageTests
 
         target.Clone().Should().BeEquivalentTo(target);
         target.ToString().Should().Contain("prompt");
-
-        AiMessagesReflection.Descriptor.Should().NotBeNull();
-        AiMessagesReflection.Descriptor.MessageTypes.Select(static type => type.Name).Should().Contain(
-            [
-                nameof(ChatRequestEvent),
-                nameof(ChatResponseEvent),
-                nameof(TextMessageStartEvent),
-                nameof(TextMessageContentEvent),
-                nameof(TextMessageReasoningEvent),
-                nameof(TextMessageEndEvent),
-                nameof(ToolCallEvent),
-                nameof(ToolResultEvent),
-                nameof(RoleChatSessionStartedEvent),
-                nameof(RoleChatSessionCompletedEvent),
-                nameof(InitializeRoleAgentEvent),
-                nameof(AIAgentConfigOverrides),
-                nameof(RoleChatSessionState),
-                nameof(RoleGAgentState),
-            ]);
-
-        var skillRef = RoundTrip(new ExactRemoteSkillRef { Guid = "11111111-1111-1111-1111-111111111111", LiteralVersion = "1.2" }, ExactRemoteSkillRef.Parser);
-        var skillsetRef = RoundTrip(new ExactRemoteSkillsetRef { Guid = "22222222-2222-2222-2222-222222222222", LiteralVersion = "3.4" }, ExactRemoteSkillsetRef.Parser);
-        (skillRef.Guid, skillRef.LiteralVersion).Should().Be(("11111111-1111-1111-1111-111111111111", "1.2"));
-        (skillsetRef.Guid, skillsetRef.LiteralVersion).Should().Be(("22222222-2222-2222-2222-222222222222", "3.4"));
-        foreach (var descriptor in new[] { ExactRemoteSkillRef.Descriptor, ExactRemoteSkillsetRef.Descriptor })
-        {
-            descriptor.Fields.InFieldNumberOrder().Select(static field => (field.FieldNumber, field.Name))
-                .Should().Equal((1, "guid"), (2, "literal_version"));
-            descriptor.Oneofs.Should().BeEmpty();
-        }
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -582,28 +582,25 @@ public sealed class AIAbstractionsProtoCoverageTests
             Headers = { ["k1"] = "v1" },
         });
 
-        target.Prompt.Should().Be("p1");
-        target.SessionId.Should().Be("s1");
-        target.Headers["k1"].Should().Be("v1");
+        (target.Prompt, target.SessionId, target.Headers["k1"]).Should().Be(("p1", "s1", "v1"));
 
         target.Clone().Should().BeEquivalentTo(target);
         target.ToString().Should().Contain("prompt");
 
         AiMessagesReflection.Descriptor.Should().NotBeNull();
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ChatRequestEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ChatResponseEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageStartEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageContentEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageReasoningEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(TextMessageEndEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ToolCallEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(ToolResultEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleChatSessionStartedEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleChatSessionCompletedEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(InitializeRoleAgentEvent));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(AIAgentConfigOverrides));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleChatSessionState));
-        AiMessagesReflection.Descriptor.MessageTypes.Should().Contain(x => x.Name == nameof(RoleGAgentState));
+        AiMessagesReflection.Descriptor.MessageTypes.Select(static type => type.Name).Should().Contain(
+            [nameof(ChatRequestEvent), nameof(ChatResponseEvent), nameof(TextMessageStartEvent), nameof(TextMessageContentEvent), nameof(TextMessageReasoningEvent), nameof(TextMessageEndEvent), nameof(ToolCallEvent), nameof(ToolResultEvent), nameof(RoleChatSessionStartedEvent), nameof(RoleChatSessionCompletedEvent), nameof(InitializeRoleAgentEvent), nameof(AIAgentConfigOverrides), nameof(RoleChatSessionState), nameof(RoleGAgentState)]);
+
+        var skillRef = RoundTrip(new ExactRemoteSkillRef { Guid = "11111111-1111-1111-1111-111111111111", LiteralVersion = "1.2" }, ExactRemoteSkillRef.Parser);
+        var skillsetRef = RoundTrip(new ExactRemoteSkillsetRef { Guid = "22222222-2222-2222-2222-222222222222", LiteralVersion = "3.4" }, ExactRemoteSkillsetRef.Parser);
+        (skillRef.Guid, skillRef.LiteralVersion).Should().Be(("11111111-1111-1111-1111-111111111111", "1.2"));
+        (skillsetRef.Guid, skillsetRef.LiteralVersion).Should().Be(("22222222-2222-2222-2222-222222222222", "3.4"));
+        foreach (var descriptor in new[] { ExactRemoteSkillRef.Descriptor, ExactRemoteSkillsetRef.Descriptor })
+        {
+            descriptor.Fields.InFieldNumberOrder().Select(static field => (field.FieldNumber, field.Name))
+                .Should().Equal((1, "guid"), (2, "literal_version"));
+            descriptor.Oneofs.Should().BeEmpty();
+        }
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIAbstractionsProtoCoverageTests.cs
@@ -589,7 +589,22 @@ public sealed class AIAbstractionsProtoCoverageTests
 
         AiMessagesReflection.Descriptor.Should().NotBeNull();
         AiMessagesReflection.Descriptor.MessageTypes.Select(static type => type.Name).Should().Contain(
-            [nameof(ChatRequestEvent), nameof(ChatResponseEvent), nameof(TextMessageStartEvent), nameof(TextMessageContentEvent), nameof(TextMessageReasoningEvent), nameof(TextMessageEndEvent), nameof(ToolCallEvent), nameof(ToolResultEvent), nameof(RoleChatSessionStartedEvent), nameof(RoleChatSessionCompletedEvent), nameof(InitializeRoleAgentEvent), nameof(AIAgentConfigOverrides), nameof(RoleChatSessionState), nameof(RoleGAgentState)]);
+            [
+                nameof(ChatRequestEvent),
+                nameof(ChatResponseEvent),
+                nameof(TextMessageStartEvent),
+                nameof(TextMessageContentEvent),
+                nameof(TextMessageReasoningEvent),
+                nameof(TextMessageEndEvent),
+                nameof(ToolCallEvent),
+                nameof(ToolResultEvent),
+                nameof(RoleChatSessionStartedEvent),
+                nameof(RoleChatSessionCompletedEvent),
+                nameof(InitializeRoleAgentEvent),
+                nameof(AIAgentConfigOverrides),
+                nameof(RoleChatSessionState),
+                nameof(RoleGAgentState),
+            ]);
 
         var skillRef = RoundTrip(new ExactRemoteSkillRef { Guid = "11111111-1111-1111-1111-111111111111", LiteralVersion = "1.2" }, ExactRemoteSkillRef.Parser);
         var skillsetRef = RoundTrip(new ExactRemoteSkillsetRef { Guid = "22222222-2222-2222-2222-222222222222", LiteralVersion = "3.4" }, ExactRemoteSkillsetRef.Parser);

--- a/test/Aevatar.AI.Tests/AIMessageDescriptorContractTests.cs
+++ b/test/Aevatar.AI.Tests/AIMessageDescriptorContractTests.cs
@@ -1,0 +1,75 @@
+using Aevatar.AI.Abstractions;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class AIMessageDescriptorContractTests
+{
+    [Fact]
+    public void MessageDescriptor_ShouldContainStableMessageTypes()
+    {
+        AiMessagesReflection.Descriptor.Should().NotBeNull();
+        AiMessagesReflection.Descriptor.MessageTypes.Select(static type => type.Name).Should().Contain(
+            [
+                nameof(ChatRequestEvent),
+                nameof(ChatResponseEvent),
+                nameof(TextMessageStartEvent),
+                nameof(TextMessageContentEvent),
+                nameof(TextMessageReasoningEvent),
+                nameof(TextMessageEndEvent),
+                nameof(ToolCallEvent),
+                nameof(ToolResultEvent),
+                nameof(RoleChatSessionStartedEvent),
+                nameof(RoleChatSessionCompletedEvent),
+                nameof(InitializeRoleAgentEvent),
+                nameof(AIAgentConfigOverrides),
+                nameof(RoleChatSessionState),
+                nameof(RoleGAgentState),
+            ]);
+    }
+
+    [Fact]
+    public void ExactRemoteReferences_ShouldRoundTripStableWireFields()
+    {
+        var skillRef = RoundTrip(
+            new ExactRemoteSkillRef
+            {
+                Guid = "11111111-1111-1111-1111-111111111111",
+                LiteralVersion = "1.2",
+            },
+            ExactRemoteSkillRef.Parser);
+        var skillsetRef = RoundTrip(
+            new ExactRemoteSkillsetRef
+            {
+                Guid = "22222222-2222-2222-2222-222222222222",
+                LiteralVersion = "3.4",
+            },
+            ExactRemoteSkillsetRef.Parser);
+
+        (skillRef.Guid, skillRef.LiteralVersion).Should()
+            .Be(("11111111-1111-1111-1111-111111111111", "1.2"));
+        (skillsetRef.Guid, skillsetRef.LiteralVersion).Should()
+            .Be(("22222222-2222-2222-2222-222222222222", "3.4"));
+        foreach (var descriptor in new[] { ExactRemoteSkillRef.Descriptor, ExactRemoteSkillsetRef.Descriptor })
+        {
+            descriptor.Fields.InFieldNumberOrder().Select(static field => (field.FieldNumber, field.Name))
+                .Should().Equal((1, "guid"), (2, "literal_version"));
+            descriptor.Oneofs.Should().BeEmpty();
+        }
+    }
+
+    private static T RoundTrip<T>(T message, MessageParser<T> parser)
+        where T : class, IMessage<T>, new()
+    {
+        var bytes = message.ToByteArray();
+        var parsed = parser.ParseFrom(bytes);
+        parsed.Should().Be(message);
+
+        var merged = new T();
+        merged.MergeFrom(message);
+        merged.Should().Be(message);
+
+        return parsed;
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
@@ -1,0 +1,213 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.ToolProviders.Skills;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class ExactRemoteReleaseVerifierTests
+{
+    private const string SkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string SkillsetGuid = "22222222-2222-2222-2222-222222222222";
+    private const string MemberGuid = "33333333-3333-3333-3333-333333333333";
+    private static readonly DateTimeOffset PublishedAt = DateTimeOffset.Parse("2026-07-10T12:30:00Z");
+    private readonly ExactRemoteReleaseVerifier _verifier = new();
+
+    [Fact]
+    public void VerifySkill_WhenEveryReviewedFieldMatches_ReturnsFetchedRelease()
+    {
+        var release = SkillRelease();
+        var expectation = SkillExpectation();
+
+        var verified = _verifier.VerifySkill(release, expectation);
+
+        verified.Should().BeSameAs(release);
+    }
+
+    [Fact]
+    public void VerifySkill_WhenReferenceOrNameDiffers_RejectsRelease()
+    {
+        var wrongReference = SkillExpectation() with
+        {
+            Reference = new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.3" },
+        };
+        var wrongName = SkillExpectation() with { PublishedName = "different" };
+
+        Action referenceAct = () => _verifier.VerifySkill(SkillRelease(), wrongReference);
+        Action nameAct = () => _verifier.VerifySkill(SkillRelease(), wrongName);
+
+        referenceAct.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        nameAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Theory]
+    [InlineData("subject")]
+    [InlineData("email-absence")]
+    [InlineData("email-value")]
+    [InlineData("display-absence")]
+    [InlineData("display-value")]
+    [InlineData("published-at")]
+    public void VerifySkill_WhenAnyPublisherSnapshotFieldDiffers_RejectsRelease(string mismatch)
+    {
+        var provenance = mismatch switch
+        {
+            "subject" => Provenance() with { PublisherSubjectId = "other-subject" },
+            "email-absence" => Provenance() with { PublisherEmailSnapshot = null },
+            "email-value" => Provenance() with { PublisherEmailSnapshot = "other@example.test" },
+            "display-absence" => Provenance() with { PublisherDisplayNameSnapshot = null },
+            "display-value" => Provenance() with { PublisherDisplayNameSnapshot = "Other Publisher" },
+            "published-at" => Provenance() with { PublishedAt = PublishedAt.AddSeconds(1) },
+            _ => throw new ArgumentOutOfRangeException(nameof(mismatch)),
+        };
+        var expectation = SkillExpectation() with { Provenance = provenance };
+
+        Action act = () => _verifier.VerifySkill(SkillRelease(), expectation);
+
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.Message.Should().Contain("provenance");
+    }
+
+    [Fact]
+    public void VerifySkill_WhenPackageExceedsReviewedBoundsOrBoundsExpandAdapterCeiling_RejectsRelease()
+    {
+        var tooTight = SkillExpectation() with
+        {
+            PackageBounds = new ExactRemotePackageBounds(1, 10, 3, 3),
+        };
+        var expanded = SkillExpectation() with
+        {
+            PackageBounds = ExactRemotePackageBounds.AdapterMaximum with
+            {
+                MaximumFileCount = ExactRemotePackageBounds.AdapterMaximum.MaximumFileCount + 1,
+            },
+        };
+
+        Action tightAct = () => _verifier.VerifySkill(SkillRelease(), tooTight);
+        Action expandedAct = () => _verifier.VerifySkill(SkillRelease(), expanded);
+
+        tightAct.Should().Throw<ExactRemoteFetchException>();
+        expandedAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Fact]
+    public void VerifySkill_WhenToolSetDiffersOrContainsDuplicates_RejectsRelease()
+    {
+        var different = SkillExpectation() with
+        {
+            DeclaredTools = [new ExactRemoteToolDeclaration("different", "builtin", [])],
+        };
+        var duplicateTool = Tool();
+        var duplicates = SkillExpectation() with { DeclaredTools = [duplicateTool, duplicateTool] };
+
+        Action differentAct = () => _verifier.VerifySkill(SkillRelease(), different);
+        Action duplicatesAct = () => _verifier.VerifySkill(SkillRelease(), duplicates);
+
+        differentAct.Should().Throw<ExactRemoteFetchException>();
+        duplicatesAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Fact]
+    public void VerifySkillset_WhenDirectMembersOrClosureDiffer_RejectsRelease()
+    {
+        var differentDirect = SkillsetExpectation() with
+        {
+            DirectMembers = [Member("1.1")],
+        };
+        var differentClosure = SkillsetExpectation() with
+        {
+            FullClosure = [Member("1.0"), Member("1.0")],
+        };
+
+        Action directAct = () => _verifier.VerifySkillset(SkillsetRelease(), differentDirect);
+        Action closureAct = () => _verifier.VerifySkillset(SkillsetRelease(), differentClosure);
+
+        directAct.Should().Throw<ExactRemoteFetchException>();
+        closureAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Fact]
+    public void ReleaseEvidence_ContainsNoAuthorizationFields()
+    {
+        typeof(ExactRemoteVersionProvenance).GetProperties().Select(static property => property.Name)
+            .Should().BeEquivalentTo(
+                nameof(ExactRemoteVersionProvenance.PublisherSubjectId),
+                nameof(ExactRemoteVersionProvenance.PublisherEmailSnapshot),
+                nameof(ExactRemoteVersionProvenance.PublisherDisplayNameSnapshot),
+                nameof(ExactRemoteVersionProvenance.PublishedAt));
+        typeof(ExactRemoteToolDeclaration).GetProperties().Select(static property => property.Name)
+            .Should().BeEquivalentTo(
+                nameof(ExactRemoteToolDeclaration.Tool),
+                nameof(ExactRemoteToolDeclaration.Type),
+                nameof(ExactRemoteToolDeclaration.McpServers));
+
+        _verifier.VerifySkill(SkillRelease(), SkillExpectation()).Should().NotBeNull();
+    }
+
+    private static ExactRemoteSkillRelease SkillRelease() => new(
+        SkillReference(),
+        "curated-skill",
+        Provenance(),
+        new ExactRemotePackage(
+            new Dictionary<string, string> { ["SKILL.md"] = "Run it." },
+            new ExactRemotePackageShape(1, 8, 7, 7)),
+        [Tool()],
+        new SkillDefinition
+        {
+            Name = "curated-skill",
+            Description = "Reviewed",
+            Instructions = "Run it.",
+            Source = SkillSource.Remote,
+            RemoteId = SkillGuid,
+        });
+
+    private static ReviewedExactRemoteSkillExpectation SkillExpectation() => new(
+        SkillReference(),
+        "curated-skill",
+        Provenance(),
+        new ExactRemotePackageBounds(10, 64, 1024, 2048),
+        [Tool()]);
+
+    private static ExactRemoteSkillsetRelease SkillsetRelease() => new(
+        SkillsetReference(),
+        "reviewed-set",
+        Provenance(),
+        "Use reviewed skills.",
+        [Member("1.0")],
+        [Member("1.0")]);
+
+    private static ReviewedExactRemoteSkillsetExpectation SkillsetExpectation() => new(
+        SkillsetReference(),
+        "reviewed-set",
+        Provenance(),
+        [Member("1.0")],
+        [Member("1.0")]);
+
+    private static ExactRemoteVersionProvenance Provenance() => new(
+        "publisher-subject",
+        "publisher@example.test",
+        "Publisher Name",
+        PublishedAt);
+
+    private static ExactRemoteToolDeclaration Tool() => new(
+        "workspace.read",
+        "mcp",
+        [new ExactRemoteMcpServerDeclaration("workspace-mcp", "2.0")]);
+
+    private static ExactRemoteSkillRef SkillReference() => new()
+    {
+        Guid = SkillGuid,
+        LiteralVersion = "1.2",
+    };
+
+    private static ExactRemoteSkillsetRef SkillsetReference() => new()
+    {
+        Guid = SkillsetGuid,
+        LiteralVersion = "2.0",
+    };
+
+    private static ExactRemoteSkillRef Member(string version) => new()
+    {
+        Guid = MemberGuid,
+        LiteralVersion = version,
+    };
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
@@ -67,26 +67,66 @@ public sealed class ExactRemoteReleaseVerifierTests
             .Which.Message.Should().Contain("provenance");
     }
 
-    [Fact]
-    public void VerifySkill_WhenPackageExceedsReviewedBoundsOrBoundsExpandAdapterCeiling_RejectsRelease()
+    [Theory]
+    [InlineData("file-count")]
+    [InlineData("path-bytes")]
+    [InlineData("file-bytes")]
+    [InlineData("total-bytes")]
+    public void VerifySkill_WhenAnyPackageShapeDimensionExceedsReviewedBound_RejectsRelease(
+        string dimension)
     {
-        var tooTight = SkillExpectation() with
+        var shape = SkillRelease().Package.Shape;
+        shape = dimension switch
         {
-            PackageBounds = new ExactRemotePackageBounds(1, 10, 3, 3),
+            "file-count" => shape with { FileCount = 11 },
+            "path-bytes" => shape with { MaximumPathUtf8Bytes = 65 },
+            "file-bytes" => shape with { MaximumFileUtf8Bytes = 1025 },
+            "total-bytes" => shape with { TotalFileUtf8Bytes = 2049 },
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension)),
         };
-        var expanded = SkillExpectation() with
+        var release = SkillRelease();
+        release = release with { Package = release.Package with { Shape = shape } };
+
+        Action act = () => _verifier.VerifySkill(release, SkillExpectation());
+
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+    }
+
+    [Theory]
+    [InlineData("file-count", false)]
+    [InlineData("path-bytes", false)]
+    [InlineData("file-bytes", false)]
+    [InlineData("total-bytes", false)]
+    [InlineData("file-count", true)]
+    [InlineData("path-bytes", true)]
+    [InlineData("file-bytes", true)]
+    [InlineData("total-bytes", true)]
+    public void VerifySkill_WhenAnyReviewedBoundIsNonPositiveOrExpandsAdapterCeiling_RejectsRelease(
+        string dimension,
+        bool expandsCeiling)
+    {
+        var bounds = expandsCeiling
+            ? ExactRemotePackageBounds.AdapterMaximum
+            : SkillExpectation().PackageBounds;
+        bounds = (dimension, expandsCeiling) switch
         {
-            PackageBounds = ExactRemotePackageBounds.AdapterMaximum with
-            {
-                MaximumFileCount = ExactRemotePackageBounds.AdapterMaximum.MaximumFileCount + 1,
-            },
+            ("file-count", false) => bounds with { MaximumFileCount = 0 },
+            ("path-bytes", false) => bounds with { MaximumPathUtf8Bytes = 0 },
+            ("file-bytes", false) => bounds with { MaximumFileUtf8Bytes = 0 },
+            ("total-bytes", false) => bounds with { MaximumTotalFileUtf8Bytes = 0 },
+            ("file-count", true) => bounds with { MaximumFileCount = bounds.MaximumFileCount + 1 },
+            ("path-bytes", true) => bounds with { MaximumPathUtf8Bytes = bounds.MaximumPathUtf8Bytes + 1 },
+            ("file-bytes", true) => bounds with { MaximumFileUtf8Bytes = bounds.MaximumFileUtf8Bytes + 1 },
+            ("total-bytes", true) => bounds with { MaximumTotalFileUtf8Bytes = bounds.MaximumTotalFileUtf8Bytes + 1 },
+            _ => throw new ArgumentOutOfRangeException(nameof(dimension)),
         };
+        var expectation = SkillExpectation() with { PackageBounds = bounds };
 
-        Action tightAct = () => _verifier.VerifySkill(SkillRelease(), tooTight);
-        Action expandedAct = () => _verifier.VerifySkill(SkillRelease(), expanded);
+        Action act = () => _verifier.VerifySkill(SkillRelease(), expectation);
 
-        tightAct.Should().Throw<ExactRemoteFetchException>();
-        expandedAct.Should().Throw<ExactRemoteFetchException>();
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
     }
 
     [Fact]
@@ -104,6 +144,26 @@ public sealed class ExactRemoteReleaseVerifierTests
 
         differentAct.Should().Throw<ExactRemoteFetchException>();
         duplicatesAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void VerifySkill_WhenActualOrExpectedToolsContainDuplicates_RejectsRelease(
+        bool duplicateActual)
+    {
+        var duplicateTool = Tool();
+        var release = duplicateActual
+            ? SkillRelease() with { DeclaredTools = [duplicateTool, duplicateTool] }
+            : SkillRelease();
+        var expectation = duplicateActual
+            ? SkillExpectation()
+            : SkillExpectation() with { DeclaredTools = [duplicateTool, duplicateTool] };
+
+        Action act = () => _verifier.VerifySkill(release, expectation);
+
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
     }
 
     [Fact]
@@ -169,6 +229,50 @@ public sealed class ExactRemoteReleaseVerifierTests
 
         directAct.Should().Throw<ExactRemoteFetchException>();
         closureAct.Should().Throw<ExactRemoteFetchException>();
+    }
+
+    [Theory]
+    [InlineData("direct-members", false)]
+    [InlineData("direct-members", true)]
+    [InlineData("full-closure", false)]
+    [InlineData("full-closure", true)]
+    public void VerifySkillset_WhenActualOrExpectedReferenceSetContainsDuplicates_RejectsRelease(
+        string field,
+        bool duplicateActual)
+    {
+        var duplicateMembers = new[] { Member("1.0"), Member("1.0") };
+        var release = (field, duplicateActual) switch
+        {
+            ("direct-members", true) => SkillsetRelease() with { DirectMembers = duplicateMembers },
+            ("full-closure", true) => SkillsetRelease() with { FullClosure = duplicateMembers },
+            _ => SkillsetRelease(),
+        };
+        var expectation = (field, duplicateActual) switch
+        {
+            ("direct-members", false) => SkillsetExpectation() with { DirectMembers = duplicateMembers },
+            ("full-closure", false) => SkillsetExpectation() with { FullClosure = duplicateMembers },
+            ("direct-members", true) or ("full-closure", true) => SkillsetExpectation(),
+            _ => throw new ArgumentOutOfRangeException(nameof(field)),
+        };
+
+        Action act = () => _verifier.VerifySkillset(release, expectation);
+
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+    }
+
+    [Fact]
+    public void VerifyMethods_WhenTopLevelArgumentIsNull_ThrowArgumentNullException()
+    {
+        Action nullSkillRelease = () => _verifier.VerifySkill(null!, SkillExpectation());
+        Action nullSkillExpectation = () => _verifier.VerifySkill(SkillRelease(), null!);
+        Action nullSkillsetRelease = () => _verifier.VerifySkillset(null!, SkillsetExpectation());
+        Action nullSkillsetExpectation = () => _verifier.VerifySkillset(SkillsetRelease(), null!);
+
+        nullSkillRelease.Should().Throw<ArgumentNullException>().WithParameterName("release");
+        nullSkillExpectation.Should().Throw<ArgumentNullException>().WithParameterName("expectation");
+        nullSkillsetRelease.Should().Throw<ArgumentNullException>().WithParameterName("release");
+        nullSkillsetExpectation.Should().Throw<ArgumentNullException>().WithParameterName("expectation");
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ExactRemoteReleaseVerifierTests.cs
@@ -107,6 +107,52 @@ public sealed class ExactRemoteReleaseVerifierTests
     }
 
     [Fact]
+    public void VerifySkill_WhenToolDeclarationsOnlyShareADelimiterKey_RejectsRelease()
+    {
+        var release = SkillRelease() with
+        {
+            DeclaredTools = [new ExactRemoteToolDeclaration("a", "b\u001fc", [])],
+        };
+        var expectation = SkillExpectation() with
+        {
+            DeclaredTools = [new ExactRemoteToolDeclaration("a\u001fb", "c", [])],
+        };
+
+        Action act = () => _verifier.VerifySkill(release, expectation);
+
+        act.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+    }
+
+    [Fact]
+    public void VerifySkillset_WhenEveryReviewedFieldMatches_ReturnsFetchedRelease()
+    {
+        var release = SkillsetRelease();
+
+        var verified = _verifier.VerifySkillset(release, SkillsetExpectation());
+
+        verified.Should().BeSameAs(release);
+    }
+
+    [Fact]
+    public void VerifySkillset_WhenReferenceOrNameDiffers_RejectsRelease()
+    {
+        var wrongReference = SkillsetExpectation() with
+        {
+            Reference = new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.1" },
+        };
+        var wrongName = SkillsetExpectation() with { PublishedName = "different" };
+
+        Action referenceAct = () => _verifier.VerifySkillset(SkillsetRelease(), wrongReference);
+        Action nameAct = () => _verifier.VerifySkillset(SkillsetRelease(), wrongName);
+
+        referenceAct.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        nameAct.Should().Throw<ExactRemoteFetchException>()
+            .Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+    }
+
+    [Fact]
     public void VerifySkillset_WhenDirectMembersOrClosureDiffer_RejectsRelease()
     {
         var differentDirect = SkillsetExpectation() with

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Skills;
@@ -109,14 +110,18 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     [Fact]
     public async Task FetchExactSkillAsync_UsesOneSharedTimeoutForAllThreeReads()
     {
-        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled();
-        var fetcher = CreateFetcher(handler, TimeSpan.FromMilliseconds(100));
+        var timeProvider = new ManualTimeProvider();
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled(expectedRequestCount: 3);
+        var fetcher = CreateFetcher(handler, TimeSpan.FromSeconds(30), timeProvider);
 
-        var act = async () => await fetcher.FetchExactSkillAsync(
+        var fetchTask = fetcher.FetchExactSkillAsync(
             "token",
             new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+        await handler.ExpectedRequestsStarted;
+        timeProvider.ExpireTimer();
 
-        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        var assertion = await fetchTask.Invoking(static task => task).Should()
+            .ThrowAsync<ExactRemoteFetchException>();
         assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
         handler.Requests.Should().HaveCount(3);
         AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
@@ -203,7 +208,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
 
     private static OrnnRemoteSkillFetcher CreateFetcher(
         OrnnTestHttpMessageHandler handler,
-        TimeSpan? timeout = null)
+        TimeSpan? timeout = null,
+        TimeProvider? timeProvider = null)
     {
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
@@ -211,7 +217,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         var client = new OrnnSkillClient(
             new OrnnOptions { NyxIdSlug = "ornn-api" },
             nyxClient,
-            timeout ?? TimeSpan.FromSeconds(30));
+            timeout ?? TimeSpan.FromSeconds(30),
+            timeProvider ?? TimeProvider.System);
         return new OrnnRemoteSkillFetcher(client);
     }
 
@@ -287,7 +294,9 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     private static string SkillPackage(
         string name = "curated-skill",
         string version = "1.2",
-        string? filesJson = null) => $$"""
+        string? filesJson = null,
+        string tool = "workspace.read",
+        string type = "mcp") => $$"""
         {
           "data": {
             "name": "{{name}}",
@@ -296,8 +305,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
             "metadata": {
               "tools": [
                 {
-                  "tool": "workspace.read",
-                  "type": "mcp",
+                  "tool": {{JsonSerializer.Serialize(tool)}},
+                  "type": {{JsonSerializer.Serialize(type)}},
                   "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
                 }
               ]
@@ -307,18 +316,23 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
         """;
 
-    private static string SkillDetail(string name = "curated-skill") => $$"""
+    private static string SkillDetail(
+        string name = "curated-skill",
+        string version = "1.2",
+        string? skillHash = null,
+        string tool = "workspace.read",
+        string type = "mcp") => $$"""
         {
           "data": {
             "guid": "{{SkillGuid}}",
             "name": "{{name}}",
-            "version": "1.2",
-            "skillHash": "{{SkillHash}}",
+            "version": "{{version}}",
+            "skillHash": "{{skillHash ?? SkillHash}}",
             "metadata": {
               "tools": [
                 {
-                  "tool": "workspace.read",
-                  "type": "mcp",
+                  "tool": {{JsonSerializer.Serialize(tool)}},
+                  "type": {{JsonSerializer.Serialize(type)}},
                   "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
                 }
               ]
@@ -327,32 +341,41 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
         """;
 
-    private static string SkillVersions() => $$"""
+    private static string SkillVersions(string? itemsJson = null) => $$"""
         {
           "data": {
             "items": [
-              {
-                "version": "1.2",
-                "skillHash": "{{SkillHash}}",
-                "integrity": "{{Integrity(SkillHash)}}",
-                "createdBy": "publisher-subject",
-                "createdByEmail": "publisher@example.test",
-                "createdByDisplayName": "Publisher Name",
-                "createdOn": "2026-07-10T12:30:00Z"
-              }
+              {{itemsJson ?? SkillVersionRow()}}
             ]
           }
         }
         """;
 
-    private static string SkillsetDetail() => $$"""
+    private static string SkillVersionRow(
+        string version = "1.2",
+        string? skillHash = null,
+        string? integrity = null) => $$"""
+        {
+          "version": "{{version}}",
+          "skillHash": "{{skillHash ?? SkillHash}}",
+          "integrity": "{{integrity ?? Integrity(skillHash ?? SkillHash)}}",
+          "createdBy": "publisher-subject",
+          "createdByEmail": "publisher@example.test",
+          "createdByDisplayName": "Publisher Name",
+          "createdOn": "2026-07-10T12:30:00Z"
+        }
+        """;
+
+    private static string SkillsetDetail(
+        string version = "2.0",
+        string? membersJson = null) => $$"""
         {
           "data": {
             "guid": "{{SkillsetGuid}}",
             "name": "reviewed-set",
-            "version": "2.0",
+            "version": "{{version}}",
             "instructions": "Use both reviewed skills.",
-            "members": ["member-a@1.0", "member-b@beta"]
+            "members": {{membersJson ?? "[\"member-a@1.0\", \"member-b@beta\"]"}}
           }
         }
         """;
@@ -370,22 +393,70 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
         """;
 
-    private static string SkillsetVersions() => """
+    private static string SkillsetVersions(string? itemsJson = null) => $$"""
         {
           "data": {
             "items": [
-              {
-                "version": "2.0",
-                "memberCount": 2,
-                "createdBy": "set-publisher",
-                "createdByDisplayName": "Set Publisher",
-                "createdOn": "2026-07-11T08:00:00+00:00"
-              }
+              {{itemsJson ?? SkillsetVersionRow()}}
             ]
           }
         }
         """;
 
+    private static string SkillsetVersionRow(string version = "2.0") => $$"""
+        {
+          "version": "{{version}}",
+          "memberCount": 2,
+          "createdBy": "set-publisher",
+          "createdByDisplayName": "Set Publisher",
+          "createdOn": "2026-07-11T08:00:00+00:00"
+        }
+        """;
+
     private static string Integrity(string hex) =>
         $"sha256-{Convert.ToBase64String(Convert.FromHexString(hex))}";
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private ManualTimer? _timer;
+
+        public override ITimer CreateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period)
+        {
+            var timer = new ManualTimer(callback, state);
+            Interlocked.Exchange(ref _timer, timer)?.Dispose();
+            return timer;
+        }
+
+        public void ExpireTimer()
+        {
+            var timer = Volatile.Read(ref _timer)
+                        ?? throw new InvalidOperationException("The timeout timer was not created.");
+            timer.Fire();
+        }
+
+        private sealed class ManualTimer(TimerCallback callback, object? state) : ITimer
+        {
+            private TimerCallback? _callback = callback;
+
+            public bool Change(TimeSpan dueTime, TimeSpan period) =>
+                Volatile.Read(ref _callback) is not null;
+
+            public void Dispose() => Interlocked.Exchange(ref _callback, null);
+
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+
+            public void Fire()
+            {
+                Interlocked.Exchange(ref _callback, null)?.Invoke(state);
+            }
+        }
+    }
 }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -292,8 +292,17 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         };
 
         var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
-        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
-        assertion.Which.Message.Should().Contain(expectedMessage);
+        var exception = assertion.Which;
+        exception.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        exception.ResourceKind.Should().Be(
+            isSkillset ? ExactRemoteResourceKind.Skillset : ExactRemoteResourceKind.Skill);
+        exception.Guid.Should().Be(isSkillset ? SkillsetGuid : SkillGuid);
+        exception.LiteralVersion.Should().Be(isSkillset ? "2.0" : "1.2");
+        exception.Message.Should().Contain(expectedMessage);
+        if (responseJson == "{")
+            exception.InnerException.Should().BeOfType<JsonException>();
+        else
+            exception.InnerException.Should().BeNull();
         AssertOnlyExactRequests(
             handler,
             isSkillset ? SkillsetGuid : SkillGuid,

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -88,6 +88,125 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
     }
 
+    [Theory]
+    [InlineData("package")]
+    [InlineData("detail")]
+    public async Task FetchExactSkillAsync_WhenPackageOrDetailVersionDiffers_FailsClosed(string source)
+    {
+        var handler = ExactSkillHandler(
+            packageJson: source == "package" ? SkillPackage(version: "9.9") : null,
+            detailJson: source == "detail" ? SkillDetail(version: "9.9") : null);
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        assertion.Which.Message.Should().Contain("version");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FetchExactSkillAsync_WhenRequestedVersionRowIsMissingOrDuplicated_FailsClosed(
+        bool duplicate)
+    {
+        var rows = duplicate
+            ? $"{SkillVersionRow()},{SkillVersionRow()}"
+            : SkillVersionRow(version: "9.9");
+        var handler = ExactSkillHandler(versionsJson: SkillVersions(rows));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain("exactly once");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenDetailAndVersionHashesDiffer_FailsClosed()
+    {
+        var otherHash = new string('b', 64);
+        var handler = ExactSkillHandler(
+            versionsJson: SkillVersions(SkillVersionRow(
+                skillHash: otherHash,
+                integrity: Integrity(otherHash))));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        assertion.Which.Message.Should().Contain("hash");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Theory]
+    [InlineData("not-hex")]
+    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
+    public async Task FetchExactSkillAsync_WhenVersionHashIsNotSha256_FailsClosed(string malformedHash)
+    {
+        var handler = ExactSkillHandler(
+            detailJson: SkillDetail(skillHash: malformedHash),
+            versionsJson: SkillVersions(SkillVersionRow(
+                skillHash: malformedHash,
+                integrity: "sha256-invalid")));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain("hash");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenIntegrityDoesNotMatchHash_FailsClosed()
+    {
+        var handler = ExactSkillHandler(
+            versionsJson: SkillVersions(SkillVersionRow(integrity: "sha256-invalid")));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        assertion.Which.Message.Should().Contain("integrity");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenToolDeclarationsOnlyShareADelimiterKey_FailsClosed()
+    {
+        var handler = ExactSkillHandler(
+            packageJson: SkillPackage(tool: "a", type: "b\u001fc"),
+            detailJson: SkillDetail(tool: "a\u001fb", type: "c"));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        assertion.Which.Message.Should().Contain("tools");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
     [Fact]
     public async Task FetchExactSkillAsync_WhenOneResponseIsUnavailable_StillMakesOnlyTheFixedReads()
     {
@@ -119,9 +238,9 @@ public sealed class OrnnExactRemoteSkillFetcherTests
             new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
         await handler.ExpectedRequestsStarted;
         timeProvider.ExpireTimer();
+        var act = async () => await fetchTask;
 
-        var assertion = await fetchTask.Invoking(static task => task).Should()
-            .ThrowAsync<ExactRemoteFetchException>();
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
         assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
         handler.Requests.Should().HaveCount(3);
         AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
@@ -203,6 +322,82 @@ public sealed class OrnnExactRemoteSkillFetcherTests
 
         var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
         assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_WhenStringMemberUsesGuidAndLiteralVersion_ResolvesExactRoot()
+    {
+        var members = $$"""["{{MemberAGuid}}@1.0", "member-b@beta"]""";
+        var handler = ExactSkillsetHandler(detailJson: SkillsetDetail(membersJson: members));
+        var fetcher = CreateFetcher(handler);
+
+        var release = await fetcher.FetchExactSkillsetAsync(
+            "token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        release.DirectMembers.Select(member => (member.Guid, member.LiteralVersion)).Should().Equal(
+            (MemberAGuid, "1.0"),
+            (MemberBGuid, "2.0"));
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_WhenObjectMemberGuidMatchesButLiteralVersionDiffers_FailsClosed()
+    {
+        var members = $$"""
+            [
+              { "guid": "{{MemberAGuid}}", "name": "member-a", "version": "9.9" },
+              { "guid": "{{MemberBGuid}}", "name": "member-b", "version": "2.0" }
+            ]
+            """;
+        var handler = ExactSkillsetHandler(detailJson: SkillsetDetail(membersJson: members));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillsetAsync(
+            "token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_WhenDetailVersionDiffers_FailsClosed()
+    {
+        var handler = ExactSkillsetHandler(detailJson: SkillsetDetail(version: "9.9"));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillsetAsync(
+            "token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        assertion.Which.Message.Should().Contain("version");
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FetchExactSkillsetAsync_WhenRequestedVersionRowIsMissingOrDuplicated_FailsClosed(
+        bool duplicate)
+    {
+        var rows = duplicate
+            ? $"{SkillsetVersionRow()},{SkillsetVersionRow()}"
+            : SkillsetVersionRow(version: "9.9");
+        var handler = ExactSkillsetHandler(versionsJson: SkillsetVersions(rows));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillsetAsync(
+            "token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain("exactly once");
         AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
     }
 

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -14,6 +14,7 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     private const string MemberAGuid = "33333333-3333-3333-3333-333333333333";
     private const string MemberBGuid = "44444444-4444-4444-4444-444444444444";
     private const string DependencyGuid = "55555555-5555-5555-5555-555555555555";
+    private const int Megabyte = 1024 * 1024;
     private static readonly string SkillHash = new('a', 64);
 
     [Fact]
@@ -71,6 +72,47 @@ public sealed class OrnnExactRemoteSkillFetcherTests
             (MemberBGuid, "2.0"));
 
         AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Theory]
+    [InlineData(false, "not-a-guid", "1.2")]
+    [InlineData(false, SkillGuid, "")]
+    [InlineData(false, SkillGuid, "latest")]
+    [InlineData(false, SkillGuid, "1")]
+    [InlineData(false, SkillGuid, "1.2.3")]
+    [InlineData(true, "not-a-guid", "2.0")]
+    [InlineData(true, SkillsetGuid, "")]
+    [InlineData(true, SkillsetGuid, "latest")]
+    [InlineData(true, SkillsetGuid, "2")]
+    [InlineData(true, SkillsetGuid, "2.0.1")]
+    public async Task FetchExactAsync_WhenReferenceIsNotGuidPlusLiteralVersion_FailsBeforeHttp(
+        bool isSkillset,
+        string guid,
+        string literalVersion)
+    {
+        var handler = OrnnTestHttpMessageHandler.Routing(
+            _ => throw new InvalidOperationException("Invalid exact references must not reach HTTP."));
+        var fetcher = CreateFetcher(handler);
+
+        Func<Task> act = async () =>
+        {
+            if (isSkillset)
+            {
+                await fetcher.FetchExactSkillsetAsync(
+                    "token",
+                    new ExactRemoteSkillsetRef { Guid = guid, LiteralVersion = literalVersion });
+            }
+            else
+            {
+                await fetcher.FetchExactSkillAsync(
+                    "token",
+                    new ExactRemoteSkillRef { Guid = guid, LiteralVersion = literalVersion });
+            }
+        };
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        handler.Requests.Should().BeEmpty();
     }
 
     [Fact]
@@ -247,6 +289,47 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     }
 
     [Fact]
+    public async Task FetchExactSkillsetAsync_UsesOneSharedTimeoutForAllThreeReads()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled(expectedRequestCount: 3);
+        var fetcher = CreateFetcher(handler, TimeSpan.FromSeconds(30), timeProvider);
+
+        var fetchTask = fetcher.FetchExactSkillsetAsync("token", SkillsetReference());
+        await handler.ExpectedRequestsStarted;
+        timeProvider.ExpireTimer();
+        var act = async () => await fetchTask;
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FetchExactAsync_WhenCallerCancels_PropagatesCancellation(bool isSkillset)
+    {
+        using var callerCts = new CancellationTokenSource();
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled(expectedRequestCount: 3);
+        var fetcher = CreateFetcher(handler);
+        Task fetchTask = isSkillset
+            ? fetcher.FetchExactSkillsetAsync("token", SkillsetReference(), callerCts.Token)
+            : fetcher.FetchExactSkillAsync("token", SkillReference(), callerCts.Token);
+
+        await handler.ExpectedRequestsStarted;
+        callerCts.Cancel();
+        var act = async () => await fetchTask;
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        AssertOnlyExactRequests(
+            handler,
+            isSkillset ? SkillsetGuid : SkillGuid,
+            isSkillset ? "2.0" : "1.2",
+            isSkillset);
+    }
+
+    [Fact]
     public async Task FetchExactSkillAsync_RejectsDeclaredContentLengthBeforeDeserialization()
     {
         var handler = ExactSkillHandler(
@@ -293,6 +376,76 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         var act = async () => await fetcher.FetchExactSkillAsync(
             "token",
             new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Theory]
+    [InlineData("missing-files")]
+    [InlineData("too-many-files")]
+    [InlineData("duplicate-normalized-path")]
+    [InlineData("unix-absolute-path")]
+    [InlineData("windows-absolute-path")]
+    [InlineData("traversal-path")]
+    [InlineData("single-file-too-large")]
+    [InlineData("total-files-too-large")]
+    public async Task FetchExactSkillAsync_WhenDecodedPackageViolatesAdapterBounds_FailsClosed(
+        string invalidPackage)
+    {
+        var handler = ExactSkillHandler(
+            packageJson: SkillPackage(filesJson: InvalidPackageFilesJson(invalidPackage)));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync("token", SkillReference());
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Theory]
+    [InlineData("too-many-tools")]
+    [InlineData("blank-tool")]
+    [InlineData("blank-type")]
+    [InlineData("duplicate-tool")]
+    [InlineData("blank-mcp-name")]
+    [InlineData("blank-mcp-version")]
+    [InlineData("duplicate-mcp")]
+    public async Task FetchExactSkillAsync_WhenDeclaredToolsAreInvalid_FailsClosed(string invalidTools)
+    {
+        var handler = ExactSkillHandler(
+            packageJson: SkillPackage(toolsJson: InvalidToolsJson(invalidTools)));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync("token", SkillReference());
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Theory]
+    [InlineData("blank-subject")]
+    [InlineData("blank-email")]
+    [InlineData("blank-display-name")]
+    [InlineData("invalid-published-at")]
+    public async Task FetchExactSkillAsync_WhenPublisherProvenanceIsInvalid_FailsClosed(
+        string invalidProvenance)
+    {
+        var versionRow = invalidProvenance switch
+        {
+            "blank-subject" => SkillVersionRow(createdBy: " "),
+            "blank-email" => SkillVersionRow(createdByEmail: " "),
+            "blank-display-name" => SkillVersionRow(createdByDisplayName: " "),
+            "invalid-published-at" => SkillVersionRow(createdOn: "not-a-timestamp"),
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidProvenance)),
+        };
+        var handler = ExactSkillHandler(versionsJson: SkillVersions(versionRow));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync("token", SkillReference());
 
         var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
         assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
@@ -401,6 +554,37 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
     }
 
+    [Theory]
+    [InlineData("empty-members", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("too-many-members", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("missing-closure", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("too-many-closure-nodes", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("missing-member-count", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("mismatched-member-count", ExactRemoteFetchFailureKind.IntegrityMismatch)]
+    [InlineData("negative-depth", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("root-count-mismatch", ExactRemoteFetchFailureKind.IntegrityMismatch)]
+    [InlineData("missing-member-identity", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("invalid-member-guid", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("missing-member-version", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("missing-closure-ref", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("missing-closure-name", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("invalid-closure-guid", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("invalid-closure-version", ExactRemoteFetchFailureKind.InvalidResponse)]
+    public async Task FetchExactSkillsetAsync_WhenMemberOrClosureEvidenceIsInvalid_FailsClosed(
+        string invalidEvidence,
+        ExactRemoteFetchFailureKind expectedFailureKind)
+    {
+        var (detailJson, closureJson, versionsJson) = InvalidSkillsetEvidence(invalidEvidence);
+        var handler = ExactSkillsetHandler(detailJson, closureJson, versionsJson);
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillsetAsync("token", SkillsetReference());
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(expectedFailureKind);
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
     private static OrnnRemoteSkillFetcher CreateFetcher(
         OrnnTestHttpMessageHandler handler,
         TimeSpan? timeout = null,
@@ -491,20 +675,15 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         string version = "1.2",
         string? filesJson = null,
         string tool = "workspace.read",
-        string type = "mcp") => $$"""
+        string type = "mcp",
+        string? toolsJson = null) => $$"""
         {
           "data": {
             "name": "{{name}}",
             "description": "A reviewed skill",
             "version": "{{version}}",
             "metadata": {
-              "tools": [
-                {
-                  "tool": {{JsonSerializer.Serialize(tool)}},
-                  "type": {{JsonSerializer.Serialize(type)}},
-                  "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
-                }
-              ]
+              "tools": {{toolsJson ?? SingleToolJson(tool, type)}}
             },
             "files": {{filesJson ?? "{\"SKILL.md\":\"---\\nname: curated-skill\\ndescription: Reviewed\\n---\\nRun it.\",\"docs/readme.md\":\"Reference\"}"}}
           }
@@ -516,7 +695,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         string version = "1.2",
         string? skillHash = null,
         string tool = "workspace.read",
-        string type = "mcp") => $$"""
+        string type = "mcp",
+        string? toolsJson = null) => $$"""
         {
           "data": {
             "guid": "{{SkillGuid}}",
@@ -524,13 +704,7 @@ public sealed class OrnnExactRemoteSkillFetcherTests
             "version": "{{version}}",
             "skillHash": "{{skillHash ?? SkillHash}}",
             "metadata": {
-              "tools": [
-                {
-                  "tool": {{JsonSerializer.Serialize(tool)}},
-                  "type": {{JsonSerializer.Serialize(type)}},
-                  "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
-                }
-              ]
+              "tools": {{toolsJson ?? SingleToolJson(tool, type)}}
             }
           }
         }
@@ -549,15 +723,19 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     private static string SkillVersionRow(
         string version = "1.2",
         string? skillHash = null,
-        string? integrity = null) => $$"""
+        string? integrity = null,
+        string createdBy = "publisher-subject",
+        string createdByEmail = "publisher@example.test",
+        string createdByDisplayName = "Publisher Name",
+        string createdOn = "2026-07-10T12:30:00Z") => $$"""
         {
           "version": "{{version}}",
           "skillHash": "{{skillHash ?? SkillHash}}",
           "integrity": "{{integrity ?? Integrity(skillHash ?? SkillHash)}}",
-          "createdBy": "publisher-subject",
-          "createdByEmail": "publisher@example.test",
-          "createdByDisplayName": "Publisher Name",
-          "createdOn": "2026-07-10T12:30:00Z"
+          "createdBy": {{JsonSerializer.Serialize(createdBy)}},
+          "createdByEmail": {{JsonSerializer.Serialize(createdByEmail)}},
+          "createdByDisplayName": {{JsonSerializer.Serialize(createdByDisplayName)}},
+          "createdOn": {{JsonSerializer.Serialize(createdOn)}}
         }
         """;
 
@@ -575,15 +753,11 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
         """;
 
-    private static string SkillsetClosure() => $$"""
+    private static string SkillsetClosure(string? itemsJson = null) => $$"""
         {
           "data": {
             "instructions": "Use both reviewed skills.",
-            "items": [
-              { "ref": "dependency@3.0", "guid": "{{DependencyGuid}}", "name": "dependency", "version": "3.0", "depth": 1 },
-              { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
-              { "ref": "member-b@2.0", "guid": "{{MemberBGuid}}", "name": "member-b", "version": "2.0", "depth": 0 }
-            ]
+            "items": {{itemsJson ?? DefaultClosureItemsJson()}}
           }
         }
         """;
@@ -598,14 +772,132 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
         """;
 
-    private static string SkillsetVersionRow(string version = "2.0") => $$"""
+    private static string SkillsetVersionRow(
+        string version = "2.0",
+        string? memberCountJson = "2") => $$"""
         {
           "version": "{{version}}",
-          "memberCount": 2,
+          {{(memberCountJson is null ? string.Empty : $"\"memberCount\": {memberCountJson},")}}
           "createdBy": "set-publisher",
           "createdByDisplayName": "Set Publisher",
           "createdOn": "2026-07-11T08:00:00+00:00"
         }
+        """;
+
+    private static ExactRemoteSkillRef SkillReference() => new()
+    {
+        Guid = SkillGuid,
+        LiteralVersion = "1.2",
+    };
+
+    private static ExactRemoteSkillsetRef SkillsetReference() => new()
+    {
+        Guid = SkillsetGuid,
+        LiteralVersion = "2.0",
+    };
+
+    private static string InvalidPackageFilesJson(string invalidPackage) => invalidPackage switch
+    {
+        "missing-files" => "null",
+        "too-many-files" => JsonSerializer.Serialize(
+            Enumerable.Range(0, ExactRemotePackageBounds.AdapterMaximum.MaximumFileCount + 1)
+                .ToDictionary(static index => $"files/{index}.txt", static _ => "x")),
+        "duplicate-normalized-path" => """{"docs/readme.md":"a","docs//readme.md":"b"}""",
+        "unix-absolute-path" => """{"/absolute.txt":"x"}""",
+        "windows-absolute-path" => """{"C:/absolute.txt":"x"}""",
+        "traversal-path" => """{"docs/../secret.txt":"x"}""",
+        "single-file-too-large" => JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["large.txt"] = new('x', checked((int)ExactRemotePackageBounds.AdapterMaximum.MaximumFileUtf8Bytes + 1)),
+        }),
+        "total-files-too-large" => JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["first.txt"] = new('x', 25 * Megabyte),
+            ["second.txt"] = new('x', 25 * Megabyte + 1),
+        }),
+        _ => throw new ArgumentOutOfRangeException(nameof(invalidPackage)),
+    };
+
+    private static string InvalidToolsJson(string invalidTools) => invalidTools switch
+    {
+        "too-many-tools" => $"[{string.Join(',', Enumerable.Range(0, 51).Select(index => ToolJson($"tool-{index}")))}]",
+        "blank-tool" => $"[{ToolJson(" ")}]",
+        "blank-type" => $"[{ToolJson("workspace.read", type: " ")}]",
+        "duplicate-tool" => $"[{ToolJson("workspace.read")},{ToolJson("workspace.read")}]",
+        "blank-mcp-name" => $"[{ToolJson("workspace.read", mcpServersJson: "[{\"mcp\":\" \",\"version\":\"2.0\"}]")}]",
+        "blank-mcp-version" => $"[{ToolJson("workspace.read", mcpServersJson: "[{\"mcp\":\"workspace-mcp\",\"version\":\" \"}]")}]",
+        "duplicate-mcp" => $"[{ToolJson("workspace.read", mcpServersJson: "[{\"mcp\":\"workspace-mcp\",\"version\":\"2.0\"},{\"mcp\":\"workspace-mcp\",\"version\":\"2.0\"}]")}]",
+        _ => throw new ArgumentOutOfRangeException(nameof(invalidTools)),
+    };
+
+    private static string SingleToolJson(string tool, string type) => $"[{ToolJson(tool, type)}]";
+
+    private static string ToolJson(
+        string tool,
+        string type = "mcp",
+        string mcpServersJson = "[{\"mcp\":\"workspace-mcp\",\"version\":\"2.0\"}]") => $$"""
+        {
+          "tool": {{JsonSerializer.Serialize(tool)}},
+          "type": {{JsonSerializer.Serialize(type)}},
+          "mcp-servers": {{mcpServersJson}}
+        }
+        """;
+
+    private static (string? DetailJson, string? ClosureJson, string? VersionsJson) InvalidSkillsetEvidence(
+        string invalidEvidence)
+    {
+        var invalidClosureItem = invalidEvidence switch
+        {
+            "negative-depth" => $$"""{ "ref": "dependency@3.0", "guid": "{{DependencyGuid}}", "name": "dependency", "version": "3.0", "depth": -1 }""",
+            "missing-closure-ref" => $$"""{ "guid": "{{DependencyGuid}}", "name": "dependency", "version": "3.0", "depth": 1 }""",
+            "missing-closure-name" => $$"""{ "ref": "dependency@3.0", "guid": "{{DependencyGuid}}", "version": "3.0", "depth": 1 }""",
+            "invalid-closure-guid" => """{ "ref": "dependency@3.0", "guid": "not-a-guid", "name": "dependency", "version": "3.0", "depth": 1 }""",
+            "invalid-closure-version" => $$"""{ "ref": "dependency@latest", "guid": "{{DependencyGuid}}", "name": "dependency", "version": "latest", "depth": 1 }""",
+            _ => null,
+        };
+
+        return invalidEvidence switch
+        {
+            "empty-members" => (SkillsetDetail(membersJson: "[]"), null, null),
+            "too-many-members" => (SkillsetDetail(membersJson: MemberReferencesJson(101)), null, null),
+            "missing-closure" => (null, SkillsetClosure("null"), null),
+            "too-many-closure-nodes" => (null, SkillsetClosure(ClosureItemsJson(501)), null),
+            "missing-member-count" => (null, null, SkillsetVersions(SkillsetVersionRow(memberCountJson: null))),
+            "mismatched-member-count" => (null, null, SkillsetVersions(SkillsetVersionRow(memberCountJson: "3"))),
+            "root-count-mismatch" => (null, SkillsetClosure(RootCountMismatchClosureItemsJson()), null),
+            "missing-member-identity" => (SkillsetDetail(membersJson: $$"""[{ "version": "1.0" }, "member-b@2.0"]"""), null, null),
+            "invalid-member-guid" => (SkillsetDetail(membersJson: $$"""[{ "guid": "not-a-guid", "name": "member-a", "version": "1.0" }, "member-b@2.0"]"""), null, null),
+            "missing-member-version" => (SkillsetDetail(membersJson: $$"""[{ "name": "member-a" }, "member-b@2.0"]"""), null, null),
+            _ when invalidClosureItem is not null =>
+                (null, SkillsetClosure($"[{invalidClosureItem},{DefaultClosureRootsJson()}]"), null),
+            _ => throw new ArgumentOutOfRangeException(nameof(invalidEvidence)),
+        };
+    }
+
+    private static string MemberReferencesJson(int count) => JsonSerializer.Serialize(
+        Enumerable.Range(0, count).Select(static index => $"member-{index}@1.0"));
+
+    private static string ClosureItemsJson(int count) => $"[{string.Join(',', Enumerable.Range(1, count).Select(index => $$"""
+        { "ref": "member-{{index}}@1.0", "guid": "00000000-0000-0000-0000-{{index.ToString("000000000000")}}", "name": "member-{{index}}", "version": "1.0", "depth": 1 }
+        """))}]";
+
+    private static string DefaultClosureItemsJson() => $"[{DefaultClosureDependencyJson()},{DefaultClosureRootsJson()}]";
+
+    private static string DefaultClosureDependencyJson() => $$"""
+        { "ref": "dependency@3.0", "guid": "{{DependencyGuid}}", "name": "dependency", "version": "3.0", "depth": 1 }
+        """;
+
+    private static string DefaultClosureRootsJson() => $$"""
+        { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
+        { "ref": "member-b@2.0", "guid": "{{MemberBGuid}}", "name": "member-b", "version": "2.0", "depth": 0 }
+        """;
+
+    private static string RootCountMismatchClosureItemsJson() => $$"""
+        [
+          {{DefaultClosureDependencyJson()}},
+          { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
+          { "ref": "member-b@2.0", "guid": "{{MemberBGuid}}", "name": "member-b", "version": "2.0", "depth": 1 }
+        ]
         """;
 
     private static string Integrity(string hex) =>

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -1,0 +1,391 @@
+using System.Net;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.AI.ToolProviders.Skills;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class OrnnExactRemoteSkillFetcherTests
+{
+    private const string SkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string SkillsetGuid = "22222222-2222-2222-2222-222222222222";
+    private const string MemberAGuid = "33333333-3333-3333-3333-333333333333";
+    private const string MemberBGuid = "44444444-4444-4444-4444-444444444444";
+    private const string DependencyGuid = "55555555-5555-5555-5555-555555555555";
+    private static readonly string SkillHash = new('a', 64);
+
+    [Fact]
+    public async Task FetchExactSkillAsync_UsesThreeGuidScopedReadsAndReturnsReviewedEvidence()
+    {
+        var handler = ExactSkillHandler();
+        var fetcher = CreateFetcher(handler);
+
+        var release = await fetcher.FetchExactSkillAsync(
+            "access-token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        release.Reference.Guid.Should().Be(SkillGuid);
+        release.Reference.LiteralVersion.Should().Be("1.2");
+        release.PublishedName.Should().Be("curated-skill");
+        release.Provenance.Should().Be(new ExactRemoteVersionProvenance(
+            "publisher-subject",
+            "publisher@example.test",
+            "Publisher Name",
+            DateTimeOffset.Parse("2026-07-10T12:30:00Z")));
+        release.Package.Files.Should().ContainKey("SKILL.md");
+        release.Package.Shape.FileCount.Should().Be(2);
+        release.DeclaredTools.Should().ContainSingle();
+        release.DeclaredTools[0].Tool.Should().Be("workspace.read");
+        release.DeclaredTools[0].McpServers.Should().ContainSingle()
+            .Which.Should().Be(new ExactRemoteMcpServerDeclaration("workspace-mcp", "2.0"));
+        release.Definition.Name.Should().Be("curated-skill");
+        release.Definition.RemoteId.Should().Be(SkillGuid);
+
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+        handler.Requests.Should().OnlyContain(request => request.Authorization!.Parameter == "access-token");
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_UsesThreeGuidScopedReadsAndResolvesLiteralMemberVersions()
+    {
+        var handler = ExactSkillsetHandler();
+        var fetcher = CreateFetcher(handler);
+
+        var release = await fetcher.FetchExactSkillsetAsync(
+            "access-token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        release.PublishedName.Should().Be("reviewed-set");
+        release.Instructions.Should().Be("Use both reviewed skills.");
+        release.Provenance.PublisherSubjectId.Should().Be("set-publisher");
+        release.Provenance.PublisherEmailSnapshot.Should().BeNull();
+        release.Provenance.PublisherDisplayNameSnapshot.Should().Be("Set Publisher");
+        release.DirectMembers.Select(member => (member.Guid, member.LiteralVersion)).Should().Equal(
+            (MemberAGuid, "1.0"),
+            (MemberBGuid, "2.0"));
+        release.FullClosure.Select(member => (member.Guid, member.LiteralVersion)).Should().Equal(
+            (DependencyGuid, "3.0"),
+            (MemberAGuid, "1.0"),
+            (MemberBGuid, "2.0"));
+
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenEvidenceMismatches_FailsClosedWithoutFallback()
+    {
+        var handler = ExactSkillHandler(detailJson: SkillDetail(name: "different-name"));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_WhenOneResponseIsUnavailable_StillMakesOnlyTheFixedReads()
+    {
+        var handler = ExactSkillHandler(
+            packageResponse: () => OrnnTestHttpMessageHandler.JsonResponse(
+                """{"error":"missing"}""",
+                HttpStatusCode.NotFound));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
+        assertion.Which.HttpStatus.Should().Be(404);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_UsesOneSharedTimeoutForAllThreeReads()
+    {
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled();
+        var fetcher = CreateFetcher(handler, TimeSpan.FromMilliseconds(100));
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.Unavailable);
+        handler.Requests.Should().HaveCount(3);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_RejectsDeclaredContentLengthBeforeDeserialization()
+    {
+        var handler = ExactSkillHandler(
+            packageResponse: () => OrnnTestHttpMessageHandler.JsonResponse(
+                SkillPackage(),
+                contentLength: NyxIdToolOptions.HardProxyFileArtifactMaxBytes + 1));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain("exceeded");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_RejectsOversizedEvidenceStreamWithoutContentLength()
+    {
+        var handler = ExactSkillHandler(
+            detailResponse: () => OrnnTestHttpMessageHandler.OversizedStreamResponse(
+                NyxIdToolOptions.DefaultProxyFileArtifactMaxBytes + 1));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillAsync_RejectsDecodedPackagePathBeyondAdapterBound()
+    {
+        var oversizedPath = new string('p', 513);
+        var files = $$"""{"{{oversizedPath}}":"content"}""";
+        var handler = ExactSkillHandler(packageJson: SkillPackage(filesJson: files));
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync(
+            "token",
+            new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = "1.2" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Fact]
+    public async Task FetchExactSkillsetAsync_WhenClosureContainsConflictingIdentity_FailsClosed()
+    {
+        var duplicateClosure = $$"""
+            {
+              "data": {
+                "instructions": "Use both reviewed skills.",
+                "items": [
+                  { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
+                  { "ref": "member-a@2.0", "guid": "{{MemberAGuid}}", "name": "member-b", "version": "2.0", "depth": 0 }
+                ]
+              }
+            }
+            """;
+        var handler = ExactSkillsetHandler(closureJson: duplicateClosure);
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillsetAsync(
+            "token",
+            new ExactRemoteSkillsetRef { Guid = SkillsetGuid, LiteralVersion = "2.0" });
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    private static OrnnRemoteSkillFetcher CreateFetcher(
+        OrnnTestHttpMessageHandler handler,
+        TimeSpan? timeout = null)
+    {
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+        var client = new OrnnSkillClient(
+            new OrnnOptions { NyxIdSlug = "ornn-api" },
+            nyxClient,
+            timeout ?? TimeSpan.FromSeconds(30));
+        return new OrnnRemoteSkillFetcher(client);
+    }
+
+    private static OrnnTestHttpMessageHandler ExactSkillHandler(
+        string? packageJson = null,
+        string? detailJson = null,
+        string? versionsJson = null,
+        Func<HttpResponseMessage>? packageResponse = null,
+        Func<HttpResponseMessage>? detailResponse = null)
+    {
+        return OrnnTestHttpMessageHandler.Routing(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith($"/skills/{SkillGuid}/json", StringComparison.Ordinal))
+                return packageResponse?.Invoke() ?? OrnnTestHttpMessageHandler.JsonResponse(packageJson ?? SkillPackage());
+            if (path.EndsWith($"/skills/{SkillGuid}/versions", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(versionsJson ?? SkillVersions());
+            if (path.EndsWith($"/skills/{SkillGuid}", StringComparison.Ordinal))
+                return detailResponse?.Invoke() ?? OrnnTestHttpMessageHandler.JsonResponse(detailJson ?? SkillDetail());
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+    }
+
+    private static OrnnTestHttpMessageHandler ExactSkillsetHandler(
+        string? detailJson = null,
+        string? closureJson = null,
+        string? versionsJson = null)
+    {
+        return OrnnTestHttpMessageHandler.Routing(request =>
+        {
+            var path = request.RequestUri!.AbsolutePath;
+            if (path.EndsWith($"/skillsets/{SkillsetGuid}/closure", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(closureJson ?? SkillsetClosure());
+            if (path.EndsWith($"/skillsets/{SkillsetGuid}/versions", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(versionsJson ?? SkillsetVersions());
+            if (path.EndsWith($"/skillsets/{SkillsetGuid}", StringComparison.Ordinal))
+                return OrnnTestHttpMessageHandler.JsonResponse(detailJson ?? SkillsetDetail());
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        });
+    }
+
+    private static void AssertOnlyExactRequests(
+        OrnnTestHttpMessageHandler handler,
+        string guid,
+        string version,
+        bool isSkillset)
+    {
+        var resource = isSkillset ? "skillsets" : "skills";
+        var expected = isSkillset
+            ? new[]
+            {
+                $"/api/v1/{resource}/{guid}?version={version}",
+                $"/api/v1/{resource}/{guid}/closure?version={version}",
+                $"/api/v1/{resource}/{guid}/versions",
+            }
+            : new[]
+            {
+                $"/api/v1/{resource}/{guid}/json?version={version}",
+                $"/api/v1/{resource}/{guid}?version={version}",
+                $"/api/v1/{resource}/{guid}/versions",
+            };
+
+        handler.Requests.Should().HaveCount(3);
+        handler.Requests.Select(request => request.RequestUri!.PathAndQuery)
+            .Should().BeEquivalentTo(expected.Select(path => $"/api/v1/proxy/s/ornn-api{path}"));
+        handler.Requests.Should().OnlyContain(request =>
+            request.RequestUri!.AbsolutePath.Contains($"/{resource}/{guid}", StringComparison.Ordinal));
+        handler.Requests.Select(request => request.RequestUri!.PathAndQuery)
+            .Should().NotContain(path => path.Contains("latest", StringComparison.OrdinalIgnoreCase) ||
+                                         path.Contains("search", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string SkillPackage(
+        string name = "curated-skill",
+        string version = "1.2",
+        string? filesJson = null) => $$"""
+        {
+          "data": {
+            "name": "{{name}}",
+            "description": "A reviewed skill",
+            "version": "{{version}}",
+            "metadata": {
+              "tools": [
+                {
+                  "tool": "workspace.read",
+                  "type": "mcp",
+                  "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
+                }
+              ]
+            },
+            "files": {{filesJson ?? "{\"SKILL.md\":\"---\\nname: curated-skill\\ndescription: Reviewed\\n---\\nRun it.\",\"docs/readme.md\":\"Reference\"}"}}
+          }
+        }
+        """;
+
+    private static string SkillDetail(string name = "curated-skill") => $$"""
+        {
+          "data": {
+            "guid": "{{SkillGuid}}",
+            "name": "{{name}}",
+            "version": "1.2",
+            "skillHash": "{{SkillHash}}",
+            "metadata": {
+              "tools": [
+                {
+                  "tool": "workspace.read",
+                  "type": "mcp",
+                  "mcp-servers": [{ "mcp": "workspace-mcp", "version": "2.0" }]
+                }
+              ]
+            }
+          }
+        }
+        """;
+
+    private static string SkillVersions() => $$"""
+        {
+          "data": {
+            "items": [
+              {
+                "version": "1.2",
+                "skillHash": "{{SkillHash}}",
+                "integrity": "{{Integrity(SkillHash)}}",
+                "createdBy": "publisher-subject",
+                "createdByEmail": "publisher@example.test",
+                "createdByDisplayName": "Publisher Name",
+                "createdOn": "2026-07-10T12:30:00Z"
+              }
+            ]
+          }
+        }
+        """;
+
+    private static string SkillsetDetail() => $$"""
+        {
+          "data": {
+            "guid": "{{SkillsetGuid}}",
+            "name": "reviewed-set",
+            "version": "2.0",
+            "instructions": "Use both reviewed skills.",
+            "members": ["member-a@1.0", "member-b@beta"]
+          }
+        }
+        """;
+
+    private static string SkillsetClosure() => $$"""
+        {
+          "data": {
+            "instructions": "Use both reviewed skills.",
+            "items": [
+              { "ref": "dependency@3.0", "guid": "{{DependencyGuid}}", "name": "dependency", "version": "3.0", "depth": 1 },
+              { "ref": "member-a@1.0", "guid": "{{MemberAGuid}}", "name": "member-a", "version": "1.0", "depth": 0 },
+              { "ref": "member-b@2.0", "guid": "{{MemberBGuid}}", "name": "member-b", "version": "2.0", "depth": 0 }
+            ]
+          }
+        }
+        """;
+
+    private static string SkillsetVersions() => """
+        {
+          "data": {
+            "items": [
+              {
+                "version": "2.0",
+                "memberCount": 2,
+                "createdBy": "set-publisher",
+                "createdByDisplayName": "Set Publisher",
+                "createdOn": "2026-07-11T08:00:00+00:00"
+              }
+            ]
+          }
+        }
+        """;
+
+    private static string Integrity(string hex) =>
+        $"sha256-{Convert.ToBase64String(Convert.FromHexString(hex))}";
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -268,6 +268,86 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
     }
 
+    [Theory]
+    [InlineData(false, "{", "not valid JSON")]
+    [InlineData(false, "{}", "omitted data")]
+    [InlineData(true, "{", "not valid JSON")]
+    [InlineData(true, "{}", "omitted data")]
+    public async Task FetchExactAsync_WhenEnvelopeIsMalformedOrOmitsData_FailsClosedWithoutFallback(
+        bool isSkillset,
+        string responseJson,
+        string expectedMessage)
+    {
+        var handler = isSkillset
+            ? ExactSkillsetHandler(detailJson: responseJson)
+            : ExactSkillHandler(packageJson: responseJson);
+        var fetcher = CreateFetcher(handler);
+
+        Func<Task> act = async () =>
+        {
+            if (isSkillset)
+                await fetcher.FetchExactSkillsetAsync("token", SkillsetReference());
+            else
+                await fetcher.FetchExactSkillAsync("token", SkillReference());
+        };
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain(expectedMessage);
+        AssertOnlyExactRequests(
+            handler,
+            isSkillset ? SkillsetGuid : SkillGuid,
+            isSkillset ? "2.0" : "1.2",
+            isSkillset);
+    }
+
+    [Theory]
+    [InlineData("package")]
+    [InlineData("detail")]
+    public async Task FetchExactSkillAsync_WhenPackageOrDetailMetadataIsMissing_FailsClosedWithoutFallback(
+        string source)
+    {
+        var handler = ExactSkillHandler(
+            packageJson: source == "package" ? SkillPackage(includeMetadata: false) : null,
+            detailJson: source == "detail" ? SkillDetail(includeMetadata: false) : null);
+        var fetcher = CreateFetcher(handler);
+
+        var act = async () => await fetcher.FetchExactSkillAsync("token", SkillReference());
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        assertion.Which.Message.Should().Contain("metadata");
+        AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FetchExactAsync_WhenReturnedGuidDiffers_FailsClosedWithoutFallback(bool isSkillset)
+    {
+        var handler = isSkillset
+            ? ExactSkillsetHandler(detailJson: SkillsetDetail(guid: SkillGuid))
+            : ExactSkillHandler(detailJson: SkillDetail(guid: SkillsetGuid));
+        var fetcher = CreateFetcher(handler);
+
+        Func<Task> act = async () =>
+        {
+            if (isSkillset)
+                await fetcher.FetchExactSkillsetAsync("token", SkillsetReference());
+            else
+                await fetcher.FetchExactSkillAsync("token", SkillReference());
+        };
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.IntegrityMismatch);
+        assertion.Which.Message.Should().Contain("returned GUID");
+        AssertOnlyExactRequests(
+            handler,
+            isSkillset ? SkillsetGuid : SkillGuid,
+            isSkillset ? "2.0" : "1.2",
+            isSkillset);
+    }
+
     [Fact]
     public async Task FetchExactSkillAsync_UsesOneSharedTimeoutForAllThreeReads()
     {
@@ -389,6 +469,9 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     [InlineData("unix-absolute-path")]
     [InlineData("windows-absolute-path")]
     [InlineData("traversal-path")]
+    [InlineData("null-file-content")]
+    [InlineData("blank-path")]
+    [InlineData("nul-path")]
     [InlineData("single-file-too-large")]
     [InlineData("total-files-too-large")]
     public async Task FetchExactSkillAsync_WhenDecodedPackageViolatesAdapterBounds_FailsClosed(
@@ -402,6 +485,15 @@ public sealed class OrnnExactRemoteSkillFetcherTests
 
         var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
         assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        var expectedMessage = invalidPackage switch
+        {
+            "null-file-content" => "null content",
+            "blank-path" or "nul-path" => "normalized relative path",
+            "total-files-too-large" => "total file bytes",
+            _ => null,
+        };
+        if (expectedMessage is not null)
+            assertion.Which.Message.Should().Contain(expectedMessage);
         AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
     }
 
@@ -676,37 +768,42 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         string? filesJson = null,
         string tool = "workspace.read",
         string type = "mcp",
-        string? toolsJson = null) => $$"""
+        string? toolsJson = null,
+        bool includeMetadata = true) => $$"""
         {
           "data": {
             "name": "{{name}}",
             "description": "A reviewed skill",
             "version": "{{version}}",
-            "metadata": {
-              "tools": {{toolsJson ?? SingleToolJson(tool, type)}}
-            },
+            "metadata": {{(includeMetadata ? SkillMetadataJson(tool, type, toolsJson) : "null")}},
             "files": {{filesJson ?? "{\"SKILL.md\":\"---\\nname: curated-skill\\ndescription: Reviewed\\n---\\nRun it.\",\"docs/readme.md\":\"Reference\"}"}}
           }
         }
         """;
 
     private static string SkillDetail(
+        string guid = SkillGuid,
         string name = "curated-skill",
         string version = "1.2",
         string? skillHash = null,
         string tool = "workspace.read",
         string type = "mcp",
-        string? toolsJson = null) => $$"""
+        string? toolsJson = null,
+        bool includeMetadata = true) => $$"""
         {
           "data": {
-            "guid": "{{SkillGuid}}",
+            "guid": "{{guid}}",
             "name": "{{name}}",
             "version": "{{version}}",
             "skillHash": "{{skillHash ?? SkillHash}}",
-            "metadata": {
-              "tools": {{toolsJson ?? SingleToolJson(tool, type)}}
-            }
+            "metadata": {{(includeMetadata ? SkillMetadataJson(tool, type, toolsJson) : "null")}}
           }
+        }
+        """;
+
+    private static string SkillMetadataJson(string tool, string type, string? toolsJson) => $$"""
+        {
+          "tools": {{toolsJson ?? SingleToolJson(tool, type)}}
         }
         """;
 
@@ -740,11 +837,12 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         """;
 
     private static string SkillsetDetail(
+        string guid = SkillsetGuid,
         string version = "2.0",
         string? membersJson = null) => $$"""
         {
           "data": {
-            "guid": "{{SkillsetGuid}}",
+            "guid": "{{guid}}",
             "name": "reviewed-set",
             "version": "{{version}}",
             "instructions": "Use both reviewed skills.",
@@ -806,6 +904,9 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         "unix-absolute-path" => """{"/absolute.txt":"x"}""",
         "windows-absolute-path" => """{"C:/absolute.txt":"x"}""",
         "traversal-path" => """{"docs/../secret.txt":"x"}""",
+        "null-file-content" => """{"empty.txt":null}""",
+        "blank-path" => """{" ":"x"}""",
+        "nul-path" => """{"bad\u0000path":"x"}""",
         "single-file-too-large" => JsonSerializer.Serialize(new Dictionary<string, string>
         {
             ["large.txt"] = new('x', checked((int)ExactRemotePackageBounds.AdapterMaximum.MaximumFileUtf8Bytes + 1)),
@@ -813,7 +914,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         "total-files-too-large" => JsonSerializer.Serialize(new Dictionary<string, string>
         {
             ["first.txt"] = new('x', 25 * Megabyte),
-            ["second.txt"] = new('x', 25 * Megabyte + 1),
+            ["second.txt"] = new('x', 25 * Megabyte),
+            ["third.txt"] = "x",
         }),
         _ => throw new ArgumentOutOfRangeException(nameof(invalidPackage)),
     };

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -514,6 +514,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     [InlineData("blank-mcp-name")]
     [InlineData("blank-mcp-version")]
     [InlineData("duplicate-mcp")]
+    [InlineData("null-tool")]
+    [InlineData("null-mcp-server")]
     public async Task FetchExactSkillAsync_WhenDeclaredToolsAreInvalid_FailsClosed(string invalidTools)
     {
         var handler = ExactSkillHandler(
@@ -523,7 +525,11 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         var act = async () => await fetcher.FetchExactSkillAsync("token", SkillReference());
 
         var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
-        assertion.Which.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        var exception = assertion.Which;
+        exception.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        exception.ResourceKind.Should().Be(ExactRemoteResourceKind.Skill);
+        exception.Guid.Should().Be(SkillGuid);
+        exception.LiteralVersion.Should().Be("1.2");
         AssertOnlyExactRequests(handler, SkillGuid, "1.2", isSkillset: false);
     }
 
@@ -657,8 +663,11 @@ public sealed class OrnnExactRemoteSkillFetcherTests
 
     [Theory]
     [InlineData("empty-members", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("null-members", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("null-member", ExactRemoteFetchFailureKind.InvalidResponse)]
     [InlineData("too-many-members", ExactRemoteFetchFailureKind.InvalidResponse)]
     [InlineData("missing-closure", ExactRemoteFetchFailureKind.InvalidResponse)]
+    [InlineData("null-closure-item", ExactRemoteFetchFailureKind.InvalidResponse)]
     [InlineData("too-many-closure-nodes", ExactRemoteFetchFailureKind.InvalidResponse)]
     [InlineData("missing-member-count", ExactRemoteFetchFailureKind.InvalidResponse)]
     [InlineData("mismatched-member-count", ExactRemoteFetchFailureKind.IntegrityMismatch)]
@@ -682,8 +691,53 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         var act = async () => await fetcher.FetchExactSkillsetAsync("token", SkillsetReference());
 
         var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
-        assertion.Which.FailureKind.Should().Be(expectedFailureKind);
+        var exception = assertion.Which;
+        exception.FailureKind.Should().Be(expectedFailureKind);
+        exception.ResourceKind.Should().Be(ExactRemoteResourceKind.Skillset);
+        var expectedGuid = invalidEvidence == "invalid-closure-guid" ? "not-a-guid" :
+            invalidEvidence == "invalid-closure-version" ? DependencyGuid : SkillsetGuid;
+        var expectedVersion = invalidEvidence switch
+        {
+            "invalid-closure-guid" => "3.0",
+            "invalid-closure-version" => "latest",
+            _ => "2.0",
+        };
+        exception.Guid.Should().Be(expectedGuid);
+        exception.LiteralVersion.Should().Be(expectedVersion);
         AssertOnlyExactRequests(handler, SkillsetGuid, "2.0", isSkillset: true);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public async Task FetchExactAsync_WhenVersionsItemsAreNullOrContainNull_FailsClosedWithoutFallback(
+        bool isSkillset,
+        bool containsNullElement)
+    {
+        var itemsJson = containsNullElement ? "[null]" : "null";
+        var handler = isSkillset
+            ? ExactSkillsetHandler(versionsJson: SkillsetVersionsWithItems(itemsJson))
+            : ExactSkillHandler(versionsJson: SkillVersionsWithItems(itemsJson));
+        var fetcher = CreateFetcher(handler);
+
+        Func<Task> act = isSkillset
+            ? async () => await fetcher.FetchExactSkillsetAsync("token", SkillsetReference())
+            : async () => await fetcher.FetchExactSkillAsync("token", SkillReference());
+
+        var assertion = await act.Should().ThrowAsync<ExactRemoteFetchException>();
+        var exception = assertion.Which;
+        exception.FailureKind.Should().Be(ExactRemoteFetchFailureKind.InvalidResponse);
+        exception.ResourceKind.Should().Be(
+            isSkillset ? ExactRemoteResourceKind.Skillset : ExactRemoteResourceKind.Skill);
+        exception.Guid.Should().Be(isSkillset ? SkillsetGuid : SkillGuid);
+        exception.LiteralVersion.Should().Be(isSkillset ? "2.0" : "1.2");
+        AssertOnlyExactRequests(
+            handler,
+            isSkillset ? SkillsetGuid : SkillGuid,
+            isSkillset ? "2.0" : "1.2",
+            isSkillset);
     }
 
     private static OrnnRemoteSkillFetcher CreateFetcher(
@@ -826,6 +880,14 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
         """;
 
+    private static string SkillVersionsWithItems(string itemsJson) => $$"""
+        {
+          "data": {
+            "items": {{itemsJson}}
+          }
+        }
+        """;
+
     private static string SkillVersionRow(
         string version = "1.2",
         string? skillHash = null,
@@ -875,6 +937,14 @@ public sealed class OrnnExactRemoteSkillFetcherTests
             "items": [
               {{itemsJson ?? SkillsetVersionRow()}}
             ]
+          }
+        }
+        """;
+
+    private static string SkillsetVersionsWithItems(string itemsJson) => $$"""
+        {
+          "data": {
+            "items": {{itemsJson}}
           }
         }
         """;
@@ -938,6 +1008,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         "blank-mcp-name" => $"[{ToolJson("workspace.read", mcpServersJson: "[{\"mcp\":\" \",\"version\":\"2.0\"}]")}]",
         "blank-mcp-version" => $"[{ToolJson("workspace.read", mcpServersJson: "[{\"mcp\":\"workspace-mcp\",\"version\":\" \"}]")}]",
         "duplicate-mcp" => $"[{ToolJson("workspace.read", mcpServersJson: "[{\"mcp\":\"workspace-mcp\",\"version\":\"2.0\"},{\"mcp\":\"workspace-mcp\",\"version\":\"2.0\"}]")}]",
+        "null-tool" => "[null]",
+        "null-mcp-server" => $"[{ToolJson("workspace.read", mcpServersJson: "[null]")}]",
         _ => throw new ArgumentOutOfRangeException(nameof(invalidTools)),
     };
 
@@ -970,8 +1042,11 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         return invalidEvidence switch
         {
             "empty-members" => (SkillsetDetail(membersJson: "[]"), null, null),
+            "null-members" => (SkillsetDetail(membersJson: "null"), null, null),
+            "null-member" => (SkillsetDetail(membersJson: "[null]"), null, null),
             "too-many-members" => (SkillsetDetail(membersJson: MemberReferencesJson(101)), null, null),
             "missing-closure" => (null, SkillsetClosure("null"), null),
+            "null-closure-item" => (null, SkillsetClosure("[null]"), null),
             "too-many-closure-nodes" => (null, SkillsetClosure(ClosureItemsJson(501)), null),
             "missing-member-count" => (null, null, SkillsetVersions(SkillsetVersionRow(memberCountJson: null))),
             "mismatched-member-count" => (null, null, SkillsetVersions(SkillsetVersionRow(memberCountJson: "3"))),

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
@@ -10,20 +10,27 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
     private readonly Func<HttpRequestMessage, HttpResponseMessage>? _responseRouter;
     private readonly bool _hangUntilCanceled;
     private readonly ConcurrentQueue<CapturedHttpRequest> _requests = new();
+    private readonly int _expectedRequestCount;
+    private readonly TaskCompletionSource _expectedRequestsStarted = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _requestCount;
 
     public IReadOnlyList<CapturedHttpRequest> Requests => _requests.ToArray();
+    public Task ExpectedRequestsStarted => _expectedRequestsStarted.Task;
 
     public OrnnTestHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
-        : this(hangUntilCanceled: false, responseRouter: null, responses)
+        : this(hangUntilCanceled: false, expectedRequestCount: 1, responseRouter: null, responses)
     {
     }
 
     private OrnnTestHttpMessageHandler(
         bool hangUntilCanceled,
+        int expectedRequestCount,
         Func<HttpRequestMessage, HttpResponseMessage>? responseRouter,
         params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
     {
         _hangUntilCanceled = hangUntilCanceled;
+        _expectedRequestCount = expectedRequestCount;
         _responseRouter = responseRouter;
         foreach (var response in responses)
             _responses.Enqueue(response);
@@ -40,19 +47,27 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
     /// the only thing that ends the wait, so the timeout assertion is deterministic regardless
     /// of the host machine's scheduler.
     /// </summary>
-    public static OrnnTestHttpMessageHandler HangingUntilCanceled()
+    public static OrnnTestHttpMessageHandler HangingUntilCanceled(int expectedRequestCount = 1)
     {
-        return new OrnnTestHttpMessageHandler(hangUntilCanceled: true, responseRouter: null);
+        return new OrnnTestHttpMessageHandler(
+            hangUntilCanceled: true,
+            expectedRequestCount,
+            responseRouter: null);
     }
 
     public static OrnnTestHttpMessageHandler Routing(Func<HttpRequestMessage, HttpResponseMessage> responseRouter)
     {
-        return new OrnnTestHttpMessageHandler(hangUntilCanceled: false, responseRouter);
+        return new OrnnTestHttpMessageHandler(
+            hangUntilCanceled: false,
+            expectedRequestCount: 1,
+            responseRouter);
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         _requests.Enqueue(CapturedHttpRequest.From(request));
+        if (Interlocked.Increment(ref _requestCount) >= _expectedRequestCount)
+            _expectedRequestsStarted.TrySetResult();
 
         if (_hangUntilCanceled)
         {

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
@@ -1,23 +1,30 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Collections.Concurrent;
 
 namespace Aevatar.AI.ToolProviders.Ornn.Tests;
 
 internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
 {
-    private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+    private readonly ConcurrentQueue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+    private readonly Func<HttpRequestMessage, HttpResponseMessage>? _responseRouter;
     private readonly bool _hangUntilCanceled;
+    private readonly ConcurrentQueue<CapturedHttpRequest> _requests = new();
 
-    public List<CapturedHttpRequest> Requests { get; } = [];
+    public IReadOnlyList<CapturedHttpRequest> Requests => _requests.ToArray();
 
     public OrnnTestHttpMessageHandler(params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
-        : this(hangUntilCanceled: false, responses)
+        : this(hangUntilCanceled: false, responseRouter: null, responses)
     {
     }
 
-    private OrnnTestHttpMessageHandler(bool hangUntilCanceled, params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
+    private OrnnTestHttpMessageHandler(
+        bool hangUntilCanceled,
+        Func<HttpRequestMessage, HttpResponseMessage>? responseRouter,
+        params Func<HttpRequestMessage, HttpResponseMessage>[] responses)
     {
         _hangUntilCanceled = hangUntilCanceled;
+        _responseRouter = responseRouter;
         foreach (var response in responses)
             _responses.Enqueue(response);
     }
@@ -35,12 +42,17 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
     /// </summary>
     public static OrnnTestHttpMessageHandler HangingUntilCanceled()
     {
-        return new OrnnTestHttpMessageHandler(hangUntilCanceled: true);
+        return new OrnnTestHttpMessageHandler(hangUntilCanceled: true, responseRouter: null);
+    }
+
+    public static OrnnTestHttpMessageHandler Routing(Func<HttpRequestMessage, HttpResponseMessage> responseRouter)
+    {
+        return new OrnnTestHttpMessageHandler(hangUntilCanceled: false, responseRouter);
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        Requests.Add(CapturedHttpRequest.From(request));
+        _requests.Enqueue(CapturedHttpRequest.From(request));
 
         if (_hangUntilCanceled)
         {
@@ -54,20 +66,78 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
             cancellationToken.ThrowIfCancellationRequested();
         }
 
-        var responseFactory = _responses.Count > 0
-            ? _responses.Dequeue()
+        if (_responseRouter is not null)
+            return _responseRouter(request);
+
+        var responseFactory = _responses.TryDequeue(out var queuedResponse)
+            ? queuedResponse
             : _ => new HttpResponseMessage(HttpStatusCode.NotFound);
 
         return responseFactory(request);
     }
 
-    public static HttpResponseMessage JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
+    public static HttpResponseMessage JsonResponse(
+        string json,
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        long? contentLength = null)
     {
-        return new HttpResponseMessage(statusCode)
+        var response = new HttpResponseMessage(statusCode)
         {
             Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
         };
+        if (contentLength is not null)
+            response.Content.Headers.ContentLength = contentLength;
+        return response;
     }
+
+    public static HttpResponseMessage OversizedStreamResponse(long byteCount)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new RepeatedByteStream(byteCount)),
+        };
+    }
+}
+
+internal sealed class RepeatedByteStream(long length) : Stream
+{
+    private long _position;
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => length;
+    public override long Position { get => _position; set => throw new NotSupportedException(); }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var remaining = length - _position;
+        if (remaining <= 0)
+            return 0;
+        var read = (int)Math.Min(count, remaining);
+        Array.Fill(buffer, (byte)'x', offset, read);
+        _position += read;
+        return read;
+    }
+
+    public override ValueTask<int> ReadAsync(
+        Memory<byte> buffer,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var remaining = length - _position;
+        if (remaining <= 0)
+            return ValueTask.FromResult(0);
+        var read = (int)Math.Min(buffer.Length, remaining);
+        buffer.Span[..read].Fill((byte)'x');
+        _position += read;
+        return ValueTask.FromResult(read);
+    }
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 }
 
 internal sealed record CapturedHttpRequest(

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnTestHttpMessageHandler.cs
@@ -51,7 +51,7 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
     {
         return new OrnnTestHttpMessageHandler(
             hangUntilCanceled: true,
-            expectedRequestCount,
+            expectedRequestCount: expectedRequestCount,
             responseRouter: null);
     }
 
@@ -60,7 +60,7 @@ internal sealed class OrnnTestHttpMessageHandler : HttpMessageHandler
         return new OrnnTestHttpMessageHandler(
             hangUntilCanceled: false,
             expectedRequestCount: 1,
-            responseRouter);
+            responseRouter: responseRouter);
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+using Aevatar.AI.ToolProviders.Skills;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -115,6 +116,31 @@ public sealed class ServiceCollectionExtensionsTests
         sources.Count(x => x is OrnnAgentToolSource).Should().Be(1);
         sources.OfType<OrnnAgentToolSource>().Should().ContainSingle()
             .Which.Should().BeSameAs(provider.GetRequiredService<OrnnAgentToolSource>());
+    }
+
+    [Fact]
+    public void AddOrnnSkills_ShouldAliasOrdinaryAndExactPortsToOneFetcherWithoutExposingItAsToolSource()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(new NotFoundHttpMessageHandler())));
+
+        services.AddOrnnSkills();
+        services.AddOrnnSkills();
+
+        using var provider = services.BuildServiceProvider();
+        var concrete = provider.GetRequiredService<OrnnRemoteSkillFetcher>();
+        var ordinary = provider.GetRequiredService<IRemoteSkillFetcher>();
+        var exact = provider.GetRequiredService<IExactRemoteSkillFetcher>();
+
+        ordinary.Should().BeSameAs(concrete);
+        exact.Should().BeSameAs(concrete);
+        provider.GetServices<IRemoteSkillFetcher>().Should().ContainSingle();
+        provider.GetServices<IExactRemoteSkillFetcher>().Should().ContainSingle();
+        provider.GetRequiredService<ExactRemoteReleaseVerifier>().Should().NotBeNull();
+        provider.GetServices<IAgentToolSource>().Should()
+            .NotContain(source => ReferenceEquals(source, exact));
     }
 
     private sealed class StubOverlayProvider : ISystemSkillOverlayProvider, ISystemSkillOverlayFallback


### PR DESCRIPTION
## Changed files

- 新增仅包含 GUID 和字面版本的 skill/skillset Protobuf 引用，以及独立的精确读取端口。
- 由 Ornn 适配器并发获取 skill 和 skillset 各三类 GUID 证据，严格比较四字段发布者快照、成员版本和包完整性，任何不一致均封闭失败。
- 将 exact 和 ordinary fetcher 注册为同一 singleton，并补充信任边界文档与快速、隔离的行为测试。

## Test results

- 解决方案构建通过，0 errors。
- Ornn 定向测试 29/29 通过；AI Protobuf/recovery 定向测试 29/29 通过。
- 全量解决方案测试 0 failures；架构门禁、测试稳定性门禁与 diff 格式检查全部通过。

## Deviations

- 无实现偏差，无授权范围扩展。
- `HOST_REFACTOR_COMMENT_POLICY` 未设置，按 `none` 处理，没有增加重构历史源码注释。

Closes #2813

⟦AI:AUTO-LOOP⟧
