### PR TITLE
Read NyxID OAuth config from environment

### DIFF
--- a/apps/aevatar-console-web/.env.example
+++ b/apps/aevatar-console-web/.env.example
@@ -24,7 +24,7 @@ AEVATAR_PROXY_PRESERVE_AUTH_HOST=true
 NYXID_BASE_URL=https://nyx.chrono-ai.fun
 NYXID_CLIENT_ID=
 NYXID_REDIRECT_URI=http://127.0.0.1:5173/auth/callback
-NYXID_SCOPE="openid profile email roles groups"
+NYXID_SCOPE="openid profile email offline_access urn:nyxid:scope:broker_binding proxy"
 
 # Ornn skills platform
 # Optional. Defaults to the public Ornn instance when omitted.

--- a/apps/aevatar-console-web/.env.production.example
+++ b/apps/aevatar-console-web/.env.production.example
@@ -8,7 +8,7 @@
 NYXID_BASE_URL=https://nyx.example.com
 NYXID_CLIENT_ID=replace-with-public-client-id
 NYXID_REDIRECT_URI=https://console.example.com/auth/callback
-NYXID_SCOPE="openid profile email roles groups"
+NYXID_SCOPE="openid profile email offline_access urn:nyxid:scope:broker_binding proxy"
 
 # Ornn skills platform for the browser client
 ORNN_BASE_URL=https://ornn.example.com

--- a/apps/aevatar-console-web/README.md
+++ b/apps/aevatar-console-web/README.md
@@ -42,24 +42,25 @@ console at the hosted backend, set both targets to the hosted API URL in
 `.env.local` and set `AEVATAR_PROXY_PRESERVE_AUTH_HOST=false` so `/api/auth/*`
 uses the hosted backend Host header.
 
-For NyxID login, the console reads `baseUrl` and `scope` from Studio Hosting via
-`/api/auth/nyxid/config`, reads the public OAuth client id from the frontend
-build environment, and finalizes callbacks through `/api/auth/nyxid/finalize`.
-Keep `/api/auth/*` proxied to the Studio backend. Set the frontend client id and
-only override the callback URI when the browser origin differs from the
-registered Studio callback:
+For NyxID login, the console reads the authority, public OAuth client id, scope,
+and callback URI from the frontend build environment. It finalizes callbacks
+through `/api/auth/nyxid/finalize`, so keep `/api/auth/*` proxied to the Studio
+backend. Configure all four browser OAuth values before building:
 
 ```bash
-NYXID_REDIRECT_URI=http://127.0.0.1:5173/auth/callback
+NYXID_BASE_URL=https://nyx.chrono-ai.fun
 NYXID_CLIENT_ID=replace-with-public-client-id
+NYXID_SCOPE="openid profile email offline_access urn:nyxid:scope:broker_binding proxy"
+NYXID_REDIRECT_URI=http://127.0.0.1:5173/auth/callback
 ORNN_BASE_URL=https://ornn.chrono-ai.fun
 # Optional when deploying under a sub-path such as /console/
 AEVATAR_CONSOLE_PUBLIC_PATH=/
 ```
 
-`NYXID_CLIENT_ID` is injected into the browser bundle at build time and is the
-single client id used for authorization, PKCE pending state, and token refresh.
-Keep it aligned with the OAuth client configured for backend token finalization.
+`NYXID_BASE_URL`, `NYXID_CLIENT_ID`, and `NYXID_SCOPE` are injected into the
+browser bundle at build time and are the single configuration source for
+authorization, PKCE pending state, and token refresh. Keep them aligned with
+the OAuth client configured for backend token finalization.
 `NYXID_REDIRECT_URI` must exactly match the Studio login callback registered in
 NyxID when you override it locally.
 Default service preselection is owned by the NyxID OAuth Client

--- a/apps/aevatar-console-web/config/config.ts
+++ b/apps/aevatar-console-web/config/config.ts
@@ -156,12 +156,14 @@ const config: ReturnType<typeof defineConfig> = defineConfig({
   esbuildMinifyIIFE: true,
   define: {
     'process.env.CI': JSON.stringify(process.env.CI),
-    'process.env.NYXID_REDIRECT_URI': JSON.stringify(
-      process.env.NYXID_REDIRECT_URI,
-    ),
+    'process.env.NYXID_BASE_URL': JSON.stringify(process.env.NYXID_BASE_URL),
     'process.env.NYXID_CLIENT_ID': JSON.stringify(
       process.env.NYXID_CLIENT_ID,
     ),
+    'process.env.NYXID_REDIRECT_URI': JSON.stringify(
+      process.env.NYXID_REDIRECT_URI,
+    ),
+    'process.env.NYXID_SCOPE': JSON.stringify(process.env.NYXID_SCOPE),
     'process.env.ORNN_BASE_URL': JSON.stringify(process.env.ORNN_BASE_URL),
     'process.env.AEVATAR_CONSOLE_TEAM_FIRST_ENABLED': JSON.stringify(
       process.env.AEVATAR_CONSOLE_TEAM_FIRST_ENABLED,

--- a/apps/aevatar-console-web/src/pages/login/index.tsx
+++ b/apps/aevatar-console-web/src/pages/login/index.tsx
@@ -100,7 +100,7 @@ const LoginPage: React.FC = () => {
             subTitle={
               config.configurationError
                 ? config.configurationError
-                : 'Ensure the Studio backend exposes NyxID login configuration at /api/auth/nyxid/config before starting the console.'
+                : 'Configure NYXID_BASE_URL, NYXID_CLIENT_ID, NYXID_SCOPE, and NYXID_REDIRECT_URI before building the console.'
             }
           />
         </Card>

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -273,15 +273,7 @@ describe("SettingsPage", () => {
     installDeterministicCrypto();
     window.history.replaceState({}, "", "/settings?section=account");
     const assign = installLocationAssignSpy();
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        baseUrl: "https://nyx.example",
-        clientId: "broker-client-1",
-        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-      }),
-    } as Response);
+    const fetchMock = jest.fn();
     global.fetch = fetchMock as typeof global.fetch;
 
     renderWithQueryClient(React.createElement(SettingsPage));
@@ -296,6 +288,7 @@ describe("SettingsPage", () => {
     const authorizeUrl = new URL(assign.mock.calls[0][0]);
     expect(authorizeUrl.searchParams.get("prompt")).toBe("consent");
     expect(authorizeUrl.searchParams.getAll("resource")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
 
     const pending = JSON.parse(
       window.localStorage.getItem(
@@ -319,15 +312,11 @@ describe("SettingsPage", () => {
     installDeterministicCrypto();
     window.history.replaceState({}, "", "/settings?section=account");
     const assign = installLocationAssignSpy();
-    global.fetch = jest.fn()
-      .mockResolvedValueOnce({
-        ok: false, status: 503, statusText: "Service Unavailable",
-        text: async () => JSON.stringify({ error: "oauth_client_not_provisioned", detail: "Unavailable." }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true, status: 200,
-        json: async () => ({ baseUrl: "https://nyx.example", clientId: "broker-client-1", scope: "openid proxy" }),
-      } as Response) as typeof global.fetch;
+    assign.mockImplementationOnce(() => {
+      throw new Error("Navigation failed");
+    });
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as typeof global.fetch;
 
     renderWithQueryClient(React.createElement(SettingsPage));
     const manageButton = await screen.findByRole("button", { name: "Manage service access" });
@@ -335,8 +324,9 @@ describe("SettingsPage", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("Could not start service access review. Try again.");
     await waitFor(() => expect(manageButton).not.toHaveClass("ant-btn-loading"));
     fireEvent.click(manageButton);
-    await waitFor(() => expect(assign).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(assign).toHaveBeenCalledTimes(2));
     expect(screen.queryByRole("alert")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("hides service access review when the user is signed out", async () => {

--- a/apps/aevatar-console-web/src/shared/auth/backend.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.test.ts
@@ -1,6 +1,5 @@
 import {
   finalizeBackendNyxIDLogin,
-  loadBackendNyxIDLoginConfig,
   refreshNyxIDTokenSet,
 } from "./backend";
 
@@ -14,49 +13,6 @@ describe("NyxID backend auth API", () => {
   afterEach(() => {
     global.fetch = originalFetch;
     jest.restoreAllMocks();
-  });
-
-  it("loads the broker URL and scope while ignoring its OAuth client id", async () => {
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        baseUrl: "https://nyx.example/",
-        clientId: "broker-client-1",
-        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-      }),
-    } as Response);
-    global.fetch = fetchMock as typeof global.fetch;
-
-    await expect(loadBackendNyxIDLoginConfig()).resolves.toEqual({
-      baseUrl: "https://nyx.example",
-      scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-    });
-
-    expect(fetchMock).toHaveBeenCalledWith("/api/auth/nyxid/config", {
-      headers: {
-        Accept: "application/json",
-      },
-    });
-  });
-
-  it("ignores redirect URI fields on the backend login config boundary", async () => {
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        baseUrl: "https://nyx.example/",
-        scope: "openid urn:nyxid:scope:broker_binding proxy",
-        redirectUri: "https://backend.example/auth/callback",
-        RedirectUri: "https://backend.example/AuthCallback",
-      }),
-    } as Response);
-    global.fetch = fetchMock as typeof global.fetch;
-
-    await expect(loadBackendNyxIDLoginConfig()).resolves.toEqual({
-      baseUrl: "https://nyx.example",
-      scope: "openid urn:nyxid:scope:broker_binding proxy",
-    });
   });
 
   it("finalizes an authorization code through the backend and preserves accepted-dispatch semantics", async () => {

--- a/apps/aevatar-console-web/src/shared/auth/backend.ts
+++ b/apps/aevatar-console-web/src/shared/auth/backend.ts
@@ -2,13 +2,7 @@ import {
   readResponseErrorDetails,
   type ResponseErrorDetails,
 } from "@/shared/api/http/error";
-import type { NyxIDRuntimeConfig } from "./config";
 import type { NyxIDAuthSession, NyxIDTokenSet, NyxIDUserInfo } from "./session";
-
-export type NyxIDBackendLoginConfig = Pick<
-  NyxIDRuntimeConfig,
-  "baseUrl" | "scope"
->;
 
 export type NyxIDLoginFinalizationRequest = {
   readonly code: string;
@@ -39,13 +33,6 @@ export class NyxIDLoginFinalizationError extends Error {
     this.status = details.status;
   }
 }
-
-type BackendLoginConfigResponse = {
-  readonly baseUrl?: unknown;
-  readonly BaseUrl?: unknown;
-  readonly scope?: unknown;
-  readonly Scope?: unknown;
-};
 
 type BackendFinalizationResponse = {
   readonly bindingDispatchAccepted?: unknown;
@@ -149,21 +136,6 @@ function readOptionalStringArray(value: unknown): string[] | undefined {
     .filter((entry): entry is string => typeof entry === "string")
     .map((entry) => entry.trim())
     .filter(Boolean);
-}
-
-function decodeBackendLoginConfig(
-  value: unknown,
-): NyxIDBackendLoginConfig {
-  const record = expectRecord(value, "NyxID backend login config") as
-    BackendLoginConfigResponse;
-
-  return {
-    baseUrl: readString(record.baseUrl ?? record.BaseUrl, "baseUrl").replace(
-      /\/+$/,
-      "",
-    ),
-    scope: readString(record.scope ?? record.Scope, "scope"),
-  };
 }
 
 function decodeTokenSet(value: unknown): NyxIDTokenSet {
@@ -279,18 +251,6 @@ async function requestBackendJson<T>(
   }
 
   return decoder(await response.json());
-}
-
-export function loadBackendNyxIDLoginConfig(): Promise<NyxIDBackendLoginConfig> {
-  return requestBackendJson(
-    "/api/auth/nyxid/config",
-    decodeBackendLoginConfig,
-    {
-      headers: {
-        Accept: "application/json",
-      },
-    },
-  );
 }
 
 export function finalizeBackendNyxIDLogin(

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -12,10 +12,10 @@ import { loadStoredAuthSession } from "./session";
 
 const runtimeConfig: NyxIDRuntimeConfig = {
   enabled: true,
-  baseUrl: "https://legacy-console-client.example",
+  baseUrl: "https://nyx.example",
   clientId: "console-client-1",
   redirectUri: "http://localhost:8000/auth/callback",
-  scope: "openid profile email",
+  scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
 };
 
 function installLocationAssignSpy() {
@@ -67,29 +67,16 @@ describe("NyxIDAuthClient", () => {
     window.localStorage.clear();
   });
 
-  it("starts authorize with the frontend client id and backend URL and scope", async () => {
+  it("starts authorize entirely from frontend runtime config", async () => {
     const assign = installLocationAssignSpy();
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        baseUrl: "https://nyx.example",
-        clientId: "broker-client-1",
-        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-        redirectUri: "https://backend.example/auth/callback",
-      }),
-    } as Response);
+    const fetchMock = jest.fn();
     global.fetch = fetchMock as typeof global.fetch;
 
     await new NyxIDAuthClient(runtimeConfig).loginWithRedirect({
       returnTo: "/scopes/scope-1/teams",
     });
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/auth/nyxid/config", {
-      headers: {
-        Accept: "application/json",
-      },
-    });
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(assign).toHaveBeenCalledTimes(1);
     const authorizeUrl = new URL(assign.mock.calls[0][0]);
     expect(authorizeUrl.origin + authorizeUrl.pathname).toBe(
@@ -124,15 +111,7 @@ describe("NyxIDAuthClient", () => {
 
   it("starts service access review with consent prompt and account return state", async () => {
     const assign = installLocationAssignSpy();
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        baseUrl: "https://nyx.example",
-        clientId: "broker-client-1",
-        scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-      }),
-    } as Response);
+    const fetchMock = jest.fn();
     global.fetch = fetchMock as typeof global.fetch;
 
     await new NyxIDAuthClient(runtimeConfig).loginWithRedirect({
@@ -143,6 +122,7 @@ describe("NyxIDAuthClient", () => {
     const authorizeUrl = new URL(assign.mock.calls[0][0]);
     expect(authorizeUrl.searchParams.get("prompt")).toBe("consent");
     expect(authorizeUrl.searchParams.getAll("resource")).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
 
     const pending = JSON.parse(
       window.localStorage.getItem(
@@ -447,15 +427,6 @@ describe("NyxIDAuthClient", () => {
         ok: true,
         status: 200,
         json: async () => ({
-          baseUrl: "https://nyx.example/",
-          clientId: "broker-client-1",
-          scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-        }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
           access_token: "access-token-2",
           refresh_token: "refresh-token-2",
           token_type: "Bearer",
@@ -484,10 +455,9 @@ describe("NyxIDAuthClient", () => {
 
     expect(hasRestorableAuthSession()).toBe(true);
     expect(loadStoredAuthSession()?.tokens.accessToken).toBe("access-token-2");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/nyxid/config");
-    expect(fetchMock.mock.calls[1][0]).toBe("https://nyx.example/oauth/token");
-    expect(String(fetchMock.mock.calls[1][1]?.body)).toBe(
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://nyx.example/oauth/token");
+    expect(String(fetchMock.mock.calls[0][1]?.body)).toBe(
       "grant_type=refresh_token&refresh_token=refresh-token-1&client_id=console-client-1",
     );
   });
@@ -535,15 +505,6 @@ describe("NyxIDAuthClient", () => {
     );
     const fetchMock = jest
       .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          baseUrl: "https://nyx.example/",
-          clientId: "broker-client-1",
-          scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-        }),
-      } as Response)
       .mockResolvedValueOnce({
         ok: true,
         status: 200,

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -4,7 +4,6 @@ import {
 } from './config';
 import {
   finalizeBackendNyxIDLogin,
-  loadBackendNyxIDLoginConfig,
   NyxIDLoginFinalizationError,
   refreshNyxIDTokenSet,
 } from './backend';
@@ -177,9 +176,8 @@ export class NyxIDAuthClient {
     const codeVerifier = randomUrlSafeString(48);
     const codeChallenge = await sha256Base64Url(codeVerifier);
     const state = randomUrlSafeString(24);
-    const loginConfig = await loadBackendNyxIDLoginConfig();
     const redirectUri = this.config.redirectUri;
-    const scope = loginConfig.scope;
+    const scope = this.config.scope;
     const flow = readAuthFlow(options.flow);
     const returnTo = resolveReturnToForFlow(flow, options.returnTo);
 
@@ -194,7 +192,7 @@ export class NyxIDAuthClient {
     };
     this.storage.setItem(this.resolvePendingKey(), JSON.stringify(pending));
 
-    const url = new URL(`${loginConfig.baseUrl}/oauth/authorize`);
+    const url = new URL(`${this.config.baseUrl}/oauth/authorize`);
     url.searchParams.set('response_type', 'code');
     url.searchParams.set('client_id', this.config.clientId);
     url.searchParams.set('redirect_uri', redirectUri);
@@ -378,9 +376,8 @@ async function refreshStoredAuthSession(
   refreshToken: string,
   config: NyxIDRuntimeConfig,
 ): Promise<NyxIDAuthSession | null> {
-  const loginConfig = await loadBackendNyxIDLoginConfig();
   const refreshedTokens = await refreshNyxIDTokenSet({
-    baseUrl: loginConfig.baseUrl,
+    baseUrl: config.baseUrl,
     clientId: config.clientId,
     refreshToken,
   });

--- a/apps/aevatar-console-web/src/shared/auth/config.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/config.test.ts
@@ -6,7 +6,10 @@ describe('NyxID runtime config', () => {
   beforeEach(() => {
     process.env = {
       ...originalEnv,
+      NYXID_BASE_URL: 'https://nyx.example/',
       NYXID_CLIENT_ID: 'console-client-1',
+      NYXID_SCOPE:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
     };
     window.history.replaceState({}, '', '/login');
   });
@@ -20,10 +23,11 @@ describe('NyxID runtime config', () => {
 
     expect(getNyxIDRuntimeConfig()).toEqual({
       enabled: true,
-      baseUrl: '',
+      baseUrl: 'https://nyx.example',
       clientId: 'console-client-1',
       redirectUri: `${window.location.origin}/auth/callback`,
-      scope: '',
+      scope:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
       configurationError: undefined,
     });
   });
@@ -33,27 +37,57 @@ describe('NyxID runtime config', () => {
 
     expect(getNyxIDRuntimeConfig()).toEqual({
       enabled: true,
-      baseUrl: '',
+      baseUrl: 'https://nyx.example',
       clientId: 'console-client-1',
       redirectUri: 'http://localhost:5173/auth/callback',
-      scope: '',
+      scope:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
       configurationError: undefined,
     });
   });
 
-  it('normalizes the frontend OAuth client id from the build environment', () => {
-    process.env.NYXID_BASE_URL = 'undefined';
+  it('normalizes frontend OAuth values from the build environment', () => {
+    process.env.NYXID_BASE_URL = '"https://login.nyx.example/"';
     process.env.NYXID_CLIENT_ID = '"console-client-2"';
     process.env.NYXID_REDIRECT_URI = 'undefined';
-    process.env.NYXID_SCOPE = 'undefined';
+    process.env.NYXID_SCOPE = '"openid   profile  proxy"';
 
     expect(getNyxIDRuntimeConfig()).toEqual({
       enabled: true,
-      baseUrl: '',
+      baseUrl: 'https://login.nyx.example',
       clientId: 'console-client-2',
       redirectUri: `${window.location.origin}/auth/callback`,
-      scope: '',
+      scope: 'openid profile proxy',
       configurationError: undefined,
+    });
+  });
+
+  it('disables NyxID auth when the authority is missing', () => {
+    process.env.NYXID_BASE_URL = 'undefined';
+
+    expect(getNyxIDRuntimeConfig()).toEqual({
+      enabled: false,
+      baseUrl: '',
+      clientId: 'console-client-1',
+      redirectUri: `${window.location.origin}/auth/callback`,
+      scope:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
+      configurationError:
+        'NYXID_BASE_URL must be configured with the NyxID HTTP(S) authority.',
+    });
+  });
+
+  it('disables NyxID auth when the authority is invalid', () => {
+    process.env.NYXID_BASE_URL = '://bad-url';
+
+    expect(getNyxIDRuntimeConfig()).toEqual({
+      enabled: false,
+      baseUrl: '',
+      clientId: 'console-client-1',
+      redirectUri: `${window.location.origin}/auth/callback`,
+      scope:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
+      configurationError: 'NYXID_BASE_URL must be a valid HTTP(S) URL.',
     });
   });
 
@@ -62,12 +96,27 @@ describe('NyxID runtime config', () => {
 
     expect(getNyxIDRuntimeConfig()).toEqual({
       enabled: false,
-      baseUrl: '',
+      baseUrl: 'https://nyx.example',
       clientId: '',
+      redirectUri: `${window.location.origin}/auth/callback`,
+      scope:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
+      configurationError:
+        'NYXID_CLIENT_ID must be configured with a non-empty public OAuth client id.',
+    });
+  });
+
+  it('disables NyxID auth when the OAuth scope is missing', () => {
+    process.env.NYXID_SCOPE = 'undefined';
+
+    expect(getNyxIDRuntimeConfig()).toEqual({
+      enabled: false,
+      baseUrl: 'https://nyx.example',
+      clientId: 'console-client-1',
       redirectUri: `${window.location.origin}/auth/callback`,
       scope: '',
       configurationError:
-        'NYXID_CLIENT_ID must be configured with a non-empty public OAuth client id.',
+        'NYXID_SCOPE must be configured with at least one OAuth scope.',
     });
   });
 
@@ -76,10 +125,11 @@ describe('NyxID runtime config', () => {
 
     expect(getNyxIDRuntimeConfig()).toEqual({
       enabled: false,
-      baseUrl: '',
+      baseUrl: 'https://nyx.example',
       clientId: 'console-client-1',
       redirectUri: '',
-      scope: '',
+      scope:
+        'openid profile email offline_access urn:nyxid:scope:broker_binding proxy',
       configurationError:
         'NYXID_REDIRECT_URI must be a valid http(s) URL or a root-relative path such as /auth/callback.',
     });

--- a/apps/aevatar-console-web/src/shared/auth/config.ts
+++ b/apps/aevatar-console-web/src/shared/auth/config.ts
@@ -111,28 +111,51 @@ function tryResolveHttpUrl(
 const MISSING_CLIENT_ID_ERROR =
   'NYXID_CLIENT_ID must be configured with a non-empty public OAuth client id.';
 
+const MISSING_BASE_URL_ERROR =
+  'NYXID_BASE_URL must be configured with the NyxID HTTP(S) authority.';
+
+const INVALID_BASE_URL_ERROR =
+  'NYXID_BASE_URL must be a valid HTTP(S) URL.';
+
+const MISSING_SCOPE_ERROR =
+  'NYXID_SCOPE must be configured with at least one OAuth scope.';
+
 const INVALID_REDIRECT_URI_ERROR =
   'NYXID_REDIRECT_URI must be a valid http(s) URL or a root-relative path such as /auth/callback.';
 
 export function getNyxIDRuntimeConfig(): NyxIDRuntimeConfig {
+  const baseUrl = trimOptional(process.env.NYXID_BASE_URL) ?? '';
+  const normalizedBaseUrl = baseUrl
+    ? tryResolveHttpUrl(baseUrl, { allowRelative: false })?.replace(/\/+$/, '')
+    : undefined;
   const clientId = trimOptional(process.env.NYXID_CLIENT_ID) ?? '';
+  const scope =
+    trimOptional(process.env.NYXID_SCOPE)?.split(/\s+/).join(' ') ?? '';
   const redirectUri =
     trimOptional(process.env.NYXID_REDIRECT_URI) ?? resolveDefaultRedirectUri();
   const normalizedRedirectUri = tryResolveHttpUrl(redirectUri, {
     allowRelative: true,
   });
-  const configurationError = !clientId
-    ? MISSING_CLIENT_ID_ERROR
-    : !normalizedRedirectUri
-      ? INVALID_REDIRECT_URI_ERROR
-      : undefined;
+  const configurationError = !baseUrl
+    ? MISSING_BASE_URL_ERROR
+    : !normalizedBaseUrl
+      ? INVALID_BASE_URL_ERROR
+      : !clientId
+        ? MISSING_CLIENT_ID_ERROR
+        : !scope
+          ? MISSING_SCOPE_ERROR
+          : !normalizedRedirectUri
+            ? INVALID_REDIRECT_URI_ERROR
+            : undefined;
 
   return {
-    enabled: Boolean(clientId && normalizedRedirectUri),
-    baseUrl: '',
+    enabled: Boolean(
+      normalizedBaseUrl && clientId && scope && normalizedRedirectUri,
+    ),
+    baseUrl: normalizedBaseUrl ?? '',
     clientId,
     redirectUri: normalizedRedirectUri ?? '',
-    scope: '',
+    scope,
     configurationError,
   };
 }

--- a/apps/aevatar-console-web/src/shared/auth/fetch.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/fetch.test.ts
@@ -91,15 +91,6 @@ describe('authFetch', () => {
         ok: true,
         status: 200,
         json: async () => ({
-          baseUrl: "https://nyx.example",
-          clientId: "broker-client-1",
-          scope: "openid profile email offline_access urn:nyxid:scope:broker_binding proxy",
-        }),
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
           access_token: "access-token-2",
           refresh_token: "refresh-token-2",
           token_type: "Bearer",
@@ -111,10 +102,9 @@ describe('authFetch', () => {
 
     await authFetch('/api/agents');
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(fetchMock.mock.calls[0][0]).toBe("/api/auth/nyxid/config");
-    expect(fetchMock.mock.calls[1][0]).toBe("https://nyx.example/oauth/token");
-    const [input, init] = fetchMock.mock.calls[2] as [
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://nyx.test/oauth/token");
+    const [input, init] = fetchMock.mock.calls[1] as [
       string,
       RequestInit | undefined,
     ];

--- a/apps/aevatar-console-web/tests/setupTests.jsx
+++ b/apps/aevatar-console-web/tests/setupTests.jsx
@@ -5,7 +5,10 @@ import { TextDecoder, TextEncoder } from 'node:util';
 defaultConfig.hashed = false;
 
 // Browser auth tests run without deployment env injection in CI.
+process.env.NYXID_BASE_URL ??= 'https://nyx.test';
 process.env.NYXID_CLIENT_ID ??= 'console-test-client';
+process.env.NYXID_SCOPE ??=
+  'openid profile email offline_access urn:nyxid:scope:broker_binding proxy';
 
 // React 19 expects the test environment to opt into act-aware updates.
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;


### PR DESCRIPTION
## Problem

The console still loaded NyxID `baseUrl` and `scope` from `/api/auth/nyxid/config`, while `clientId` came from the frontend environment. This split configuration source could make one deployed client request scopes or an authority that do not match its build-time OAuth configuration.

## Solution

- Read `NYXID_BASE_URL`, `NYXID_CLIENT_ID`, `NYXID_SCOPE`, and `NYXID_REDIRECT_URI` from the frontend build environment.
- Validate the authority, client id, scope, and callback URI before enabling NyxID login.
- Remove the unused frontend `/api/auth/nyxid/config` decoder and request path.
- Use the environment authority for authorization and token refresh, and the environment scope for authorization and PKCE pending state.
- Update login guidance, environment examples, README, and tests.
- Keep callback finalization on the backend `/api/auth/nyxid/finalize` boundary.

## Impact

Each console deployment now has one explicit build-time source for its browser OAuth authority, client id, and scope. Deployments must provide all four `NYXID_*` values and keep them aligned with backend finalization and the NyxID OAuth client registration.

## Validation

- CI-equivalent `pnpm test -- --runInBand`: 130 suites, 1073 tests passed
- Focused Jest: 6 suites, 49 tests passed
- TypeScript type check: passed
- Changed-file Biome lint: passed
- `bash tools/ci/test_stability_guards.sh`: passed
- Production frontend build with all four `NYXID_*` values: passed
- Built bundle contains the injected authority, client id, and scope: verified