### PR TITLE
Add durable approval coordination for deterministic connector calls

### DIFF
--- a/docs/canon/connector.md
+++ b/docs/canon/connector.md
@@ -180,6 +180,55 @@ Ergonomic 别名（解析期归一化到 `connector_call`）：
 - continue：`connector.continued_on_error`, `connector.error`
 - 具体实现附加字段：`connector.http.*` / `connector.cli.*` / `connector.mcp.*` / `host_callback.result.*`
 
+### Durable approval-gated execution
+
+`connector_call` and `secure_connector_call` can suspend before dispatching an external action by setting
+`approval.policy: required`. Approval is an execution gate for one exact logical action; it is not evidence that
+the connector call succeeded.
+
+The required typed approval parameters are:
+
+- `approval.service_ref`, `approval.node_id`, `approval.http_verb`, `approval.resource`, and
+  `approval.permission_scope`;
+- `approval.expiration_seconds`, which defines the local validity window;
+- a stable step `idempotency_key`, plus the normal workflow `run_id` and `step_id` identities.
+
+`approval.status_check_interval_seconds` defaults to 2 and must be positive and no greater than the approval
+validity window. `approval.destructive`, `approval.team_id`, `approval.member_id`, `approval.workflow_id`,
+`approval.published_service_id`, and `approval.policy_reason` add typed policy and provenance facts.
+
+The workflow actor owns the coordination state. Before submitting to NyxID it:
+
+1. resolves the connector payload and parameters;
+2. creates a versioned `WorkflowExternalActionPlan` and stable action identity;
+3. serializes the exact request material as Protobuf into `IRuntimeSecretStore`;
+4. stores only the safe plan, lifecycle facts, and protected-material reference in actor state;
+5. computes a SHA-256 digest over the protected Protobuf material and binds that digest to the remote request.
+
+Raw payload, input, parameters, credentials, and authorization headers never enter approval records, logs,
+committed-state projections, or public APIs. The committed-state redaction hook also removes the protected-material
+reference before projection.
+
+NyxID submission is never repeated after an indeterminate response because the current external Tool Approval API
+creates a unique request for every submission. A missing port, indeterminate submission, unavailable status read,
+binding mismatch, authority mismatch, digest mismatch, expiry mismatch, denial, expiration, cancellation, or
+superseded plan fails closed without connector execution.
+
+Status checks are durable self callbacks. Approval resumes only when the callback still matches the actor-owned
+remote request ID, action ID, material digest, principal, scope, node, service, permission scope, and remote expiry.
+Immediately before each physical connector dispatch, the actor re-resolves the protected material, rechecks the
+digest and current authority, and verifies both local and remote expiry. Every physical retry uses the same logical
+`idempotency_key`. HTTP connector approvals additionally fail closed unless the approved verb and resource match the
+concrete `method` and normalized `path` that the connector will execute.
+
+The actor persists approval and connector execution as separate facts. The current-state projection and
+`GET /api/workflow-actors/{actorId}/current-state` expose only safe plan fields and distinguish
+`waiting_approval`, `approved`, `denied`, `expired`, `cancelled`, `executing`, `succeeded`, and `failed` lifecycle
+states. Dispatch intent is persisted before invocation and acknowledged afterward; an unacknowledged dispatch is
+replayed with the same idempotency key. The exact pending step completion is also stored as protected Protobuf until
+publication is durably acknowledged, so terminal recovery can republish the original result without exposing it in
+Actor audit facts. Recovery then revokes both protected request and completion material.
+
 ## 3.3 三类 Connector 的执行逻辑
 
 ### HTTP Connector

--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -679,6 +679,11 @@ steps:
 - 作用：调用外部 connector（HTTP/CLI/MCP 等），支持重试和降级策略。
 - 常用参数：`connector`、`operation`、`retry`、`timeout_ms`、`optional`、`on_missing`、`on_error`。
 - `connector_call` / `secure_connector_call` side effect 是 at-least-once。workflow actor 按 logical run id + step id + logical attempt 解析并持久化 typed `idempotency_key`；若 step 声明 `compensation`，同一 seam 先写入 `PROVISIONAL` compensation ledger，再发布 connector request。connector physical retry / pending replay 复用同一个 key；HTTP connector 会在 key 非空时发送 `Idempotency-Key` header，其他 connector 可按自身边界使用或忽略。该 key 不提供 engine-side dedup 或 exactly-once。
+- `approval.policy: required` enables actor-owned durable approval coordination before connector dispatch. The step must provide `approval.service_ref`, `approval.node_id`, `approval.http_verb`, `approval.resource`, `approval.permission_scope`, `approval.expiration_seconds`, and a stable `idempotency_key`. `approval.status_check_interval_seconds` defaults to 2.
+- The exact payload, input, parameters, and execution options are stored as protected Protobuf material and bound to the safe approval plan by SHA-256. They are absent from approval records, committed projections, logs, and public APIs.
+- Approval state survives restart through actor state plus durable self callbacks. NyxID submission or status uncertainty fails closed; an indeterminate submission is not retried because NyxID creates a unique request for each submission.
+- Approved execution revalidates the remote binding, action, digest, caller authority, scope, node, service, permission scope, and effective expiry immediately before dispatch. HTTP approvals also require the approved verb/resource to match the concrete connector method/path. Dispatch replay and connector retries reuse the same physical `idempotency_key`; approval success and connector success remain separate persisted facts.
+- The Actor persists a dispatch acknowledgement and keeps the exact pending `StepCompletedEvent` as protected Protobuf until publication succeeds. Restart recovery can therefore redispatch an unacknowledged invocation or republish an acknowledged external result without copying response content into audit facts or public read models.
 - Ergonomic 说明（统一归一化到 `connector_call`）：
   - `http_get`/`http_post`/`http_put`/`http_delete`：自动补 `method=GET/POST/PUT/DELETE`（若未显式提供）。
   - `mcp_call`：若只写 `tool` 且未写 `operation/action`，会自动补 `operation=<tool>`。
@@ -705,6 +710,28 @@ steps:
     parameters:
       connector: "internal_http"
       path: "/healthz"
+```
+
+```yaml
+steps:
+  - id: create_resource
+    type: connector_call
+    target_role: coordinator
+    idempotency_key: "${input.idempotency_key}"
+    parameters:
+      connector: "service_proxy"
+      operation: "create_resource"
+      method: "POST"
+      path: "/resources/alpha"
+      approval.policy: "required"
+      approval.service_ref: "service-alpha"
+      approval.node_id: "node-alpha"
+      approval.http_verb: "POST"
+      approval.resource: "/resources/alpha"
+      approval.permission_scope: "resources.write"
+      approval.expiration_seconds: "300"
+      approval.status_check_interval_seconds: "2"
+      approval.destructive: "true"
 ```
 
 ### `emit`（别名：`publish`）

--- a/src/Aevatar.AI.Abstractions/ToolProviders/IRemoteToolApprovalPort.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/IRemoteToolApprovalPort.cs
@@ -75,5 +75,6 @@ public enum RemoteToolApprovalStatus
     Approved = 1,
     Rejected = 2,
     Expired = 3,
-    Unknown = 4,
+    Cancelled = 4,
+    Unknown = 5,
 }

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -436,9 +436,15 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
             case RemoteToolApprovalStatus.Rejected:
             case RemoteToolApprovalStatus.Expired:
+            case RemoteToolApprovalStatus.Cancelled:
                 await PersistApprovalTerminalFailureThenClearPendingAsync(
                     pending,
-                    snapshot.Status == RemoteToolApprovalStatus.Expired ? "approval_timeout" : "approval_denied",
+                    snapshot.Status switch
+                    {
+                        RemoteToolApprovalStatus.Expired => "approval_timeout",
+                        RemoteToolApprovalStatus.Cancelled => "approval_cancelled",
+                        _ => "approval_denied",
+                    },
                     string.IsNullOrWhiteSpace(snapshot.Reason)
                         ? "Tool approval timed out or was denied remotely."
                         : snapshot.Reason);

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdRemoteToolApprovalPort.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdRemoteToolApprovalPort.cs
@@ -89,6 +89,7 @@ public sealed class NyxIdRemoteToolApprovalPort : IRemoteToolApprovalPort
             "approved" => RemoteToolApprovalStatus.Approved,
             "rejected" or "denied" => RemoteToolApprovalStatus.Rejected,
             "expired" => RemoteToolApprovalStatus.Expired,
+            "cancelled" or "canceled" => RemoteToolApprovalStatus.Cancelled,
             "pending" => RemoteToolApprovalStatus.Pending,
             _ => RemoteToolApprovalStatus.Unknown,
         };

--- a/src/Aevatar.Foundation.Abstractions/Credentials/CredentialSecretPurposes.cs
+++ b/src/Aevatar.Foundation.Abstractions/Credentials/CredentialSecretPurposes.cs
@@ -7,6 +7,8 @@ public static class CredentialSecretPurposes
     public const string WorkflowCallerDurableBearerToken = "workflow.caller-durable-bearer-token";
     public const string WorkflowCallerBearerToken = "workflow.caller-bearer-token";
     public const string WorkflowSecureInputValue = "workflow.secure-input-value";
+    public const string WorkflowConnectorExternalActionMaterial = "workflow.connector-external-action-material";
+    public const string WorkflowConnectorExternalActionCompletion = "workflow.connector-external-action-completion";
     public const string DeviceHmacSigningKey = "device.hmac-signing-key";
     public const string OAuthStateTokenHmacKey = "identity.oauth-state-token-hmac-key";
     public const string ChannelWorkflowResultDeliveryAgentKey = "channel.workflow-result-delivery-agent-key";

--- a/src/workflow/Aevatar.Workflow.Abstractions/Aevatar.Workflow.Abstractions.csproj
+++ b/src/workflow/Aevatar.Workflow.Abstractions/Aevatar.Workflow.Abstractions.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Protobuf Include="workflow_external_action.proto" GrpcServices="None" />
     <Protobuf Include="workflow_execution_messages.proto" GrpcServices="None" AdditionalImportDirs="..\..\Aevatar.Foundation.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -6,6 +6,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "Credentials/credential_secret_references.proto";
 import "Interactions/interaction_spec.proto";
+import "workflow_external_action.proto";
 
 enum WorkflowChatInputPartKind {
   WORKFLOW_CHAT_INPUT_PART_KIND_UNSPECIFIED = 0;
@@ -483,6 +484,7 @@ message WorkflowStepParameters
   WorkflowAgentToolScope agent_tool_scope = 8;
   WorkflowHumanApprovalOptions human_approval = 9;
   WorkflowExternalApprovalWaitOptions external_approval = 10;
+  WorkflowConnectorApprovalOptions connector_approval = 11;
 }
 message StepRequestEvent
 {

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_external_action.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_external_action.proto
@@ -1,0 +1,126 @@
+syntax = "proto3";
+
+package aevatar.workflow;
+
+option csharp_namespace = "Aevatar.Workflow.Abstractions";
+
+import "google/protobuf/timestamp.proto";
+
+enum WorkflowExternalActionApprovalPolicy {
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_POLICY_UNSPECIFIED = 0;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_POLICY_REQUIRED = 1;
+}
+
+enum WorkflowExternalActionLifecycleStatus {
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_UNSPECIFIED = 0;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_WAITING_APPROVAL = 1;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_APPROVED = 2;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_DENIED = 3;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_EXPIRED = 4;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_CANCELLED = 5;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_EXECUTING = 6;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_SUCCEEDED = 7;
+  WORKFLOW_EXTERNAL_ACTION_LIFECYCLE_STATUS_FAILED = 8;
+}
+
+enum WorkflowExternalActionApprovalStatus {
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_UNSPECIFIED = 0;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_PENDING = 1;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_APPROVED = 2;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_DENIED = 3;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_EXPIRED = 4;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_CANCELLED = 5;
+  WORKFLOW_EXTERNAL_ACTION_APPROVAL_STATUS_FAILED = 6;
+}
+
+enum WorkflowExternalActionExecutionStatus {
+  WORKFLOW_EXTERNAL_ACTION_EXECUTION_STATUS_UNSPECIFIED = 0;
+  WORKFLOW_EXTERNAL_ACTION_EXECUTION_STATUS_NOT_STARTED = 1;
+  WORKFLOW_EXTERNAL_ACTION_EXECUTION_STATUS_EXECUTING = 2;
+  WORKFLOW_EXTERNAL_ACTION_EXECUTION_STATUS_SUCCEEDED = 3;
+  WORKFLOW_EXTERNAL_ACTION_EXECUTION_STATUS_FAILED = 4;
+}
+
+message WorkflowExternalActionProvenance {
+  string scope_id = 1;
+  string team_id = 2;
+  string member_id = 3;
+  string workflow_id = 4;
+  string published_service_id = 5;
+  string workflow_actor_id = 6;
+  string run_id = 7;
+  string step_id = 8;
+  string execution_id = 9;
+  string requester_platform = 10;
+  string requester_tenant = 11;
+  string requester_external_user_id = 12;
+  string principal_subject = 13;
+  string requester_capability_scope = 14;
+}
+
+message WorkflowConnectorApprovalOptions {
+  WorkflowExternalActionApprovalPolicy policy = 1;
+  string service_ref = 2;
+  string node_id = 3;
+  string http_verb = 4;
+  string resource = 5;
+  string permission_scope = 6;
+  int32 expiration_seconds = 7;
+  int32 status_check_interval_seconds = 8;
+  bool destructive = 9;
+  string team_id = 10;
+  string member_id = 11;
+  string workflow_id = 12;
+  string published_service_id = 13;
+  string policy_reason = 14;
+}
+
+message WorkflowExternalActionPlan {
+  string schema_version = 1;
+  string action_id = 2;
+  string idempotency_key = 3;
+  WorkflowExternalActionProvenance provenance = 4;
+  string service_ref = 5;
+  string node_id = 6;
+  string connector_name = 7;
+  string connector_type = 8;
+  string operation = 9;
+  string http_verb = 10;
+  string resource = 11;
+  string permission_scope = 12;
+  google.protobuf.Timestamp created_at = 13;
+  google.protobuf.Timestamp expires_at = 14;
+  string material_digest_sha256 = 15;
+  string digest_algorithm = 16;
+  string summary = 17;
+  WorkflowExternalActionApprovalPolicy approval_policy = 18;
+  string policy_reason = 19;
+  bool destructive = 20;
+}
+
+message WorkflowExternalActionApprovalSnapshot {
+  WorkflowExternalActionPlan plan = 1;
+  string remote_approval_id = 2;
+  google.protobuf.Timestamp remote_expires_at = 3;
+  WorkflowExternalActionLifecycleStatus lifecycle_status = 4;
+  WorkflowExternalActionApprovalStatus approval_status = 5;
+  string approval_reason_code = 6;
+  google.protobuf.Timestamp approval_resolved_at = 7;
+  WorkflowExternalActionExecutionStatus execution_status = 8;
+  string execution_reason_code = 9;
+  google.protobuf.Timestamp execution_started_at = 10;
+  google.protobuf.Timestamp execution_completed_at = 11;
+}
+
+message WorkflowConnectorApprovalStatusCheckFiredEvent {
+  string action_id = 1;
+  string remote_approval_id = 2;
+  string material_digest_sha256 = 3;
+  string principal_subject = 4;
+  string scope_id = 5;
+  string node_id = 6;
+  int32 check_number = 7;
+  string service_ref = 8;
+  string permission_scope = 9;
+  google.protobuf.Timestamp remote_expires_at = 10;
+}

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/workflow_projection_query_models.proto
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/workflow_projection_query_models.proto
@@ -7,6 +7,7 @@ option csharp_namespace = "Aevatar.Workflow.Application.Abstractions.Queries";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "workflow_execution_messages.proto";
+import "workflow_external_action.proto";
 
 message WorkflowActorSnapshot {
   string actor_id = 1;
@@ -31,6 +32,7 @@ message WorkflowActorSnapshot {
   google.protobuf.Timestamp started_at_utc = 20;
   string scope_id = 21;
   string run_origin = 22;
+  repeated aevatar.workflow.WorkflowExternalActionApprovalSnapshot connector_approvals = 23;
 }
 
 message WorkflowRunFileRef {

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1912,6 +1912,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         ApplyTransformOperation(request, step.TransformOperation, state);
         ApplyHumanApprovalOptions(request, step.HumanApprovalOptions);
         ApplyExternalApprovalOptions(request, step.ExternalApprovalOptions, state);
+        ApplyConnectorApprovalOptions(request, step.ConnectorApprovalOptions, state);
         ApplyInteractionPresentation(request, step.Presentation, state);
 
         return request;
@@ -1995,6 +1996,36 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         string.IsNullOrWhiteSpace(value)
             ? string.Empty
             : _expressionEvaluator.Evaluate(value, state.Variables).Trim();
+
+    private void ApplyConnectorApprovalOptions(
+        StepRequestEvent request,
+        ConnectorApprovalOptionsDefinition? options,
+        WorkflowExecutionKernelState state)
+    {
+        if (options == null)
+            return;
+
+        (request.StepParameters ??= new WorkflowStepParameters()).ConnectorApproval =
+            new WorkflowConnectorApprovalOptions
+            {
+                Policy = WorkflowExternalActionApprovalPolicy.Required,
+                ServiceRef = EvaluateOption(options.ServiceRef, state),
+                NodeId = EvaluateOption(options.NodeId, state),
+                HttpVerb = EvaluateOption(options.HttpVerb, state),
+                Resource = EvaluateOption(options.Resource, state),
+                PermissionScope = EvaluateOption(options.PermissionScope, state),
+                ExpirationSeconds = options.ExpirationSeconds,
+                StatusCheckIntervalSeconds = options.StatusCheckIntervalSeconds,
+                Destructive = options.Destructive,
+                TeamId = EvaluateOption(options.TeamId, state),
+                MemberId = EvaluateOption(options.MemberId, state),
+                WorkflowId = EvaluateOption(options.WorkflowId, state),
+                PublishedServiceId = EvaluateOption(options.PublishedServiceId, state),
+                PolicyReason = string.IsNullOrWhiteSpace(options.PolicyReason)
+                    ? "workflow-step-required-approval"
+                    : EvaluateOption(options.PolicyReason, state),
+            };
+    }
 
     private static string NormalizeOptionToken(string? value) =>
         string.IsNullOrWhiteSpace(value)

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
@@ -28,6 +28,12 @@ internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePu
                 stateEvent.State = Any.Pack(RedactSecureInputState(secureState));
                 context.Published.StateEvent.EventData = Any.Pack(stateEvent);
             }
+            else if (stateEvent.State?.Is(ConnectorCallModuleState.Descriptor) == true)
+            {
+                var connectorState = stateEvent.State.Unpack<ConnectorCallModuleState>() ?? new ConnectorCallModuleState();
+                stateEvent.State = Any.Pack(RedactConnectorCallState(connectorState));
+                context.Published.StateEvent.EventData = Any.Pack(stateEvent);
+            }
         }
 
         if (context.Published.StateEvent?.EventData?.Is(WorkflowRunExecutionStartedEvent.Descriptor) == true)
@@ -47,6 +53,7 @@ internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePu
         var state = context.Published.StateRoot.Unpack<WorkflowRunState>() ?? new WorkflowRunState();
         state.ExecutionContext = WorkflowRunExecutionContextStateAccess.RedactedClone(state.ExecutionContext);
         RedactSecureInputExecutionState(state);
+        RedactConnectorCallExecutionState(state);
 
         context.Published.StateRoot = Any.Pack(state);
         return Task.CompletedTask;
@@ -69,6 +76,29 @@ internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePu
         var redacted = source.Clone();
         foreach (var captured in redacted.Captured.Values)
             captured.Value = string.Empty;
+        return redacted;
+    }
+
+    private static void RedactConnectorCallExecutionState(WorkflowRunState state)
+    {
+        foreach (var pair in state.ExecutionStates.ToList())
+        {
+            if (!pair.Value.Is(ConnectorCallModuleState.Descriptor))
+                continue;
+
+            var connectorState = pair.Value.Unpack<ConnectorCallModuleState>() ?? new ConnectorCallModuleState();
+            state.ExecutionStates[pair.Key] = Any.Pack(RedactConnectorCallState(connectorState));
+        }
+    }
+
+    private static ConnectorCallModuleState RedactConnectorCallState(ConnectorCallModuleState source)
+    {
+        var redacted = source.Clone();
+        foreach (var coordination in redacted.ApprovalsByActionId.Values)
+        {
+            coordination.MaterialReference = null;
+            coordination.CompletionReference = null;
+        }
         return redacted;
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.Approval.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.Approval.cs
@@ -1,0 +1,879 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Core.Execution;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Workflow.Core.Modules;
+
+public sealed partial class ConnectorCallModule
+{
+    private const string ApprovalStatusCallbackPrefix = "workflow-connector-approval-status";
+
+    private async Task BeginConnectorApprovalAsync(
+        StepRequestEvent request,
+        string runId,
+        string connectorName,
+        string operation,
+        IConnector connector,
+        int attempts,
+        int timeoutMs,
+        bool onErrorContinue,
+        bool isSecureStep,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var actionId = BuildApprovalActionId(
+            runId,
+            request.StepId,
+            request.ExecutionId,
+            request.IdempotencyKey);
+        var initialState = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        initialState.ApprovalsByActionId.TryGetValue(actionId, out var existingCoordination);
+
+        ConnectorApprovalMaterialBundle bundle;
+        try
+        {
+            bundle = await BuildApprovalMaterialAsync(
+                request,
+                runId,
+                connectorName,
+                operation,
+                connector,
+                attempts,
+                timeoutMs,
+                onErrorContinue,
+                isSecureStep,
+                existingCoordination?.Snapshot?.Plan,
+                ctx,
+                ct);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(
+                "ConnectorCall approval preflight failed. run={RunId} step={StepId} failure_type={FailureType}",
+                runId,
+                request.StepId,
+                ex.GetType().Name);
+            await PublishFailureAsync(ctx, request, "connector approval preflight failed", ct);
+            return;
+        }
+
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (state.ApprovalsByActionId.TryGetValue(actionId, out existingCoordination))
+        {
+            await HandleExistingApprovalAsync(state, existingCoordination, bundle, ctx, ct);
+            return;
+        }
+
+        var stepKey = BuildStepKey(runId, request.StepId);
+        if (state.ApprovalActionIdByStepId.TryGetValue(stepKey, out var previousActionId) &&
+            state.ApprovalsByActionId.TryGetValue(previousActionId, out var previousCoordination))
+        {
+            await CancelSupersededApprovalAsync(state, previousCoordination, ctx, ct);
+            state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        }
+
+        RuntimeSecretReference materialReference;
+        try
+        {
+            materialReference = await StoreApprovalMaterialAsync(bundle, ctx, ct);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(
+                "ConnectorCall approval material store failed. run={RunId} step={StepId} failure_type={FailureType}",
+                runId,
+                request.StepId,
+                ex.GetType().Name);
+            await PublishFailureAsync(ctx, request, "connector approval material is unavailable", ct);
+            return;
+        }
+
+        var options = request.StepParameters!.ConnectorApproval;
+        var coordination = new ConnectorApprovalCoordinationState
+        {
+            Snapshot = new WorkflowExternalActionApprovalSnapshot
+            {
+                Plan = bundle.Plan.Clone(),
+                LifecycleStatus = WorkflowExternalActionLifecycleStatus.WaitingApproval,
+                ApprovalStatus = WorkflowExternalActionApprovalStatus.Pending,
+                ExecutionStatus = WorkflowExternalActionExecutionStatus.NotStarted,
+            },
+            MaterialReference = materialReference,
+            Attempts = attempts,
+            TimeoutMs = timeoutMs,
+            OnErrorContinue = onErrorContinue,
+            SecureStep = isSecureStep,
+            ConnectorType = connector.Type,
+            StatusCheckIntervalSeconds = options.StatusCheckIntervalSeconds,
+        };
+        state.ApprovalsByActionId[actionId] = coordination;
+        state.ApprovalActionIdByStepId[stepKey] = actionId;
+        await SaveStateAsync(state, ctx, ct);
+
+        if (_remoteToolApprovalPort == null)
+        {
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Failed,
+                WorkflowExternalActionLifecycleStatus.Failed,
+                "approval_path_unavailable",
+                bundle.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        RemoteToolApprovalSubmission submission;
+        try
+        {
+            var remoteRequest = BuildRemoteApprovalRequest(bundle.Plan);
+            submission = await WithRemoteApprovalContextAsync(
+                bundle.Plan,
+                ctx,
+                () => _remoteToolApprovalPort.SubmitAsync(remoteRequest, ct),
+                ct);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(
+                "ConnectorCall remote approval submission is indeterminate. action={ActionId} failure_type={FailureType}",
+                actionId,
+                ex.GetType().Name);
+            state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+            if (state.ApprovalsByActionId.TryGetValue(actionId, out coordination))
+            {
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    WorkflowExternalActionApprovalStatus.Failed,
+                    WorkflowExternalActionLifecycleStatus.Failed,
+                    "approval_submission_indeterminate",
+                    bundle.Material,
+                    ctx,
+                    ct);
+            }
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(submission.RemoteApprovalId) ||
+            submission.ExpiresAt == null ||
+            submission.ExpiresAt <= ctx.UtcNow)
+        {
+            state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+            if (state.ApprovalsByActionId.TryGetValue(actionId, out coordination))
+            {
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    WorkflowExternalActionApprovalStatus.Failed,
+                    WorkflowExternalActionLifecycleStatus.Failed,
+                    "approval_remote_binding_invalid",
+                    bundle.Material,
+                    ctx,
+                    ct);
+            }
+            return;
+        }
+
+        state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.ApprovalsByActionId.TryGetValue(actionId, out coordination) ||
+            coordination.Snapshot?.LifecycleStatus != WorkflowExternalActionLifecycleStatus.WaitingApproval)
+        {
+            return;
+        }
+
+        coordination.Snapshot.RemoteApprovalId = submission.RemoteApprovalId.Trim();
+        coordination.Snapshot.RemoteExpiresAt = Timestamp.FromDateTimeOffset(submission.ExpiresAt.Value);
+        await SaveStateAsync(state, ctx, ct);
+        await ScheduleApprovalStatusCheckAsync(state, coordination, checkNumber: 1, ctx, ct);
+    }
+
+    private async Task HandleExistingApprovalAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        ConnectorApprovalMaterialBundle bundle,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var snapshot = coordination.Snapshot;
+        var plan = snapshot?.Plan;
+        if (snapshot == null ||
+            plan == null ||
+            !FixedTimeDigestEquals(plan.MaterialDigestSha256 ?? string.Empty, bundle.Plan.MaterialDigestSha256))
+        {
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Failed,
+                WorkflowExternalActionLifecycleStatus.Failed,
+                "approval_plan_mismatch",
+                bundle.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        switch (snapshot.LifecycleStatus)
+        {
+            case WorkflowExternalActionLifecycleStatus.WaitingApproval:
+                if (string.IsNullOrWhiteSpace(snapshot.RemoteApprovalId))
+                {
+                    await CompleteApprovalWithoutExecutionAsync(
+                        state,
+                        coordination,
+                        WorkflowExternalActionApprovalStatus.Failed,
+                        WorkflowExternalActionLifecycleStatus.Failed,
+                        "approval_submission_indeterminate",
+                        bundle.Material,
+                        ctx,
+                        ct);
+                }
+                else if (coordination.StatusCheckLease == null)
+                {
+                    await ScheduleApprovalStatusCheckAsync(
+                        state,
+                        coordination,
+                        Math.Max(1, coordination.StatusCheckCount),
+                        ctx,
+                        ct);
+                }
+                return;
+
+            case WorkflowExternalActionLifecycleStatus.Approved:
+                await StartApprovedExecutionAsync(state, coordination, attempt: 1, ctx, ct);
+                return;
+
+            case WorkflowExternalActionLifecycleStatus.Executing:
+                var pending = FindPendingApprovalExecution(state, plan.ActionId);
+                if (pending == null)
+                {
+                    await StartApprovedExecutionAsync(
+                        state,
+                        coordination,
+                        Math.Max(1, coordination.CurrentAttempt),
+                        ctx,
+                        ct);
+                }
+                else if (!pending.RequestDispatched)
+                {
+                    await ResumeUndispatchedApprovedExecutionAsync(
+                        pending,
+                        state,
+                        coordination,
+                        ctx,
+                        ct);
+                }
+                return;
+        }
+
+        if (!coordination.StepCompletionPublished)
+        {
+            if (coordination.CompletionReference != null ||
+                snapshot.ExecutionStatus is WorkflowExternalActionExecutionStatus.Succeeded or
+                    WorkflowExternalActionExecutionStatus.Failed)
+            {
+                await RecoverUnpublishedApprovalTerminalAsync(
+                    state,
+                    coordination,
+                    bundle.Material,
+                    ctx,
+                    ct);
+            }
+            else
+            {
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    snapshot.ApprovalStatus,
+                    snapshot.LifecycleStatus,
+                    snapshot.ApprovalReasonCode,
+                    bundle.Material,
+                    ctx,
+                    ct);
+            }
+            return;
+        }
+
+        if (coordination.MaterialReference != null || coordination.CompletionReference != null)
+        {
+            await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+            await SaveStateAsync(state, ctx, ct);
+        }
+    }
+
+    private async Task HandleApprovalStatusCheckAsync(
+        WorkflowConnectorApprovalStatusCheckFiredEvent evt,
+        EventEnvelope envelope,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(evt.ActionId))
+            return;
+
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.ApprovalsByActionId.TryGetValue(evt.ActionId, out var coordination) ||
+            !MatchesApprovalStatusCheck(evt, envelope, coordination))
+        {
+            return;
+        }
+
+        var snapshot = coordination.Snapshot;
+        var plan = snapshot.Plan;
+        if (IsTerminalLifecycle(snapshot.LifecycleStatus))
+        {
+            if (!coordination.StepCompletionPublished)
+            {
+                var terminalMaterial = await ResolveAndVerifyMaterialAsync(
+                    coordination,
+                    ctx,
+                    ct,
+                    requireUnexpired: false);
+                await RecoverUnpublishedApprovalTerminalAsync(
+                    state,
+                    coordination,
+                    terminalMaterial.Material,
+                    ctx,
+                    ct);
+            }
+            else if (coordination.MaterialReference != null || coordination.CompletionReference != null)
+            {
+                await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+                await SaveStateAsync(state, ctx, ct);
+            }
+            return;
+        }
+
+        if (snapshot.LifecycleStatus != WorkflowExternalActionLifecycleStatus.WaitingApproval ||
+            snapshot.ApprovalStatus != WorkflowExternalActionApprovalStatus.Pending)
+        {
+            return;
+        }
+
+        if (!MatchesCurrentApprovalAuthority(plan, ctx))
+        {
+            var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Failed,
+                WorkflowExternalActionLifecycleStatus.Failed,
+                "approval_authority_mismatch",
+                materialResult.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        if (ResolveEffectiveExpiry(snapshot) <= ctx.UtcNow)
+        {
+            var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Expired,
+                WorkflowExternalActionLifecycleStatus.Expired,
+                "approval_expired",
+                materialResult.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        if (_remoteToolApprovalPort == null)
+        {
+            var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Failed,
+                WorkflowExternalActionLifecycleStatus.Failed,
+                "approval_path_unavailable",
+                materialResult.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        RemoteToolApprovalStatusSnapshot remoteStatus;
+        try
+        {
+            remoteStatus = await WithRemoteApprovalContextAsync(
+                plan,
+                ctx,
+                () => _remoteToolApprovalPort.GetStatusAsync(
+                    new RemoteToolApprovalStatusQuery(plan.ActionId, snapshot.RemoteApprovalId),
+                    ct),
+                ct);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(
+                "ConnectorCall remote approval status is unavailable. action={ActionId} failure_type={FailureType}",
+                plan.ActionId,
+                ex.GetType().Name);
+            var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Failed,
+                WorkflowExternalActionLifecycleStatus.Failed,
+                "approval_status_unavailable",
+                materialResult.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        if (remoteStatus.ExpiresAt == null ||
+            remoteStatus.ExpiresAt.Value != snapshot.RemoteExpiresAt.ToDateTimeOffset())
+        {
+            var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Failed,
+                WorkflowExternalActionLifecycleStatus.Failed,
+                "approval_remote_expiry_mismatch",
+                materialResult.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        switch (remoteStatus.Status)
+        {
+            case RemoteToolApprovalStatus.Approved:
+                if (ResolveEffectiveExpiry(snapshot) <= ctx.UtcNow)
+                {
+                    var expiredMaterial = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+                    await CompleteApprovalWithoutExecutionAsync(
+                        state,
+                        coordination,
+                        WorkflowExternalActionApprovalStatus.Expired,
+                        WorkflowExternalActionLifecycleStatus.Expired,
+                        "approval_expired",
+                        expiredMaterial.Material,
+                        ctx,
+                        ct);
+                    return;
+                }
+
+                await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+                    ctx,
+                    coordination.StatusCheckLease,
+                    "connector approval status callback",
+                    ct);
+                coordination.StatusCheckLease = null;
+                snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Approved;
+                snapshot.ApprovalReasonCode = "approval_approved";
+                snapshot.ApprovalResolvedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+                snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Approved;
+                await SaveStateAsync(state, ctx, ct);
+                await StartApprovedExecutionAsync(state, coordination, attempt: 1, ctx, ct);
+                return;
+
+            case RemoteToolApprovalStatus.Rejected:
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    WorkflowExternalActionApprovalStatus.Denied,
+                    WorkflowExternalActionLifecycleStatus.Denied,
+                    "approval_denied",
+                    (await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false)).Material,
+                    ctx,
+                    ct);
+                return;
+
+            case RemoteToolApprovalStatus.Expired:
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    WorkflowExternalActionApprovalStatus.Expired,
+                    WorkflowExternalActionLifecycleStatus.Expired,
+                    "approval_expired",
+                    (await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false)).Material,
+                    ctx,
+                    ct);
+                return;
+
+            case RemoteToolApprovalStatus.Cancelled:
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    WorkflowExternalActionApprovalStatus.Cancelled,
+                    WorkflowExternalActionLifecycleStatus.Cancelled,
+                    "approval_cancelled",
+                    (await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false)).Material,
+                    ctx,
+                    ct);
+                return;
+
+            case RemoteToolApprovalStatus.Pending:
+                await ScheduleApprovalStatusCheckAsync(state, coordination, evt.CheckNumber + 1, ctx, ct);
+                return;
+
+            case RemoteToolApprovalStatus.Unknown:
+                await CompleteApprovalWithoutExecutionAsync(
+                    state,
+                    coordination,
+                    WorkflowExternalActionApprovalStatus.Failed,
+                    WorkflowExternalActionLifecycleStatus.Failed,
+                    "approval_status_unknown",
+                    (await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false)).Material,
+                    ctx,
+                    ct);
+                return;
+        }
+    }
+
+    private async Task ScheduleApprovalStatusCheckAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        int checkNumber,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var snapshot = coordination.Snapshot;
+        var plan = snapshot.Plan;
+        var remaining = ResolveEffectiveExpiry(snapshot) - ctx.UtcNow;
+        if (remaining <= TimeSpan.Zero)
+        {
+            var material = (await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false)).Material;
+            await CompleteApprovalWithoutExecutionAsync(
+                state,
+                coordination,
+                WorkflowExternalActionApprovalStatus.Expired,
+                WorkflowExternalActionLifecycleStatus.Expired,
+                "approval_expired",
+                material,
+                ctx,
+                ct);
+            return;
+        }
+
+        var callbackId = RuntimeCallbackKeyComposer.BuildCallbackId(
+            ApprovalStatusCallbackPrefix,
+            plan.ActionId,
+            snapshot.RemoteApprovalId,
+            checkNumber.ToString());
+        coordination.StatusCheckCount = checkNumber;
+        coordination.StatusCheckCallbackId = callbackId;
+        coordination.StatusCheckLease = null;
+        await SaveStateAsync(state, ctx, ct);
+
+        var configuredDelay = TimeSpan.FromSeconds(coordination.StatusCheckIntervalSeconds);
+        var dueTime = configuredDelay <= remaining ? configuredDelay : remaining;
+        var lease = await ctx.ScheduleSelfDurableTimeoutAsync(
+            callbackId,
+            dueTime,
+            new WorkflowConnectorApprovalStatusCheckFiredEvent
+            {
+                ActionId = plan.ActionId,
+                RemoteApprovalId = snapshot.RemoteApprovalId,
+                MaterialDigestSha256 = plan.MaterialDigestSha256,
+                PrincipalSubject = plan.Provenance.PrincipalSubject,
+                ScopeId = plan.Provenance.ScopeId,
+                NodeId = plan.NodeId,
+                CheckNumber = checkNumber,
+                ServiceRef = plan.ServiceRef,
+                PermissionScope = plan.PermissionScope,
+                RemoteExpiresAt = snapshot.RemoteExpiresAt.Clone(),
+            },
+            ct: ct);
+
+        state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.ApprovalsByActionId.TryGetValue(plan.ActionId, out coordination) ||
+            coordination.StatusCheckCount != checkNumber ||
+            !string.Equals(coordination.StatusCheckCallbackId, callbackId, StringComparison.Ordinal) ||
+            coordination.Snapshot?.LifecycleStatus != WorkflowExternalActionLifecycleStatus.WaitingApproval)
+        {
+            await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+                ctx,
+                lease,
+                "stale connector approval status callback",
+                ct);
+            return;
+        }
+
+        coordination.StatusCheckLease = WorkflowRuntimeCallbackLeaseStateCodec.ToState(lease);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private static bool MatchesApprovalStatusCheck(
+        WorkflowConnectorApprovalStatusCheckFiredEvent evt,
+        EventEnvelope envelope,
+        ConnectorApprovalCoordinationState coordination)
+    {
+        var snapshot = coordination.Snapshot;
+        var plan = snapshot?.Plan;
+        if (snapshot == null || plan == null || plan.Provenance == null || snapshot.RemoteExpiresAt == null)
+            return false;
+
+        var leaseMatches = coordination.StatusCheckLease != null
+            ? WorkflowRuntimeCallbackLeaseSupport.MatchesLease(envelope, coordination.StatusCheckLease)
+            : RuntimeCallbackEnvelopeStateReader.TryRead(envelope, out var callbackState) &&
+              string.Equals(callbackState.CallbackId, coordination.StatusCheckCallbackId, StringComparison.Ordinal);
+        return leaseMatches &&
+               coordination.StatusCheckCount == evt.CheckNumber &&
+               string.Equals(evt.ActionId, plan.ActionId, StringComparison.Ordinal) &&
+               string.Equals(evt.RemoteApprovalId, snapshot.RemoteApprovalId, StringComparison.Ordinal) &&
+               FixedTimeDigestEquals(evt.MaterialDigestSha256 ?? string.Empty, plan.MaterialDigestSha256 ?? string.Empty) &&
+               string.Equals(evt.PrincipalSubject, plan.Provenance.PrincipalSubject, StringComparison.Ordinal) &&
+               string.Equals(evt.ScopeId, plan.Provenance.ScopeId, StringComparison.Ordinal) &&
+               string.Equals(evt.NodeId, plan.NodeId, StringComparison.Ordinal) &&
+               string.Equals(evt.ServiceRef, plan.ServiceRef, StringComparison.Ordinal) &&
+               string.Equals(evt.PermissionScope, plan.PermissionScope, StringComparison.Ordinal) &&
+               evt.RemoteExpiresAt != null &&
+               evt.RemoteExpiresAt.Equals(snapshot.RemoteExpiresAt);
+    }
+
+    private async Task CompleteApprovalWithoutExecutionAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        WorkflowExternalActionApprovalStatus approvalStatus,
+        WorkflowExternalActionLifecycleStatus lifecycleStatus,
+        string reasonCode,
+        ConnectorCallProtectedMaterial? material,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+            ctx,
+            coordination.StatusCheckLease,
+            "connector approval status callback",
+            ct);
+        coordination.StatusCheckLease = null;
+        coordination.Snapshot.ApprovalStatus = approvalStatus;
+        coordination.Snapshot.ApprovalReasonCode = reasonCode;
+        coordination.Snapshot.ApprovalResolvedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+        coordination.Snapshot.LifecycleStatus = lifecycleStatus;
+        coordination.Snapshot.ExecutionStatus = WorkflowExternalActionExecutionStatus.NotStarted;
+        await SaveStateAsync(state, ctx, ct);
+
+        if (!coordination.StepCompletionPublished)
+        {
+            await PublishApprovalStepFailureAsync(coordination, material, reasonCode, ctx, ct);
+            coordination.StepCompletionPublished = true;
+            await SaveStateAsync(state, ctx, ct);
+        }
+
+        await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task RecoverUnpublishedApprovalTerminalAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        ConnectorCallProtectedMaterial? material,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var snapshot = coordination.Snapshot;
+        if (coordination.CompletionReference != null)
+        {
+            var completion = await ResolveApprovedCompletionAsync(coordination, ctx, ct);
+            await ctx.PublishAsync(completion, TopologyAudience.Self, ct);
+        }
+        else
+        {
+            if (snapshot.ExecutionStatus == WorkflowExternalActionExecutionStatus.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    "Approved connector succeeded without durable completion material.");
+            }
+
+            var reasonCode = snapshot.ExecutionStatus == WorkflowExternalActionExecutionStatus.Failed
+                ? snapshot.ExecutionReasonCode
+                : snapshot.ApprovalReasonCode;
+            await PublishApprovalStepFailureAsync(coordination, material, reasonCode, ctx, ct);
+        }
+
+        coordination.StepCompletionPublished = true;
+        foreach (var pending in state.PendingByOperationId.Values
+                     .Where(candidate => string.Equals(
+                         candidate.ApprovalActionId,
+                         snapshot.Plan.ActionId,
+                         StringComparison.Ordinal))
+                     .ToList())
+        {
+            await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+                ctx,
+                pending.TimeoutLease,
+                "recovered approved connector terminal timeout",
+                ct);
+            RemovePending(state, pending);
+        }
+
+        await SaveStateAsync(state, ctx, ct);
+        await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private static async Task PublishApprovalStepFailureAsync(
+        ConnectorApprovalCoordinationState coordination,
+        ConnectorCallProtectedMaterial? material,
+        string reasonCode,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var plan = coordination.Snapshot.Plan;
+        var continueOnError = material?.OnErrorContinue == true;
+        var completed = new StepCompletedEvent
+        {
+            StepId = plan.Provenance.StepId,
+            RunId = plan.Provenance.RunId,
+            ExecutionId = plan.Provenance.ExecutionId,
+            Success = continueOnError,
+            Output = continueOnError ? material?.Input ?? string.Empty : string.Empty,
+            Error = continueOnError ? string.Empty : DescribeApprovalFailure(reasonCode),
+        };
+        completed.Annotations["connector.name"] = plan.ConnectorName;
+        completed.Annotations["connector.type"] = plan.ConnectorType;
+        completed.Annotations["connector.operation"] = plan.Operation;
+        completed.Annotations["connector.approval.action_id"] = plan.ActionId;
+        completed.Annotations["connector.approval.status"] = coordination.Snapshot.ApprovalStatus.ToString();
+        completed.Annotations["connector.approval.reason_code"] = reasonCode;
+        if (continueOnError)
+        {
+            completed.Annotations["connector.continued_on_error"] = "true";
+            completed.Annotations["connector.error"] = DescribeApprovalFailure(reasonCode);
+        }
+
+        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+    }
+
+    private async Task CancelSupersededApprovalAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+            ctx,
+            coordination.StatusCheckLease,
+            "superseded connector approval status callback",
+            ct);
+        foreach (var pending in state.PendingByOperationId.Values
+                     .Where(pending => string.Equals(
+                         pending.ApprovalActionId,
+                         coordination.Snapshot.Plan.ActionId,
+                         StringComparison.Ordinal))
+                     .ToList())
+        {
+            await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+                ctx,
+                pending.TimeoutLease,
+                "superseded approved connector timeout",
+                ct);
+            RemovePending(state, pending);
+        }
+
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Cancelled;
+        if (coordination.Snapshot.ApprovalStatus == WorkflowExternalActionApprovalStatus.Pending)
+        {
+            coordination.Snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Cancelled;
+            coordination.Snapshot.ApprovalReasonCode = "approval_superseded";
+            coordination.Snapshot.ApprovalResolvedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+        }
+        if (coordination.Snapshot.ExecutionStatus == WorkflowExternalActionExecutionStatus.Executing)
+        {
+            coordination.Snapshot.ExecutionStatus = WorkflowExternalActionExecutionStatus.Failed;
+            coordination.Snapshot.ExecutionReasonCode = "approval_superseded";
+            coordination.Snapshot.ExecutionCompletedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+        }
+        coordination.StepCompletionPublished = true;
+        await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task HandleApprovalRunTerminatedAsync(
+        string runId,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(runId))
+            return;
+
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        var changed = false;
+        foreach (var coordination in state.ApprovalsByActionId.Values.ToList())
+        {
+            var snapshot = coordination.Snapshot;
+            if (snapshot?.Plan?.Provenance == null ||
+                !string.Equals(snapshot.Plan.Provenance.RunId, runId, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+                ctx,
+                coordination.StatusCheckLease,
+                "terminated connector approval status callback",
+                ct);
+            foreach (var pending in state.PendingByOperationId.Values
+                         .Where(pending => string.Equals(
+                             pending.ApprovalActionId,
+                             snapshot.Plan.ActionId,
+                             StringComparison.Ordinal))
+                         .ToList())
+            {
+                await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+                    ctx,
+                    pending.TimeoutLease,
+                    "terminated approved connector timeout",
+                    ct);
+                RemovePending(state, pending);
+            }
+
+            if (!IsTerminalLifecycle(snapshot.LifecycleStatus))
+            {
+                snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Cancelled;
+                if (snapshot.ApprovalStatus == WorkflowExternalActionApprovalStatus.Pending)
+                {
+                    snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Cancelled;
+                    snapshot.ApprovalReasonCode = "workflow_run_terminated";
+                    snapshot.ApprovalResolvedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+                }
+                if (snapshot.ExecutionStatus == WorkflowExternalActionExecutionStatus.Executing)
+                {
+                    snapshot.ExecutionStatus = WorkflowExternalActionExecutionStatus.Failed;
+                    snapshot.ExecutionReasonCode = "workflow_run_terminated";
+                    snapshot.ExecutionCompletedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+                }
+            }
+
+            coordination.StepCompletionPublished = true;
+            await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+            changed = true;
+        }
+
+        if (changed)
+            await SaveStateAsync(state, ctx, ct);
+    }
+
+    private static bool IsTerminalLifecycle(WorkflowExternalActionLifecycleStatus status) =>
+        status is WorkflowExternalActionLifecycleStatus.Denied or
+            WorkflowExternalActionLifecycleStatus.Expired or
+            WorkflowExternalActionLifecycleStatus.Cancelled or
+            WorkflowExternalActionLifecycleStatus.Succeeded or
+            WorkflowExternalActionLifecycleStatus.Failed;
+
+    private static string DescribeApprovalFailure(string reasonCode) =>
+        reasonCode switch
+        {
+            "approval_denied" => "Connector action approval was denied.",
+            "approval_expired" => "Connector action approval expired.",
+            "approval_cancelled" => "Connector action approval was cancelled.",
+            "approval_path_unavailable" => "Connector action approval path is unavailable.",
+            "approval_status_unavailable" => "Connector action approval status is unavailable.",
+            "approval_submission_indeterminate" => "Connector action approval submission was indeterminate.",
+            "approval_authority_mismatch" => "Connector action approval authority no longer matches.",
+            "approval_plan_mismatch" => "Connector action approval plan no longer matches.",
+            "approval_material_digest_mismatch" => "Connector action material failed digest verification.",
+            _ => "Connector action approval failed closed.",
+        };
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.ApprovalExecution.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.ApprovalExecution.cs
@@ -1,0 +1,503 @@
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Workflow.Core.Execution;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Workflow.Core.Modules;
+
+public sealed partial class ConnectorCallModule
+{
+    private async Task StartApprovedExecutionAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        int attempt,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var snapshot = coordination.Snapshot;
+        var plan = snapshot.Plan;
+        var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: true);
+        if (materialResult.Material == null || ResolveEffectiveExpiry(snapshot) <= ctx.UtcNow)
+        {
+            await FailApprovedBeforeDispatchAsync(
+                state,
+                coordination,
+                materialResult.ReasonCode.Length == 0 ? "approval_expired" : materialResult.ReasonCode,
+                materialResult.Material,
+                ctx,
+                ct);
+            return;
+        }
+
+        var material = materialResult.Material;
+        var connector = await _connectorResolver.ResolveAsync(ctx, material.ConnectorName, ct);
+        if (connector == null || !string.Equals(connector.Type, material.ConnectorType, StringComparison.Ordinal))
+        {
+            await FailApprovedBeforeDispatchAsync(
+                state,
+                coordination,
+                connector == null ? "connector_unavailable" : "connector_binding_mismatch",
+                material,
+                ctx,
+                ct);
+            return;
+        }
+
+        var request = BuildApprovedStepRequest(material);
+        var pending = await RegisterPendingAsync(
+            new EventEnvelope { Id = plan.ActionId },
+            request,
+            material.RunId,
+            material.ConnectorName,
+            material.Operation,
+            material.ConnectorType,
+            attempt,
+            material.Attempts,
+            material.TimeoutMs,
+            material.OnErrorContinue,
+            material.SecureStep,
+            ctx,
+            ct,
+            plan.ActionId);
+
+        state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.ApprovalsByActionId.TryGetValue(plan.ActionId, out coordination))
+            return;
+
+        var verified = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: true);
+        if (verified.Material == null || ResolveEffectiveExpiry(coordination.Snapshot) <= ctx.UtcNow)
+        {
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: false,
+                output: string.Empty,
+                error: "Approved connector material failed verification before dispatch.",
+                durationMs: 0,
+                responseAnnotations: new Dictionary<string, string>(),
+                reasonCode: verified.ReasonCode.Length == 0 ? "approval_expired" : verified.ReasonCode,
+                ctx,
+                ct);
+            return;
+        }
+
+        material = verified.Material;
+        coordination.CurrentAttempt = attempt;
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Executing;
+        coordination.Snapshot.ExecutionStatus = WorkflowExternalActionExecutionStatus.Executing;
+        coordination.Snapshot.ExecutionReasonCode = "connector_executing";
+        coordination.Snapshot.ExecutionStartedAt ??= Timestamp.FromDateTimeOffset(ctx.UtcNow);
+        await SaveStateAsync(state, ctx, ct);
+
+        await DispatchApprovedConnectorAsync(
+            pending,
+            state,
+            coordination,
+            material,
+            connector,
+            ctx,
+            ct);
+    }
+
+    private async Task ResumeUndispatchedApprovedExecutionAsync(
+        PendingConnectorCallState pending,
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        pending = await EnsurePendingTimeoutScheduledAsync(pending, ctx, ct);
+        state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.ApprovalsByActionId.TryGetValue(pending.ApprovalActionId, out coordination))
+            return;
+
+        var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: true);
+        if (materialResult.Material == null || ResolveEffectiveExpiry(coordination.Snapshot) <= ctx.UtcNow)
+        {
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: false,
+                output: string.Empty,
+                error: "Approved connector material failed verification before resumed dispatch.",
+                durationMs: 0,
+                responseAnnotations: new Dictionary<string, string>(),
+                reasonCode: materialResult.ReasonCode.Length == 0 ? "approval_expired" : materialResult.ReasonCode,
+                ctx,
+                ct);
+            return;
+        }
+
+        var connector = await _connectorResolver.ResolveAsync(ctx, materialResult.Material.ConnectorName, ct);
+        if (connector == null ||
+            !string.Equals(connector.Type, materialResult.Material.ConnectorType, StringComparison.Ordinal))
+        {
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: false,
+                output: string.Empty,
+                error: "Approved connector binding is unavailable before resumed dispatch.",
+                durationMs: 0,
+                responseAnnotations: new Dictionary<string, string>(),
+                reasonCode: connector == null ? "connector_unavailable" : "connector_binding_mismatch",
+                ctx,
+                ct);
+            return;
+        }
+
+        await DispatchApprovedConnectorAsync(
+            pending,
+            state,
+            coordination,
+            materialResult.Material,
+            connector,
+            ctx,
+            ct);
+    }
+
+    private async Task DispatchApprovedConnectorAsync(
+        PendingConnectorCallState pending,
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        ConnectorCallProtectedMaterial material,
+        IConnector connector,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var plan = coordination.Snapshot.Plan;
+
+        string httpAuthorization;
+        try
+        {
+            httpAuthorization = await ReconstructConnectorHttpAuthorizationAsync(ctx, ct);
+        }
+        catch (Exception ex)
+        {
+            ctx.Logger.LogWarning(
+                "ConnectorCall approved execution authorization failed. action={ActionId} failure_type={FailureType}",
+                plan.ActionId,
+                ex.GetType().Name);
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: false,
+                output: string.Empty,
+                error: "Approved connector authorization is unavailable.",
+                durationMs: 0,
+                responseAnnotations: new Dictionary<string, string>(),
+                reasonCode: "connector_authorization_unavailable",
+                ctx,
+                ct);
+            return;
+        }
+
+        if (!MatchesCurrentApprovalAuthority(plan, ctx) ||
+            ResolveEffectiveExpiry(coordination.Snapshot) <= ctx.UtcNow ||
+            IsExpired(plan.ExpiresAt, ctx.UtcNow))
+        {
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: false,
+                output: string.Empty,
+                error: "Approved connector authority or expiry changed before dispatch.",
+                durationMs: 0,
+                responseAnnotations: new Dictionary<string, string>(),
+                reasonCode: MatchesCurrentApprovalAuthority(plan, ctx)
+                    ? "approval_expired"
+                    : "approval_authority_mismatch",
+                ctx,
+                ct);
+            return;
+        }
+
+        var connectorRequest = new ConnectorRequest
+        {
+            HttpAuthorization = httpAuthorization,
+            RunId = material.RunId,
+            StepId = material.StepId,
+            Connector = material.ConnectorName,
+            Operation = material.Operation,
+            Payload = material.Payload,
+            Parameters = material.Parameters.ToDictionary(
+                static parameter => parameter.Key,
+                static parameter => parameter.Value,
+                StringComparer.Ordinal),
+            IdempotencyKey = material.IdempotencyKey,
+        };
+        _ = ExecuteConnectorAndSignalAsync(ctx, connector, connectorRequest, pending);
+        await MarkConnectorRequestDispatchedAsync(pending, ctx, ct);
+    }
+
+    private static StepRequestEvent BuildApprovedStepRequest(ConnectorCallProtectedMaterial material)
+    {
+        var request = new StepRequestEvent
+        {
+            StepId = material.StepId,
+            StepType = material.SecureStep ? "secure_connector_call" : "connector_call",
+            RunId = material.RunId,
+            Input = material.Input,
+            ExecutionId = material.ExecutionId,
+            IdempotencyKey = material.IdempotencyKey,
+        };
+        foreach (var parameter in material.Parameters)
+            request.Parameters[parameter.Key] = parameter.Value;
+        return request;
+    }
+
+    private static PendingConnectorCallState? FindPendingApprovalExecution(
+        ConnectorCallModuleState state,
+        string actionId) =>
+        state.PendingByOperationId.Values.FirstOrDefault(pending =>
+            string.Equals(pending.ApprovalActionId, actionId, StringComparison.Ordinal));
+
+    private async Task HandleApprovedAttemptCompletedAsync(
+        WorkflowConnectorAttemptCompletedEvent evt,
+        PendingConnectorCallState pending,
+        ConnectorCallModuleState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!state.ApprovalsByActionId.TryGetValue(pending.ApprovalActionId, out var coordination))
+            return;
+        if (coordination.StepCompletionPublished)
+        {
+            if (coordination.MaterialReference != null || coordination.CompletionReference != null)
+            {
+                await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+                await SaveStateAsync(state, ctx, ct);
+            }
+            return;
+        }
+        if (IsTerminalLifecycle(coordination.Snapshot.LifecycleStatus))
+        {
+            await RecoverUnpublishedApprovalTerminalAsync(state, coordination, null, ctx, ct);
+            return;
+        }
+
+        await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+            ctx,
+            pending.TimeoutLease,
+            "approved connector timeout",
+            ct);
+        var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+        var material = materialResult.Material;
+        if (material == null)
+        {
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: false,
+                output: string.Empty,
+                error: "Approved connector material is unavailable.",
+                ParseDuration(evt),
+                evt.Annotations,
+                materialResult.ReasonCode,
+                ctx,
+                ct);
+            return;
+        }
+
+        var durationMs = ParseDuration(evt);
+        if (evt.Success)
+        {
+            var resolvedOutput = evt.Output ?? string.Empty;
+            if (!TryAssertResponseOutput(
+                    material.Parameters.ToDictionary(static x => x.Key, static x => x.Value, StringComparer.Ordinal),
+                    resolvedOutput,
+                    out var assertionError))
+            {
+                await FinalizeApprovedExecutionAsync(
+                    pending,
+                    state,
+                    coordination,
+                    success: false,
+                    output: string.Empty,
+                    error: assertionError,
+                    durationMs,
+                    evt.Annotations,
+                    "connector_response_assertion_failed",
+                    ctx,
+                    ct);
+                return;
+            }
+
+            if (ParseBool(material.Parameters.FirstOrDefault(static x => x.Key == "pass_through_input")?.Value ?? "false"))
+                resolvedOutput = material.Input;
+
+            await FinalizeApprovedExecutionAsync(
+                pending,
+                state,
+                coordination,
+                success: true,
+                output: resolvedOutput,
+                error: string.Empty,
+                durationMs,
+                evt.Annotations,
+                "connector_succeeded",
+                ctx,
+                ct);
+            return;
+        }
+
+        var error = string.IsNullOrWhiteSpace(evt.Error) ? "connector call failed" : evt.Error;
+        if (pending.Attempt < pending.Attempts &&
+            ResolveEffectiveExpiry(coordination.Snapshot) > ctx.UtcNow &&
+            !IsExpired(coordination.Snapshot.Plan.ExpiresAt, ctx.UtcNow))
+        {
+            await StartApprovedExecutionAsync(state, coordination, pending.Attempt + 1, ctx, ct);
+            return;
+        }
+
+        await FinalizeApprovedExecutionAsync(
+            pending,
+            state,
+            coordination,
+            success: false,
+            output: string.Empty,
+            error,
+            durationMs,
+            evt.Annotations,
+            "connector_failed",
+            ctx,
+            ct);
+    }
+
+    private async Task HandleApprovedTimeoutAsync(
+        PendingConnectorCallState pending,
+        WorkflowConnectorTimeoutFiredEvent evt,
+        ConnectorCallModuleState state,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (!state.ApprovalsByActionId.TryGetValue(pending.ApprovalActionId, out var coordination) ||
+            coordination.StepCompletionPublished)
+        {
+            if (coordination != null &&
+                (coordination.MaterialReference != null || coordination.CompletionReference != null))
+            {
+                await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+                await SaveStateAsync(state, ctx, ct);
+            }
+            return;
+        }
+
+        if (!pending.RequestDispatched)
+        {
+            await StartApprovedExecutionAsync(
+                state,
+                coordination,
+                Math.Max(1, pending.Attempt),
+                ctx,
+                ct);
+            return;
+        }
+
+        var materialResult = await ResolveAndVerifyMaterialAsync(coordination, ctx, ct, requireUnexpired: false);
+        if (pending.Attempt < pending.Attempts &&
+            materialResult.Material != null &&
+            ResolveEffectiveExpiry(coordination.Snapshot) > ctx.UtcNow &&
+            !IsExpired(coordination.Snapshot.Plan.ExpiresAt, ctx.UtcNow))
+        {
+            await StartApprovedExecutionAsync(state, coordination, pending.Attempt + 1, ctx, ct);
+            return;
+        }
+
+        var annotations = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["connector.timeout_fired"] = "true",
+        };
+        await FinalizeApprovedExecutionAsync(
+            pending,
+            state,
+            coordination,
+            success: false,
+            output: string.Empty,
+            error: $"connector call timed out after {evt.TimeoutMs}ms",
+            durationMs: evt.TimeoutMs,
+            annotations,
+            materialResult.Material == null ? materialResult.ReasonCode : "connector_timeout",
+            ctx,
+            ct);
+    }
+
+    private async Task FailApprovedBeforeDispatchAsync(
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        string reasonCode,
+        ConnectorCallProtectedMaterial? material,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Failed;
+        coordination.Snapshot.ExecutionStatus = WorkflowExternalActionExecutionStatus.Failed;
+        coordination.Snapshot.ExecutionReasonCode = reasonCode;
+        coordination.Snapshot.ExecutionCompletedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+        await SaveStateAsync(state, ctx, ct);
+        await PublishApprovalStepFailureAsync(coordination, material, reasonCode, ctx, ct);
+        coordination.StepCompletionPublished = true;
+        await SaveStateAsync(state, ctx, ct);
+        await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+
+    private async Task FinalizeApprovedExecutionAsync(
+        PendingConnectorCallState pending,
+        ConnectorCallModuleState state,
+        ConnectorApprovalCoordinationState coordination,
+        bool success,
+        string output,
+        string error,
+        double durationMs,
+        IReadOnlyDictionary<string, string> responseAnnotations,
+        string reasonCode,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        await WorkflowRuntimeCallbackLeaseSupport.TryCancelAsync(
+            ctx,
+            pending.TimeoutLease,
+            "approved connector terminal timeout",
+            ct);
+        var snapshot = coordination.Snapshot;
+        snapshot.LifecycleStatus = success
+            ? WorkflowExternalActionLifecycleStatus.Succeeded
+            : WorkflowExternalActionLifecycleStatus.Failed;
+        snapshot.ExecutionStatus = success
+            ? WorkflowExternalActionExecutionStatus.Succeeded
+            : WorkflowExternalActionExecutionStatus.Failed;
+        snapshot.ExecutionReasonCode = reasonCode;
+        snapshot.ExecutionCompletedAt = Timestamp.FromDateTimeOffset(ctx.UtcNow);
+
+        var completion = BuildPendingCompletion(
+            pending,
+            success,
+            output,
+            error,
+            durationMs,
+            responseAnnotations);
+        completion.Annotations["connector.approval.action_id"] = snapshot.Plan.ActionId;
+        completion.Annotations["connector.approval.status"] = snapshot.ApprovalStatus.ToString();
+        completion.Annotations["connector.approval.execution_status"] = snapshot.ExecutionStatus.ToString();
+        coordination.CompletionReference = await StoreApprovedCompletionAsync(
+            coordination,
+            completion,
+            ctx,
+            ct);
+        await SaveStateAsync(state, ctx, ct);
+        await ctx.PublishAsync(completion, TopologyAudience.Self, ct);
+
+        coordination.StepCompletionPublished = true;
+        RemovePending(state, pending);
+        await SaveStateAsync(state, ctx, ct);
+        await RevokeProtectedExecutionDataAsync(coordination, ctx, ct);
+        await SaveStateAsync(state, ctx, ct);
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.ApprovalMaterial.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.ApprovalMaterial.cs
@@ -1,0 +1,523 @@
+using System.Security.Cryptography;
+using System.Text;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Workflow.Core.Execution;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Core.Modules;
+
+public sealed partial class ConnectorCallModule
+{
+    private const string ExternalActionPlanSchema = "workflow-external-action.v1";
+    private const string ProtectedMaterialSchema = "connector-call-protected-material.v1";
+    private const string ProtectedCompletionSchema = "connector-call-protected-completion.v1";
+    private const string ExternalActionToolName = "workflow_connector_external_action";
+    private const string ProtectedMaterialAuditReason = "workflow.connector-external-action-material";
+    private const string ProtectedCompletionAuditReason = "workflow.connector-external-action-completion";
+
+    private sealed record ConnectorApprovalMaterialBundle(
+        ConnectorCallProtectedMaterial Material,
+        WorkflowExternalActionPlan Plan);
+
+    private static bool RequiresConnectorApproval(StepRequestEvent request) =>
+        request.StepParameters?.ConnectorApproval?.Policy == WorkflowExternalActionApprovalPolicy.Required;
+
+    private async Task<ConnectorApprovalMaterialBundle> BuildApprovalMaterialAsync(
+        StepRequestEvent request,
+        string runId,
+        string connectorName,
+        string operation,
+        IConnector connector,
+        int attempts,
+        int timeoutMs,
+        bool onErrorContinue,
+        bool isSecureStep,
+        WorkflowExternalActionPlan? existingPlan,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var options = request.StepParameters?.ConnectorApproval
+            ?? throw new InvalidOperationException("Connector approval options are required.");
+        ValidateApprovalConfiguration(request, runId, operation, options, connector, ctx);
+
+        var createdAt = existingPlan?.CreatedAt?.ToDateTimeOffset() ?? ctx.UtcNow;
+        var expiresAt = createdAt.AddSeconds(options.ExpirationSeconds);
+        var actionId = BuildApprovalActionId(
+            runId,
+            request.StepId,
+            request.ExecutionId,
+            request.IdempotencyKey);
+        var authority = ctx.CallerNyxIdAuthority!;
+        var plan = new WorkflowExternalActionPlan
+        {
+            SchemaVersion = ExternalActionPlanSchema,
+            ActionId = actionId,
+            IdempotencyKey = request.IdempotencyKey,
+            Provenance = new WorkflowExternalActionProvenance
+            {
+                ScopeId = ctx.ScopeId.Trim(),
+                TeamId = Normalize(options.TeamId),
+                MemberId = Normalize(options.MemberId),
+                WorkflowId = Normalize(options.WorkflowId),
+                PublishedServiceId = Normalize(options.PublishedServiceId),
+                WorkflowActorId = ctx.AgentId,
+                RunId = runId,
+                StepId = request.StepId.Trim(),
+                ExecutionId = Normalize(request.ExecutionId),
+                RequesterPlatform = authority.Platform.Trim(),
+                RequesterTenant = Normalize(authority.Tenant),
+                RequesterExternalUserId = authority.ExternalUserId.Trim(),
+                PrincipalSubject = authority.ExternalUserId.Trim(),
+                RequesterCapabilityScope = authority.Scope.Trim(),
+            },
+            ServiceRef = options.ServiceRef.Trim(),
+            NodeId = options.NodeId.Trim(),
+            ConnectorName = connectorName,
+            ConnectorType = connector.Type,
+            Operation = operation.Trim(),
+            HttpVerb = options.HttpVerb.Trim().ToUpperInvariant(),
+            Resource = options.Resource.Trim(),
+            PermissionScope = options.PermissionScope.Trim(),
+            CreatedAt = Timestamp.FromDateTimeOffset(createdAt),
+            ExpiresAt = Timestamp.FromDateTimeOffset(expiresAt),
+            DigestAlgorithm = "sha256",
+            Summary = BuildApprovalSummary(options.HttpVerb, options.Resource, options.ServiceRef, options.NodeId),
+            ApprovalPolicy = WorkflowExternalActionApprovalPolicy.Required,
+            PolicyReason = string.IsNullOrWhiteSpace(options.PolicyReason)
+                ? "workflow-step-required-approval"
+                : options.PolicyReason.Trim(),
+            Destructive = options.Destructive,
+        };
+
+        var material = new ConnectorCallProtectedMaterial
+        {
+            SchemaVersion = ProtectedMaterialSchema,
+            ActionId = actionId,
+            IdempotencyKey = request.IdempotencyKey,
+            RunId = runId,
+            StepId = request.StepId.Trim(),
+            ExecutionId = Normalize(request.ExecutionId),
+            ConnectorName = connectorName,
+            ConnectorType = connector.Type,
+            Operation = operation.Trim(),
+            Payload = await ResolvePayloadAsync(request, isSecureStep, ctx, ct) ?? string.Empty,
+            Input = request.Input ?? string.Empty,
+            SecureStep = isSecureStep,
+            Attempts = attempts,
+            TimeoutMs = timeoutMs,
+            OnErrorContinue = onErrorContinue,
+            ApprovalPlan = plan.Clone(),
+        };
+        material.Parameters.Add(request.Parameters
+            .OrderBy(static pair => pair.Key, StringComparer.Ordinal)
+            .Select(static pair => new ConnectorCallProtectedParameter
+            {
+                Key = pair.Key,
+                Value = pair.Value,
+            }));
+
+        plan.MaterialDigestSha256 = ComputeMaterialDigest(material);
+        return new ConnectorApprovalMaterialBundle(material, plan);
+    }
+
+    private static async Task<RuntimeSecretReference> StoreApprovalMaterialAsync(
+        ConnectorApprovalMaterialBundle bundle,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var runtimeSecretStore = WorkflowRunExecutionContextStateAccess.ResolveRuntimeSecretStore(ctx)
+            ?? throw new InvalidOperationException("Workflow connector approval runtime secret store is unavailable.");
+        var plan = bundle.Plan;
+        var material = bundle.Material;
+        var approvalWindow = plan.ExpiresAt.ToDateTimeOffset() - plan.CreatedAt.ToDateTimeOffset();
+        var executionWindow = TimeSpan.FromMilliseconds((long)material.Attempts * material.TimeoutMs);
+        var stored = await runtimeSecretStore.PutAsync(
+            new StoreRuntimeSecretRequest(
+                CredentialSecretPurposes.WorkflowConnectorExternalActionMaterial,
+                material.RunId,
+                material.StepId,
+                Convert.ToBase64String(material.ToByteArray()),
+                approvalWindow + executionWindow,
+                ConsumeOnce: false,
+                AuditReason: ProtectedMaterialAuditReason),
+            ct);
+        return stored.Reference.Clone();
+    }
+
+    private static void ValidateApprovalConfiguration(
+        StepRequestEvent request,
+        string runId,
+        string operation,
+        WorkflowConnectorApprovalOptions options,
+        IConnector connector,
+        IWorkflowExecutionContext ctx)
+    {
+        if (string.IsNullOrWhiteSpace(runId) ||
+            string.IsNullOrWhiteSpace(request.StepId) ||
+            string.IsNullOrWhiteSpace(request.IdempotencyKey))
+        {
+            throw new InvalidOperationException(
+                "Connector approval requires run_id, step_id, and a stable idempotency_key.");
+        }
+
+        if (string.IsNullOrWhiteSpace(ctx.ScopeId) ||
+            string.IsNullOrWhiteSpace(ctx.AgentId) ||
+            ctx.CallerNyxIdAuthority == null)
+        {
+            throw new InvalidOperationException(
+                "Connector approval requires workflow scope, actor, and caller NyxID authority.");
+        }
+
+        if (string.IsNullOrWhiteSpace(operation) ||
+            string.IsNullOrWhiteSpace(options.ServiceRef) ||
+            string.IsNullOrWhiteSpace(options.NodeId) ||
+            string.IsNullOrWhiteSpace(options.HttpVerb) ||
+            string.IsNullOrWhiteSpace(options.Resource) ||
+            string.IsNullOrWhiteSpace(options.PermissionScope))
+        {
+            throw new InvalidOperationException(
+                "Connector approval requires operation, service_ref, node_id, http_verb, resource, and permission_scope.");
+        }
+
+        if (options.ExpirationSeconds <= 0 ||
+            options.StatusCheckIntervalSeconds <= 0 ||
+            options.StatusCheckIntervalSeconds > options.ExpirationSeconds)
+        {
+            throw new InvalidOperationException(
+                "Connector approval requires a positive expiration and a status-check interval within that expiration.");
+        }
+
+        ValidateHttpApprovalBinding(request, operation, options, connector);
+    }
+
+    private static void ValidateHttpApprovalBinding(
+        StepRequestEvent request,
+        string operation,
+        WorkflowConnectorApprovalOptions options,
+        IConnector connector)
+    {
+        if (!string.Equals(connector.Type, "http", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var actualVerb = request.Parameters.TryGetValue("method", out var method) &&
+                         !string.IsNullOrWhiteSpace(method)
+            ? method.Trim().ToUpperInvariant()
+            : "POST";
+        var rawResource = request.Parameters.TryGetValue("path", out var path) &&
+                          !string.IsNullOrWhiteSpace(path)
+            ? path
+            : operation;
+        var actualResource = NormalizeHttpResource(rawResource);
+        if (!string.Equals(options.HttpVerb.Trim(), actualVerb, StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(NormalizeHttpResource(options.Resource), actualResource, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Connector approval HTTP verb and resource must match the concrete connector request.");
+        }
+    }
+
+    private static string NormalizeHttpResource(string? resource)
+    {
+        var normalized = string.IsNullOrWhiteSpace(resource) ? "/" : resource.Trim();
+        return normalized.StartsWith('/') ? normalized : "/" + normalized;
+    }
+
+    private static string BuildApprovalActionId(
+        string runId,
+        string stepId,
+        string executionId,
+        string idempotencyKey)
+    {
+        var identity = string.Join('\n', runId, stepId, executionId, idempotencyKey);
+        return "workflow-connector-action:" + ComputeSha256Hex(Encoding.UTF8.GetBytes(identity));
+    }
+
+    private static string BuildApprovalSummary(
+        string httpVerb,
+        string resource,
+        string serviceRef,
+        string nodeId) =>
+        $"{httpVerb.Trim().ToUpperInvariant()} {resource.Trim()} via {serviceRef.Trim()} on node {nodeId.Trim()}";
+
+    private static string ComputeMaterialDigest(ConnectorCallProtectedMaterial material) =>
+        ComputeSha256Hex(material.ToByteArray());
+
+    private static string ComputeSha256Hex(byte[] bytes) =>
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static bool FixedTimeDigestEquals(string left, string right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.ASCII.GetBytes(left),
+            Encoding.ASCII.GetBytes(right));
+    }
+
+    private async Task<(ConnectorCallProtectedMaterial? Material, string ReasonCode)> ResolveAndVerifyMaterialAsync(
+        ConnectorApprovalCoordinationState coordination,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct,
+        bool requireUnexpired)
+    {
+        var snapshot = coordination.Snapshot;
+        var plan = snapshot?.Plan;
+        var reference = coordination.MaterialReference;
+        if (plan == null || reference == null || string.IsNullOrWhiteSpace(reference.Ref))
+            return (null, "approval_material_unavailable");
+
+        var runtimeSecretStore = WorkflowRunExecutionContextStateAccess.ResolveRuntimeSecretStore(ctx);
+        if (runtimeSecretStore == null)
+            return (null, "approval_material_store_unavailable");
+
+        var resolved = await runtimeSecretStore.ResolveAsync(
+            new ResolveRuntimeSecretRequest(
+                reference.Ref,
+                reference.Purpose,
+                reference.OwnerRunId,
+                reference.OwnerStepId,
+                ProtectedMaterialAuditReason),
+            ct);
+        if (!resolved.Resolved || string.IsNullOrWhiteSpace(resolved.Secret))
+            return (null, "approval_material_unavailable");
+
+        ConnectorCallProtectedMaterial material;
+        try
+        {
+            material = ConnectorCallProtectedMaterial.Parser.ParseFrom(
+                Convert.FromBase64String(resolved.Secret));
+        }
+        catch (FormatException)
+        {
+            return (null, "approval_material_invalid");
+        }
+        catch (InvalidProtocolBufferException)
+        {
+            return (null, "approval_material_invalid");
+        }
+
+        if (!string.Equals(material.SchemaVersion, ProtectedMaterialSchema, StringComparison.Ordinal) ||
+            !FixedTimeDigestEquals(ComputeMaterialDigest(material), plan.MaterialDigestSha256 ?? string.Empty))
+        {
+            return (null, "approval_material_digest_mismatch");
+        }
+
+        var expectedPlan = plan.Clone();
+        expectedPlan.MaterialDigestSha256 = string.Empty;
+        if (material.ApprovalPlan == null || !material.ApprovalPlan.Equals(expectedPlan))
+            return (null, "approval_plan_mismatch");
+
+        if (!MatchesCurrentApprovalAuthority(plan, ctx))
+            return (null, "approval_authority_mismatch");
+
+        if (requireUnexpired && IsExpired(plan.ExpiresAt, ctx.UtcNow))
+            return (null, "approval_expired");
+
+        return (material, string.Empty);
+    }
+
+    private static bool MatchesCurrentApprovalAuthority(
+        WorkflowExternalActionPlan plan,
+        IWorkflowExecutionContext ctx)
+    {
+        var provenance = plan.Provenance;
+        var authority = ctx.CallerNyxIdAuthority;
+        return provenance != null &&
+               authority != null &&
+               string.Equals(provenance.WorkflowActorId, ctx.AgentId, StringComparison.Ordinal) &&
+               string.Equals(provenance.ScopeId, ctx.ScopeId, StringComparison.Ordinal) &&
+               string.Equals(provenance.RequesterPlatform, authority.Platform, StringComparison.Ordinal) &&
+               string.Equals(provenance.RequesterTenant, authority.Tenant, StringComparison.Ordinal) &&
+               string.Equals(provenance.RequesterExternalUserId, authority.ExternalUserId, StringComparison.Ordinal) &&
+               string.Equals(provenance.PrincipalSubject, authority.ExternalUserId, StringComparison.Ordinal) &&
+               string.Equals(provenance.RequesterCapabilityScope, authority.Scope, StringComparison.Ordinal);
+    }
+
+    private static bool IsExpired(Timestamp? expiresAt, DateTimeOffset now) =>
+        expiresAt == null || expiresAt.ToDateTimeOffset() <= now;
+
+    private static DateTimeOffset ResolveEffectiveExpiry(WorkflowExternalActionApprovalSnapshot snapshot)
+    {
+        var planExpiry = snapshot.Plan?.ExpiresAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue;
+        var remoteExpiry = snapshot.RemoteExpiresAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue;
+        return planExpiry <= remoteExpiry ? planExpiry : remoteExpiry;
+    }
+
+    private async Task<TResult> WithRemoteApprovalContextAsync<TResult>(
+        WorkflowExternalActionPlan plan,
+        IWorkflowExecutionContext ctx,
+        Func<Task<TResult>> operation,
+        CancellationToken ct)
+    {
+        var credential = await WorkflowCallerCredentialRuntimeContextAccess.TryGetCredentialAsync(ctx, ct);
+        if (!credential.Found || string.IsNullOrWhiteSpace(credential.Credential.BearerToken))
+            throw new InvalidOperationException("Workflow caller credential is unavailable for remote approval.");
+        if (!MatchesCurrentApprovalAuthority(plan, ctx))
+            throw new InvalidOperationException("Workflow caller authority no longer matches the approval plan.");
+
+        var provenance = plan.Provenance;
+        var toolContext = AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity(plan.ActionId, plan.ActionId, plan.IdempotencyKey),
+            Credentials = new AgentToolCredentials(
+                credential.Credential.BearerToken,
+                NyxIdOrgToken: null,
+                SenderNyxIdAccessToken: null),
+            Caller = new AgentToolCallerContext(
+                provenance.ScopeId,
+                provenance.PrincipalSubject,
+                ResponseId: null),
+            NyxIdAuthority = new AgentToolNyxIdAuthorityContext(
+                provenance.RequesterPlatform,
+                provenance.RequesterTenant,
+                provenance.RequesterExternalUserId),
+            Routing = LLMRequestRoutingContext.Empty,
+        };
+        using var scope = AgentToolContextScope.Push(toolContext);
+        return await operation();
+    }
+
+    private static RemoteToolApprovalRequest BuildRemoteApprovalRequest(WorkflowExternalActionPlan plan) =>
+        new(
+            plan.ActionId,
+            ExternalActionToolName,
+            plan.ActionId,
+            JsonFormatter.Default.Format(plan),
+            ToolApprovalPolicies.ExternalInvocation,
+            plan.Destructive);
+
+    private static async Task<RuntimeSecretReference> StoreApprovedCompletionAsync(
+        ConnectorApprovalCoordinationState coordination,
+        StepCompletedEvent completion,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var runtimeSecretStore = WorkflowRunExecutionContextStateAccess.ResolveRuntimeSecretStore(ctx)
+            ?? throw new InvalidOperationException("Workflow connector approval runtime secret store is unavailable.");
+        var plan = coordination.Snapshot?.Plan
+            ?? throw new InvalidOperationException("Workflow connector approval plan is unavailable.");
+        var protectedCompletion = new ConnectorCallProtectedCompletion
+        {
+            SchemaVersion = ProtectedCompletionSchema,
+            Completion = completion.Clone(),
+        };
+        var approvalWindow = plan.ExpiresAt.ToDateTimeOffset() - plan.CreatedAt.ToDateTimeOffset();
+        var executionWindow = TimeSpan.FromMilliseconds(
+            (long)Math.Max(1, coordination.Attempts) * Math.Max(1, coordination.TimeoutMs));
+        var stored = await runtimeSecretStore.PutAsync(
+            new StoreRuntimeSecretRequest(
+                CredentialSecretPurposes.WorkflowConnectorExternalActionCompletion,
+                plan.Provenance.RunId,
+                plan.Provenance.StepId,
+                Convert.ToBase64String(protectedCompletion.ToByteArray()),
+                approvalWindow + executionWindow,
+                ConsumeOnce: false,
+                AuditReason: ProtectedCompletionAuditReason),
+            ct);
+        return stored.Reference.Clone();
+    }
+
+    private static async Task<StepCompletedEvent> ResolveApprovedCompletionAsync(
+        ConnectorApprovalCoordinationState coordination,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var reference = coordination.CompletionReference;
+        if (reference == null || string.IsNullOrWhiteSpace(reference.Ref))
+            throw new InvalidOperationException("Approved connector completion reference is unavailable.");
+
+        var runtimeSecretStore = WorkflowRunExecutionContextStateAccess.ResolveRuntimeSecretStore(ctx)
+            ?? throw new InvalidOperationException("Workflow connector approval runtime secret store is unavailable.");
+        var resolved = await runtimeSecretStore.ResolveAsync(
+            new ResolveRuntimeSecretRequest(
+                reference.Ref,
+                reference.Purpose,
+                reference.OwnerRunId,
+                reference.OwnerStepId,
+                ProtectedCompletionAuditReason),
+            ct);
+        if (!resolved.Resolved || string.IsNullOrWhiteSpace(resolved.Secret))
+            throw new InvalidOperationException("Approved connector completion material is unavailable.");
+
+        try
+        {
+            var protectedCompletion = ConnectorCallProtectedCompletion.Parser.ParseFrom(
+                Convert.FromBase64String(resolved.Secret));
+            if (!string.Equals(
+                    protectedCompletion.SchemaVersion,
+                    ProtectedCompletionSchema,
+                    StringComparison.Ordinal) ||
+                protectedCompletion.Completion == null)
+            {
+                throw new InvalidOperationException("Approved connector completion material is invalid.");
+            }
+
+            return protectedCompletion.Completion.Clone();
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException("Approved connector completion material is invalid.", ex);
+        }
+        catch (InvalidProtocolBufferException ex)
+        {
+            throw new InvalidOperationException("Approved connector completion material is invalid.", ex);
+        }
+    }
+
+    private static async Task RevokeProtectedExecutionDataAsync(
+        ConnectorApprovalCoordinationState coordination,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var runtimeSecretStore = WorkflowRunExecutionContextStateAccess.ResolveRuntimeSecretStore(ctx);
+        if (runtimeSecretStore == null &&
+            (coordination.MaterialReference != null || coordination.CompletionReference != null))
+        {
+            throw new InvalidOperationException("Workflow connector approval runtime secret store is unavailable.");
+        }
+
+        if (coordination.MaterialReference is { } materialReference &&
+            !string.IsNullOrWhiteSpace(materialReference.Ref))
+        {
+            await RevokeReferenceAsync(
+                runtimeSecretStore!,
+                materialReference,
+                ProtectedMaterialAuditReason,
+                ct);
+        }
+
+        coordination.MaterialReference = null;
+        if (coordination.CompletionReference is { } completionReference &&
+            !string.IsNullOrWhiteSpace(completionReference.Ref))
+        {
+            await RevokeReferenceAsync(
+                runtimeSecretStore!,
+                completionReference,
+                ProtectedCompletionAuditReason,
+                ct);
+        }
+
+        coordination.CompletionReference = null;
+    }
+
+    private static Task<RevokeRuntimeSecretResult> RevokeReferenceAsync(
+        IRuntimeSecretStore runtimeSecretStore,
+        RuntimeSecretReference reference,
+        string auditReason,
+        CancellationToken ct) =>
+        runtimeSecretStore.RevokeAsync(
+            new RevokeRuntimeSecretRequest(
+                reference.Ref,
+                reference.Purpose,
+                reference.OwnerRunId,
+                reference.OwnerStepId,
+                auditReason),
+            ct);
+
+    private static string Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.Payload.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.Payload.cs
@@ -1,0 +1,258 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Aevatar.Workflow.Abstractions.Credentials;
+using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Primitives;
+
+namespace Aevatar.Workflow.Core.Modules;
+
+public sealed partial class ConnectorCallModule
+{
+    private async Task<string?> ResolvePayloadAsync(
+        StepRequestEvent request,
+        bool isSecureStep,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var mode = WorkflowParameterValueParser.GetString(
+            request.Parameters,
+            isSecureStep ? "secure_template" : "input",
+            "stdin_mode",
+            "stdin").Trim();
+        if (string.Equals(mode, "input", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, "inherit", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            return request.Input;
+        }
+
+        if (string.Equals(mode, "secure_variable", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, "secure_input", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, "secret_input", StringComparison.OrdinalIgnoreCase))
+        {
+            var variable = WorkflowParameterValueParser.GetString(
+                request.Parameters,
+                string.Empty,
+                "stdin_secret_variable",
+                "secret_variable",
+                "secure_variable",
+                "variable");
+            return await ResolveSecureVariableAsync(ctx, request.RunId, variable, ct);
+        }
+
+        if (string.Equals(mode, "template", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mode, "secure_template", StringComparison.OrdinalIgnoreCase))
+        {
+            var template = WorkflowParameterValueParser.GetString(
+                request.Parameters,
+                request.Input ?? string.Empty,
+                "stdin_template",
+                "payload_template",
+                "stdin_value");
+            return await ResolveSecureTemplateAsync(ctx, request.RunId, template, ct);
+        }
+
+        return request.Input;
+    }
+
+    private static async Task<string> ResolveSecureVariableAsync(
+        IWorkflowExecutionContext ctx,
+        string? runId,
+        string variable,
+        CancellationToken ct)
+    {
+        var normalizedVariable = NormalizeSecureVariableName(variable);
+        if (string.IsNullOrWhiteSpace(normalizedVariable))
+            throw new InvalidOperationException("connector_call secure stdin requires 'stdin_secret_variable'.");
+
+        var captured = await SecureInputRuntimeContextAccess.TryGetCapturedValueAsync(ctx, runId, normalizedVariable, ct);
+        if (captured.Found)
+            return captured.Value;
+
+        throw new InvalidOperationException(
+            $"connector_call is missing captured secure value '{normalizedVariable}' for run '{WorkflowRunIdNormalizer.Normalize(runId)}'.");
+    }
+
+    private static async Task<string> ResolveSecureTemplateAsync(
+        IWorkflowExecutionContext ctx,
+        string? runId,
+        string template,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(template))
+            return string.Empty;
+
+        var withJsonEscapedSecureValues = await ReplaceSecurePlaceholdersAsync(
+            template,
+            SecureJsonPlaceholderPattern(),
+            async variable =>
+            {
+                var value = await ResolveSecureVariableAsync(ctx, runId, variable, ct);
+                return JsonEncodedText.Encode(value, JavaScriptEncoder.UnsafeRelaxedJsonEscaping).ToString();
+            });
+
+        return await ReplaceSecurePlaceholdersAsync(
+            withJsonEscapedSecureValues,
+            SecurePlaceholderPattern(),
+            variable => ResolveSecureVariableAsync(ctx, runId, variable, ct));
+    }
+
+    private static async Task<string> ReplaceSecurePlaceholdersAsync(
+        string template,
+        Regex pattern,
+        Func<string, Task<string>> resolveAsync)
+    {
+        var matches = pattern.Matches(template);
+        if (matches.Count == 0)
+            return template;
+
+        var builder = new StringBuilder(template.Length);
+        var cursor = 0;
+        foreach (Match match in matches)
+        {
+            builder.Append(template, cursor, match.Index - cursor);
+            var variable = match.Groups[1].Value;
+            builder.Append(await resolveAsync(variable));
+            cursor = match.Index + match.Length;
+        }
+
+        builder.Append(template, cursor, template.Length - cursor);
+        return builder.ToString();
+    }
+
+    private static string NormalizeSecureVariableName(string? variable) =>
+        string.IsNullOrWhiteSpace(variable) ? string.Empty : variable.Trim();
+
+    [GeneratedRegex(@"\[\[secure:([A-Za-z0-9_.:-]+)\]\]", RegexOptions.Compiled)]
+    private static partial Regex SecurePlaceholderPattern();
+
+    [GeneratedRegex(@"\[\[secure_json:([A-Za-z0-9_.:-]+)\]\]", RegexOptions.Compiled)]
+    private static partial Regex SecureJsonPlaceholderPattern();
+
+    private static void AppendBaseMetadata(
+        StepCompletedEvent evt,
+        PendingConnectorCallState pending,
+        double durationMs)
+    {
+        evt.Annotations["connector.name"] = pending.ConnectorName;
+        evt.Annotations["connector.type"] = pending.ConnectorType;
+        evt.Annotations["connector.operation"] = pending.Operation;
+        evt.Annotations["connector.attempts"] = pending.Attempt.ToString();
+        evt.Annotations["connector.timeout_ms"] = pending.TimeoutMs.ToString();
+        evt.Annotations["connector.duration_ms"] = durationMs.ToString("F2");
+    }
+
+    private static bool TryAssertResponseOutput(
+        IReadOnlyDictionary<string, string> parameters,
+        string responseOutput,
+        out string error)
+    {
+        error = string.Empty;
+        var responsePath = WorkflowParameterValueParser.GetString(
+            parameters,
+            string.Empty,
+            "assert_response_path");
+        if (string.IsNullOrWhiteSpace(responsePath))
+            return true;
+
+        if (string.IsNullOrWhiteSpace(responseOutput))
+        {
+            error = $"connector_call assertion failed: response path '{responsePath}' is missing";
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(responseOutput);
+            if (!TryResolveJsonPath(document.RootElement, responsePath, out var value))
+            {
+                error = $"connector_call assertion failed: response path '{responsePath}' is missing";
+                return false;
+            }
+
+            if (!IsTruthy(value))
+            {
+                error = $"connector_call assertion failed: response path '{responsePath}' was not truthy";
+                return false;
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            error = $"connector_call assertion failed: response output is not valid JSON for path '{responsePath}'";
+            return false;
+        }
+    }
+
+    private static bool TryResolveJsonPath(JsonElement current, string path, out JsonElement value)
+    {
+        var normalizedSegments = path
+            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (normalizedSegments.Length == 0)
+        {
+            value = current;
+            return true;
+        }
+
+        foreach (var segment in normalizedSegments)
+        {
+            if (current.ValueKind == JsonValueKind.Object &&
+                current.TryGetProperty(segment, out var property))
+            {
+                current = property;
+                continue;
+            }
+
+            if (current.ValueKind == JsonValueKind.Array &&
+                int.TryParse(segment, out var index) &&
+                index >= 0 &&
+                index < current.GetArrayLength())
+            {
+                current = current[index];
+                continue;
+            }
+
+            value = default;
+            return false;
+        }
+
+        value = current;
+        return true;
+    }
+
+    private static bool IsTruthy(JsonElement value)
+    {
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number => !string.Equals(value.GetRawText(), "0", StringComparison.Ordinal),
+            JsonValueKind.String => !string.IsNullOrWhiteSpace(value.GetString()) &&
+                                    !string.Equals(value.GetString(), "false", StringComparison.OrdinalIgnoreCase),
+            JsonValueKind.Null => false,
+            JsonValueKind.Undefined => false,
+            _ => true,
+        };
+    }
+
+    private async Task<string> ReconstructConnectorHttpAuthorizationAsync(
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var credential = await WorkflowCallerCredentialRuntimeContextAccess.TryGetCredentialAsync(ctx, ct);
+        if (credential.Found)
+        {
+            var resolved = await WorkflowCallerAccessTokenResolver.ResolveAsync(
+                credential.Credential,
+                _callerAccessTokenProvider,
+                ct);
+            var parsed = WorkflowCallerCredentialTokens.ParseOptional(resolved.BearerToken);
+            return parsed.IsValid ? $"Bearer {parsed.NormalizedBearerToken}" : string.Empty;
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -1,7 +1,4 @@
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using System.Text.RegularExpressions;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.Connectors;
@@ -25,13 +22,16 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
     private const string TimeoutCallbackPrefix = "workflow-connector-timeout";
     private readonly IWorkflowConnectorResolver _connectorResolver;
     private readonly IWorkflowCallerAccessTokenProvider? _callerAccessTokenProvider;
+    private readonly IRemoteToolApprovalPort? _remoteToolApprovalPort;
 
     public ConnectorCallModule(
         IWorkflowConnectorResolver connectorResolver,
-        IWorkflowCallerAccessTokenProvider? callerAccessTokenProvider = null)
+        IWorkflowCallerAccessTokenProvider? callerAccessTokenProvider = null,
+        IRemoteToolApprovalPort? remoteToolApprovalPort = null)
     {
         _connectorResolver = connectorResolver ?? throw new ArgumentNullException(nameof(connectorResolver));
         _callerAccessTokenProvider = callerAccessTokenProvider;
+        _remoteToolApprovalPort = remoteToolApprovalPort;
     }
 
     public string Name => "connector_call";
@@ -46,6 +46,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
                 payload.Is(SecureValueCapturedEvent.Descriptor) ||
                 payload.Is(WorkflowConnectorTimeoutFiredEvent.Descriptor) ||
                 payload.Is(WorkflowConnectorAttemptCompletedEvent.Descriptor) ||
+                payload.Is(WorkflowConnectorApprovalStatusCheckFiredEvent.Descriptor) ||
+                payload.Is(WorkflowRunStoppedEvent.Descriptor) ||
                 payload.Is(WorkflowCompletedEvent.Descriptor));
     }
 
@@ -72,9 +74,30 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
 
         if (envelope.Payload.Is(WorkflowCompletedEvent.Descriptor))
         {
+            var completed = envelope.Payload.Unpack<WorkflowCompletedEvent>();
             await SecureInputRuntimeContextAccess.RemoveRunAsync(
                 ctx,
-                envelope.Payload.Unpack<WorkflowCompletedEvent>().RunId,
+                completed.RunId,
+                ct);
+            await HandleApprovalRunTerminatedAsync(completed.RunId, ctx, ct);
+            return;
+        }
+
+        if (envelope.Payload.Is(WorkflowRunStoppedEvent.Descriptor))
+        {
+            await HandleApprovalRunTerminatedAsync(
+                envelope.Payload.Unpack<WorkflowRunStoppedEvent>().RunId,
+                ctx,
+                ct);
+            return;
+        }
+
+        if (envelope.Payload.Is(WorkflowConnectorApprovalStatusCheckFiredEvent.Descriptor))
+        {
+            await HandleApprovalStatusCheckAsync(
+                envelope.Payload.Unpack<WorkflowConnectorApprovalStatusCheckFiredEvent>(),
+                envelope,
+                ctx,
                 ct);
             return;
         }
@@ -156,6 +179,23 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         var runId = string.IsNullOrEmpty(request.RunId)
             ? envelope.Propagation?.CorrelationId ?? string.Empty
             : request.RunId;
+        if (RequiresConnectorApproval(request))
+        {
+            await BeginConnectorApprovalAsync(
+                request,
+                runId,
+                connectorName,
+                operation,
+                connector,
+                attempts,
+                timeoutMs,
+                string.Equals(onError, "continue", StringComparison.OrdinalIgnoreCase),
+                isSecureStep,
+                ctx,
+                ct);
+            return;
+        }
+
         await StartAttemptAsync(
             envelope,
             request,
@@ -190,6 +230,12 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             ctx.Logger.LogDebug(
                 "ConnectorCall: ignore timeout without matching lease operation={OperationId}",
                 evt.OperationId);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(pending.ApprovalActionId))
+        {
+            await HandleApprovedTimeoutAsync(pending, evt, state, ctx, ct);
             return;
         }
 
@@ -238,6 +284,12 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
         if (!state.PendingByOperationId.TryGetValue(evt.OperationId, out var pending))
             return;
+
+        if (!string.IsNullOrWhiteSpace(pending.ApprovalActionId))
+        {
+            await HandleApprovedAttemptCompletedAsync(evt, pending, state, ctx, ct);
+            return;
+        }
 
         RemovePending(state, pending);
         await SaveStateAsync(state, ctx, ct);
@@ -323,7 +375,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         bool onErrorContinue,
         bool isSecureStep,
         IWorkflowExecutionContext ctx,
-        CancellationToken ct)
+        CancellationToken ct,
+        string approvalActionId = "")
     {
         var pending = await RegisterPendingAsync(
             envelope,
@@ -338,7 +391,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             onErrorContinue,
             isSecureStep,
             ctx,
-            ct);
+            ct,
+            approvalActionId);
         var requestMetadata = new Dictionary<string, string>(StringComparer.Ordinal);
         WorkflowRequestMetadataRuntimeContextAccess.CopyRequestMetadata(ctx, requestMetadata);
         var connectorRequest = new ConnectorRequest
@@ -402,7 +456,8 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         bool onErrorContinue,
         bool isSecureStep,
         IWorkflowExecutionContext ctx,
-        CancellationToken ct)
+        CancellationToken ct,
+        string approvalActionId = "")
     {
         var operationId = BuildOperationId(runId, request.StepId, attempt, request.ExecutionId, ResolveOriginEnvelopeId(envelope));
         var callbackId = RuntimeCallbackKeyComposer.BuildCallbackId(
@@ -416,7 +471,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             StepId = request.StepId,
             RunId = runId,
             OperationId = operationId,
-            Input = request.Input ?? string.Empty,
+            Input = string.IsNullOrWhiteSpace(approvalActionId) ? request.Input ?? string.Empty : string.Empty,
             ConnectorName = connectorName,
             Operation = operation,
             Attempt = attempt,
@@ -428,9 +483,14 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             SecureStep = isSecureStep,
             ConnectorType = connectorType,
             IdempotencyKey = request.IdempotencyKey ?? string.Empty,
+            ApprovalActionId = approvalActionId,
+            RequestDispatched = false,
         };
-        foreach (var (key, value) in request.Parameters)
-            pending.Parameters[key] = value;
+        if (string.IsNullOrWhiteSpace(approvalActionId))
+        {
+            foreach (var (key, value) in request.Parameters)
+                pending.Parameters[key] = value;
+        }
 
         var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
         RemovePendingForStep(state, runId, request.StepId);
@@ -438,27 +498,52 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         state.PendingOperationIdByStepId[BuildStepKey(runId, request.StepId)] = operationId;
         await SaveStateAsync(state, ctx, ct);
 
+        return await EnsurePendingTimeoutScheduledAsync(pending, ctx, ct);
+    }
+
+    private async Task<PendingConnectorCallState> EnsurePendingTimeoutScheduledAsync(
+        PendingConnectorCallState pending,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        if (pending.TimeoutLease != null)
+            return pending;
+
         var lease = await ctx.ScheduleSelfDurableTimeoutAsync(
-            callbackId,
-            TimeSpan.FromMilliseconds(timeoutMs),
+            pending.TimeoutCallbackId,
+            TimeSpan.FromMilliseconds(pending.TimeoutMs),
             new WorkflowConnectorTimeoutFiredEvent
             {
-                RunId = runId,
-                StepId = request.StepId,
-                OperationId = operationId,
-                TimeoutMs = timeoutMs,
-                Attempt = attempt,
+                RunId = pending.RunId,
+                StepId = pending.StepId,
+                OperationId = pending.OperationId,
+                TimeoutMs = pending.TimeoutMs,
+                Attempt = pending.Attempt,
             },
             ct: ct);
 
-        state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
-        if (!state.PendingByOperationId.TryGetValue(operationId, out pending))
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.PendingByOperationId.TryGetValue(pending.OperationId, out var persistedPending))
             return pending;
 
-        pending.TimeoutLease = WorkflowRuntimeCallbackLeaseStateCodec.ToState(lease);
-        state.PendingByOperationId[operationId] = pending;
+        persistedPending.TimeoutLease = WorkflowRuntimeCallbackLeaseStateCodec.ToState(lease);
+        state.PendingByOperationId[persistedPending.OperationId] = persistedPending;
         await SaveStateAsync(state, ctx, ct);
-        return pending;
+        return persistedPending;
+    }
+
+    private static async Task MarkConnectorRequestDispatchedAsync(
+        PendingConnectorCallState pending,
+        IWorkflowExecutionContext ctx,
+        CancellationToken ct)
+    {
+        var state = WorkflowExecutionStateAccess.Load<ConnectorCallModuleState>(ctx, ModuleStateKey);
+        if (!state.PendingByOperationId.TryGetValue(pending.OperationId, out var persistedPending))
+            return;
+
+        persistedPending.RequestDispatched = true;
+        state.PendingByOperationId[persistedPending.OperationId] = persistedPending;
+        await SaveStateAsync(state, ctx, ct);
     }
 
     private static bool MatchesPendingTimeout(EventEnvelope envelope, PendingConnectorCallState pending)
@@ -552,6 +637,26 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         IWorkflowExecutionContext ctx,
         CancellationToken ct)
     {
+        await ctx.PublishAsync(
+            BuildPendingCompletion(
+                pending,
+                success,
+                output,
+                error,
+                durationMs,
+                responseAnnotations),
+            TopologyAudience.Self,
+            ct);
+    }
+
+    private static StepCompletedEvent BuildPendingCompletion(
+        PendingConnectorCallState pending,
+        bool success,
+        string output,
+        string error,
+        double durationMs,
+        IReadOnlyDictionary<string, string> responseAnnotations)
+    {
         var completed = new StepCompletedEvent
         {
             StepId = pending.StepId,
@@ -577,7 +682,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             completed.Annotations["connector.error"] = error ?? string.Empty;
         }
 
-        await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
+        return completed;
     }
 
     private static async Task PublishFailureAsync(
@@ -619,236 +724,6 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         await ctx.PublishAsync(skipped, TopologyAudience.Self, ct);
     }
 
-    private async Task<string?> ResolvePayloadAsync(
-        StepRequestEvent request,
-        bool isSecureStep,
-        IWorkflowExecutionContext ctx,
-        CancellationToken ct)
-    {
-        var mode = WorkflowParameterValueParser.GetString(
-            request.Parameters,
-            isSecureStep ? "secure_template" : "input",
-            "stdin_mode",
-            "stdin").Trim();
-        if (string.Equals(mode, "input", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(mode, "inherit", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(mode, "none", StringComparison.OrdinalIgnoreCase))
-        {
-            return request.Input;
-        }
-
-        if (string.Equals(mode, "secure_variable", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(mode, "secure_input", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(mode, "secret_input", StringComparison.OrdinalIgnoreCase))
-        {
-            var variable = WorkflowParameterValueParser.GetString(
-                request.Parameters,
-                string.Empty,
-                "stdin_secret_variable",
-                "secret_variable",
-                "secure_variable",
-                "variable");
-            return await ResolveSecureVariableAsync(ctx, request.RunId, variable, ct);
-        }
-
-        if (string.Equals(mode, "template", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(mode, "secure_template", StringComparison.OrdinalIgnoreCase))
-        {
-            var template = WorkflowParameterValueParser.GetString(
-                request.Parameters,
-                request.Input ?? string.Empty,
-                "stdin_template",
-                "payload_template",
-                "stdin_value");
-            return await ResolveSecureTemplateAsync(ctx, request.RunId, template, ct);
-        }
-
-        return request.Input;
-    }
-
-    private static async Task<string> ResolveSecureVariableAsync(
-        IWorkflowExecutionContext ctx,
-        string? runId,
-        string variable,
-        CancellationToken ct)
-    {
-        var normalizedVariable = NormalizeSecureVariableName(variable);
-        if (string.IsNullOrWhiteSpace(normalizedVariable))
-            throw new InvalidOperationException("connector_call secure stdin requires 'stdin_secret_variable'.");
-
-        var captured = await SecureInputRuntimeContextAccess.TryGetCapturedValueAsync(ctx, runId, normalizedVariable, ct);
-        if (captured.Found)
-        {
-            return captured.Value;
-        }
-
-        throw new InvalidOperationException(
-            $"connector_call is missing captured secure value '{normalizedVariable}' for run '{WorkflowRunIdNormalizer.Normalize(runId)}'.");
-    }
-
-    private static async Task<string> ResolveSecureTemplateAsync(
-        IWorkflowExecutionContext ctx,
-        string? runId,
-        string template,
-        CancellationToken ct)
-    {
-        if (string.IsNullOrEmpty(template))
-            return string.Empty;
-
-        var withJsonEscapedSecureValues = await ReplaceSecurePlaceholdersAsync(
-            template,
-            SecureJsonPlaceholderPattern(),
-            async variable =>
-        {
-            var value = await ResolveSecureVariableAsync(ctx, runId, variable, ct);
-            return JsonEncodedText.Encode(value, JavaScriptEncoder.UnsafeRelaxedJsonEscaping).ToString();
-        });
-
-        return await ReplaceSecurePlaceholdersAsync(
-            withJsonEscapedSecureValues,
-            SecurePlaceholderPattern(),
-            variable => ResolveSecureVariableAsync(ctx, runId, variable, ct));
-    }
-
-    private static async Task<string> ReplaceSecurePlaceholdersAsync(
-        string template,
-        Regex pattern,
-        Func<string, Task<string>> resolveAsync)
-    {
-        var matches = pattern.Matches(template);
-        if (matches.Count == 0)
-            return template;
-
-        var builder = new StringBuilder(template.Length);
-        var cursor = 0;
-        foreach (Match match in matches)
-        {
-            builder.Append(template, cursor, match.Index - cursor);
-            var variable = match.Groups[1].Value;
-            builder.Append(await resolveAsync(variable));
-            cursor = match.Index + match.Length;
-        }
-
-        builder.Append(template, cursor, template.Length - cursor);
-        return builder.ToString();
-    }
-
-    private static string NormalizeSecureVariableName(string? variable) =>
-        string.IsNullOrWhiteSpace(variable) ? string.Empty : variable.Trim();
-
-    [GeneratedRegex(@"\[\[secure:([A-Za-z0-9_.:-]+)\]\]", RegexOptions.Compiled)]
-    private static partial Regex SecurePlaceholderPattern();
-
-    [GeneratedRegex(@"\[\[secure_json:([A-Za-z0-9_.:-]+)\]\]", RegexOptions.Compiled)]
-    private static partial Regex SecureJsonPlaceholderPattern();
-
-    private static void AppendBaseMetadata(
-        StepCompletedEvent evt,
-        PendingConnectorCallState pending,
-        double durationMs)
-    {
-        evt.Annotations["connector.name"] = pending.ConnectorName;
-        evt.Annotations["connector.type"] = pending.ConnectorType;
-        evt.Annotations["connector.operation"] = pending.Operation;
-        evt.Annotations["connector.attempts"] = pending.Attempt.ToString();
-        evt.Annotations["connector.timeout_ms"] = pending.TimeoutMs.ToString();
-        evt.Annotations["connector.duration_ms"] = durationMs.ToString("F2");
-    }
-
-    private static bool TryAssertResponseOutput(
-        IReadOnlyDictionary<string, string> parameters,
-        string responseOutput,
-        out string error)
-    {
-        error = string.Empty;
-        var responsePath = WorkflowParameterValueParser.GetString(
-            parameters,
-            string.Empty,
-            "assert_response_path");
-        if (string.IsNullOrWhiteSpace(responsePath))
-            return true;
-
-        if (string.IsNullOrWhiteSpace(responseOutput))
-        {
-            error = $"connector_call assertion failed: response path '{responsePath}' is missing";
-            return false;
-        }
-
-        try
-        {
-            using var document = JsonDocument.Parse(responseOutput);
-            if (!TryResolveJsonPath(document.RootElement, responsePath, out var value))
-            {
-                error = $"connector_call assertion failed: response path '{responsePath}' is missing";
-                return false;
-            }
-
-            if (!IsTruthy(value))
-            {
-                error = $"connector_call assertion failed: response path '{responsePath}' was not truthy";
-                return false;
-            }
-
-            return true;
-        }
-        catch (JsonException)
-        {
-            error = $"connector_call assertion failed: response output is not valid JSON for path '{responsePath}'";
-            return false;
-        }
-    }
-
-    private static bool TryResolveJsonPath(JsonElement current, string path, out JsonElement value)
-    {
-        var normalizedSegments = path
-            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (normalizedSegments.Length == 0)
-        {
-            value = current;
-            return true;
-        }
-
-        foreach (var segment in normalizedSegments)
-        {
-            if (current.ValueKind == JsonValueKind.Object &&
-                current.TryGetProperty(segment, out var property))
-            {
-                current = property;
-                continue;
-            }
-
-            if (current.ValueKind == JsonValueKind.Array &&
-                int.TryParse(segment, out var index) &&
-                index >= 0 &&
-                index < current.GetArrayLength())
-            {
-                current = current[index];
-                continue;
-            }
-
-            value = default;
-            return false;
-        }
-
-        value = current;
-        return true;
-    }
-
-    private static bool IsTruthy(JsonElement value)
-    {
-        return value.ValueKind switch
-        {
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => !string.Equals(value.GetRawText(), "0", StringComparison.Ordinal),
-            JsonValueKind.String => !string.IsNullOrWhiteSpace(value.GetString()) &&
-                                    !string.Equals(value.GetString(), "false", StringComparison.OrdinalIgnoreCase),
-            JsonValueKind.Null => false,
-            JsonValueKind.Undefined => false,
-            _ => true,
-        };
-    }
-
     private static int ParseBoundedInt(string raw, int min, int max, int fallback)
     {
         if (!int.TryParse(raw, out var parsed)) return fallback;
@@ -862,21 +737,4 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
         string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(raw, "yes", StringComparison.OrdinalIgnoreCase);
 
-    private async Task<string> ReconstructConnectorHttpAuthorizationAsync(
-        IWorkflowExecutionContext ctx,
-        CancellationToken ct)
-    {
-        var credential = await WorkflowCallerCredentialRuntimeContextAccess.TryGetCredentialAsync(ctx, ct);
-        if (credential.Found)
-        {
-            var resolved = await WorkflowCallerAccessTokenResolver.ResolveAsync(
-                credential.Credential,
-                _callerAccessTokenProvider,
-                ct);
-            var parsed = WorkflowCallerCredentialTokens.ParseOptional(resolved.BearerToken);
-            return parsed.IsValid ? $"Bearer {parsed.NormalizedBearerToken}" : string.Empty;
-        }
-
-        return string.Empty;
-    }
 }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
@@ -41,6 +41,8 @@ public sealed class StepDefinition
 
     public ExternalApprovalWaitOptionsDefinition? ExternalApprovalOptions { get; init; }
 
+    public ConnectorApprovalOptionsDefinition? ConnectorApprovalOptions { get; init; }
+
     /// <summary>
     /// 下一步骤 ID，用于线性流程控制。
     /// </summary>
@@ -103,6 +105,37 @@ public sealed class ExternalApprovalWaitOptionsDefinition
     public string? CallbackIdempotencyKey { get; init; }
 
     public string? RequestId { get; init; }
+}
+
+public sealed class ConnectorApprovalOptionsDefinition
+{
+    public const int DefaultStatusCheckIntervalSeconds = 2;
+
+    public string? ServiceRef { get; init; }
+
+    public string? NodeId { get; init; }
+
+    public string? HttpVerb { get; init; }
+
+    public string? Resource { get; init; }
+
+    public string? PermissionScope { get; init; }
+
+    public int ExpirationSeconds { get; init; }
+
+    public int StatusCheckIntervalSeconds { get; init; } = DefaultStatusCheckIntervalSeconds;
+
+    public bool Destructive { get; init; }
+
+    public string? TeamId { get; init; }
+
+    public string? MemberId { get; init; }
+
+    public string? WorkflowId { get; init; }
+
+    public string? PublishedServiceId { get; init; }
+
+    public string? PolicyReason { get; init; }
 }
 
 public sealed class StepRetryPolicy

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -194,6 +194,7 @@ public sealed class WorkflowParser
             AgentToolScope = agentToolScope,
             HumanApprovalOptions = MapHumanApprovalOptions(canonicalType, parameters),
             ExternalApprovalOptions = MapExternalApprovalOptions(canonicalType, parameters),
+            ConnectorApprovalOptions = MapConnectorApprovalOptions(canonicalType, parameters),
             Next = s.Next,
             Compensation = NormalizeText(s.Compensation),
             Children = s.Children?.Select(MapStep).ToList(),
@@ -1046,6 +1047,58 @@ public sealed class WorkflowParser
             RequestId = GetParameter(parameters, "external_approval.request_id", "request_id").Trim(),
         };
     }
+
+    private static ConnectorApprovalOptionsDefinition? MapConnectorApprovalOptions(
+        string canonicalType,
+        IReadOnlyDictionary<string, string> parameters)
+    {
+        if (canonicalType is not ("connector_call" or "secure_connector_call"))
+            return null;
+
+        var policy = NormalizeEnumToken(GetParameter(
+            parameters,
+            "approval.policy",
+            "approval_policy",
+            "approval_required"));
+        if (policy is not ("required" or "always" or "true"))
+            return null;
+
+        var expirationSeconds = ParseNonNegativeInt(GetParameter(
+            parameters,
+            "approval.expiration_seconds",
+            "approval_expiration_seconds"));
+        var statusCheckIntervalSeconds = ParseNonNegativeInt(GetParameter(
+            parameters,
+            "approval.status_check_interval_seconds",
+            "approval_status_check_interval_seconds"));
+
+        return new ConnectorApprovalOptionsDefinition
+        {
+            ServiceRef = GetParameter(parameters, "approval.service_ref", "approval_service_ref").Trim(),
+            NodeId = GetParameter(parameters, "approval.node_id", "approval_node_id").Trim(),
+            HttpVerb = GetParameter(parameters, "approval.http_verb", "approval_http_verb").Trim(),
+            Resource = GetParameter(parameters, "approval.resource", "approval_resource").Trim(),
+            PermissionScope = GetParameter(parameters, "approval.permission_scope", "approval_permission_scope").Trim(),
+            ExpirationSeconds = expirationSeconds,
+            StatusCheckIntervalSeconds = statusCheckIntervalSeconds == 0
+                ? ConnectorApprovalOptionsDefinition.DefaultStatusCheckIntervalSeconds
+                : statusCheckIntervalSeconds,
+            Destructive = ParseBool(GetParameter(parameters, "approval.destructive", "approval_destructive")),
+            TeamId = GetParameter(parameters, "approval.team_id", "approval_team_id").Trim(),
+            MemberId = GetParameter(parameters, "approval.member_id", "approval_member_id").Trim(),
+            WorkflowId = GetParameter(parameters, "approval.workflow_id", "approval_workflow_id").Trim(),
+            PublishedServiceId = GetParameter(
+                parameters,
+                "approval.published_service_id",
+                "approval_published_service_id").Trim(),
+            PolicyReason = GetParameter(parameters, "approval.policy_reason", "approval_policy_reason").Trim(),
+        };
+    }
+
+    private static int ParseNonNegativeInt(string? value) =>
+        int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed > 0
+            ? parsed
+            : 0;
 
     private static TransformOperationKind ParseTransformOperationKind(string? value) =>
         NormalizeEnumToken(value) switch

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -5,6 +5,7 @@ option csharp_namespace = "Aevatar.Workflow.Core";
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "workflow_execution_messages.proto";
+import "workflow_external_action.proto";
 import "Credentials/credential_secret_references.proto";
 
 message WorkflowState
@@ -620,12 +621,67 @@ message PendingConnectorCallState
   bool secure_step = 15;
   string connector_type = 16;
   string idempotency_key = 17;
+  string approval_action_id = 18;
+  bool request_dispatched = 19;
+}
+
+message ConnectorCallProtectedParameter
+{
+  string key = 1;
+  string value = 2;
+}
+
+message ConnectorCallProtectedMaterial
+{
+  string schema_version = 1;
+  string action_id = 2;
+  string idempotency_key = 3;
+  string run_id = 4;
+  string step_id = 5;
+  string execution_id = 6;
+  string connector_name = 7;
+  string connector_type = 8;
+  string operation = 9;
+  string payload = 10;
+  repeated ConnectorCallProtectedParameter parameters = 11;
+  string input = 12;
+  bool secure_step = 13;
+  int32 attempts = 14;
+  int32 timeout_ms = 15;
+  bool on_error_continue = 16;
+  aevatar.workflow.WorkflowExternalActionPlan approval_plan = 17;
+}
+
+message ConnectorCallProtectedCompletion
+{
+  string schema_version = 1;
+  aevatar.workflow.StepCompletedEvent completion = 2;
+}
+
+message ConnectorApprovalCoordinationState
+{
+  aevatar.workflow.WorkflowExternalActionApprovalSnapshot snapshot = 1;
+  aevatar.credentials.RuntimeSecretReference material_reference = 2;
+  WorkflowRuntimeCallbackLeaseState status_check_lease = 3;
+  string status_check_callback_id = 4;
+  int32 status_check_count = 5;
+  int32 attempts = 6;
+  int32 timeout_ms = 7;
+  bool on_error_continue = 8;
+  bool secure_step = 9;
+  string connector_type = 10;
+  int32 status_check_interval_seconds = 11;
+  bool step_completion_published = 12;
+  int32 current_attempt = 13;
+  aevatar.credentials.RuntimeSecretReference completion_reference = 14;
 }
 
 message ConnectorCallModuleState
 {
   map<string, PendingConnectorCallState> pending_by_operation_id = 1;
   map<string, string> pending_operation_id_by_step_id = 2;
+  map<string, ConnectorApprovalCoordinationState> approvals_by_action_id = 3;
+  map<string, string> approval_action_id_by_step_id = 4;
 }
 
 message EvalContextState

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Capabilities/WorkflowInfrastructureCapabilitiesProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Capabilities/WorkflowInfrastructureCapabilitiesProvider.cs
@@ -28,16 +28,10 @@ internal sealed class WorkflowInfrastructureCapabilitiesProvider : IWorkflowCapa
                 ]),
             ["connector_call"] = new(
                 "Invokes an external connector configured in connectors.json.",
-                [
-                    new PrimitiveParameterDescriptor("connector", "string", true, "Connector name."),
-                    new PrimitiveParameterDescriptor("operation", "string", false, "Connector-specific operation or method."),
-                ]),
+                ConnectorParameterDescriptors()),
             ["secure_connector_call"] = new(
                 "Invokes an external connector with secure payload handling.",
-                [
-                    new PrimitiveParameterDescriptor("connector", "string", true, "Connector name."),
-                    new PrimitiveParameterDescriptor("operation", "string", false, "Connector-specific operation or method."),
-                ]),
+                ConnectorParameterDescriptors()),
             ["llm_call"] = new(
                 "Runs an LLM role step and returns generated output.",
                 [
@@ -65,6 +59,31 @@ internal sealed class WorkflowInfrastructureCapabilitiesProvider : IWorkflowCapa
                     new PrimitiveParameterDescriptor("prompt", "string", false, "Prompt for the scheduled workflow chat request."),
                 ]),
         };
+
+    private static IReadOnlyList<PrimitiveParameterDescriptor> ConnectorParameterDescriptors() =>
+    [
+        new("connector", "string", true, "Connector name."),
+        new("operation", "string", false, "Connector-specific operation or method."),
+        new("approval.policy", "string", false, "Set to required to suspend before connector execution.", EnumValuesInput: ["required"]),
+        new("approval.service_ref", "string", false, "NyxID connected-service reference bound to the approval."),
+        new("approval.node_id", "string", false, "Required NyxID node routing identity."),
+        new("approval.http_verb", "string", false, "Normalized external action HTTP verb."),
+        new("approval.resource", "string", false, "Redacted external resource identity."),
+        new("approval.permission_scope", "string", false, "Permission scope granted by this single action approval."),
+        new("approval.expiration_seconds", "int", false, "Local approval validity window in seconds."),
+        new(
+            "approval.status_check_interval_seconds",
+            "int",
+            false,
+            "Durable remote status check interval in seconds.",
+            DefaultValue: $"{ConnectorApprovalOptionsDefinition.DefaultStatusCheckIntervalSeconds}"),
+        new("approval.destructive", "bool", false, "Whether the action is destructive."),
+        new("approval.team_id", "string", false, "Owning Studio team identity."),
+        new("approval.member_id", "string", false, "Owning Studio member identity."),
+        new("approval.workflow_id", "string", false, "Workflow definition identity."),
+        new("approval.published_service_id", "string", false, "Published service runtime identity."),
+        new("approval.policy_reason", "string", false, "Stable reason code for requiring approval."),
+    ];
 
     private readonly IEnumerable<IWorkflowModulePack> _modulePacks;
     private readonly WorkflowCatalogReadModelQueryPort _catalogQueryPort;

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
@@ -241,7 +241,51 @@ public static class ChatQueryEndpoints
             snapshot.TotalSteps,
             snapshot.RequestedSteps,
             snapshot.CompletedSteps,
-            snapshot.RoleReplyCount);
+            snapshot.RoleReplyCount,
+            snapshot.ConnectorApprovals.Select(MapConnectorApproval).ToList());
+
+    private static WorkflowExternalActionApprovalHttpResponse MapConnectorApproval(
+        WorkflowExternalActionApprovalSnapshot snapshot)
+    {
+        var plan = snapshot.Plan ?? new WorkflowExternalActionPlan();
+        var provenance = plan.Provenance ?? new WorkflowExternalActionProvenance();
+        return new WorkflowExternalActionApprovalHttpResponse(
+            plan.ActionId,
+            plan.Summary,
+            plan.ServiceRef,
+            plan.NodeId,
+            plan.ConnectorName,
+            plan.ConnectorType,
+            plan.Operation,
+            plan.HttpVerb,
+            plan.Resource,
+            plan.PermissionScope,
+            provenance.ScopeId,
+            provenance.TeamId,
+            provenance.MemberId,
+            provenance.WorkflowId,
+            provenance.PublishedServiceId,
+            provenance.WorkflowActorId,
+            provenance.RunId,
+            provenance.StepId,
+            provenance.ExecutionId,
+            provenance.RequesterPlatform,
+            provenance.RequesterTenant,
+            provenance.RequesterExternalUserId,
+            provenance.PrincipalSubject,
+            provenance.RequesterCapabilityScope,
+            plan.CreatedAt?.ToDateTimeOffset(),
+            plan.ExpiresAt?.ToDateTimeOffset(),
+            snapshot.RemoteExpiresAt?.ToDateTimeOffset(),
+            snapshot.LifecycleStatus,
+            snapshot.ApprovalStatus,
+            snapshot.ApprovalReasonCode,
+            snapshot.ApprovalResolvedAt?.ToDateTimeOffset(),
+            snapshot.ExecutionStatus,
+            snapshot.ExecutionReasonCode,
+            snapshot.ExecutionStartedAt?.ToDateTimeOffset(),
+            snapshot.ExecutionCompletedAt?.ToDateTimeOffset());
+    }
 
     private static WorkflowCompensationDeadLetterHttpResponse? MapDeadLetter(WorkflowActorSnapshot snapshot)
     {
@@ -339,7 +383,48 @@ public sealed record WorkflowActorCurrentStateHttpResponse(
     int TotalSteps,
     int RequestedSteps,
     int CompletedSteps,
-    int RoleReplyCount);
+    int RoleReplyCount,
+    IReadOnlyList<WorkflowExternalActionApprovalHttpResponse> ConnectorApprovals);
+
+public sealed record WorkflowExternalActionApprovalHttpResponse(
+    string ActionId,
+    string Summary,
+    string ServiceRef,
+    string NodeId,
+    string ConnectorName,
+    string ConnectorType,
+    string Operation,
+    string HttpVerb,
+    string Resource,
+    string PermissionScope,
+    string ScopeId,
+    string TeamId,
+    string MemberId,
+    string WorkflowId,
+    string PublishedServiceId,
+    string WorkflowActorId,
+    string RunId,
+    string StepId,
+    string ExecutionId,
+    string RequesterPlatform,
+    string RequesterTenant,
+    string RequesterExternalUserId,
+    string PrincipalSubject,
+    string RequesterCapabilityScope,
+    DateTimeOffset? CreatedAt,
+    DateTimeOffset? ExpiresAt,
+    DateTimeOffset? RemoteExpiresAt,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))]
+    WorkflowExternalActionLifecycleStatus LifecycleStatus,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))]
+    WorkflowExternalActionApprovalStatus ApprovalStatus,
+    string ApprovalReasonCode,
+    DateTimeOffset? ApprovalResolvedAt,
+    [property: JsonConverter(typeof(JsonStringEnumConverter))]
+    WorkflowExternalActionExecutionStatus ExecutionStatus,
+    string ExecutionReasonCode,
+    DateTimeOffset? ExecutionStartedAt,
+    DateTimeOffset? ExecutionCompletedAt);
 
 public sealed record WorkflowCompensationDeadLetterHttpResponse(
     string FailedCompensationStepId,

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs
@@ -85,6 +85,7 @@ public sealed class WorkflowExecutionCurrentStateProjector
                 x => MapStepIdempotency(x.Value),
                 StringComparer.Ordinal),
             InputFileRefs = seedSnapshot.InputFileRefs.Select(MapInputFileRef).ToList(),
+            ConnectorApprovals = MapConnectorApprovals(state),
         };
 
         // O2 (06-19-workflow-run-observatory): started_at is derived from the committed WorkflowRunState's
@@ -94,6 +95,24 @@ public sealed class WorkflowExecutionCurrentStateProjector
             document.StartedAtUtcValue = state.StartedAtUtc;
 
         return document;
+    }
+
+    private static IList<WorkflowExternalActionApprovalSnapshot> MapConnectorApprovals(WorkflowRunState state)
+    {
+        foreach (var executionState in state.ExecutionStates.Values)
+        {
+            if (!executionState.Is(ConnectorCallModuleState.Descriptor))
+                continue;
+
+            var connectorState = executionState.Unpack<ConnectorCallModuleState>();
+            return connectorState.ApprovalsByActionId.Values
+                .Where(static coordination => coordination.Snapshot?.Plan != null)
+                .OrderBy(static coordination => coordination.Snapshot.Plan.ActionId, StringComparer.Ordinal)
+                .Select(static coordination => coordination.Snapshot.Clone())
+                .ToList();
+        }
+
+        return [];
     }
 
     private static WorkflowStepIdempotencyReadModel MapStepIdempotency(

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
@@ -31,6 +31,7 @@ public sealed class WorkflowExecutionReadModelMapper
             CompletedSteps = 0,
             RoleReplyCount = 0,
             InputFileRefs = { source.InputFileRefs.Select(MapInputFileRef) },
+            ConnectorApprovals = { source.ConnectorApprovals.Select(static approval => approval.Clone()) },
         };
     }
 

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunReadModels.Partial.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunReadModels.Partial.cs
@@ -206,6 +206,12 @@ public sealed partial class WorkflowExecutionCurrentStateDocument : IProjectionR
         get => InputFileRefEntries;
         set => WorkflowExecutionReadModelCollections.ReplaceCollection(InputFileRefEntries, value);
     }
+
+    public IList<WorkflowExternalActionApprovalSnapshot> ConnectorApprovals
+    {
+        get => ConnectorApprovalEntries;
+        set => WorkflowExecutionReadModelCollections.ReplaceCollection(ConnectorApprovalEntries, value);
+    }
 }
 
 public sealed partial class WorkflowExternalApprovalContinuationDocument

--- a/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
+++ b/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
@@ -5,6 +5,7 @@ option csharp_namespace = "Aevatar.Workflow.Projection.ReadModels";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "workflow_execution_messages.proto";
+import "workflow_external_action.proto";
 
 message WorkflowRunInsightReportDocument {
   string id = 1;
@@ -71,6 +72,7 @@ message WorkflowExecutionCurrentStateDocument {
   // Per-schedule correlation id carried from the committed WorkflowRunState. Observatory filter
   // dimension for "this schedule's runs"; empty for non-scheduled/legacy runs.
   string schedule_id = 32;
+  repeated aevatar.workflow.WorkflowExternalActionApprovalSnapshot connector_approval_entries = 33;
 }
 
 message WorkflowExternalApprovalContinuationDocument {

--- a/test/Aevatar.AI.Tests/NyxIdRemoteToolApprovalPortTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdRemoteToolApprovalPortTests.cs
@@ -52,6 +52,8 @@ public sealed class NyxIdRemoteToolApprovalPortTests
     [InlineData("denied", RemoteToolApprovalStatus.Rejected)]
     [InlineData("pending", RemoteToolApprovalStatus.Pending)]
     [InlineData("expired", RemoteToolApprovalStatus.Expired)]
+    [InlineData("cancelled", RemoteToolApprovalStatus.Cancelled)]
+    [InlineData("canceled", RemoteToolApprovalStatus.Cancelled)]
     [InlineData("unexpected", RemoteToolApprovalStatus.Unknown)]
     public async Task GetStatusAsync_ShouldCallStatusEndpointOnceAndMapStatuses(
         string rawStatus,

--- a/test/Aevatar.AI.Tests/RoleGAgentRemoteApprovalEscalationTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentRemoteApprovalEscalationTests.cs
@@ -117,6 +117,49 @@ public sealed class RoleGAgentRemoteApprovalEscalationTests
                 x.ActorId == "role-timeout-lark-notify-fails");
     }
 
+    [Fact]
+    public async Task HandleRemoteApprovalStatusCheck_WhenCancelled_ShouldPersistTerminalFailureAndClearPending()
+    {
+        using var provider = BuildServiceProvider();
+        var remotePort = new StubRemoteApprovalPort(
+            submit: _ => throw new InvalidOperationException("submit should not be called"),
+            status: _ => Task.FromResult(new RemoteToolApprovalStatusSnapshot(
+                RemoteToolApprovalStatus.Cancelled,
+                "cancelled remotely")));
+        var notificationPort = new StubRemoteApprovalNotificationPort(
+            _ => throw new InvalidOperationException("support should not be checked"),
+            _ => throw new InvalidOperationException("notification should not be sent"));
+        var agent = CreateRoleAgent(
+            provider,
+            "role-status-cancelled",
+            remotePort,
+            notificationPort);
+        await agent.ActivateAsync();
+        agent.State.PendingApproval = new PendingToolApprovalState
+        {
+            RequestId = "req-1",
+            SessionId = "session-a",
+            ToolName = "dangerous_tool",
+            ToolCallId = "call-1",
+            ArgumentsJson = "{}",
+            RemoteApprovalId = "remote-1",
+            RemoteStatusCheckAttempt = 1,
+        };
+
+        await agent.HandleRemoteApprovalStatusCheck(new ToolApprovalRemoteStatusCheckFiredEvent
+        {
+            RequestId = "req-1",
+            SessionId = "session-a",
+            RemoteApprovalId = "remote-1",
+            Attempt = 1,
+        });
+
+        agent.State.PendingApproval.Should().BeNull();
+        agent.State.Sessions["session-a"].Completed.Should().BeTrue();
+        agent.State.Sessions["session-a"].FinalContent.Should()
+            .Contain("approval_cancelled: cancelled remotely");
+    }
+
     private static ServiceProvider BuildServiceProvider()
     {
         return new ServiceCollection()

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleApprovalFailureRecoveryTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleApprovalFailureRecoveryTests.cs
@@ -1,0 +1,442 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core;
+using FluentAssertions;
+using ApprovalHarness = Aevatar.Integration.Tests.ConnectorCallModuleApprovalTests.ApprovalHarness;
+using RecordingConnector = Aevatar.Integration.Tests.ConnectorCallModuleApprovalTests.RecordingConnector;
+using TamperingRuntimeSecretStore = Aevatar.Integration.Tests.ConnectorCallModuleApprovalTests.TamperingRuntimeSecretStore;
+
+namespace Aevatar.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "ConnectorCallApproval")]
+public sealed class ConnectorCallModuleApprovalFailureRecoveryTests
+{
+    [Theory]
+    [InlineData("identity")]
+    [InlineData("authority")]
+    [InlineData("action")]
+    [InlineData("timing")]
+    public async Task InvalidApprovalConfiguration_ShouldFailBeforeSubmission(string invalidField)
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        var request = harness.CreateRequest(
+            "execution-alpha",
+            ApprovalHarness.IdempotencyKey,
+            ApprovalHarness.RawPayload,
+            "POST",
+            "/resources/alpha");
+        switch (invalidField)
+        {
+            case "identity":
+                request.IdempotencyKey = string.Empty;
+                break;
+            case "authority":
+                await harness.Agent.ClearExecutionContextAsync();
+                break;
+            case "action":
+                request.StepParameters.ConnectorApproval.ServiceRef = string.Empty;
+                break;
+            case "timing":
+                request.StepParameters.ConnectorApproval.ExpirationSeconds = 0;
+                break;
+        }
+
+        await harness.BeginAsync(request);
+
+        harness.ApprovalPort.Submissions.Should().BeEmpty();
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.State().ApprovalsByActionId.Should().BeEmpty();
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task InvalidRemoteApprovalBinding_ShouldFailClosed()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        harness.ApprovalPort.Submission = new RemoteToolApprovalSubmission(string.Empty, harness.RemoteExpiresAt);
+
+        await harness.BeginAsync();
+
+        harness.Coordination().Snapshot.ApprovalReasonCode.Should().Be("approval_remote_binding_invalid");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WaitingApprovalWithoutRemoteBinding_ShouldFailOnRedelivery()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var state = harness.State();
+        var coordination = state.ApprovalsByActionId.Values.Single();
+        coordination.Snapshot.RemoteApprovalId = string.Empty;
+        await harness.SaveStateAsync(state);
+
+        await harness.BeginAsync();
+
+        harness.ApprovalPort.Submissions.Should().ContainSingle();
+        harness.Coordination().Snapshot.ApprovalReasonCode.Should().Be("approval_submission_indeterminate");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task ApprovedState_ShouldStartExecutionOnRequestRedelivery()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var state = harness.State();
+        var coordination = state.ApprovalsByActionId.Values.Single();
+        coordination.StatusCheckLease = null;
+        coordination.Snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Approved;
+        coordination.Snapshot.ApprovalReasonCode = "approval_approved";
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Approved;
+        await harness.SaveStateAsync(state);
+
+        await harness.BeginAsync();
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task ExecutingStateWithoutPendingDispatch_ShouldRestartExecutionOnRedelivery()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var state = harness.State();
+        var coordination = state.ApprovalsByActionId.Values.Single();
+        coordination.StatusCheckLease = null;
+        coordination.CurrentAttempt = 1;
+        coordination.Snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Approved;
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Executing;
+        coordination.Snapshot.ExecutionStatus = WorkflowExternalActionExecutionStatus.Executing;
+        await harness.SaveStateAsync(state);
+
+        await harness.BeginAsync();
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task UnknownRemoteApprovalStatus_ShouldFailClosed()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Unknown,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.Coordination().Snapshot.ApprovalReasonCode.Should().Be("approval_status_unknown");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+        harness.Connector.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LocallyExpiredApproval_ShouldFailBeforeRemoteStatusRead()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.Context.UtcNow = harness.RemoteExpiresAt;
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.ApprovalPort.StatusQueries.Should().BeEmpty();
+        harness.Coordination().Snapshot.ApprovalReasonCode.Should().Be("approval_expired");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Expired);
+    }
+
+    [Fact]
+    public async Task ApprovalPortLostAfterRestart_ShouldFailClosedOnStatusCheck()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var callback = harness.LatestApprovalStatusCallback();
+        harness.RecreateModuleAndContext(configurePort: false);
+
+        await harness.FireAsync(callback);
+
+        harness.ApprovalPort.StatusQueries.Should().BeEmpty();
+        harness.Coordination().Snapshot.ApprovalReasonCode.Should().Be("approval_path_unavailable");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task DenialWithContinueOnError_ShouldPublishOriginalInput()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        var request = harness.CreateRequest(
+            "execution-alpha",
+            ApprovalHarness.IdempotencyKey,
+            ApprovalHarness.RawPayload,
+            "POST",
+            "/resources/alpha");
+        request.Parameters["on_error"] = "continue";
+        await harness.BeginAsync(request);
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Rejected,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        var completion = harness.StepCompletions().Should().ContainSingle().Subject;
+        completion.Success.Should().BeTrue();
+        completion.Output.Should().Be(ApprovalHarness.RawPayload);
+        completion.Annotations["connector.continued_on_error"].Should().Be("true");
+        completion.Annotations["connector.error"].Should().Contain("denied");
+    }
+
+    [Theory]
+    [InlineData(true, "connector_unavailable")]
+    [InlineData(false, "connector_binding_mismatch")]
+    public async Task ChangedConnectorBinding_ShouldFailBeforeApprovedDispatch(
+        bool removeConnector,
+        string reasonCode)
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ConnectorResolver.Connector = removeConnector
+            ? null
+            : new RecordingConnector(new ConnectorResponse { Success = true, Output = "unexpected" })
+            {
+                Type = "different",
+            };
+
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be(reasonCode);
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task MaterialChangedBetweenPendingRegistrationAndDispatch_ShouldFailSecondVerification()
+    {
+        var secretStore = new TamperingRuntimeSecretStore
+        {
+            TamperConnectorMaterialOnResolveNumber = 2,
+        };
+        var harness = await ApprovalHarness.CreateAsync(secretStore: secretStore);
+        await harness.BeginAsync();
+
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.State().PendingByOperationId.Should().BeEmpty();
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be("approval_material_digest_mismatch");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task UndispatchedExecutionWithRevokedMaterial_ShouldFailOnRedelivery()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+        var state = harness.State();
+        var coordination = state.ApprovalsByActionId.Values.Single();
+        var materialReference = coordination.MaterialReference.Clone();
+        state.PendingByOperationId.Values.Single().RequestDispatched = false;
+        await harness.SaveStateAsync(state);
+        await RevokeAsync(harness, materialReference);
+        harness.RecreateModuleAndContext();
+
+        await harness.BeginAsync();
+
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be("approval_material_unavailable");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task UndispatchedExecutionWithChangedConnector_ShouldFailOnRedelivery()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+        var state = harness.State();
+        state.PendingByOperationId.Values.Single().RequestDispatched = false;
+        await harness.SaveStateAsync(state);
+        harness.RecreateModuleAndContext();
+        harness.ConnectorResolver.Resolutions.Enqueue(harness.Connector);
+        harness.ConnectorResolver.Resolutions.Enqueue(null);
+
+        await harness.BeginAsync();
+
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be("connector_unavailable");
+        harness.Coordination().Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task FailedConnectorWithoutRetry_ShouldPersistExecutionFailure()
+    {
+        var connector = new RecordingConnector(new ConnectorResponse { Success = false, Error = "connector-boom" });
+        var harness = await ApprovalHarness.CreateAsync(connector: connector);
+        await harness.BeginAsync();
+
+        await ApproveAsync(harness);
+
+        harness.StepCompletions().Should().ContainSingle().Which.Error.Should().Be("connector-boom");
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be("connector_failed");
+        harness.Coordination().Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.Failed);
+    }
+
+    [Theory]
+    [InlineData("", "valid", false)]
+    [InlineData("not-json", "valid", false)]
+    [InlineData("{}", "valid", false)]
+    [InlineData("{\"items\":[true]}", "items.0", true)]
+    [InlineData("{\"value\":0}", "value", false)]
+    [InlineData("{\"value\":\"false\"}", "value", false)]
+    [InlineData("{\"value\":null}", "value", false)]
+    [InlineData("{\"value\":[]}", "value", true)]
+    [InlineData("{\"value\":{}}", ".", true)]
+    public async Task ApprovedResponseAssertion_ShouldFollowJsonPathTruthiness(
+        string responseOutput,
+        string responsePath,
+        bool expectedSuccess)
+    {
+        var connector = new RecordingConnector(new ConnectorResponse { Success = true, Output = responseOutput });
+        var harness = await ApprovalHarness.CreateAsync(connector: connector);
+        var request = harness.CreateRequest(
+            "execution-alpha",
+            ApprovalHarness.IdempotencyKey,
+            ApprovalHarness.RawPayload,
+            "POST",
+            "/resources/alpha");
+        request.Parameters["assert_response_path"] = responsePath;
+        await harness.BeginAsync(request);
+
+        await ApproveAsync(harness);
+
+        var completion = harness.StepCompletions().Should().ContainSingle().Subject;
+        completion.Success.Should().Be(expectedSuccess);
+        if (expectedSuccess)
+            completion.Error.Should().BeEmpty();
+        else
+            completion.Error.Should().Contain("assertion failed");
+    }
+
+    [Fact]
+    public async Task ApprovedPassThroughInput_ShouldPublishOriginalInput()
+    {
+        var connector = new RecordingConnector(
+            new ConnectorResponse { Success = true, Output = "{\"valid\":true}" });
+        var harness = await ApprovalHarness.CreateAsync(connector: connector);
+        var request = harness.CreateRequest(
+            "execution-alpha",
+            ApprovalHarness.IdempotencyKey,
+            ApprovalHarness.RawPayload,
+            "POST",
+            "/resources/alpha");
+        request.Parameters["assert_response_path"] = "valid";
+        request.Parameters["pass_through_input"] = "true";
+        await harness.BeginAsync(request);
+
+        await ApproveAsync(harness);
+
+        harness.StepCompletions().Should().ContainSingle().Which.Output.Should().Be(ApprovalHarness.RawPayload);
+    }
+
+    [Fact]
+    public async Task ConnectorCompletionWithRevokedMaterial_ShouldPersistFailure()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+        var materialReference = harness.Coordination().MaterialReference.Clone();
+        await RevokeAsync(harness, materialReference);
+
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be("approval_material_unavailable");
+        harness.Coordination().Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.Failed);
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ApprovedConnectorTimeout_ShouldPersistTerminalFailure()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+
+        await harness.FireAsync(harness.LatestConnectorTimeoutCallback());
+
+        var completion = harness.StepCompletions().Should().ContainSingle().Subject;
+        completion.Success.Should().BeFalse();
+        completion.Error.Should().Contain("timed out");
+        completion.Annotations["connector.timeout_fired"].Should().Be("true");
+        harness.Coordination().Snapshot.ExecutionReasonCode.Should().Be("connector_timeout");
+        harness.State().PendingByOperationId.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ApprovedConnectorTimeoutWithRetry_ShouldReuseLogicalIdempotencyKey()
+    {
+        var connector = new RecordingConnector(
+            new ConnectorResponse { Success = true, Output = "first" },
+            new ConnectorResponse { Success = true, Output = "second" });
+        var harness = await ApprovalHarness.CreateAsync(connector: connector, retry: 1);
+        await harness.BeginAsync();
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+
+        await harness.FireAsync(harness.LatestConnectorTimeoutCallback());
+
+        connector.Requests.Should().HaveCount(2);
+        connector.Requests.Select(static request => request.IdempotencyKey)
+            .Should().OnlyContain(key => key == ApprovalHarness.IdempotencyKey);
+        harness.Coordination().CurrentAttempt.Should().Be(2);
+        harness.Coordination().Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.Executing);
+    }
+
+    [Fact]
+    public async Task UndispatchedApprovedTimeout_ShouldRedriveTheSameAttempt()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        await ApproveAsync(harness, drainConnectorCompletions: false);
+        var timeout = harness.LatestConnectorTimeoutCallback();
+        var state = harness.State();
+        state.PendingByOperationId.Values.Single().RequestDispatched = false;
+        await harness.SaveStateAsync(state);
+
+        await harness.FireAsync(timeout);
+
+        harness.Connector.Requests.Should().HaveCount(2);
+        harness.Connector.Requests.Select(static request => request.IdempotencyKey)
+            .Should().OnlyContain(key => key == ApprovalHarness.IdempotencyKey);
+        harness.Coordination().CurrentAttempt.Should().Be(1);
+    }
+
+    private static async Task ApproveAsync(
+        ApprovalHarness harness,
+        bool drainConnectorCompletions = true)
+    {
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+        if (drainConnectorCompletions)
+            await harness.DrainConnectorCompletionsAsync();
+    }
+
+    private static Task<RevokeRuntimeSecretResult> RevokeAsync(
+        ApprovalHarness harness,
+        RuntimeSecretReference reference) =>
+        harness.SecretStore.RevokeAsync(new RevokeRuntimeSecretRequest(
+            reference.Ref,
+            reference.Purpose,
+            reference.OwnerRunId,
+            reference.OwnerStepId,
+            "connector-approval-coverage-test"));
+}

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleApprovalTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleApprovalTests.cs
@@ -557,7 +557,7 @@ public sealed class ConnectorCallModuleApprovalTests
         resolved.Resolved.Should().BeFalse();
     }
 
-    private static EventEnvelope Envelope(IMessage evt) =>
+    internal static EventEnvelope Envelope(IMessage evt) =>
         new()
         {
             Id = Guid.NewGuid().ToString("N"),
@@ -566,7 +566,7 @@ public sealed class ConnectorCallModuleApprovalTests
             Route = EnvelopeRouteSemantics.CreateTopologyPublication("test", TopologyAudience.Self),
         };
 
-    private sealed class ApprovalHarness
+    internal sealed class ApprovalHarness
     {
         public const string RunId = "run-approval";
         public const string StepId = "connector-approval";
@@ -586,6 +586,7 @@ public sealed class ConnectorCallModuleApprovalTests
         {
             Agent = agent;
             Connector = connector;
+            ConnectorResolver = new MutableConnectorResolver(connector);
             ApprovalPort = approvalPort;
             SecretStore = secretStore;
             ConfigurePort = configurePort;
@@ -599,13 +600,14 @@ public sealed class ConnectorCallModuleApprovalTests
         public TestAgent Agent { get; }
         public RecordingConnector Connector { get; }
         public RecordingApprovalPort ApprovalPort { get; }
+        public MutableConnectorResolver ConnectorResolver { get; }
         public IRuntimeSecretStore SecretStore { get; }
-        public RecordingLogger Logger { get; }
-        public IServiceProvider Services { get; }
+        private RecordingLogger Logger { get; }
+        private IServiceProvider Services { get; }
         public DateTimeOffset RemoteExpiresAt { get; } = Now.AddMinutes(2);
         public TestEventHandlerContext Context { get; private set; }
         public ConnectorCallModule Module { get; private set; }
-        private bool ConfigurePort { get; }
+        private bool ConfigurePort { get; set; }
         private int Retry { get; }
 
         public static async Task<ApprovalHarness> CreateAsync(
@@ -641,14 +643,17 @@ public sealed class ConnectorCallModuleApprovalTests
             return harness;
         }
 
-        public async Task BeginAsync(
+        public Task BeginAsync(
             string executionId = "execution-alpha",
             string idempotencyKey = IdempotencyKey,
             string input = RawPayload,
             string httpVerb = "POST",
             string resource = "/resources/alpha") =>
-            await Module.HandleAsync(
-                Envelope(CreateRequest(executionId, idempotencyKey, input, httpVerb, resource)),
+            BeginAsync(CreateRequest(executionId, idempotencyKey, input, httpVerb, resource));
+
+        public Task BeginAsync(StepRequestEvent request) =>
+            Module.HandleAsync(
+                Envelope(request),
                 Context,
                 CancellationToken.None);
 
@@ -693,8 +698,10 @@ public sealed class ConnectorCallModuleApprovalTests
             }
         }
 
-        public void RecreateModuleAndContext()
+        public void RecreateModuleAndContext(bool? configurePort = null)
         {
+            if (configurePort.HasValue)
+                ConfigurePort = configurePort.Value;
             Context = NewContext();
             Module = NewModule();
         }
@@ -720,6 +727,10 @@ public sealed class ConnectorCallModuleApprovalTests
             Context.Scheduled.Last(callback =>
                 callback.Event is WorkflowConnectorApprovalStatusCheckFiredEvent);
 
+        public ScheduledCallback LatestConnectorTimeoutCallback() =>
+            Context.Scheduled.Last(callback =>
+                callback.Event is WorkflowConnectorTimeoutFiredEvent);
+
         public IReadOnlyList<StepCompletedEvent> StepCompletions() =>
             Context.Published.Select(static published => published.evt).OfType<StepCompletedEvent>().ToList();
 
@@ -728,10 +739,10 @@ public sealed class ConnectorCallModuleApprovalTests
 
         private ConnectorCallModule NewModule() =>
             new(
-                new FixedConnectorResolver(Connector),
+                ConnectorResolver,
                 remoteToolApprovalPort: ConfigurePort ? ApprovalPort : null);
 
-        private StepRequestEvent CreateRequest(
+        public StepRequestEvent CreateRequest(
             string executionId,
             string idempotencyKey,
             string input,
@@ -777,20 +788,26 @@ public sealed class ConnectorCallModuleApprovalTests
             };
     }
 
-    private sealed class FixedConnectorResolver(IConnector connector) : IWorkflowConnectorResolver
+    internal sealed class MutableConnectorResolver(IConnector connector) : IWorkflowConnectorResolver
     {
+        public IConnector? Connector { get; set; } = connector;
+        public Queue<IConnector?> Resolutions { get; } = [];
+
         public ValueTask<IConnector?> ResolveAsync(
             IWorkflowExecutionContext context,
             string connectorName,
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            var resolved = Resolutions.Count > 0 ? Resolutions.Dequeue() : Connector;
             return ValueTask.FromResult<IConnector?>(
-                string.Equals(connector.Name, connectorName, StringComparison.Ordinal) ? connector : null);
+                resolved != null && string.Equals(resolved.Name, connectorName, StringComparison.Ordinal)
+                    ? resolved
+                    : null);
         }
     }
 
-    private sealed class RecordingConnector(params ConnectorResponse[] responses) : IConnector
+    internal sealed class RecordingConnector(params ConnectorResponse[] responses) : IConnector
     {
         private readonly Queue<ConnectorResponse> _responses = new(responses);
 
@@ -808,7 +825,7 @@ public sealed class ConnectorCallModuleApprovalTests
         }
     }
 
-    private sealed class RecordingApprovalPort : IRemoteToolApprovalPort
+    internal sealed class RecordingApprovalPort : IRemoteToolApprovalPort
     {
         public RemoteToolApprovalSubmission Submission { get; set; } = new("remote", ApprovalHarness.Now.AddMinutes(1));
         public RemoteToolApprovalStatusSnapshot NextStatus { get; set; } = new(
@@ -873,11 +890,13 @@ public sealed class ConnectorCallModuleApprovalTests
         }
     }
 
-    private sealed class TamperingRuntimeSecretStore : IRuntimeSecretStore
+    internal sealed class TamperingRuntimeSecretStore : IRuntimeSecretStore
     {
         private readonly InMemoryRuntimeSecretStore _inner = new();
+        private int _materialResolveCount;
 
         public bool TamperConnectorMaterialOnResolve { get; set; }
+        public int? TamperConnectorMaterialOnResolveNumber { get; set; }
 
         public Task<StoreRuntimeSecretResult> PutAsync(
             StoreRuntimeSecretRequest request,
@@ -889,10 +908,16 @@ public sealed class ConnectorCallModuleApprovalTests
             CancellationToken ct = default)
         {
             var result = await _inner.ResolveAsync(request, ct);
-            if (!TamperConnectorMaterialOnResolve ||
-                request.Purpose != CredentialSecretPurposes.WorkflowConnectorExternalActionMaterial ||
+            if (request.Purpose != CredentialSecretPurposes.WorkflowConnectorExternalActionMaterial ||
                 !result.Resolved ||
                 string.IsNullOrWhiteSpace(result.Secret))
+            {
+                return result;
+            }
+
+            _materialResolveCount++;
+            if (!TamperConnectorMaterialOnResolve &&
+                TamperConnectorMaterialOnResolveNumber != _materialResolveCount)
             {
                 return result;
             }

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleApprovalTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleApprovalTests.cs
@@ -1,0 +1,918 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Credentials.Testing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Credentials;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Modules;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "ConnectorCallApproval")]
+public sealed class ConnectorCallModuleApprovalTests
+{
+    [Fact]
+    public async Task ApprovedAction_ShouldBindExecutePersistAndRevokeWithoutLeakingMaterial()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+
+        await harness.BeginAsync();
+
+        var waiting = harness.Coordination();
+        var materialReference = waiting.MaterialReference.Clone();
+        waiting.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.WaitingApproval);
+        waiting.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Pending);
+        waiting.Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.NotStarted);
+        waiting.StatusCheckLease.Should().NotBeNull();
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.ApprovalPort.Submissions.Should().ContainSingle();
+        var remoteRequest = harness.ApprovalPort.Submissions.Single();
+        remoteRequest.RequestId.Should().Be(waiting.Snapshot.Plan.ActionId);
+        remoteRequest.ToolCallId.Should().Be(waiting.Snapshot.Plan.ActionId);
+        remoteRequest.ArgumentsJson.Should().Contain("service-alpha");
+        remoteRequest.ArgumentsJson.Should().Contain("node-alpha");
+        remoteRequest.ArgumentsJson.Should().Contain(waiting.Snapshot.Plan.MaterialDigestSha256);
+        remoteRequest.ArgumentsJson.Should().NotContain(ApprovalHarness.RawPayload);
+        remoteRequest.ArgumentsJson.Should().NotContain(ApprovalHarness.RawParameter);
+        remoteRequest.ArgumentsJson.Should().NotContain(ApprovalHarness.BearerToken);
+
+        var originalCallback = harness.LatestApprovalStatusCallback();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+        await harness.FireAsync(originalCallback);
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.Connector.Requests.Should().ContainSingle();
+        var connectorRequest = harness.Connector.Requests.Single();
+        connectorRequest.Payload.Should().Be(ApprovalHarness.RawPayload);
+        connectorRequest.Parameters["api_secret"].Should().Be(ApprovalHarness.RawParameter);
+        connectorRequest.IdempotencyKey.Should().Be(ApprovalHarness.IdempotencyKey);
+        connectorRequest.HttpAuthorization.Should().Be($"Bearer {ApprovalHarness.BearerToken}");
+
+        var completed = harness.StepCompletions().Should().ContainSingle().Subject;
+        completed.Success.Should().BeTrue();
+        completed.Output.Should().Be("connector-ok");
+        completed.Annotations["connector.approval.action_id"].Should().Be(waiting.Snapshot.Plan.ActionId);
+        var terminal = harness.Coordination();
+        terminal.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Approved);
+        terminal.Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.Succeeded);
+        terminal.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+        terminal.MaterialReference.Should().BeNull();
+        terminal.StepCompletionPublished.Should().BeTrue();
+        harness.State().PendingByOperationId.Should().BeEmpty();
+        await AssertReferenceRevokedAsync(harness.SecretStore, materialReference);
+
+        await harness.FireAsync(originalCallback);
+        await harness.DrainConnectorCompletionsAsync();
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.StepCompletions().Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task PendingApproval_ShouldResumeAfterContextAndModuleRecreation()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Pending,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.Coordination().StatusCheckCount.Should().Be(2);
+        var resumedCallback = harness.LatestApprovalStatusCallback();
+        harness.RecreateModuleAndContext();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+        await harness.FireAsync(resumedCallback);
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.ApprovalPort.Submissions.Should().ContainSingle();
+        harness.ApprovalPort.StatusQueries.Should().HaveCount(2);
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.Coordination().Snapshot.LifecycleStatus
+            .Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task UndispatchedExecutingState_ShouldReplayWithTheSameLogicalIdempotencyKey()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        var state = harness.State();
+        var pending = state.PendingByOperationId.Values.Should().ContainSingle().Subject;
+        pending.RequestDispatched.Should().BeTrue();
+        pending.RequestDispatched = false;
+        await harness.SaveStateAsync(state);
+        harness.RecreateModuleAndContext();
+
+        await harness.BeginAsync();
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.Connector.Requests.Should().HaveCount(2);
+        harness.Connector.Requests.Select(static request => request.IdempotencyKey)
+            .Should().OnlyContain(key => key == ApprovalHarness.IdempotencyKey);
+        harness.StepCompletions().Should().ContainSingle().Which.Output.Should().Be("connector-ok");
+        harness.Coordination().Snapshot.LifecycleStatus
+            .Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task PersistedSuccessfulOutcome_ShouldRecoverExactCompletionAfterPublicationFailure()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+        harness.Context.OnPublish = static (evt, _) =>
+        {
+            if (evt is StepCompletedEvent)
+                throw new InvalidOperationException("simulated publication failure");
+        };
+
+        var drain = harness.DrainConnectorCompletionsAsync;
+        await drain.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("simulated publication failure");
+
+        var persisted = harness.Coordination();
+        persisted.Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.Succeeded);
+        persisted.StepCompletionPublished.Should().BeFalse();
+        var materialReference = persisted.MaterialReference.Clone();
+        var completionReference = persisted.CompletionReference.Clone();
+        harness.RecreateModuleAndContext();
+
+        await harness.BeginAsync();
+
+        var completion = harness.StepCompletions().Should().ContainSingle().Subject;
+        completion.Success.Should().BeTrue();
+        completion.Output.Should().Be("connector-ok");
+        harness.Coordination().StepCompletionPublished.Should().BeTrue();
+        harness.Coordination().MaterialReference.Should().BeNull();
+        harness.Coordination().CompletionReference.Should().BeNull();
+        harness.State().PendingByOperationId.Should().BeEmpty();
+        await AssertReferenceRevokedAsync(harness.SecretStore, materialReference);
+        await AssertReferenceRevokedAsync(harness.SecretStore, completionReference);
+    }
+
+    [Theory]
+    [InlineData("GET", "/resources/alpha")]
+    [InlineData("POST", "/resources/beta")]
+    public async Task HttpApprovalPlanMismatch_ShouldFailBeforeRemoteSubmission(
+        string approvedVerb,
+        string approvedResource)
+    {
+        var connector = new RecordingConnector(
+            new ConnectorResponse { Success = true, Output = "connector-ok" })
+        {
+            Type = "http",
+        };
+        var harness = await ApprovalHarness.CreateAsync(connector: connector);
+
+        await harness.BeginAsync(httpVerb: approvedVerb, resource: approvedResource);
+
+        harness.ApprovalPort.Submissions.Should().BeEmpty();
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.State().ApprovalsByActionId.Should().BeEmpty();
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(
+        RemoteToolApprovalStatus.Rejected,
+        WorkflowExternalActionApprovalStatus.Denied,
+        WorkflowExternalActionLifecycleStatus.Denied,
+        "approval_denied")]
+    [InlineData(
+        RemoteToolApprovalStatus.Expired,
+        WorkflowExternalActionApprovalStatus.Expired,
+        WorkflowExternalActionLifecycleStatus.Expired,
+        "approval_expired")]
+    [InlineData(
+        RemoteToolApprovalStatus.Cancelled,
+        WorkflowExternalActionApprovalStatus.Cancelled,
+        WorkflowExternalActionLifecycleStatus.Cancelled,
+        "approval_cancelled")]
+    public async Task TerminalApprovalDecision_ShouldNeverExecuteConnector(
+        RemoteToolApprovalStatus remoteStatus,
+        WorkflowExternalActionApprovalStatus approvalStatus,
+        WorkflowExternalActionLifecycleStatus lifecycleStatus,
+        string reasonCode)
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var reference = harness.Coordination().MaterialReference.Clone();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            remoteStatus,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.Connector.Requests.Should().BeEmpty();
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(approvalStatus);
+        coordination.Snapshot.LifecycleStatus.Should().Be(lifecycleStatus);
+        coordination.Snapshot.ApprovalReasonCode.Should().Be(reasonCode);
+        coordination.Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.NotStarted);
+        coordination.MaterialReference.Should().BeNull();
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+        await AssertReferenceRevokedAsync(harness.SecretStore, reference);
+    }
+
+    [Theory]
+    [InlineData("action")]
+    [InlineData("remote")]
+    [InlineData("digest")]
+    [InlineData("principal")]
+    [InlineData("scope")]
+    [InlineData("node")]
+    [InlineData("service")]
+    [InlineData("permission")]
+    public async Task TamperedStatusCallback_ShouldBeIgnoredWithoutRemoteReadOrExecution(string field)
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var callback = harness.LatestApprovalStatusCallback();
+        var fired = ((WorkflowConnectorApprovalStatusCheckFiredEvent)callback.Event).Clone();
+        switch (field)
+        {
+            case "action": fired.ActionId += "-tampered"; break;
+            case "remote": fired.RemoteApprovalId += "-tampered"; break;
+            case "digest": fired.MaterialDigestSha256 = new string('0', 64); break;
+            case "principal": fired.PrincipalSubject += "-tampered"; break;
+            case "scope": fired.ScopeId += "-tampered"; break;
+            case "node": fired.NodeId += "-tampered"; break;
+            case "service": fired.ServiceRef += "-tampered"; break;
+            case "permission": fired.PermissionScope += "-tampered"; break;
+        }
+
+        await harness.FireAsync(callback, fired);
+
+        harness.ApprovalPort.StatusQueries.Should().BeEmpty();
+        harness.Connector.Requests.Should().BeEmpty();
+        harness.Coordination().Snapshot.LifecycleStatus
+            .Should().Be(WorkflowExternalActionLifecycleStatus.WaitingApproval);
+    }
+
+    [Fact]
+    public async Task TamperedProtectedPayload_ShouldFailDigestCheckBeforeConnectorDispatch()
+    {
+        var secretStore = new TamperingRuntimeSecretStore();
+        var harness = await ApprovalHarness.CreateAsync(secretStore: secretStore);
+        await harness.BeginAsync();
+        secretStore.TamperConnectorMaterialOnResolve = true;
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.Connector.Requests.Should().BeEmpty();
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Approved);
+        coordination.Snapshot.ExecutionStatus.Should().Be(WorkflowExternalActionExecutionStatus.Failed);
+        coordination.Snapshot.ExecutionReasonCode.Should().Be("approval_material_digest_mismatch");
+        coordination.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+        coordination.MaterialReference.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RemoteExpiryMismatch_ShouldFailClosedBeforeConnectorDispatch()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt.AddSeconds(1));
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.Connector.Requests.Should().BeEmpty();
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Failed);
+        coordination.Snapshot.ApprovalReasonCode.Should().Be("approval_remote_expiry_mismatch");
+        coordination.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task UnavailableRemoteStatus_ShouldFailClosedWithoutConnectorExecution()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        harness.ApprovalPort.ThrowOnStatus = true;
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.Connector.Requests.Should().BeEmpty();
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Failed);
+        coordination.Snapshot.ApprovalReasonCode.Should().Be("approval_status_unavailable");
+        coordination.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+        coordination.MaterialReference.Should().BeNull();
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ChangedCallerAuthority_ShouldFailClosedBeforeRemoteReadOrConnectorExecution()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        await harness.SetCallerAuthorityAsync("user-beta");
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+
+        harness.ApprovalPort.StatusQueries.Should().BeEmpty();
+        harness.Connector.Requests.Should().BeEmpty();
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Failed);
+        coordination.Snapshot.ApprovalReasonCode.Should().Be("approval_authority_mismatch");
+        coordination.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+    }
+
+    [Fact]
+    public async Task PersistedRemoteBindingWithoutCallbackLease_ShouldRescheduleWithoutResubmission()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var state = harness.State();
+        state.ApprovalsByActionId.Values.Single().StatusCheckLease = null;
+        await harness.SaveStateAsync(state);
+        harness.Context.Scheduled.Clear();
+
+        await harness.BeginAsync();
+
+        harness.ApprovalPort.Submissions.Should().ContainSingle();
+        harness.Context.Scheduled.Should().ContainSingle();
+        harness.Coordination().StatusCheckLease.Should().NotBeNull();
+        harness.Connector.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ScheduledCallbackWithoutPersistedLease_ShouldUsePersistedCallbackIdentity()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var callback = harness.LatestApprovalStatusCallback();
+        var state = harness.State();
+        state.ApprovalsByActionId.Values.Single().StatusCheckLease = null;
+        await harness.SaveStateAsync(state);
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(callback);
+        await harness.DrainConnectorCompletionsAsync();
+
+        harness.Connector.Requests.Should().ContainSingle();
+        harness.Coordination().Snapshot.LifecycleStatus
+            .Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task PersistedTerminalWithoutCompletion_ShouldPublishAndRevokeOnRequestRedelivery()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var state = harness.State();
+        var coordination = state.ApprovalsByActionId.Values.Single();
+        var reference = coordination.MaterialReference.Clone();
+        coordination.StatusCheckLease = null;
+        coordination.Snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Denied;
+        coordination.Snapshot.ApprovalReasonCode = "approval_denied";
+        coordination.Snapshot.ApprovalResolvedAt = Timestamp.FromDateTimeOffset(ApprovalHarness.Now);
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Denied;
+        coordination.StepCompletionPublished = false;
+        await harness.SaveStateAsync(state);
+        harness.Context.Published.Clear();
+
+        await harness.BeginAsync();
+
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+        harness.Coordination().StepCompletionPublished.Should().BeTrue();
+        harness.Coordination().MaterialReference.Should().BeNull();
+        await AssertReferenceRevokedAsync(harness.SecretStore, reference);
+    }
+
+    [Fact]
+    public async Task PublishedTerminalWithProtectedMaterial_ShouldRevokeWithoutRepublishing()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var state = harness.State();
+        var coordination = state.ApprovalsByActionId.Values.Single();
+        var reference = coordination.MaterialReference.Clone();
+        coordination.StatusCheckLease = null;
+        coordination.Snapshot.ApprovalStatus = WorkflowExternalActionApprovalStatus.Denied;
+        coordination.Snapshot.ApprovalReasonCode = "approval_denied";
+        coordination.Snapshot.ApprovalResolvedAt = Timestamp.FromDateTimeOffset(ApprovalHarness.Now);
+        coordination.Snapshot.LifecycleStatus = WorkflowExternalActionLifecycleStatus.Denied;
+        coordination.StepCompletionPublished = true;
+        await harness.SaveStateAsync(state);
+        harness.Context.Published.Clear();
+
+        await harness.BeginAsync();
+
+        harness.StepCompletions().Should().BeEmpty();
+        harness.Coordination().MaterialReference.Should().BeNull();
+        await AssertReferenceRevokedAsync(harness.SecretStore, reference);
+    }
+
+    [Fact]
+    public async Task SupersededPlan_ShouldIgnoreDelayedCallbackAndExecuteOnlyReplacement()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var originalCallback = harness.LatestApprovalStatusCallback();
+        var originalState = harness.State();
+        var originalCoordination = originalState.ApprovalsByActionId.Values.Single();
+        var originalReference = originalCoordination.MaterialReference.Clone();
+        var originalActionId = originalCoordination.Snapshot.Plan.ActionId;
+        harness.ApprovalPort.Submission = new RemoteToolApprovalSubmission(
+            "remote-approval-beta",
+            ApprovalHarness.Now.AddMinutes(2));
+
+        await harness.BeginAsync(
+            executionId: "execution-beta",
+            idempotencyKey: "connector-idempotency-beta",
+            input: "replacement-payload");
+
+        var superseded = harness.State().ApprovalsByActionId[originalActionId];
+        superseded.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Cancelled);
+        superseded.MaterialReference.Should().BeNull();
+        await AssertReferenceRevokedAsync(harness.SecretStore, originalReference);
+
+        await harness.FireAsync(originalCallback);
+        harness.ApprovalPort.StatusQueries.Should().BeEmpty();
+        harness.Connector.Requests.Should().BeEmpty();
+
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+        await harness.DrainConnectorCompletionsAsync();
+
+        var connectorRequest = harness.Connector.Requests.Should().ContainSingle().Subject;
+        connectorRequest.IdempotencyKey.Should().Be("connector-idempotency-beta");
+        connectorRequest.Payload.Should().Be("replacement-payload");
+    }
+
+    [Fact]
+    public async Task ApprovedPhysicalRetry_ShouldReuseStableIdempotencyKey()
+    {
+        var connector = new RecordingConnector(
+            new ConnectorResponse { Success = false, Error = "transient" },
+            new ConnectorResponse { Success = true, Output = "retried-ok" });
+        var harness = await ApprovalHarness.CreateAsync(connector: connector, retry: 1);
+        await harness.BeginAsync();
+        harness.ApprovalPort.NextStatus = new RemoteToolApprovalStatusSnapshot(
+            RemoteToolApprovalStatus.Approved,
+            ExpiresAt: harness.RemoteExpiresAt);
+
+        await harness.FireAsync(harness.LatestApprovalStatusCallback());
+        await harness.DrainConnectorCompletionsAsync();
+
+        connector.Requests.Should().HaveCount(2);
+        connector.Requests.Select(static request => request.IdempotencyKey)
+            .Should().OnlyContain(key => key == ApprovalHarness.IdempotencyKey);
+        harness.StepCompletions().Should().ContainSingle().Which.Output.Should().Be("retried-ok");
+        harness.Coordination().Snapshot.ExecutionStatus
+            .Should().Be(WorkflowExternalActionExecutionStatus.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UnavailableApprovalPath_ShouldFailClosedWithoutConnectorExecution(bool throwOnSubmit)
+    {
+        var harness = await ApprovalHarness.CreateAsync(
+            configurePort: throwOnSubmit,
+            throwOnSubmit: throwOnSubmit);
+
+        await harness.BeginAsync();
+
+        harness.Connector.Requests.Should().BeEmpty();
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Failed);
+        coordination.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Failed);
+        coordination.Snapshot.ApprovalReasonCode.Should().Be(
+            throwOnSubmit ? "approval_submission_indeterminate" : "approval_path_unavailable");
+        coordination.MaterialReference.Should().BeNull();
+        harness.StepCompletions().Should().ContainSingle().Which.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunTermination_ShouldCancelPendingApprovalAndRevokeMaterial()
+    {
+        var harness = await ApprovalHarness.CreateAsync();
+        await harness.BeginAsync();
+        var reference = harness.Coordination().MaterialReference.Clone();
+
+        await harness.Module.HandleAsync(
+            Envelope(new WorkflowRunStoppedEvent
+            {
+                RunId = ApprovalHarness.RunId,
+                Reason = "cancelled",
+            }),
+            harness.Context,
+            CancellationToken.None);
+
+        var coordination = harness.Coordination();
+        coordination.Snapshot.ApprovalStatus.Should().Be(WorkflowExternalActionApprovalStatus.Cancelled);
+        coordination.Snapshot.LifecycleStatus.Should().Be(WorkflowExternalActionLifecycleStatus.Cancelled);
+        coordination.MaterialReference.Should().BeNull();
+        coordination.StepCompletionPublished.Should().BeTrue();
+        harness.Connector.Requests.Should().BeEmpty();
+        await AssertReferenceRevokedAsync(harness.SecretStore, reference);
+    }
+
+    private static async Task AssertReferenceRevokedAsync(
+        IRuntimeSecretStore secretStore,
+        RuntimeSecretReference reference)
+    {
+        var resolved = await secretStore.ResolveAsync(new ResolveRuntimeSecretRequest(
+            reference.Ref,
+            reference.Purpose,
+            reference.OwnerRunId,
+            reference.OwnerStepId,
+            "test-verify-revoked"));
+        resolved.Resolved.Should().BeFalse();
+    }
+
+    private static EventEnvelope Envelope(IMessage evt) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(ApprovalHarness.Now),
+            Payload = Any.Pack(evt),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication("test", TopologyAudience.Self),
+        };
+
+    private sealed class ApprovalHarness
+    {
+        public const string RunId = "run-approval";
+        public const string StepId = "connector-approval";
+        public const string IdempotencyKey = "connector-idempotency-alpha";
+        public const string BearerToken = "nyx-bearer-secret";
+        public const string RawPayload = "raw-payload-secret";
+        public const string RawParameter = "parameter-secret";
+        public static readonly DateTimeOffset Now = new(2026, 7, 17, 8, 0, 0, TimeSpan.Zero);
+
+        private ApprovalHarness(
+            TestAgent agent,
+            RecordingConnector connector,
+            RecordingApprovalPort approvalPort,
+            IRuntimeSecretStore secretStore,
+            bool configurePort,
+            int retry)
+        {
+            Agent = agent;
+            Connector = connector;
+            ApprovalPort = approvalPort;
+            SecretStore = secretStore;
+            ConfigurePort = configurePort;
+            Retry = retry;
+            Logger = new RecordingLogger();
+            Services = new ServiceCollection().BuildServiceProvider();
+            Context = NewContext();
+            Module = NewModule();
+        }
+
+        public TestAgent Agent { get; }
+        public RecordingConnector Connector { get; }
+        public RecordingApprovalPort ApprovalPort { get; }
+        public IRuntimeSecretStore SecretStore { get; }
+        public RecordingLogger Logger { get; }
+        public IServiceProvider Services { get; }
+        public DateTimeOffset RemoteExpiresAt { get; } = Now.AddMinutes(2);
+        public TestEventHandlerContext Context { get; private set; }
+        public ConnectorCallModule Module { get; private set; }
+        private bool ConfigurePort { get; }
+        private int Retry { get; }
+
+        public static async Task<ApprovalHarness> CreateAsync(
+            RecordingConnector? connector = null,
+            IRuntimeSecretStore? secretStore = null,
+            bool configurePort = true,
+            bool throwOnSubmit = false,
+            int retry = 0)
+        {
+            secretStore ??= new InMemoryRuntimeSecretStore();
+            connector ??= new RecordingConnector(
+                new ConnectorResponse { Success = true, Output = "connector-ok" });
+            var approvalPort = new RecordingApprovalPort
+            {
+                Submission = new RemoteToolApprovalSubmission("remote-approval-alpha", Now.AddMinutes(2)),
+                ThrowOnSubmit = throwOnSubmit,
+            };
+            var agent = new TestAgent("workflow-actor-alpha", RunId, "scope-alpha", secretStore);
+            var harness = new ApprovalHarness(agent, connector, approvalPort, secretStore, configurePort, retry);
+            await WorkflowCallerCredentialRuntimeContextAccess.SetCredentialAsync(
+                agent,
+                new WorkflowCallerCredential
+                {
+                    BearerToken = BearerToken,
+                    NyxIdAuthority = new WorkflowCallerNyxIdAuthority
+                    {
+                        Platform = "nyxid",
+                        Tenant = "tenant-alpha",
+                        ExternalUserId = "user-alpha",
+                        Scope = "proxy",
+                    },
+                });
+            return harness;
+        }
+
+        public async Task BeginAsync(
+            string executionId = "execution-alpha",
+            string idempotencyKey = IdempotencyKey,
+            string input = RawPayload,
+            string httpVerb = "POST",
+            string resource = "/resources/alpha") =>
+            await Module.HandleAsync(
+                Envelope(CreateRequest(executionId, idempotencyKey, input, httpVerb, resource)),
+                Context,
+                CancellationToken.None);
+
+        public Task SaveStateAsync(ConnectorCallModuleState state) =>
+            Context.SaveStateAsync("connector_call", state, CancellationToken.None);
+
+        public Task SetCallerAuthorityAsync(string externalUserId) =>
+            WorkflowCallerCredentialRuntimeContextAccess.SetCredentialAsync(
+                Agent,
+                new WorkflowCallerCredential
+                {
+                    BearerToken = BearerToken,
+                    NyxIdAuthority = new WorkflowCallerNyxIdAuthority
+                    {
+                        Platform = "nyxid",
+                        Tenant = "tenant-alpha",
+                        ExternalUserId = externalUserId,
+                        Scope = "proxy",
+                    },
+                });
+
+        public async Task FireAsync(ScheduledCallback callback, IMessage? replacement = null)
+        {
+            var envelope = Context.CreateScheduledEnvelope(callback);
+            if (replacement != null)
+                envelope.Payload = Any.Pack(replacement);
+            await Module.HandleAsync(envelope, Context, CancellationToken.None);
+        }
+
+        public async Task DrainConnectorCompletionsAsync()
+        {
+            while (true)
+            {
+                var index = Context.Published.FindIndex(static published =>
+                    published.evt is WorkflowConnectorAttemptCompletedEvent);
+                if (index < 0)
+                    return;
+
+                var completed = (WorkflowConnectorAttemptCompletedEvent)Context.Published[index].evt;
+                Context.Published.RemoveAt(index);
+                await Module.HandleAsync(Envelope(completed), Context, CancellationToken.None);
+            }
+        }
+
+        public void RecreateModuleAndContext()
+        {
+            Context = NewContext();
+            Module = NewModule();
+        }
+
+        public ConnectorCallModuleState State() =>
+            Context.LoadState<ConnectorCallModuleState>("connector_call");
+
+        public ConnectorApprovalCoordinationState Coordination()
+        {
+            var state = State();
+            state.ApprovalsByActionId.Values.Should().ContainSingle(
+                "logs={0}; pending={1}; connector_requests={2}; published={3}",
+                string.Join(" | ", Logger.Messages),
+                state.PendingByOperationId.Count,
+                Connector.Requests.Count,
+                string.Join(",", Context.Published.Select(static item => item.evt is StepCompletedEvent completed
+                    ? $"{StepCompletedEvent.Descriptor.Name}:{completed.Error}"
+                    : item.evt.Descriptor.Name)));
+            return state.ApprovalsByActionId.Values.Single();
+        }
+
+        public ScheduledCallback LatestApprovalStatusCallback() =>
+            Context.Scheduled.Last(callback =>
+                callback.Event is WorkflowConnectorApprovalStatusCheckFiredEvent);
+
+        public IReadOnlyList<StepCompletedEvent> StepCompletions() =>
+            Context.Published.Select(static published => published.evt).OfType<StepCompletedEvent>().ToList();
+
+        private TestEventHandlerContext NewContext() =>
+            new(Services, Agent, Logger) { UtcNow = Now };
+
+        private ConnectorCallModule NewModule() =>
+            new(
+                new FixedConnectorResolver(Connector),
+                remoteToolApprovalPort: ConfigurePort ? ApprovalPort : null);
+
+        private StepRequestEvent CreateRequest(
+            string executionId,
+            string idempotencyKey,
+            string input,
+            string httpVerb,
+            string resource) =>
+            new()
+            {
+                StepId = StepId,
+                StepType = "connector_call",
+                RunId = RunId,
+                ExecutionId = executionId,
+                IdempotencyKey = idempotencyKey,
+                Input = input,
+                StepParameters = new WorkflowStepParameters
+                {
+                    Parameters =
+                    {
+                        ["connector"] = Connector.Name,
+                        ["operation"] = "create_resource",
+                        ["method"] = "POST",
+                        ["path"] = "/resources/alpha",
+                        ["api_secret"] = RawParameter,
+                        ["retry"] = Retry.ToString(),
+                    },
+                    ConnectorApproval = new WorkflowConnectorApprovalOptions
+                    {
+                        Policy = WorkflowExternalActionApprovalPolicy.Required,
+                        ServiceRef = "service-alpha",
+                        NodeId = "node-alpha",
+                        HttpVerb = httpVerb,
+                        Resource = resource,
+                        PermissionScope = "resources.write",
+                        ExpirationSeconds = 300,
+                        StatusCheckIntervalSeconds = 2,
+                        Destructive = true,
+                        TeamId = "team-alpha",
+                        MemberId = "member-alpha",
+                        WorkflowId = "workflow-alpha",
+                        PublishedServiceId = "published-service-alpha",
+                        PolicyReason = "external-write",
+                    },
+                },
+            };
+    }
+
+    private sealed class FixedConnectorResolver(IConnector connector) : IWorkflowConnectorResolver
+    {
+        public ValueTask<IConnector?> ResolveAsync(
+            IWorkflowExecutionContext context,
+            string connectorName,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return ValueTask.FromResult<IConnector?>(
+                string.Equals(connector.Name, connectorName, StringComparison.Ordinal) ? connector : null);
+        }
+    }
+
+    private sealed class RecordingConnector(params ConnectorResponse[] responses) : IConnector
+    {
+        private readonly Queue<ConnectorResponse> _responses = new(responses);
+
+        public string Name => "connector-alpha";
+        public string Type { get; init; } = "test";
+        public List<ConnectorRequest> Requests { get; } = [];
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(_responses.Count == 0
+                ? new ConnectorResponse { Success = true, Output = "connector-ok" }
+                : _responses.Dequeue());
+        }
+    }
+
+    private sealed class RecordingApprovalPort : IRemoteToolApprovalPort
+    {
+        public RemoteToolApprovalSubmission Submission { get; set; } = new("remote", ApprovalHarness.Now.AddMinutes(1));
+        public RemoteToolApprovalStatusSnapshot NextStatus { get; set; } = new(
+            RemoteToolApprovalStatus.Pending,
+            ExpiresAt: ApprovalHarness.Now.AddMinutes(2));
+        public bool ThrowOnSubmit { get; init; }
+        public bool ThrowOnStatus { get; set; }
+        public List<RemoteToolApprovalRequest> Submissions { get; } = [];
+        public List<RemoteToolApprovalStatusQuery> StatusQueries { get; } = [];
+
+        public Task<RemoteToolApprovalSubmission> SubmitAsync(
+            RemoteToolApprovalRequest request,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            AgentToolRequestContext.NyxIdAccessToken.Should().Be(ApprovalHarness.BearerToken);
+            Submissions.Add(request);
+            return ThrowOnSubmit
+                ? Task.FromException<RemoteToolApprovalSubmission>(new HttpRequestException("unavailable"))
+                : Task.FromResult(Submission);
+        }
+
+        public Task<RemoteToolApprovalStatusSnapshot> GetStatusAsync(
+            RemoteToolApprovalStatusQuery query,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            AgentToolRequestContext.NyxIdAccessToken.Should().Be(ApprovalHarness.BearerToken);
+            StatusQueries.Add(query);
+            return ThrowOnStatus
+                ? Task.FromException<RemoteToolApprovalStatusSnapshot>(new HttpRequestException("unavailable"))
+                : Task.FromResult(NextStatus);
+        }
+
+        public Task<RemoteToolApprovalDecisionResult> DecideAsync(
+            RemoteToolApprovalDecision decision,
+            CancellationToken ct) =>
+            Task.FromResult(new RemoteToolApprovalDecisionResult(true));
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull =>
+            null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var message = formatter(state, exception);
+            if (exception != null)
+                message += $" exception={exception.GetType().Name}: {exception.Message}";
+            Messages.Add(message);
+        }
+    }
+
+    private sealed class TamperingRuntimeSecretStore : IRuntimeSecretStore
+    {
+        private readonly InMemoryRuntimeSecretStore _inner = new();
+
+        public bool TamperConnectorMaterialOnResolve { get; set; }
+
+        public Task<StoreRuntimeSecretResult> PutAsync(
+            StoreRuntimeSecretRequest request,
+            CancellationToken ct = default) =>
+            _inner.PutAsync(request, ct);
+
+        public async Task<ResolveRuntimeSecretResult> ResolveAsync(
+            ResolveRuntimeSecretRequest request,
+            CancellationToken ct = default)
+        {
+            var result = await _inner.ResolveAsync(request, ct);
+            if (!TamperConnectorMaterialOnResolve ||
+                request.Purpose != CredentialSecretPurposes.WorkflowConnectorExternalActionMaterial ||
+                !result.Resolved ||
+                string.IsNullOrWhiteSpace(result.Secret))
+            {
+                return result;
+            }
+
+            var material = ConnectorCallProtectedMaterial.Parser.ParseFrom(
+                Convert.FromBase64String(result.Secret));
+            material.Payload += "-tampered";
+            return new ResolveRuntimeSecretResult(
+                result.Reference,
+                Convert.ToBase64String(material.ToByteArray()));
+        }
+
+        public Task<ConsumeRuntimeSecretResult> ConsumeAsync(
+            ConsumeRuntimeSecretRequest request,
+            CancellationToken ct = default) =>
+            _inner.ConsumeAsync(request, ct);
+
+        public Task<RevokeRuntimeSecretResult> RevokeAsync(
+            RevokeRuntimeSecretRequest request,
+            CancellationToken ct = default) =>
+            _inner.RevokeAsync(request, ct);
+    }
+}

--- a/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
@@ -41,6 +41,17 @@ internal sealed class TestEventHandlerContext :
     public IServiceProvider Services { get; }
     public ILogger Logger { get; }
     public string RunId => Agent is IWorkflowExecutionStateHost host ? host.RunId : Agent.Id;
+    public string ScopeId => StateHost.ScopeId;
+    public WorkflowCallerNyxIdAuthority? CallerNyxIdAuthority
+    {
+        get
+        {
+            var source = StateHost.ExecutionContextSnapshot.CallerCredential?.NyxIdAuthority;
+            return WorkflowRunExecutionContextStateAccess.TryNormalizeCallerNyxIdAuthority(source, out var authority)
+                ? authority
+                : null;
+        }
+    }
     public WorkflowExecutionRuntimeContext RuntimeContext => Agent is IWorkflowExecutionStateHost host
         ? host.RuntimeContext
         : _fallbackRuntimeContext;
@@ -273,17 +284,23 @@ internal sealed record CanceledCallback(
     public long ExpectedGeneration => Lease.Generation;
 }
 
-internal sealed class TestAgent(string id, string? runId = null) :
+internal sealed class TestAgent(
+    string id,
+    string? runId = null,
+    string? scopeId = null,
+    IRuntimeSecretStore? runtimeSecretStore = null) :
     IAgent,
     IWorkflowExecutionStateHost,
     IRuntimeSecretStoreAccessor
 {
     private readonly Dictionary<string, Any> _executionStates = new(StringComparer.Ordinal);
-    private readonly IRuntimeSecretStore _runtimeSecretStore = new InMemoryRuntimeSecretStore();
+    private readonly IRuntimeSecretStore _runtimeSecretStore = runtimeSecretStore ?? new InMemoryRuntimeSecretStore();
 
     public string Id { get; } = id;
 
     public string RunId { get; } = string.IsNullOrWhiteSpace(runId) ? id : runId;
+
+    public string ScopeId { get; } = string.IsNullOrWhiteSpace(scopeId) ? string.Empty : scopeId.Trim();
 
     public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowConnectorApprovalRedactionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowConnectorApprovalRedactionTests.cs
@@ -1,0 +1,114 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.EventSourcing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core.Execution;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Core.Tests.Execution;
+
+public sealed class WorkflowConnectorApprovalRedactionTests
+{
+    [Fact]
+    public async Task BeforePublishAsync_ShouldRemoveProtectedMaterialReferenceFromEventAndStateRoot()
+    {
+        const string materialReference = "runtime-secret://connector-material-alpha";
+        const string completionReference = "runtime-secret://connector-completion-alpha";
+        var connectorState = CreateConnectorState(materialReference, completionReference);
+        var published = new CommittedStateEventPublished
+        {
+            StateEvent = new StateEvent
+            {
+                EventId = "evt-connector-approval",
+                Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                Version = 7,
+                AgentId = "run-approval",
+                EventType = nameof(WorkflowExecutionStateUpsertedEvent),
+                EventData = Any.Pack(new WorkflowExecutionStateUpsertedEvent
+                {
+                    ScopeKey = "connector_call",
+                    State = Any.Pack(connectorState),
+                }),
+            },
+            StateRoot = Any.Pack(new WorkflowRunState
+            {
+                RunId = "run-approval",
+                ExecutionStates =
+                {
+                    ["connector_call"] = Any.Pack(connectorState),
+                },
+            }),
+        };
+        var hook = new WorkflowRunCommittedStateRedactionHook();
+
+        await hook.BeforePublishAsync(new CommittedStatePublicationContext
+        {
+            ActorId = "run-approval",
+            ActorType = typeof(WorkflowRunGAgent),
+            Published = published,
+        }, CancellationToken.None);
+
+        var upserted = published.StateEvent.EventData.Unpack<WorkflowExecutionStateUpsertedEvent>();
+        var eventState = upserted.State.Unpack<ConnectorCallModuleState>();
+        var eventApproval = eventState.ApprovalsByActionId.Values.Should().ContainSingle().Subject;
+        eventApproval.MaterialReference.Should().BeNull();
+        eventApproval.CompletionReference.Should().BeNull();
+        eventApproval.Snapshot.Plan.ActionId.Should().Be("action-alpha");
+
+        var stateRoot = published.StateRoot.Unpack<WorkflowRunState>();
+        var rootState = stateRoot.ExecutionStates["connector_call"].Unpack<ConnectorCallModuleState>();
+        var rootApproval = rootState.ApprovalsByActionId.Values.Should().ContainSingle().Subject;
+        rootApproval.MaterialReference.Should().BeNull();
+        rootApproval.CompletionReference.Should().BeNull();
+        rootApproval.Snapshot.Plan.Summary.Should().Be("POST /resources/alpha");
+
+        published.ToString().Should().NotContain(materialReference);
+        published.ToString().Should().NotContain(completionReference);
+        published.ToString().Should().NotContain("raw-payload-secret");
+        connectorState.ApprovalsByActionId.Values.Single().MaterialReference.Ref
+            .Should().Be(materialReference);
+    }
+
+    private static ConnectorCallModuleState CreateConnectorState(
+        string materialReference,
+        string completionReference)
+    {
+        var state = new ConnectorCallModuleState();
+        state.ApprovalsByActionId["action-alpha"] = new ConnectorApprovalCoordinationState
+        {
+            Snapshot = new WorkflowExternalActionApprovalSnapshot
+            {
+                Plan = new WorkflowExternalActionPlan
+                {
+                    ActionId = "action-alpha",
+                    Summary = "POST /resources/alpha",
+                    MaterialDigestSha256 = new string('a', 64),
+                    Provenance = new WorkflowExternalActionProvenance
+                    {
+                        RunId = "run-approval",
+                        StepId = "connector-approval",
+                    },
+                },
+                LifecycleStatus = WorkflowExternalActionLifecycleStatus.WaitingApproval,
+                ApprovalStatus = WorkflowExternalActionApprovalStatus.Pending,
+                ExecutionStatus = WorkflowExternalActionExecutionStatus.NotStarted,
+            },
+            MaterialReference = new RuntimeSecretReference
+            {
+                Ref = materialReference,
+                Purpose = CredentialSecretPurposes.WorkflowConnectorExternalActionMaterial,
+                OwnerRunId = "run-approval",
+                OwnerStepId = "connector-approval",
+            },
+            CompletionReference = new RuntimeSecretReference
+            {
+                Ref = completionReference,
+                Purpose = CredentialSecretPurposes.WorkflowConnectorExternalActionCompletion,
+                OwnerRunId = "run-approval",
+                OwnerStepId = "connector-approval",
+            },
+        };
+        return state;
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -174,6 +174,74 @@ public class WorkflowLoopModuleExpressionEvaluationTests
     }
 
     [Fact]
+    public async Task DispatchStep_ShouldEvaluateTypedConnectorApprovalBeforeDispatch()
+    {
+        var workflow = new WorkflowDefinition
+        {
+            Name = "wf",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "connector",
+                    Type = "connector_call",
+                    Parameters = new Dictionary<string, string>
+                    {
+                        ["connector"] = "service_proxy",
+                        ["operation"] = "create_resource",
+                    },
+                    ConnectorApprovalOptions = new ConnectorApprovalOptionsDefinition
+                    {
+                        ServiceRef = "${concat('service-', input)}",
+                        NodeId = "${concat('node-', input)}",
+                        HttpVerb = "post",
+                        Resource = "${concat('/resources/', input)}",
+                        PermissionScope = "resources.write",
+                        ExpirationSeconds = 300,
+                        StatusCheckIntervalSeconds = 3,
+                        Destructive = true,
+                        TeamId = "team-alpha",
+                        MemberId = "member-alpha",
+                        WorkflowId = "workflow-alpha",
+                        PublishedServiceId = "published-service-alpha",
+                        PolicyReason = "external-write",
+                    },
+                },
+            ],
+        };
+        var ctx = new CapturingContext();
+        var module = new WorkflowExecutionKernel(workflow, (IWorkflowExecutionStateHost)ctx.Agent);
+
+        await module.HandleAsync(Wrap(new StartWorkflowEvent
+        {
+            WorkflowName = "wf",
+            RunId = "run-connector-approval",
+            Input = "alpha",
+        }), ctx, CancellationToken.None);
+
+        var request = ctx.Published.Single(x => x.Event is StepRequestEvent).Event
+            .Should().BeOfType<StepRequestEvent>().Subject;
+        request.Parameters.Should().Contain("connector", "service_proxy");
+        request.Parameters.Should().Contain("operation", "create_resource");
+        var approval = request.StepParameters.ConnectorApproval;
+        approval.Policy.Should().Be(WorkflowExternalActionApprovalPolicy.Required);
+        approval.ServiceRef.Should().Be("service-alpha");
+        approval.NodeId.Should().Be("node-alpha");
+        approval.HttpVerb.Should().Be("post");
+        approval.Resource.Should().Be("/resources/alpha");
+        approval.PermissionScope.Should().Be("resources.write");
+        approval.ExpirationSeconds.Should().Be(300);
+        approval.StatusCheckIntervalSeconds.Should().Be(3);
+        approval.Destructive.Should().BeTrue();
+        approval.TeamId.Should().Be("team-alpha");
+        approval.MemberId.Should().Be("member-alpha");
+        approval.WorkflowId.Should().Be("workflow-alpha");
+        approval.PublishedServiceId.Should().Be("published-service-alpha");
+        approval.PolicyReason.Should().Be("external-write");
+    }
+
+    [Fact]
     public async Task DispatchStep_WhenLlmCallOmitsRole_ShouldAssignImplicitAssistantTarget()
     {
         var workflow = new WorkflowDefinition

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConnectorApprovalTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConnectorApprovalTests.cs
@@ -1,0 +1,79 @@
+using Aevatar.Workflow.Core.Primitives;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Core.Tests.Primitives;
+
+public sealed class WorkflowParserConnectorApprovalTests
+{
+    [Theory]
+    [InlineData("connector_call")]
+    [InlineData("secure_connector_call")]
+    public void Parse_WhenConnectorApprovalIsRequired_ShouldLiftTypedOptions(string stepType)
+    {
+        var workflow = new WorkflowParser().Parse(
+            $$"""
+              name: connector_approval
+              roles: []
+              steps:
+                - id: invoke
+                  type: {{stepType}}
+                  parameters:
+                    connector: service_proxy
+                    operation: create_resource
+                    approval.policy: required
+                    approval.service_ref: "${input.service_ref}"
+                    approval.node_id: node-alpha
+                    approval.http_verb: post
+                    approval.resource: /resources/alpha
+                    approval.permission_scope: resources.write
+                    approval.expiration_seconds: 300
+                    approval.status_check_interval_seconds: 3
+                    approval.destructive: true
+                    approval.team_id: team-alpha
+                    approval.member_id: member-alpha
+                    approval.workflow_id: workflow-alpha
+                    approval.published_service_id: published-service-alpha
+                    approval.policy_reason: external-write
+              """);
+
+        var step = workflow.Steps.Should().ContainSingle().Subject;
+        step.ConnectorApprovalOptions.Should().NotBeNull();
+        var approval = step.ConnectorApprovalOptions!;
+        approval.ServiceRef.Should().Be("${input.service_ref}");
+        approval.NodeId.Should().Be("node-alpha");
+        approval.HttpVerb.Should().Be("post");
+        approval.Resource.Should().Be("/resources/alpha");
+        approval.PermissionScope.Should().Be("resources.write");
+        approval.ExpirationSeconds.Should().Be(300);
+        approval.StatusCheckIntervalSeconds.Should().Be(3);
+        approval.Destructive.Should().BeTrue();
+        approval.TeamId.Should().Be("team-alpha");
+        approval.MemberId.Should().Be("member-alpha");
+        approval.WorkflowId.Should().Be("workflow-alpha");
+        approval.PublishedServiceId.Should().Be("published-service-alpha");
+        approval.PolicyReason.Should().Be("external-write");
+        step.Parameters.Should().Contain("connector", "service_proxy");
+    }
+
+    [Theory]
+    [InlineData("connector_call", "optional")]
+    [InlineData("transform", "required")]
+    public void Parse_WhenApprovalIsNotRequiredForConnector_ShouldNotCreateTypedOptions(
+        string stepType,
+        string policy)
+    {
+        var workflow = new WorkflowParser().Parse(
+            $$"""
+              name: connector_without_approval
+              roles: []
+              steps:
+                - id: invoke
+                  type: {{stepType}}
+                  parameters:
+                    approval.policy: {{policy}}
+              """);
+
+        workflow.Steps.Should().ContainSingle()
+            .Which.ConnectorApprovalOptions.Should().BeNull();
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
@@ -7,6 +7,7 @@ using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.Workflow.Projection.ReadModels;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -284,6 +285,104 @@ public sealed class ChatQueryEndpointsTests
         deadLetter.GetProperty("error").GetString().Should().Be("refund provider rejected compensation");
         service.Calls.Should().ContainSingle()
             .Which.Should().Be("GetWorkflowActorCurrentState:run-dead-letter");
+    }
+
+    [Fact]
+    public async Task GetWorkflowActorCurrentStateRoute_ShouldSerializeSafeConnectorApprovalLifecycles()
+    {
+        var lifecycleStatuses = new[]
+        {
+            WorkflowExternalActionLifecycleStatus.WaitingApproval,
+            WorkflowExternalActionLifecycleStatus.Approved,
+            WorkflowExternalActionLifecycleStatus.Denied,
+            WorkflowExternalActionLifecycleStatus.Expired,
+            WorkflowExternalActionLifecycleStatus.Executing,
+            WorkflowExternalActionLifecycleStatus.Succeeded,
+            WorkflowExternalActionLifecycleStatus.Failed,
+        };
+        var snapshot = new WorkflowActorSnapshot
+        {
+            ActorId = "run-connector-approval",
+            WorkflowName = "connector-approval",
+            CompletionStatus = WorkflowRunCompletionStatus.Running,
+            StateVersion = 17,
+        };
+        foreach (var (status, index) in lifecycleStatuses.Select(static (status, index) => (status, index)))
+        {
+            snapshot.ConnectorApprovals.Add(new WorkflowExternalActionApprovalSnapshot
+            {
+                Plan = new WorkflowExternalActionPlan
+                {
+                    ActionId = $"action-{index}",
+                    IdempotencyKey = $"private-idempotency-{index}",
+                    MaterialDigestSha256 = new string('a', 64),
+                    Summary = "POST /resources/alpha",
+                    ServiceRef = "service-alpha",
+                    NodeId = "node-alpha",
+                    ConnectorName = "service_proxy",
+                    ConnectorType = "http",
+                    Operation = "create_resource",
+                    HttpVerb = "POST",
+                    Resource = "/resources/alpha",
+                    PermissionScope = "resources.write",
+                    CreatedAt = Timestamp.FromDateTime(new DateTime(2026, 7, 17, 8, 0, 0, DateTimeKind.Utc)),
+                    ExpiresAt = Timestamp.FromDateTime(new DateTime(2026, 7, 17, 8, 5, 0, DateTimeKind.Utc)),
+                    Provenance = new WorkflowExternalActionProvenance
+                    {
+                        ScopeId = "scope-alpha",
+                        TeamId = "team-alpha",
+                        MemberId = "member-alpha",
+                        WorkflowId = "workflow-alpha",
+                        PublishedServiceId = "published-service-alpha",
+                        WorkflowActorId = "run-connector-approval",
+                        RunId = "run-connector-approval",
+                        StepId = "connector-approval",
+                        ExecutionId = "execution-alpha",
+                        RequesterPlatform = "nyxid",
+                        RequesterTenant = "tenant-alpha",
+                        RequesterExternalUserId = "user-alpha",
+                        PrincipalSubject = "user-alpha",
+                        RequesterCapabilityScope = "proxy",
+                    },
+                },
+                RemoteApprovalId = $"private-remote-{index}",
+                RemoteExpiresAt = Timestamp.FromDateTime(new DateTime(2026, 7, 17, 8, 2, 0, DateTimeKind.Utc)),
+                LifecycleStatus = status,
+                ApprovalStatus = status == WorkflowExternalActionLifecycleStatus.Denied
+                    ? WorkflowExternalActionApprovalStatus.Denied
+                    : WorkflowExternalActionApprovalStatus.Approved,
+                ApprovalReasonCode = "approval_result",
+                ExecutionStatus = status switch
+                {
+                    WorkflowExternalActionLifecycleStatus.Executing => WorkflowExternalActionExecutionStatus.Executing,
+                    WorkflowExternalActionLifecycleStatus.Succeeded => WorkflowExternalActionExecutionStatus.Succeeded,
+                    WorkflowExternalActionLifecycleStatus.Failed => WorkflowExternalActionExecutionStatus.Failed,
+                    _ => WorkflowExternalActionExecutionStatus.NotStarted,
+                },
+                ExecutionReasonCode = "execution_result",
+            });
+        }
+        var service = new FakeWorkflowExecutionQueryApplicationService { Snapshot = snapshot };
+        await using var app = await CreateRouteAppAsync(service);
+        using var client = CreateClient(app);
+
+        var response = await client.GetAsync("/api/workflow-actors/run-connector-approval/current-state");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.EnsureSuccessStatusCode();
+        using var json = JsonDocument.Parse(body);
+        var approvals = json.RootElement.GetProperty("connectorApprovals").EnumerateArray().ToList();
+        approvals.Select(static approval => approval.GetProperty("lifecycleStatus").GetString())
+            .Should().Equal(lifecycleStatuses.Select(static status => status.ToString()));
+        approvals[0].GetProperty("actionId").GetString().Should().Be("action-0");
+        approvals[0].GetProperty("principalSubject").GetString().Should().Be("user-alpha");
+        approvals[0].GetProperty("nodeId").GetString().Should().Be("node-alpha");
+        approvals[0].GetProperty("permissionScope").GetString().Should().Be("resources.write");
+        approvals[0].GetProperty("expiresAt").GetDateTimeOffset()
+            .Should().Be(new DateTimeOffset(2026, 7, 17, 8, 5, 0, TimeSpan.Zero));
+        body.Should().NotContain("private-idempotency");
+        body.Should().NotContain("private-remote");
+        body.Should().NotContain(new string('a', 64));
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConnectorApprovalProjectionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConnectorApprovalProjectionTests.cs
@@ -1,0 +1,152 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Projection;
+using Aevatar.Workflow.Projection.Projectors;
+using Aevatar.Workflow.Projection.ReadModels;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowConnectorApprovalProjectionTests
+{
+    [Fact]
+    public async Task ProjectAndMap_ShouldExposeAuthoritativeConnectorApprovalSnapshots()
+    {
+        var connectorState = new ConnectorCallModuleState();
+        connectorState.ApprovalsByActionId["action-b"] = Coordination(
+            "action-b",
+            WorkflowExternalActionLifecycleStatus.WaitingApproval,
+            WorkflowExternalActionApprovalStatus.Pending,
+            WorkflowExternalActionExecutionStatus.NotStarted);
+        connectorState.ApprovalsByActionId["action-a"] = Coordination(
+            "action-a",
+            WorkflowExternalActionLifecycleStatus.Succeeded,
+            WorkflowExternalActionApprovalStatus.Approved,
+            WorkflowExternalActionExecutionStatus.Succeeded);
+        var state = new WorkflowRunState
+        {
+            RunId = "run-approval",
+            WorkflowName = "connector-approval",
+            ScopeId = "scope-alpha",
+            Status = "running",
+            ExecutionStates =
+            {
+                ["connector_call"] = Any.Pack(connectorState),
+            },
+        };
+        var dispatcher = new RecordingWriteDispatcher<WorkflowExecutionCurrentStateDocument>();
+        var projector = new WorkflowExecutionCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(new DateTimeOffset(2026, 7, 17, 8, 1, 0, TimeSpan.Zero)));
+
+        await projector.ProjectAsync(
+            new WorkflowExecutionMaterializationContext
+            {
+                RootActorId = "run-approval",
+                ProjectionKind = "workflow",
+            },
+            WrapCommitted(state));
+
+        var document = dispatcher.Upserts.Should().ContainSingle().Subject;
+        document.ConnectorApprovals.Select(static approval => approval.Plan.ActionId)
+            .Should().ContainInOrder("action-a", "action-b");
+        document.ConnectorApprovals[0].LifecycleStatus
+            .Should().Be(WorkflowExternalActionLifecycleStatus.Succeeded);
+        document.ConnectorApprovals[0].ExecutionStatus
+            .Should().Be(WorkflowExternalActionExecutionStatus.Succeeded);
+        document.ConnectorApprovals[1].ApprovalStatus
+            .Should().Be(WorkflowExternalActionApprovalStatus.Pending);
+
+        var snapshot = new WorkflowExecutionReadModelMapper().ToActorSnapshot(document);
+
+        snapshot.ConnectorApprovals.Should().HaveCount(2);
+        snapshot.ConnectorApprovals[0].Plan.ActionId.Should().Be("action-a");
+        snapshot.ConnectorApprovals[0].Plan.Provenance.PrincipalSubject.Should().Be("user-alpha");
+        snapshot.ConnectorApprovals[1].Plan.NodeId.Should().Be("node-alpha");
+        document.ConnectorApprovals[0].Plan.Summary = "mutated-after-map";
+        snapshot.ConnectorApprovals[0].Plan.Summary.Should().Be("POST /resources/action-a");
+    }
+
+    private static ConnectorApprovalCoordinationState Coordination(
+        string actionId,
+        WorkflowExternalActionLifecycleStatus lifecycleStatus,
+        WorkflowExternalActionApprovalStatus approvalStatus,
+        WorkflowExternalActionExecutionStatus executionStatus) =>
+        new()
+        {
+            Snapshot = new WorkflowExternalActionApprovalSnapshot
+            {
+                Plan = new WorkflowExternalActionPlan
+                {
+                    ActionId = actionId,
+                    Summary = $"POST /resources/{actionId}",
+                    ServiceRef = "service-alpha",
+                    NodeId = "node-alpha",
+                    Operation = "create_resource",
+                    HttpVerb = "POST",
+                    Resource = $"/resources/{actionId}",
+                    PermissionScope = "resources.write",
+                    Provenance = new WorkflowExternalActionProvenance
+                    {
+                        ScopeId = "scope-alpha",
+                        RunId = "run-approval",
+                        StepId = "connector-approval",
+                        PrincipalSubject = "user-alpha",
+                    },
+                },
+                LifecycleStatus = lifecycleStatus,
+                ApprovalStatus = approvalStatus,
+                ExecutionStatus = executionStatus,
+            },
+        };
+
+    private static EventEnvelope WrapCommitted(WorkflowRunState state) =>
+        new()
+        {
+            Id = "evt-connector-approval",
+            Timestamp = Timestamp.FromDateTime(new DateTime(2026, 7, 17, 8, 1, 0, DateTimeKind.Utc)),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication("run-approval"),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = "evt-connector-approval",
+                    Version = 11,
+                    EventData = Any.Pack(new WorkflowExecutionStateUpsertedEvent
+                    {
+                        ScopeKey = "connector_call",
+                    }),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+
+    private sealed class RecordingWriteDispatcher<TReadModel> : IProjectionWriteDispatcher<TReadModel>
+        where TReadModel : class, IProjectionReadModel
+    {
+        public List<TReadModel> Upserts { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Upserts.Add(readModel);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+    }
+
+    private sealed class FixedProjectionClock(DateTimeOffset utcNow) : IProjectionClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+    }
+}


### PR DESCRIPTION
## Problem

Deterministic `connector_call` steps need to pause before an externally gated action, bind the approval to the exact operation, and resume after restart without exposing request material or executing the action more than once.

Closes #2788.

## Solution

- Add a strongly typed Protobuf external action plan and actor-owned approval/execution state machine.
- Store connector request material and pending completion events in `IRuntimeSecretStore`, while persisting only protected references and SHA-256 bindings in workflow state.
- Submit the current NyxID Tool Approval request before persisting the remote request identity, and fail closed on an indeterminate submission outcome instead of creating duplicate approvals.
- Revalidate action, digest, principal, scope, node, service, HTTP verb/resource, and expiry before dispatch.
- Persist dispatch intent with a stable idempotency key, then persist the protected connector result before publishing `StepCompletedEvent`, so restart recovery can replay the original outcome.
- Keep approval resolution and connector execution outcome as separate durable facts.
- Revoke protected request and completion material when the workflow reaches a terminal state, and expose only a redacted current-state projection.
- Document the connector approval and workflow primitive contracts. No NyxID repository or protocol changes are required.

## Impact

The change touches workflow contracts, connector execution, workflow state redaction, current-state projection, the existing remote approval port, and their focused tests. Existing connector calls without approval configuration retain their current execution path.

## Validation

- `dotnet restore aevatar.slnx --nologo` - passed
- `dotnet build aevatar.slnx --nologo --no-restore --verbosity minimal` - passed with 0 errors
- `dotnet test aevatar.slnx --nologo --no-build --no-restore` - passed; all enabled test projects succeeded
- `bash tools/ci/architecture_guards.sh` - passed, including docs lint (76 files, 0 errors)
- `git diff --check origin/feature/integrate...HEAD` - passed

⟦AI:FKST⟧
