### PR TITLE
修复 Garnet 非默认逻辑数据库的 Secret Store CAS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
               - 'src/Aevatar.Foundation.Runtime.Persistence.Implementations.Garnet/**'
               - 'test/Aevatar.Foundation.Core.Tests/**'
               - 'test/Aevatar.Foundation.Runtime.Hosting.Tests/**'
+              - 'test/Aevatar.SecretStore.Tools.Tests/**'
+              - 'tools/secret-store/**'
               - 'tools/ci/event_sourcing_regression.sh'
               - 'tools/ci/orleans_garnet_persistence_smoke.sh'
               - 'tools/ci/architecture_guards.sh'

--- a/docs/canon/secret-vault.md
+++ b/docs/canon/secret-vault.md
@@ -53,8 +53,8 @@ dotnet run --project tools/secret-store -- reencrypt-sweep --keyring ~/.aevatar/
 
 - 使用 Redis `SCAN` 按 `SecretVaultPrefix` 与 `RuntimeSecretPrefix` 分别扫描；
 - 每条记录先按 Protobuf 解析并用 keyring 解密，再用当前 active 数据密钥重新 AES-256-GCM 加密；
-- 写回必须用 Lua compare-and-set，对比原始 value，避免覆盖并发写入；
-- Lua 写回时读取 `PTTL` 并保留 TTL：有 TTL 用 `PSETEX`，无 TTL 用 `SET`；
+- 扫描、读取与写回必须通过 `--database` 选定的同一个 Redis 逻辑数据库；写回使用带原始 value 条件的事务 compare-and-set，避免覆盖并发改写或删除；
+- 条件事务提交前读取剩余 TTL，并把该值作为事务内写入的 expiry：有 TTL 的记录保持过期语义，无 TTL 的记录继续永久保存；
 - 支持 `--dry-run`、`--checkpoint`、`--resume`、`--verify`；
 - sweep 失败、CAS 冲突、verify 失败都必须显式暴露，不能静默当成功。
 

--- a/test/Aevatar.SecretStore.Tools.Tests/SecretStoreToolTests.cs
+++ b/test/Aevatar.SecretStore.Tools.Tests/SecretStoreToolTests.cs
@@ -468,12 +468,19 @@ public sealed class SecretStoreToolTests
         var key = $"{prefix}:record";
         var defaultDatabaseKey = $"{prefix}:default-database-record";
         var missingKey = $"{prefix}:missing";
+        var changedBeforeCommitKey = $"{prefix}:changed-before-commit";
+        var deletedBeforeCommitKey = $"{prefix}:deleted-before-commit";
+        var permanentKey = $"{prefix}:permanent";
         var originalValue = Encoding.UTF8.GetBytes("old-record");
         var updatedValue = Encoding.UTF8.GetBytes("new-record");
         var wrongExpectedValue = Encoding.UTF8.GetBytes("wrong-record");
+        var competingValue = Encoding.UTF8.GetBytes("competing-record");
         var defaultDatabaseValue = Encoding.UTF8.GetBytes("default-database-record");
 
         (await database.StringSetAsync(key, originalValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
+        (await database.StringSetAsync(changedBeforeCommitKey, originalValue)).Should().BeTrue();
+        (await database.StringSetAsync(deletedBeforeCommitKey, originalValue)).Should().BeTrue();
+        (await database.StringSetAsync(permanentKey, originalValue)).Should().BeTrue();
         (await defaultDatabase.StringSetAsync(key, defaultDatabaseValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
         (await defaultDatabase.StringSetAsync(missingKey, defaultDatabaseValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
         (await defaultDatabase.StringSetAsync(defaultDatabaseKey, defaultDatabaseValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
@@ -500,6 +507,34 @@ public sealed class SecretStoreToolTests
         (await database.KeyTimeToLiveAsync(key)).Should().NotBeNull().And.BePositive();
         ((byte[]?)await defaultDatabase.StringGetAsync(key)).Should().Equal(defaultDatabaseValue);
         ((byte[]?)await defaultDatabase.StringGetAsync(missingKey)).Should().Equal(defaultDatabaseValue);
+
+        var changedBeforeCommit = await target.CompareExchangeWithBeforeCommitAsync(
+            changedBeforeCommitKey,
+            originalValue,
+            updatedValue,
+            async _ =>
+            {
+                (await database.StringSetAsync(changedBeforeCommitKey, competingValue)).Should().BeTrue();
+            });
+        changedBeforeCommit.Status.Should().Be(SecretStoreCasStatus.Conflict);
+        ((byte[]?)await database.StringGetAsync(changedBeforeCommitKey)).Should().Equal(competingValue);
+
+        var deletedBeforeCommit = await target.CompareExchangeWithBeforeCommitAsync(
+            deletedBeforeCommitKey,
+            originalValue,
+            updatedValue,
+            async _ =>
+            {
+                (await database.KeyDeleteAsync(deletedBeforeCommitKey)).Should().BeTrue();
+            });
+        deletedBeforeCommit.Status.Should().Be(SecretStoreCasStatus.Missing);
+        (await database.KeyExistsAsync(deletedBeforeCommitKey)).Should().BeFalse();
+
+        var permanentUpdated = await target.CompareExchangeAsync(permanentKey, originalValue, updatedValue);
+        permanentUpdated.Status.Should().Be(SecretStoreCasStatus.Updated);
+        permanentUpdated.PreservedTtlMs.Should().Be(-1);
+        ((byte[]?)await database.StringGetAsync(permanentKey)).Should().Equal(updatedValue);
+        (await database.KeyTimeToLiveAsync(permanentKey)).Should().BeNull();
     }
 
     private static string RequireGarnetConnectionString() =>

--- a/test/Aevatar.SecretStore.Tools.Tests/SecretStoreToolTests.cs
+++ b/test/Aevatar.SecretStore.Tools.Tests/SecretStoreToolTests.cs
@@ -476,6 +476,7 @@ public sealed class SecretStoreToolTests
         var wrongExpectedValue = Encoding.UTF8.GetBytes("wrong-record");
         var competingValue = Encoding.UTF8.GetBytes("competing-record");
         var defaultDatabaseValue = Encoding.UTF8.GetBytes("default-database-record");
+        const long ttlPreservationToleranceMs = 5_000;
 
         (await database.StringSetAsync(key, originalValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
         (await database.StringSetAsync(changedBeforeCommitKey, originalValue)).Should().BeTrue();
@@ -499,12 +500,20 @@ public sealed class SecretStoreToolTests
         missing.Status.Should().Be(SecretStoreCasStatus.Missing);
         var ttlBeforeUpdate = await database.KeyTimeToLiveAsync(key);
         ttlBeforeUpdate.Should().NotBeNull().And.BePositive();
+        var ttlBeforeUpdateMs = (long)Math.Ceiling(ttlBeforeUpdate!.Value.TotalMilliseconds);
         var updated = await target.CompareExchangeAsync(key, originalValue, updatedValue);
         updated.Status.Should().Be(SecretStoreCasStatus.Updated);
-        updated.PreservedTtlMs.Should().BeGreaterThan(0);
+        updated.PreservedTtlMs.Should().BeInRange(
+            ttlBeforeUpdateMs - ttlPreservationToleranceMs,
+            ttlBeforeUpdateMs);
 
         ((byte[]?)await database.StringGetAsync(key)).Should().Equal(updatedValue);
-        (await database.KeyTimeToLiveAsync(key)).Should().NotBeNull().And.BePositive();
+        var ttlAfterUpdate = await database.KeyTimeToLiveAsync(key);
+        ttlAfterUpdate.Should().NotBeNull().And.BePositive();
+        var ttlAfterUpdateMs = (long)Math.Ceiling(ttlAfterUpdate!.Value.TotalMilliseconds);
+        ttlAfterUpdateMs.Should().BeInRange(
+            updated.PreservedTtlMs - ttlPreservationToleranceMs,
+            updated.PreservedTtlMs);
         ((byte[]?)await defaultDatabase.StringGetAsync(key)).Should().Equal(defaultDatabaseValue);
         ((byte[]?)await defaultDatabase.StringGetAsync(missingKey)).Should().Equal(defaultDatabaseValue);
 

--- a/test/Aevatar.SecretStore.Tools.Tests/SecretStoreToolTests.cs
+++ b/test/Aevatar.SecretStore.Tools.Tests/SecretStoreToolTests.cs
@@ -471,9 +471,12 @@ public sealed class SecretStoreToolTests
         var originalValue = Encoding.UTF8.GetBytes("old-record");
         var updatedValue = Encoding.UTF8.GetBytes("new-record");
         var wrongExpectedValue = Encoding.UTF8.GetBytes("wrong-record");
+        var defaultDatabaseValue = Encoding.UTF8.GetBytes("default-database-record");
 
         (await database.StringSetAsync(key, originalValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
-        (await defaultDatabase.StringSetAsync(defaultDatabaseKey, originalValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
+        (await defaultDatabase.StringSetAsync(key, defaultDatabaseValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
+        (await defaultDatabase.StringSetAsync(missingKey, defaultDatabaseValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
+        (await defaultDatabase.StringSetAsync(defaultDatabaseKey, defaultDatabaseValue, TimeSpan.FromMinutes(5))).Should().BeTrue();
         using var target = await RedisSecretStoreSweepTarget.ConnectAsync(connectionString, configuredDatabase);
 
         var scan = await target.ScanAsync($"{prefix}:*", cursor: 0, count: 100);
@@ -484,14 +487,19 @@ public sealed class SecretStoreToolTests
 
         var conflict = await target.CompareExchangeAsync(key, wrongExpectedValue, updatedValue);
         conflict.Status.Should().Be(SecretStoreCasStatus.Conflict);
+        ((byte[]?)await database.StringGetAsync(key)).Should().Equal(originalValue);
         var missing = await target.CompareExchangeAsync(missingKey, originalValue, updatedValue);
         missing.Status.Should().Be(SecretStoreCasStatus.Missing);
+        var ttlBeforeUpdate = await database.KeyTimeToLiveAsync(key);
+        ttlBeforeUpdate.Should().NotBeNull().And.BePositive();
         var updated = await target.CompareExchangeAsync(key, originalValue, updatedValue);
         updated.Status.Should().Be(SecretStoreCasStatus.Updated);
         updated.PreservedTtlMs.Should().BeGreaterThan(0);
 
         ((byte[]?)await database.StringGetAsync(key)).Should().Equal(updatedValue);
         (await database.KeyTimeToLiveAsync(key)).Should().NotBeNull().And.BePositive();
+        ((byte[]?)await defaultDatabase.StringGetAsync(key)).Should().Equal(defaultDatabaseValue);
+        ((byte[]?)await defaultDatabase.StringGetAsync(missingKey)).Should().Equal(defaultDatabaseValue);
     }
 
     private static string RequireGarnetConnectionString() =>

--- a/tools/secret-store/Aevatar.SecretStore.Tools.csproj
+++ b/tools/secret-store/Aevatar.SecretStore.Tools.csproj
@@ -13,4 +13,7 @@
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aevatar.SecretStore.Tools.Tests" />
+  </ItemGroup>
 </Project>

--- a/tools/secret-store/RedisSecretStoreSweepTarget.cs
+++ b/tools/secret-store/RedisSecretStoreSweepTarget.cs
@@ -67,11 +67,30 @@ public sealed class RedisSecretStoreSweepTarget : ISecretStoreSweepTarget, IDisp
         return value.IsNull ? null : (byte[]?)value;
     }
 
-    public async Task<SecretStoreCasResult> CompareExchangeAsync(
+    public Task<SecretStoreCasResult> CompareExchangeAsync(
         string key,
         byte[] expectedValue,
         byte[] newValue,
+        CancellationToken ct = default) =>
+        CompareExchangeCoreAsync(key, expectedValue, newValue, beforeTransactionCommit: null, ct);
+
+    internal Task<SecretStoreCasResult> CompareExchangeWithBeforeCommitAsync(
+        string key,
+        byte[] expectedValue,
+        byte[] newValue,
+        Func<CancellationToken, Task> beforeTransactionCommit,
         CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(beforeTransactionCommit);
+        return CompareExchangeCoreAsync(key, expectedValue, newValue, beforeTransactionCommit, ct);
+    }
+
+    private async Task<SecretStoreCasResult> CompareExchangeCoreAsync(
+        string key,
+        byte[] expectedValue,
+        byte[] newValue,
+        Func<CancellationToken, Task>? beforeTransactionCommit,
+        CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
         ArgumentNullException.ThrowIfNull(expectedValue);
@@ -87,6 +106,11 @@ public sealed class RedisSecretStoreSweepTarget : ISecretStoreSweepTarget, IDisp
 
         var remainingTtl = await _database.KeyTimeToLiveAsync(key);
         ct.ThrowIfCancellationRequested();
+        if (beforeTransactionCommit != null)
+        {
+            await beforeTransactionCommit(ct);
+            ct.ThrowIfCancellationRequested();
+        }
 
         var transaction = _database.CreateTransaction();
         transaction.AddCondition(Condition.StringEqual(key, expectedValue));

--- a/tools/secret-store/RedisSecretStoreSweepTarget.cs
+++ b/tools/secret-store/RedisSecretStoreSweepTarget.cs
@@ -5,27 +5,6 @@ namespace Aevatar.SecretStore.Tools;
 
 public sealed class RedisSecretStoreSweepTarget : ISecretStoreSweepTarget, IDisposable
 {
-    // Single integer return matches Garnet's reliable EVAL surface (multi-bulk tables can
-    // collapse status/TTL differently across Redis-compatible engines).
-    // 1 = updated, -1 = conflict, -2 = missing.
-    private const string CompareAndSetScript =
-        """
-        local current = redis.call('GET', KEYS[1])
-        if current == false then
-          return -2
-        end
-        if current ~= ARGV[1] then
-          return -1
-        end
-        local ttl = redis.call('PTTL', KEYS[1])
-        if ttl >= 0 then
-          redis.call('PSETEX', KEYS[1], ttl, ARGV[2])
-        else
-          redis.call('SET', KEYS[1], ARGV[2])
-        end
-        return 1
-        """;
-
     private readonly ConnectionMultiplexer _connection;
     private readonly IDatabase _database;
 
@@ -40,9 +19,6 @@ public sealed class RedisSecretStoreSweepTarget : ISecretStoreSweepTarget, IDisp
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
         var options = ConfigurationOptions.Parse(connectionString);
         options.AbortOnConnectFail = false;
-        // Pin default database so raw server commands and EVAL share the same logical DB
-        // as StringGet/StringSet against the configured index.
-        options.DefaultDatabase = database;
         var connection = await ConnectionMultiplexer.ConnectAsync(options);
         return new RedisSecretStoreSweepTarget(connection, database);
     }
@@ -102,32 +78,38 @@ public sealed class RedisSecretStoreSweepTarget : ISecretStoreSweepTarget, IDisp
         ArgumentNullException.ThrowIfNull(newValue);
         ct.ThrowIfCancellationRequested();
 
-        RedisKey[] keys = [(RedisKey)key];
-        RedisValue[] values = [expectedValue, newValue];
-        var result = await _database.ScriptEvaluateAsync(CompareAndSetScript, keys, values);
+        var currentValue = await _database.StringGetAsync(key);
+        ct.ThrowIfCancellationRequested();
+        if (currentValue.IsNull)
+            return SecretStoreCasResult.Missing();
+        if (currentValue != (RedisValue)expectedValue)
+            return SecretStoreCasResult.Conflict();
+
+        var remainingTtl = await _database.KeyTimeToLiveAsync(key);
         ct.ThrowIfCancellationRequested();
 
-        var status = (long)result;
-        return status switch
+        var transaction = _database.CreateTransaction();
+        transaction.AddCondition(Condition.StringEqual(key, expectedValue));
+        var writeTask = transaction.StringSetAsync(key, newValue, remainingTtl, When.Always);
+        var committed = await transaction.ExecuteAsync();
+        ct.ThrowIfCancellationRequested();
+        if (committed && await writeTask)
         {
-            1 => SecretStoreCasResult.Updated(await ReadPreservedTtlMsAsync(key, ct)),
-            -2 => SecretStoreCasResult.Missing(),
-            _ => SecretStoreCasResult.Conflict(),
-        };
+            ct.ThrowIfCancellationRequested();
+            return SecretStoreCasResult.Updated(ToTtlMilliseconds(remainingTtl));
+        }
+
+        currentValue = await _database.StringGetAsync(key);
+        ct.ThrowIfCancellationRequested();
+        return currentValue.IsNull
+            ? SecretStoreCasResult.Missing()
+            : SecretStoreCasResult.Conflict();
     }
 
     public void Dispose() => _connection.Dispose();
 
-    private async Task<long> ReadPreservedTtlMsAsync(string key, CancellationToken ct)
-    {
-        ct.ThrowIfCancellationRequested();
-        var ttl = await _database.KeyTimeToLiveAsync(key);
-        ct.ThrowIfCancellationRequested();
-        if (!ttl.HasValue)
-            return -1;
-
-        return Math.Max(0, (long)Math.Ceiling(ttl.Value.TotalMilliseconds));
-    }
+    private static long ToTtlMilliseconds(TimeSpan? ttl) =>
+        ttl.HasValue ? Math.Max(0, (long)Math.Ceiling(ttl.Value.TotalMilliseconds)) : -1;
 
     private static RedisResult[] ReadArray(RedisResult result, string label) =>
         (RedisResult[]?)result ?? throw new InvalidOperationException($"Redis {label} was not an array.");


### PR DESCRIPTION
## Changed files

- `RedisSecretStoreSweepTarget` 删除 Lua/EVAL 与 `DefaultDatabase` workaround，统一在构造时选定的 `IDatabase` 上执行读取、TTL 获取和条件事务 CAS。
- 增加仅向 Secret Store 测试程序集开放的 internal pre-commit hook，在真实 Garnet 上确定性制造预读后、事务提交前的改写与删除，不引入轮询或概率竞争。
- Garnet 集成测试覆盖 DB 0/DB 1 同名键隔离、Missing、Conflict、Updated，并关联断言更新前 TTL、CAS 返回 TTL 与更新后 TTL 单调递减。
- CI 的 event-sourcing/Garnet 路由纳入 `tools/secret-store/**` 与对应测试目录，确保相关 PR 实际执行目标 Garnet 测试。
- Secret Vault canon 同步 selected-database 条件事务 CAS 与 TTL 保留语义。

## Test results

- 全量 solution build 通过，0 error。
- Secret Store 工具测试通过；真实 Garnet smoke 中 Orleans/Garnet 2 项和 Secret Store 目标测试 1 项通过，0 skipped。
- test stability guard、architecture guards、docs lint 与 `git diff --check` 全部通过。

## Deviations

- scope 明确扩展到 `tools/secret-store/Aevatar.SecretStore.Tools.csproj`、`.github/workflows/ci.yml` 与 `docs/canon/secret-vault.md`：分别用于确定性并发测试入口、真实 Garnet CI 路由和权威文档同步。
- 未修改 schema/protocol，未新增依赖；`HOST_REFACTOR_COMMENT_POLICY` 归一化为 `none`。

Closes #2829

⟦AI:AUTO-LOOP⟧
