### PR TITLE
绑定 NyxID Chat 创建时 Agent Profile 快照

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/DisabledNyxIdChatAgentProfileSnapshotSource.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/DisabledNyxIdChatAgentProfileSnapshotSource.cs
@@ -1,0 +1,8 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat.AgentProfiles;
+
+public sealed class DisabledNyxIdChatAgentProfileSnapshotSource : INyxIdChatAgentProfileSnapshotSource
+{
+    public AgentProfileSnapshot? GetSnapshotForNewConversation() => null;
+}

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/INyxIdChatAgentProfileSnapshotSource.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/INyxIdChatAgentProfileSnapshotSource.cs
@@ -1,0 +1,8 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat.AgentProfiles;
+
+public interface INyxIdChatAgentProfileSnapshotSource
+{
+    AgentProfileSnapshot? GetSnapshotForNewConversation();
+}

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
@@ -7,12 +7,14 @@ using Aevatar.AI.Core;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.Core.Prompting;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Google.Protobuf;
@@ -130,6 +132,8 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         var correlationId = ActiveInboundEnvelope?.Propagation?.CorrelationId ?? commandId;
         var registryCommandPort = Services.GetRequiredService<IGAgentActorRegistryCommandPort>();
         var createdLocally = command.CreatedLocally;
+
+        await BindAgentProfileAsync(command.AgentProfile);
 
         await PersistDomainEventAsync(new NyxIdChatConversationCreationStartedEvent
         {
@@ -398,6 +402,29 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         return initializeEvent;
     }
 
+    private async Task BindAgentProfileAsync(AgentProfileSnapshot? profile)
+    {
+        var boundProfile = State.AgentProfile;
+        if (profile is null)
+        {
+            if (boundProfile is not null)
+                throw new InvalidOperationException("A bound agent profile cannot be removed from a conversation.");
+            return;
+        }
+
+        if (!AgentProfileSnapshotCodec.Verify(profile))
+            throw new InvalidOperationException("The agent profile snapshot digest is invalid.");
+
+        if (boundProfile is null)
+        {
+            await PersistDomainEventAsync(new AgentProfileBoundEvent { Profile = profile.Clone() });
+            return;
+        }
+
+        if (!AgentProfileSnapshotCodec.ByteEquivalent(boundProfile, profile))
+            throw new InvalidOperationException("A conversation cannot replace its bound agent profile.");
+    }
+
     private async Task PersistRegistrationUnavailableAndCompensateAsync(
         string scopeId,
         string actorId,
@@ -483,5 +510,28 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         return source.Length <= maxTitleLength
             ? source
             : source[..maxTitleLength].TrimEnd();
+    }
+
+    protected override RoleGAgentState TransitionState(RoleGAgentState current, IMessage evt)
+    {
+        if (!StateTransitionMatcher.TryExtract<AgentProfileBoundEvent>(evt, out var profileBound))
+            return base.TransitionState(current, evt);
+
+        if (profileBound.Profile is null)
+            throw new InvalidOperationException("Agent profile binding events require a complete snapshot.");
+
+        if (!AgentProfileSnapshotCodec.Verify(profileBound.Profile))
+            throw new InvalidOperationException("Agent profile binding events require a valid digest.");
+
+        if (current.AgentProfile is not null)
+        {
+            if (!AgentProfileSnapshotCodec.ByteEquivalent(current.AgentProfile, profileBound.Profile))
+                throw new InvalidOperationException("Committed agent profile bindings cannot be replaced.");
+            return current;
+        }
+
+        var next = current.Clone();
+        next.AgentProfile = profileBound.Profile.Clone();
+        return next;
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatLifecycleFacade.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatLifecycleFacade.cs
@@ -4,6 +4,7 @@ using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Capabilities;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -176,15 +177,19 @@ internal sealed class NyxIdChatConversationCreateCommandTargetResolver
     private readonly IActorRuntime _actorRuntime;
     private readonly IChatRoutePolicyQueryPort _routeQueryPort;
     private readonly ChatRouteResolver _routeResolver;
+    private readonly INyxIdChatAgentProfileSnapshotSource _agentProfileSnapshotSource;
 
     public NyxIdChatConversationCreateCommandTargetResolver(
         IActorRuntime actorRuntime,
         IChatRoutePolicyQueryPort routeQueryPort,
-        ChatRouteResolver routeResolver)
+        ChatRouteResolver routeResolver,
+        INyxIdChatAgentProfileSnapshotSource agentProfileSnapshotSource)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _routeQueryPort = routeQueryPort ?? throw new ArgumentNullException(nameof(routeQueryPort));
         _routeResolver = routeResolver ?? throw new ArgumentNullException(nameof(routeResolver));
+        _agentProfileSnapshotSource = agentProfileSnapshotSource ??
+                                      throw new ArgumentNullException(nameof(agentProfileSnapshotSource));
     }
 
     public async Task<CommandTargetResolution<NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandStartError>> ResolveAsync(
@@ -208,6 +213,19 @@ internal sealed class NyxIdChatConversationCreateCommandTargetResolver
         if (decision.Action.Reject is not null)
             return CommandTargetResolution<NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandStartError>.Failure(
                 NyxIdChatLifecycleCommandStartError.RouteRejected);
+
+        var agentProfile = _agentProfileSnapshotSource.GetSnapshotForNewConversation();
+        if (agentProfile is not null)
+        {
+            var routeToolSetName = decision.Action.ForwardToModel?.ToolSetRef?.Name;
+            if (!string.Equals(routeToolSetName, agentProfile.RouteToolSetRef, StringComparison.Ordinal))
+            {
+                return CommandTargetResolution<NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandStartError>.Failure(
+                    NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
+            }
+
+            command.AgentProfile = agentProfile.Clone();
+        }
 
         // Refactor (issue1321-first): ForwardToModel.tool_choice_hint is tool prefill only,
         // so conversation creation never treats hint arguments as actor addressing.

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using Aevatar.GAgents.Channel.Abstractions.Slash;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat.LlmSelection;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.GAgents.NyxidChat.Slash;
 using Aevatar.GAgents.NyxidChat.WorkflowDraftRun;
 using Aevatar.GAgents.NyxidChat.WorkflowRunDelivery;
@@ -53,6 +54,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NyxIdRelayTransport>();
         services.TryAddSingleton<NyxIdRelayAuthValidator>();
         services.TryAddSingleton<INyxIdRelayIngressPort, NyxIdRelayIngressPort>();
+        services.TryAddSingleton<INyxIdChatAgentProfileSnapshotSource, DisabledNyxIdChatAgentProfileSnapshotSource>();
         services.TryAddSingleton<IChannelRelayTailTextSender, MissingChannelRelayTailTextSender>();
         services.TryAddSingleton<IChannelRelayProxyResponseClassifier, MissingChannelRelayProxyResponseClassifier>();
         services.TryAddSingleton<NyxIdChatLifecycleFacade>();

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -683,6 +683,7 @@ message NyxIdChatConversationDeletionCompensationRequested {
 message NyxIdChatConversationCreateCommand {
   string scope_id = 1;
   bool created_locally = 2;
+  aevatar.ai.AgentProfileSnapshot agent_profile = 3;
 }
 
 message NyxIdChatConversationDeleteCommand {

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,13 @@
 Authoritative architecture and developer guides. Each covers one topic.
 
 - [Actor Evolution Canon Matrix](canon/actor-evolution.md)
+- [Aevatar Admin Authorization](canon/admin-authorization.md)
 - [[RFC] Aevatar Chat — Multi-Channel Adapter Architecture](canon/aevatar-channel-architecture.md)
 - [Approval Quota Ledger](canon/approval-quota-ledger.md)
 - [Architecture Vocabulary](canon/architecture-vocabulary.md)
 - [Aevatar Foundation](canon/architecture.md)
+- [Platform Audit Trail](canon/audit-trail.md)
+- [Backend Console Static Assets](canon/backend-console.md)
 - [Workflow Chat API 能力说明（框架层）](canon/chat-api.md)
 - [Connector 配置与执行逻辑](canon/connector.md)
 - [Aevatar CQRS 架构（Maker 插件化后）](canon/cqrs-projection.md)
@@ -21,6 +24,7 @@ Authoritative architecture and developer guides. Each covers one topic.
 - [Lark Reply Chain Completion Semantics](canon/lark-reply-completion-semantics.md)
 - [Workflow LLM 流式链路详细架构文档（2026-02-25）](canon/llm-streaming.md)
 - [Module Placement Map](canon/module-placement-map.md)
+- [NyxID Chat Agent Profile Binding](canon/nyxid-chat-agent-profile-binding.md)
 - [NyxID Connected-Service LLM Tools](canon/nyxid-connected-service-tools.md)
 - [NyxID LLM Provider 集成指南](canon/nyxid-llm-integration.md)
 - [NyxID Responses 直连](canon/nyxid-responses-direct.md)
@@ -30,6 +34,7 @@ Authoritative architecture and developer guides. Each covers one topic.
 - [Scheduled Skill Runners](canon/scheduled-skill-runners.md)
 - [Aevatar.Scripting 架构文档](canon/scripting.md)
 - [.NET Workflow SDK Quick Start](canon/sdk-dotnet.md)
+- [Secret Vault](canon/secret-vault.md)
 - [Aevatar /status 状态面板架构](canon/status-dashboard.md)
 - [System Skill Overlay Authoring Contract](canon/system-skill-overlay-authoring-contract.md)
 - [Voice Presence Integration — aevatar as the /ws/voice Brain](canon/voice-presence-integration.md)
@@ -76,6 +81,11 @@ Immutable records of architectural choices and their rationale.
 - [Scope Workflow as the Authoritative Runnable Workflow Model](adr/0036-scope-workflow-authoritative-runnable-model.md)
 - [定时任务调用凭证的权威来源模型](adr/0037-scheduled-invocation-credential-source-model.md)
 - [Scripting Capability Is Opt-In and Disabled on Mainnet](adr/0038-scripting-capability-opt-in-disabled-on-mainnet.md)
+- [Platform Audit Trail](adr/0039-platform-audit-trail.md)
+- [Current-State Readmodel Disaster-Recovery Rebuild via Committed-State Re-Publication](adr/0040-current-state-readmodel-dr-rebuild.md)
+- [定时任务 Agent Key 凭证引用补充决策](adr/0041-scheduled-invocation-agent-key-credential-reference.md)
+- [Scheduled Invocation Durable Credential Uses SecretReference](adr/0042-scheduled-invocation-durable-secret-reference.md)
+- [Scheduled Credential Lifecycle Compensation](adr/0043-scheduled-credential-lifecycle-compensation.md)
 - [Agent Kind Primary-Only Identity](adr/2026-06-04-agent-kind-primary-only-identity.md)
 
 ## History

--- a/docs/canon/nyxid-chat-agent-profile-binding.md
+++ b/docs/canon/nyxid-chat-agent-profile-binding.md
@@ -1,0 +1,42 @@
+---
+title: NyxID Chat Agent Profile Binding
+status: canonical
+owner: Aevatar AI
+---
+
+# NyxID Chat Agent Profile Binding
+
+NyxID Chat 的 agent profile 是 conversation actor 的创建输入。Mainnet Host 只在进程启动时读取、校验并 seal 一份部署快照；create resolver 对每次新建会话读取一次本地 clone，不在请求路径访问 Ornn、NyxID 或其他网络服务。
+
+## 权威边界
+
+`NyxIdChatAgentProfileOptions` 只承载部署开关、稳定外部引用 `nyxid-chat` 和 typed profile payload。恢复工具必选名单与旧工具拒绝名单属于 Host 安全政策，由独立的 immutable `NyxIdChatAgentProfileValidationBaseline` 提供，不从 profile 配置绑定，也不进入 snapshot、digest、command、event 或 actor state。
+
+Host 启动校验固定覆盖三个 schema root：
+
+1. `AgentProfileSnapshot.Descriptor` 可达的仓库自有 Protobuf graph。
+2. `NyxIdChatAgentProfileOptions` 的仓库自有 public property graph。
+3. `NyxIdChatAgentProfileValidationBaseline` 的仓库自有 public property graph。
+
+扫描只检查 schema 名称，不读取配置值，不遍历 BCL 实现或全仓 assembly。启用 profile 或提供 profile payload 时，两组 baseline 都必须非空，且 profile 必须通过完整 identity、bounds、policy subset、known tool-set 和 baseline 校验。默认的 disabled、无 payload、empty baseline 配置可以启动。
+
+## 创建与绑定
+
+create resolver 继续以 `CHAT_SOURCE_KIND_DIRECT` 的 chat-route decision 为权威。启用 profile 时，route 的 `ForwardToModel.ToolSetRef.Name` 必须与 snapshot 的 `route_tool_set_ref` 按 `Ordinal` 完全一致；不一致在 actor 创建前沿用现有 503 admission-unavailable 语义。route policy 的明确拒绝仍返回 403，成功仍返回原有 202 accepted receipt、`Location` 和 `statusUrl`。
+
+`NyxIdChatGAgent` 在 creation-started event 和 registry I/O 前验证 snapshot digest并执行一次性绑定：
+
+- 未绑定且 command 带有效 snapshot：先提交 `AgentProfileBoundEvent`。
+- 已绑定且完整 deterministic bytes 相同：幂等继续，不追加 binding event。
+- 已绑定后收到不同 snapshot、缺失 snapshot 或无效 digest：拒绝并停止注册。
+- 未绑定且 command 不带 snapshot：保持 legacy 行为。
+
+`RoleGAgentState.agent_profile` 是会话绑定的唯一权威当前态。完整 sealed snapshot 随 committed event 进入既有 observation 主链；Host options 不是存量会话的事实源。
+
+## Identity 与演进
+
+`ExactRemoteSkillRef` 和 `ExactRemoteSkillsetRef` 只接受非零、lowercase canonical `D` GUID，以及 Ornn `<major>.<minor>` literal version。validator 不 Trim、不转小写、不做读取时 normalization，也不附加 UUID version/variant 限制。
+
+协议采用 additive tags：`RoleGAgentState.agent_profile = 12`，`NyxIdChatConversationCreateCommand.agent_profile = 3`。旧 bytes 的字段缺失值为空，因此旧会话保持未绑定；系统不 replay、backfill、lazy bind 或 hot-upgrade。配置和 validation baseline 变更都需要重新部署并重启，只影响之后创建的会话。
+
+本边界不增加公开 profile diagnostics、readmodel/query/API、create-time exact fetch、release verification或第二条 chat pipeline。具体 reviewed GUID、publisher、member、recovery/deny 名单和 enablement 属于发布配置，不属于本协议。

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -392,6 +392,69 @@ message SystemSkillOverlay {
   int64 materialized_at = 3;
 }
 
+message ExactRemoteSkillRef {
+  string guid = 1;
+  string literal_version = 2;
+}
+
+message ExactRemoteSkillsetRef {
+  string guid = 1;
+  string literal_version = 2;
+}
+
+message AgentProfileToolPolicy {
+  repeated string tool_names = 1;
+  repeated string tool_set_refs = 2;
+}
+
+enum AgentProfileSideEffectClass {
+  AGENT_PROFILE_SIDE_EFFECT_CLASS_UNSPECIFIED = 0;
+  AGENT_PROFILE_SIDE_EFFECT_CLASS_READ_ONLY = 1;
+  AGENT_PROFILE_SIDE_EFFECT_CLASS_EXTERNAL_HANDOFF = 2;
+  AGENT_PROFILE_SIDE_EFFECT_CLASS_SERVICE_CALL = 3;
+  AGENT_PROFILE_SIDE_EFFECT_CLASS_MAINTENANCE = 4;
+}
+
+enum AgentProfileActivationMode {
+  AGENT_PROFILE_ACTIVATION_MODE_UNSPECIFIED = 0;
+  AGENT_PROFILE_ACTIVATION_MODE_SHADOW = 1;
+  AGENT_PROFILE_ACTIVATION_MODE_ENFORCED = 2;
+}
+
+message AgentProfileSkillMember {
+  string intent_id = 1;
+  string routing_description = 2;
+  ExactRemoteSkillRef skill_ref = 3;
+  repeated string explicit_trigger_aliases = 4;
+  AgentProfileToolPolicy task_tool_policy = 5;
+  AgentProfileSideEffectClass side_effect_class = 6;
+  string expected_skill_name = 7;
+  string reviewed_publisher_id = 8;
+}
+
+message AgentProfileSnapshot {
+  string profile_id = 1;
+  string profile_version = 2;
+  string agent_kind = 3;
+  string policy_revision = 4;
+  bytes deterministic_policy_sha256 = 5;
+  ExactRemoteSkillsetRef skillset_provenance = 6;
+  string route_tool_set_ref = 7;
+  AgentProfileToolPolicy maximum_tool_policy = 8;
+  AgentProfileToolPolicy recovery_tool_policy = 9;
+  repeated AgentProfileSkillMember members = 10;
+  int32 max_plan_steps = 11;
+  int32 handoff_ttl_seconds = 12;
+  int32 classifier_timeout_ms = 13;
+  int32 exact_skill_fetch_timeout_ms = 14;
+  int32 max_selected_skill_bytes = 15;
+  AgentProfileActivationMode activation_mode = 16;
+}
+
+message AgentProfileBoundEvent {
+  AgentProfileSnapshot profile = 1;
+}
+
 // Retired (issue #2498): no longer emitted — the overlay is sourced by the host-level provider, not
 // materialized per-actor. Kept defined so historical journals / queued durable timeouts still
 // deserialize and replay through their no-op handlers. Remove in a later release once no grain journal
@@ -454,6 +517,7 @@ message RoleGAgentState {
   // materialized into actor state. Reserved so the tag is never reused and old snapshots parse cleanly.
   reserved 11;
   reserved "system_skill_overlay";
+  AgentProfileSnapshot agent_profile = 12;
 }
 
 // ─── Multi-turn tool approval continuation ───

--- a/src/Aevatar.AI.Core/AgentProfiles/AgentProfileSnapshotCodec.cs
+++ b/src/Aevatar.AI.Core/AgentProfiles/AgentProfileSnapshotCodec.cs
@@ -1,0 +1,62 @@
+using System.Security.Cryptography;
+using Aevatar.AI.Abstractions;
+using Google.Protobuf;
+
+namespace Aevatar.AI.Core.AgentProfiles;
+
+public static class AgentProfileSnapshotCodec
+{
+    private const int Sha256Length = 32;
+
+    public static AgentProfileSnapshot Seal(AgentProfileSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (!snapshot.DeterministicPolicySha256.IsEmpty)
+            throw new ArgumentException("The profile snapshot digest must be empty before sealing.", nameof(snapshot));
+
+        var sealedSnapshot = snapshot.Clone();
+        sealedSnapshot.DeterministicPolicySha256 = ByteString.CopyFrom(
+            SHA256.HashData(SerializeWithoutDigest(sealedSnapshot)));
+        return sealedSnapshot;
+    }
+
+    public static bool Verify(AgentProfileSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (snapshot.DeterministicPolicySha256.Length != Sha256Length)
+            return false;
+
+        var expected = SHA256.HashData(SerializeWithoutDigest(snapshot));
+        return CryptographicOperations.FixedTimeEquals(
+            expected,
+            snapshot.DeterministicPolicySha256.Span);
+    }
+
+    public static bool ByteEquivalent(AgentProfileSnapshot left, AgentProfileSnapshot right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        return SerializeDeterministically(left).AsSpan()
+            .SequenceEqual(SerializeDeterministically(right));
+    }
+
+    private static byte[] SerializeWithoutDigest(AgentProfileSnapshot snapshot)
+    {
+        var hashInput = snapshot.Clone();
+        hashInput.DeterministicPolicySha256 = ByteString.Empty;
+        return SerializeDeterministically(hashInput);
+    }
+
+    private static byte[] SerializeDeterministically(IMessage message)
+    {
+        using var stream = new MemoryStream(message.CalculateSize());
+        using (var output = new CodedOutputStream(stream, leaveOpen: true))
+        {
+            output.Deterministic = true;
+            message.WriteTo(output);
+            output.Flush();
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
+++ b/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aevatar.Audit.Abstractions\Aevatar.Audit.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Audit.Core\Aevatar.Audit.Core.csproj" />
+    <ProjectReference Include="..\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <InternalsVisibleTo Include="Aevatar.Capabilities.Tests" />
     <InternalsVisibleTo Include="Aevatar.ChatRouting.Voice.Integration.Tests" />
   </ItemGroup>

--- a/src/Aevatar.Mainnet.Host.Api/AgentProfiles/AgentProfileProductionSchemaScanner.cs
+++ b/src/Aevatar.Mainnet.Host.Api/AgentProfiles/AgentProfileProductionSchemaScanner.cs
@@ -1,0 +1,150 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Aevatar.AI.Abstractions;
+using Google.Protobuf.Reflection;
+
+namespace Aevatar.Mainnet.Host.Api.AgentProfiles;
+
+public static partial class AgentProfileProductionSchemaScanner
+{
+    private static readonly HashSet<string> AtomicDeniedTokens = new(StringComparer.Ordinal)
+    {
+        "token", "secret", "credential", "password", "passphrase", "authorization",
+        "bearer", "cookie", "prompt", "body", "script", "markdown",
+    };
+
+    private static readonly HashSet<string> CompoundDeniedTokens = new(StringComparer.Ordinal)
+    {
+        "api_key", "access_key", "private_key", "client_secret", "system_prompt",
+        "prompt_body", "skill_body", "skill_content", "skill_payload", "raw_prompt",
+        "raw_content", "raw_payload",
+    };
+
+    public static IReadOnlyList<string> FindForbiddenNames()
+    {
+        var forbiddenNames = new HashSet<string>(StringComparer.Ordinal);
+        VisitMessage(
+            AgentProfileSnapshot.Descriptor,
+            new HashSet<string>(StringComparer.Ordinal),
+            forbiddenNames);
+        VisitType(
+            typeof(NyxIdChatAgentProfileOptions),
+            new HashSet<Type>(),
+            forbiddenNames);
+        VisitType(
+            typeof(NyxIdChatAgentProfileValidationBaseline),
+            new HashSet<Type>(),
+            forbiddenNames);
+        return forbiddenNames.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static void VisitMessage(
+        MessageDescriptor descriptor,
+        HashSet<string> visitedDescriptors,
+        HashSet<string> forbiddenNames)
+    {
+        if (!visitedDescriptors.Add(descriptor.FullName))
+            return;
+
+        foreach (var field in descriptor.Fields.InFieldNumberOrder())
+        {
+            InspectName($"{descriptor.FullName}.{field.Name}", field.Name, forbiddenNames);
+            InspectName($"{descriptor.FullName}.{field.JsonName}", field.JsonName, forbiddenNames);
+            if (field.FieldType == FieldType.Message &&
+                string.Equals(field.MessageType.File.Package, AgentProfileSnapshot.Descriptor.File.Package, StringComparison.Ordinal))
+            {
+                VisitMessage(field.MessageType, visitedDescriptors, forbiddenNames);
+            }
+        }
+    }
+
+    private static void VisitType(
+        Type type,
+        HashSet<Type> visitedTypes,
+        HashSet<string> forbiddenNames)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        if (IsTerminal(type) || !visitedTypes.Add(type))
+            return;
+
+        if (TryGetCollectionElementType(type, out var elementType))
+        {
+            VisitType(elementType, visitedTypes, forbiddenNames);
+            return;
+        }
+
+        if (!string.Equals(type.Namespace, typeof(NyxIdChatAgentProfileOptions).Namespace, StringComparison.Ordinal))
+            return;
+
+        foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            InspectName($"{type.FullName}.{property.Name}", property.Name, forbiddenNames);
+            VisitType(property.PropertyType, visitedTypes, forbiddenNames);
+        }
+    }
+
+    private static bool IsTerminal(Type type) =>
+        type.IsPrimitive ||
+        type.IsEnum ||
+        type == typeof(string) ||
+        type == typeof(decimal) ||
+        type == typeof(DateTime) ||
+        type == typeof(DateTimeOffset) ||
+        type == typeof(TimeSpan) ||
+        typeof(Google.Protobuf.IMessage).IsAssignableFrom(type);
+
+    private static bool TryGetCollectionElementType(Type type, out Type elementType)
+    {
+        if (type.IsArray)
+        {
+            elementType = type.GetElementType()!;
+            return true;
+        }
+
+        var enumerable = type
+            .GetInterfaces()
+            .Append(type)
+            .FirstOrDefault(candidate =>
+                candidate.IsGenericType &&
+                candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+        if (enumerable is not null)
+        {
+            elementType = enumerable.GetGenericArguments()[0];
+            return true;
+        }
+
+        elementType = typeof(void);
+        return false;
+    }
+
+    private static void InspectName(
+        string qualifiedName,
+        string identifier,
+        HashSet<string> forbiddenNames)
+    {
+        var words = IdentifierWordPattern()
+            .Matches(identifier)
+            .Select(static match => match.Value.ToLowerInvariant())
+            .ToArray();
+        if (words.Any(AtomicDeniedTokens.Contains))
+        {
+            forbiddenNames.Add(qualifiedName);
+            return;
+        }
+
+        for (var start = 0; start < words.Length; start++)
+        {
+            for (var length = 2; start + length <= words.Length; length++)
+            {
+                if (CompoundDeniedTokens.Contains(string.Join('_', words, start, length)))
+                {
+                    forbiddenNames.Add(qualifiedName);
+                    return;
+                }
+            }
+        }
+    }
+
+    [GeneratedRegex("[A-Z]+(?=[A-Z][a-z]|[0-9]|$)|[A-Z]?[a-z]+|[0-9]+", RegexOptions.CultureInvariant)]
+    private static partial Regex IdentifierWordPattern();
+}

--- a/src/Aevatar.Mainnet.Host.Api/AgentProfiles/AgentProfileProductionSchemaScanner.cs
+++ b/src/Aevatar.Mainnet.Host.Api/AgentProfiles/AgentProfileProductionSchemaScanner.cs
@@ -122,27 +122,29 @@ public static partial class AgentProfileProductionSchemaScanner
         string identifier,
         HashSet<string> forbiddenNames)
     {
+        if (IsForbiddenIdentifier(identifier))
+            forbiddenNames.Add(qualifiedName);
+    }
+
+    internal static bool IsForbiddenIdentifier(string identifier)
+    {
         var words = IdentifierWordPattern()
             .Matches(identifier)
             .Select(static match => match.Value.ToLowerInvariant())
             .ToArray();
         if (words.Any(AtomicDeniedTokens.Contains))
-        {
-            forbiddenNames.Add(qualifiedName);
-            return;
-        }
+            return true;
 
         for (var start = 0; start < words.Length; start++)
         {
             for (var length = 2; start + length <= words.Length; length++)
             {
                 if (CompoundDeniedTokens.Contains(string.Join('_', words, start, length)))
-                {
-                    forbiddenNames.Add(qualifiedName);
-                    return;
-                }
+                    return true;
             }
         }
+
+        return false;
     }
 
     [GeneratedRegex("[A-Z]+(?=[A-Z][a-z]|[0-9]|$)|[A-Z]?[a-z]+|[0-9]+", RegexOptions.CultureInvariant)]

--- a/src/Aevatar.Mainnet.Host.Api/AgentProfiles/MainnetNyxIdChatAgentProfileSnapshotSource.cs
+++ b/src/Aevatar.Mainnet.Host.Api/AgentProfiles/MainnetNyxIdChatAgentProfileSnapshotSource.cs
@@ -1,0 +1,22 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Mainnet.Host.Api.AgentProfiles;
+
+public sealed class MainnetNyxIdChatAgentProfileSnapshotSource : INyxIdChatAgentProfileSnapshotSource
+{
+    private readonly AgentProfileSnapshot? _sealedSnapshot;
+
+    public MainnetNyxIdChatAgentProfileSnapshotSource(IOptions<NyxIdChatAgentProfileOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var configured = options.Value;
+        _sealedSnapshot = configured.Enabled && configured.Profile is not null
+            ? AgentProfileSnapshotCodec.Seal(configured.Profile)
+            : null;
+    }
+
+    public AgentProfileSnapshot? GetSnapshotForNewConversation() => _sealedSnapshot?.Clone();
+}

--- a/src/Aevatar.Mainnet.Host.Api/AgentProfiles/NyxIdChatAgentProfileOptions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/AgentProfiles/NyxIdChatAgentProfileOptions.cs
@@ -1,0 +1,46 @@
+using System.Collections.Frozen;
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.Mainnet.Host.Api.AgentProfiles;
+
+public sealed class NyxIdChatAgentProfileOptions
+{
+    public const string SectionName = "Aevatar:AgentProfiles:NyxIdChat";
+    public const string StableExternalReference = "nyxid-chat";
+
+    public bool Enabled { get; set; }
+
+    public string ExternalReference { get; set; } = StableExternalReference;
+
+    public AgentProfileSnapshot? Profile { get; set; }
+}
+
+public sealed class NyxIdChatAgentProfileValidationBaseline
+{
+    public NyxIdChatAgentProfileValidationBaseline(
+        IEnumerable<string> requiredRecoveryToolNames,
+        IEnumerable<string> deniedLegacyToolNames)
+    {
+        ArgumentNullException.ThrowIfNull(requiredRecoveryToolNames);
+        ArgumentNullException.ThrowIfNull(deniedLegacyToolNames);
+        RequiredRecoveryToolNames = FreezeNames(
+            requiredRecoveryToolNames,
+            nameof(requiredRecoveryToolNames));
+        DeniedLegacyToolNames = FreezeNames(
+            deniedLegacyToolNames,
+            nameof(deniedLegacyToolNames));
+    }
+
+    public IReadOnlySet<string> RequiredRecoveryToolNames { get; }
+
+    public IReadOnlySet<string> DeniedLegacyToolNames { get; }
+
+    private static FrozenSet<string> FreezeNames(IEnumerable<string> source, string parameterName)
+    {
+        var names = source.ToArray();
+        var frozen = names.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        if (frozen.Count != names.Length)
+            throw new ArgumentException("Tool names cannot contain duplicates ignoring case.", parameterName);
+        return frozen;
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/AgentProfiles/NyxIdChatAgentProfileOptionsValidator.cs
+++ b/src/Aevatar.Mainnet.Host.Api/AgentProfiles/NyxIdChatAgentProfileOptionsValidator.cs
@@ -1,0 +1,388 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Mainnet.Host.Api.AgentProfiles;
+
+public sealed class NyxIdChatAgentProfileOptionsValidator : IValidateOptions<NyxIdChatAgentProfileOptions>
+{
+    private const int MaximumSnapshotBytes = 65_536;
+    private const int MaximumMembers = 32;
+    private const int MaximumAliasesPerMember = 16;
+    private const int MaximumPolicyEntries = 64;
+    private const int MaximumStringBytes = 128;
+    private const int MaximumRoutingDescriptionBytes = 512;
+    private const int MaximumColdPreTurnMilliseconds = 2_100;
+    private const string RequiredAgentKind = "nyxid.chat";
+
+    private static readonly Regex ProfileIdPattern = new(
+        "^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+    private static readonly Regex ProfileVersionPattern = new(
+        "^[0-9A-Za-z]+(?:[._+-][0-9A-Za-z]+)*$",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+    private static readonly Regex ToolNamePattern = new(
+        "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+    private static readonly Regex LiteralVersionPattern = new(
+        "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
+    private readonly IToolSetRegistry _toolSetRegistry;
+    private readonly NyxIdChatAgentProfileValidationBaseline _validationBaseline;
+
+    public NyxIdChatAgentProfileOptionsValidator(
+        IToolSetRegistry toolSetRegistry,
+        NyxIdChatAgentProfileValidationBaseline validationBaseline)
+    {
+        _toolSetRegistry = toolSetRegistry ?? throw new ArgumentNullException(nameof(toolSetRegistry));
+        _validationBaseline = validationBaseline ?? throw new ArgumentNullException(nameof(validationBaseline));
+    }
+
+    public ValidateOptionsResult Validate(string? name, NyxIdChatAgentProfileOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var errors = new List<string>();
+
+        if (!string.Equals(
+                options.ExternalReference,
+                NyxIdChatAgentProfileOptions.StableExternalReference,
+                StringComparison.Ordinal))
+        {
+            errors.Add($"ExternalReference must be '{NyxIdChatAgentProfileOptions.StableExternalReference}'.");
+        }
+
+        foreach (var forbiddenName in AgentProfileProductionSchemaScanner.FindForbiddenNames())
+            errors.Add($"Production profile schema name '{forbiddenName}' is forbidden.");
+
+        var profileIsPresent = options.Profile is not null;
+        var requiresBaseline = options.Enabled || profileIsPresent;
+        var requiredRecoveryNames = ValidateBaselineNames(
+            _validationBaseline.RequiredRecoveryToolNames,
+            nameof(NyxIdChatAgentProfileValidationBaseline.RequiredRecoveryToolNames),
+            requiresBaseline,
+            errors);
+        var deniedLegacyNames = ValidateBaselineNames(
+            _validationBaseline.DeniedLegacyToolNames,
+            nameof(NyxIdChatAgentProfileValidationBaseline.DeniedLegacyToolNames),
+            requiresBaseline,
+            errors);
+
+        if (options.Enabled && options.Profile is null)
+            errors.Add("An enabled NyxID chat agent profile requires a complete Profile payload.");
+
+        if (options.Profile is not null)
+            ValidateProfile(options.Profile, requiredRecoveryNames, deniedLegacyNames, errors);
+
+        return errors.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(errors);
+    }
+
+    private void ValidateProfile(
+        AgentProfileSnapshot profile,
+        HashSet<string> requiredRecoveryNames,
+        HashSet<string> deniedLegacyNames,
+        List<string> errors)
+    {
+        ValidateIdentifier(profile.ProfileId, nameof(profile.ProfileId), ProfileIdPattern, errors);
+        ValidateIdentifier(profile.ProfileVersion, nameof(profile.ProfileVersion), ProfileVersionPattern, errors);
+        ValidateRequiredString(profile.PolicyRevision, nameof(profile.PolicyRevision), MaximumStringBytes, errors);
+        if (!string.Equals(profile.AgentKind, RequiredAgentKind, StringComparison.Ordinal))
+            errors.Add($"{nameof(profile.AgentKind)} must be '{RequiredAgentKind}'.");
+
+        if (!profile.DeterministicPolicySha256.IsEmpty)
+            errors.Add($"{nameof(profile.DeterministicPolicySha256)} must be empty in configuration input.");
+
+        ValidateExactRef(profile.SkillsetProvenance, nameof(profile.SkillsetProvenance), errors);
+        ValidateToolName(profile.RouteToolSetRef, nameof(profile.RouteToolSetRef), errors);
+        var registeredToolSets = new HashSet<string>(_toolSetRegistry.GetRegisteredNames(), StringComparer.Ordinal);
+        EnsureRegisteredToolSet(profile.RouteToolSetRef, nameof(profile.RouteToolSetRef), registeredToolSets, errors);
+
+        var maximumPolicy = ValidatePolicy(
+            profile.MaximumToolPolicy,
+            nameof(profile.MaximumToolPolicy),
+            registeredToolSets,
+            errors);
+        var recoveryPolicy = ValidatePolicy(
+            profile.RecoveryToolPolicy,
+            nameof(profile.RecoveryToolPolicy),
+            registeredToolSets,
+            errors);
+        ValidateProperSubset(recoveryPolicy, maximumPolicy, nameof(profile.RecoveryToolPolicy), errors);
+
+        if (profile.Members.Count is < 1 or > MaximumMembers)
+            errors.Add($"{nameof(profile.Members)} must contain between 1 and {MaximumMembers} entries.");
+
+        ValidateMembers(profile, maximumPolicy, registeredToolSets, errors);
+        ValidateRuntimeParameters(profile, errors);
+
+        foreach (var requiredName in requiredRecoveryNames)
+        {
+            if (!maximumPolicy.ToolNames.Contains(requiredName))
+                errors.Add($"Required recovery tool '{requiredName}' is missing from the maximum policy.");
+            if (!recoveryPolicy.ToolNames.Contains(requiredName))
+                errors.Add($"Required recovery tool '{requiredName}' is missing from the recovery policy.");
+        }
+
+        foreach (var deniedName in deniedLegacyNames)
+        {
+            if (maximumPolicy.ToolNames.Contains(deniedName) || recoveryPolicy.ToolNames.Contains(deniedName))
+                errors.Add($"Denied legacy tool '{deniedName}' appears in a profile policy.");
+            if (profile.Members.Any(member => member.TaskToolPolicy?.ToolNames.Contains(deniedName, StringComparer.OrdinalIgnoreCase) == true))
+                errors.Add($"Denied legacy tool '{deniedName}' appears in a member policy.");
+        }
+
+        if (profile.DeterministicPolicySha256.IsEmpty &&
+            AgentProfileSnapshotCodec.Seal(profile).CalculateSize() > MaximumSnapshotBytes)
+        {
+            errors.Add($"The sealed profile snapshot cannot exceed {MaximumSnapshotBytes} bytes.");
+        }
+    }
+
+    private static void ValidateMembers(
+        AgentProfileSnapshot profile,
+        PolicySet maximumPolicy,
+        HashSet<string> registeredToolSets,
+        List<string> errors)
+    {
+        var intentIds = new HashSet<string>(StringComparer.Ordinal);
+        var aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var exactSkillRefs = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < profile.Members.Count; index++)
+        {
+            var member = profile.Members[index];
+            var path = $"{nameof(profile.Members)}[{index}]";
+            ValidateIdentifier(member.IntentId, $"{path}.{nameof(member.IntentId)}", ProfileIdPattern, errors);
+            if (!intentIds.Add(member.IntentId))
+                errors.Add($"{path}.{nameof(member.IntentId)} must be unique within the profile.");
+
+            ValidateRequiredString(
+                member.RoutingDescription,
+                $"{path}.{nameof(member.RoutingDescription)}",
+                MaximumRoutingDescriptionBytes,
+                errors);
+            ValidateExactRef(member.SkillRef, $"{path}.{nameof(member.SkillRef)}", errors);
+            if (member.SkillRef is not null &&
+                !exactSkillRefs.Add($"{member.SkillRef.Guid}\n{member.SkillRef.LiteralVersion}"))
+            {
+                errors.Add($"{path}.{nameof(member.SkillRef)} must be unique within the profile.");
+            }
+
+            if (member.ExplicitTriggerAliases.Count > MaximumAliasesPerMember)
+                errors.Add($"{path}.{nameof(member.ExplicitTriggerAliases)} cannot exceed {MaximumAliasesPerMember} entries.");
+            foreach (var alias in member.ExplicitTriggerAliases)
+            {
+                ValidateRequiredString(
+                    alias,
+                    $"{path}.{nameof(member.ExplicitTriggerAliases)}",
+                    MaximumStringBytes,
+                    errors);
+                if (!aliases.Add(alias))
+                    errors.Add($"{path}.{nameof(member.ExplicitTriggerAliases)} values must be globally unique ignoring case.");
+            }
+
+            var taskPolicy = ValidatePolicy(
+                member.TaskToolPolicy,
+                $"{path}.{nameof(member.TaskToolPolicy)}",
+                registeredToolSets,
+                errors);
+            ValidateProperSubset(taskPolicy, maximumPolicy, $"{path}.{nameof(member.TaskToolPolicy)}", errors);
+            if ((int)member.SideEffectClass is < 1 or > 4)
+                errors.Add($"{path}.{nameof(member.SideEffectClass)} must be explicit.");
+            ValidateRequiredString(
+                member.ExpectedSkillName,
+                $"{path}.{nameof(member.ExpectedSkillName)}",
+                MaximumStringBytes,
+                errors);
+            ValidateRequiredString(
+                member.ReviewedPublisherId,
+                $"{path}.{nameof(member.ReviewedPublisherId)}",
+                MaximumStringBytes,
+                errors);
+        }
+    }
+
+    private static void ValidateRuntimeParameters(AgentProfileSnapshot profile, List<string> errors)
+    {
+        if (profile.MaxPlanSteps != 4)
+            errors.Add($"{nameof(profile.MaxPlanSteps)} must be 4.");
+        if (profile.HandoffTtlSeconds != 900)
+            errors.Add($"{nameof(profile.HandoffTtlSeconds)} must be 900.");
+        if (profile.ClassifierTimeoutMs != 600)
+            errors.Add($"{nameof(profile.ClassifierTimeoutMs)} must be 600.");
+        if (profile.ExactSkillFetchTimeoutMs != 1_500)
+            errors.Add($"{nameof(profile.ExactSkillFetchTimeoutMs)} must be 1500.");
+        if (profile.MaxSelectedSkillBytes != 24_576)
+            errors.Add($"{nameof(profile.MaxSelectedSkillBytes)} must be 24576.");
+        if (profile.ClassifierTimeoutMs + profile.ExactSkillFetchTimeoutMs > MaximumColdPreTurnMilliseconds)
+            errors.Add($"The cold pre-turn budget cannot exceed {MaximumColdPreTurnMilliseconds} ms.");
+        if ((int)profile.ActivationMode is < 1 or > 2)
+            errors.Add($"{nameof(profile.ActivationMode)} must be Shadow or Enforced.");
+    }
+
+    private static HashSet<string> ValidateBaselineNames(
+        IReadOnlySet<string> names,
+        string path,
+        bool requireNonEmpty,
+        List<string> errors)
+    {
+        if (requireNonEmpty && names.Count == 0)
+            errors.Add($"{path} cannot be empty when a profile is enabled or supplied.");
+
+        var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in names)
+        {
+            ValidateToolName(value, path, errors);
+            if (!values.Add(value))
+                errors.Add($"{path} cannot contain duplicates ignoring case.");
+        }
+
+        return values;
+    }
+
+    private static PolicySet ValidatePolicy(
+        AgentProfileToolPolicy? policy,
+        string path,
+        HashSet<string> registeredToolSets,
+        List<string> errors)
+    {
+        if (policy is null)
+        {
+            errors.Add($"{path} is required.");
+            return PolicySet.Empty;
+        }
+
+        if (policy.ToolNames.Count > MaximumPolicyEntries)
+            errors.Add($"{path}.{nameof(policy.ToolNames)} cannot exceed {MaximumPolicyEntries} entries.");
+        if (policy.ToolSetRefs.Count > MaximumPolicyEntries)
+            errors.Add($"{path}.{nameof(policy.ToolSetRefs)} cannot exceed {MaximumPolicyEntries} entries.");
+
+        var toolNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var toolName in policy.ToolNames)
+        {
+            ValidateToolName(toolName, $"{path}.{nameof(policy.ToolNames)}", errors);
+            if (!toolNames.Add(toolName))
+                errors.Add($"{path}.{nameof(policy.ToolNames)} cannot contain duplicates ignoring case.");
+        }
+
+        var toolSets = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var toolSetRef in policy.ToolSetRefs)
+        {
+            ValidateToolName(toolSetRef, $"{path}.{nameof(policy.ToolSetRefs)}", errors);
+            if (!toolSets.Add(toolSetRef))
+                errors.Add($"{path}.{nameof(policy.ToolSetRefs)} cannot contain duplicate values.");
+            EnsureRegisteredToolSet(toolSetRef, $"{path}.{nameof(policy.ToolSetRefs)}", registeredToolSets, errors);
+        }
+
+        return new PolicySet(toolNames, toolSets);
+    }
+
+    private static void ValidateProperSubset(
+        PolicySet candidate,
+        PolicySet maximum,
+        string path,
+        List<string> errors)
+    {
+        if (!candidate.ToolNames.IsSubsetOf(maximum.ToolNames) ||
+            !candidate.ToolSets.IsSubsetOf(maximum.ToolSets) ||
+            candidate.ToolNames.SetEquals(maximum.ToolNames) && candidate.ToolSets.SetEquals(maximum.ToolSets))
+        {
+            errors.Add($"{path} must be a component-wise proper subset of the maximum policy.");
+        }
+    }
+
+    private static void ValidateExactRef(ExactRemoteSkillRef? exactRef, string path, List<string> errors)
+    {
+        if (exactRef is null)
+        {
+            errors.Add($"{path} is required.");
+            return;
+        }
+
+        ValidateExactIdentity(exactRef.Guid, exactRef.LiteralVersion, path, errors);
+    }
+
+    private static void ValidateExactRef(ExactRemoteSkillsetRef? exactRef, string path, List<string> errors)
+    {
+        if (exactRef is null)
+        {
+            errors.Add($"{path} is required.");
+            return;
+        }
+
+        ValidateExactIdentity(exactRef.Guid, exactRef.LiteralVersion, path, errors);
+    }
+
+    private static void ValidateExactIdentity(string guid, string literalVersion, string path, List<string> errors)
+    {
+        if (!Guid.TryParseExact(guid, "D", out var parsedGuid) ||
+            parsedGuid == Guid.Empty ||
+            !string.Equals(guid, parsedGuid.ToString("D"), StringComparison.Ordinal))
+        {
+            errors.Add($"{path}.Guid must be a nonzero canonical lowercase D GUID.");
+        }
+
+        ValidateRequiredString(literalVersion, $"{path}.LiteralVersion", MaximumStringBytes, errors);
+        if (!LiteralVersionPattern.IsMatch(literalVersion ?? string.Empty))
+            errors.Add($"{path}.LiteralVersion must use the '<major>.<minor>' literal form.");
+    }
+
+    private static void ValidateIdentifier(
+        string value,
+        string path,
+        Regex pattern,
+        List<string> errors)
+    {
+        ValidateRequiredString(value, path, MaximumStringBytes, errors);
+        if (!pattern.IsMatch(value ?? string.Empty))
+            errors.Add($"{path} has an invalid canonical form.");
+    }
+
+    private static void ValidateToolName(string value, string path, List<string> errors)
+    {
+        ValidateRequiredString(value, path, MaximumStringBytes, errors);
+        if (!ToolNamePattern.IsMatch(value ?? string.Empty))
+            errors.Add($"{path} has an invalid tool or tool-set name.");
+    }
+
+    private static void ValidateRequiredString(
+        string? value,
+        string path,
+        int maximumBytes,
+        List<string> errors)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            errors.Add($"{path} is required.");
+            return;
+        }
+
+        if (!string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            errors.Add($"{path} cannot contain leading or trailing whitespace.");
+        if (!value.IsNormalized(NormalizationForm.FormC))
+            errors.Add($"{path} must already be normalized to Unicode NFC.");
+        if (Encoding.UTF8.GetByteCount(value) > maximumBytes)
+            errors.Add($"{path} cannot exceed {maximumBytes} UTF-8 bytes.");
+    }
+
+    private static void EnsureRegisteredToolSet(
+        string name,
+        string path,
+        HashSet<string> registeredToolSets,
+        List<string> errors)
+    {
+        if (!registeredToolSets.Contains(name))
+            errors.Add($"{path} references unknown tool set '{name}'.");
+    }
+
+    private sealed record PolicySet(HashSet<string> ToolNames, HashSet<string> ToolSets)
+    {
+        public static PolicySet Empty { get; } = new(
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(StringComparer.Ordinal));
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -37,6 +37,7 @@ using Aevatar.GAgents.ChatRouting;
 using Aevatar.GAgents.ChatbotClassifier;
 using Aevatar.GAgents.Device;
 using Aevatar.GAgents.NyxidChat;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.GAgents.Platform.Lark;
 using Aevatar.GAgents.Platform.Telegram;
 using Aevatar.GAgents.Scheduled;
@@ -50,6 +51,7 @@ using Aevatar.Mainnet.Host.Api.ChatCompletions;
 using Aevatar.Mainnet.Host.Api.ChatRouting;
 using Aevatar.Mainnet.Host.Api.Cqrs;
 using Aevatar.Mainnet.Host.Api.Messages;
+using Aevatar.Mainnet.Host.Api.AgentProfiles;
 using Aevatar.Mainnet.Host.Api.Responses;
 using Aevatar.Mainnet.Host.Api.Scheduled;
 using Aevatar.Mainnet.Host.Api.Skills;
@@ -66,6 +68,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.Mainnet.Host.Api.Hosting;
 
@@ -151,6 +154,7 @@ public static class MainnetHostBuilderExtensions
         builder.Services.AddNyxIdAuthentication();
         builder.AddAevatarAuthentication();
         builder.Services.AddNyxIdChat(builder.Configuration);
+        AddNyxIdChatAgentProfile(builder);
         builder.Services.AddStreamingProxy(builder.Configuration);
         builder.Services.AddChatbotClassifier();
         builder.Services.AddRetiredActorCleanup();
@@ -364,6 +368,22 @@ public static class MainnetHostBuilderExtensions
         });
 
         return builder;
+    }
+
+    private static void AddNyxIdChatAgentProfile(WebApplicationBuilder builder)
+    {
+        builder.Services.TryAddSingleton(
+            new NyxIdChatAgentProfileValidationBaseline([], []));
+        builder.Services
+            .AddOptions<NyxIdChatAgentProfileOptions>()
+            .Bind(builder.Configuration.GetSection(NyxIdChatAgentProfileOptions.SectionName))
+            .ValidateOnStart();
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<NyxIdChatAgentProfileOptions>,
+                NyxIdChatAgentProfileOptionsValidator>());
+        builder.Services.Replace(
+            ServiceDescriptor.Singleton<INyxIdChatAgentProfileSnapshotSource,
+                MainnetNyxIdChatAgentProfileSnapshotSource>());
     }
 
     private static IAgentToolSource CreateToolSource<TSource>(IServiceProvider serviceProvider)

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -32,6 +32,12 @@
       "MaxSkills": 32,
       "MaxBytes": 32768
     },
+    "AgentProfiles": {
+      "NyxIdChat": {
+        "Enabled": false,
+        "ExternalReference": "nyxid-chat"
+      }
+    },
     "Responses": {
       "ModelMetadataFallbacks": {
         "deepseek": {

--- a/test/Aevatar.AI.Tests/AgentProfileSnapshotCodecTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileSnapshotCodecTests.cs
@@ -1,0 +1,100 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.GAgents.NyxidChat;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class AgentProfileSnapshotCodecTests
+{
+    [Fact]
+    public void ExactReferences_ShouldKeepFrozenWireShape()
+    {
+        ExactRemoteSkillRef.Descriptor.Fields.InFieldNumberOrder()
+            .Select(static field => (field.Name, field.FieldNumber))
+            .Should()
+            .Equal(("guid", 1), ("literal_version", 2));
+        ExactRemoteSkillsetRef.Descriptor.Fields.InFieldNumberOrder()
+            .Select(static field => (field.Name, field.FieldNumber))
+            .Should()
+            .Equal(("guid", 1), ("literal_version", 2));
+        ExactRemoteSkillRef.Descriptor.Fields.InFieldNumberOrder()
+            .Should().NotContain(static field => field.Name == "name");
+        ExactRemoteSkillsetRef.Descriptor.Fields.InFieldNumberOrder()
+            .Should().NotContain(static field => field.Name == "name");
+    }
+
+    [Fact]
+    public void AdditiveFields_ShouldRemainAbsentForOldBytes()
+    {
+        RoleGAgentState.Parser.ParseFrom(Array.Empty<byte>()).AgentProfile.Should().BeNull();
+        NyxIdChatConversationCreateCommand.Parser.ParseFrom(Array.Empty<byte>()).AgentProfile.Should().BeNull();
+    }
+
+    [Fact]
+    public void Seal_ShouldCloneInputAndExcludeDigestFromItsOwnHash()
+    {
+        var input = BuildProfile("profile-v1");
+
+        var sealedProfile = AgentProfileSnapshotCodec.Seal(input);
+        input.ProfileVersion = "mutated";
+
+        sealedProfile.ProfileVersion.Should().Be("profile-v1");
+        sealedProfile.DeterministicPolicySha256.Length.Should().Be(32);
+        AgentProfileSnapshotCodec.Verify(sealedProfile).Should().BeTrue();
+        var resealable = sealedProfile.Clone();
+        resealable.DeterministicPolicySha256 = ByteString.Empty;
+        AgentProfileSnapshotCodec.Seal(resealable)
+            .DeterministicPolicySha256
+            .Should()
+            .Equal(sealedProfile.DeterministicPolicySha256);
+    }
+
+    [Fact]
+    public void Verify_ShouldRejectTamperedSnapshot()
+    {
+        var sealedProfile = AgentProfileSnapshotCodec.Seal(BuildProfile("profile-v1"));
+        sealedProfile.ProfileVersion = "profile-v2";
+
+        AgentProfileSnapshotCodec.Verify(sealedProfile).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Seal_ShouldPreserveRepeatedOrderInDigestAndEquality()
+    {
+        var left = BuildProfile("profile-v1");
+        left.MaximumToolPolicy.ToolNames.Add(["alpha", "beta"]);
+        var right = BuildProfile("profile-v1");
+        right.MaximumToolPolicy.ToolNames.Add(["beta", "alpha"]);
+
+        var sealedLeft = AgentProfileSnapshotCodec.Seal(left);
+        var sealedRight = AgentProfileSnapshotCodec.Seal(right);
+
+        sealedLeft.DeterministicPolicySha256.Should().NotEqual(sealedRight.DeterministicPolicySha256);
+        AgentProfileSnapshotCodec.ByteEquivalent(sealedLeft, sealedRight).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Seal_ShouldIncludeUnknownFieldsInDigest()
+    {
+        var baselineBytes = BuildProfile("profile-v1").ToByteArray();
+        var withUnknownA = AgentProfileSnapshot.Parser.ParseFrom(
+            baselineBytes.Concat(new byte[] { 0xA0, 0x06, 0x01 }).ToArray());
+        var withUnknownB = AgentProfileSnapshot.Parser.ParseFrom(
+            baselineBytes.Concat(new byte[] { 0xA0, 0x06, 0x02 }).ToArray());
+
+        var sealedA = AgentProfileSnapshotCodec.Seal(withUnknownA);
+        var sealedB = AgentProfileSnapshotCodec.Seal(withUnknownB);
+
+        sealedA.DeterministicPolicySha256.Should().NotEqual(sealedB.DeterministicPolicySha256);
+        AgentProfileSnapshotCodec.Verify(sealedA).Should().BeTrue();
+    }
+
+    private static AgentProfileSnapshot BuildProfile(string profileVersion) => new()
+    {
+        ProfileId = "profile-alpha",
+        ProfileVersion = profileVersion,
+        MaximumToolPolicy = new AgentProfileToolPolicy(),
+    };
+}

--- a/test/Aevatar.AI.Tests/AgentProfileSnapshotCodecTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileSnapshotCodecTests.cs
@@ -52,12 +52,36 @@ public sealed class AgentProfileSnapshotCodecTests
     }
 
     [Fact]
+    public void Seal_ShouldRejectSnapshotWithExistingDigest()
+    {
+        var sealedProfile = AgentProfileSnapshotCodec.Seal(BuildProfile("profile-v1"));
+
+        var act = () => AgentProfileSnapshotCodec.Seal(sealedProfile);
+
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("*digest must be empty before sealing*");
+    }
+
+    [Fact]
     public void Verify_ShouldRejectTamperedSnapshot()
     {
         var sealedProfile = AgentProfileSnapshotCodec.Seal(BuildProfile("profile-v1"));
         sealedProfile.ProfileVersion = "profile-v2";
 
         AgentProfileSnapshotCodec.Verify(sealedProfile).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(31)]
+    [InlineData(33)]
+    public void Verify_ShouldRejectDigestWithInvalidLength(int digestLength)
+    {
+        var profile = BuildProfile("profile-v1");
+        profile.DeterministicPolicySha256 = ByteString.CopyFrom(new byte[digestLength]);
+
+        AgentProfileSnapshotCodec.Verify(profile).Should().BeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -29,6 +29,7 @@ using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.AGUI.Contracts;
 using FluentAssertions;
 using Google.Protobuf;
@@ -2907,7 +2908,7 @@ public class NyxIdChatEndpointsCoverageTests
         var facade = new NyxIdChatLifecycleFacade(
             new DefaultCommandDispatchService<NyxIdChatConversationCreateCommand, NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandReceipt, NyxIdChatLifecycleCommandStartError>(
                 new DefaultCommandDispatchPipeline<NyxIdChatConversationCreateCommand, NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandReceipt, NyxIdChatLifecycleCommandStartError>(
-                    new NyxIdChatConversationCreateCommandTargetResolver(runtime, routeQueryPort, resolver),
+                    new NyxIdChatConversationCreateCommandTargetResolver(runtime, routeQueryPort, resolver, new DisabledNyxIdChatAgentProfileSnapshotSource()),
                     new DefaultCommandContextPolicy(),
                     new NyxIdChatLifecycleCommandEnvelopeFactory(),
                     new ActorCommandTargetDispatcher<NyxIdChatConversationCreateCommandTarget>(dispatchPort),
@@ -2919,7 +2920,6 @@ public class NyxIdChatEndpointsCoverageTests
                     new NyxIdChatLifecycleCommandEnvelopeFactory(),
                     new ActorCommandTargetDispatcher<NyxIdChatConversationDeleteCommandTarget>(dispatchPort),
                     new NyxIdChatDeleteLifecycleCommandReceiptFactory())));
-
         return RebuildArgs(parameters, args, facade);
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -208,6 +208,72 @@ public class NyxIdChatGAgentTests
         AgentProfileSnapshotCodec.Verify(restored.State.AgentProfile).Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData(false, "complete snapshot")]
+    [InlineData(true, "valid digest")]
+    public async Task ActivateAsync_ShouldRejectCommittedBindingWithoutValidCompleteProfile(
+        bool tamperDigest,
+        string expectedMessage)
+    {
+        using var provider = BuildServiceProvider();
+        var actorId = tamperDigest
+            ? "nyxid-chat-profile-replay-invalid-digest"
+            : "nyxid-chat-profile-replay-missing";
+        var binding = new AgentProfileBoundEvent();
+        if (tamperDigest)
+        {
+            var profile = BuildSealedProfile("profile-v1");
+            profile.ProfileVersion = "tampered";
+            binding.Profile = profile;
+        }
+
+        await AppendCommittedEventsAsync(provider, actorId, binding);
+        var agent = CreateAgent(provider, actorId);
+
+        var act = () => agent.ActivateAsync();
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{expectedMessage}*");
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldReplayEquivalentCommittedBindingIdempotently()
+    {
+        using var provider = BuildServiceProvider();
+        const string actorId = "nyxid-chat-profile-replay-equivalent";
+        var profile = BuildSealedProfile("profile-v1");
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = profile.Clone() },
+            new AgentProfileBoundEvent { Profile = profile.Clone() });
+        var agent = CreateAgent(provider, actorId);
+
+        await agent.ActivateAsync();
+
+        AgentProfileSnapshotCodec.ByteEquivalent(agent.State.AgentProfile, profile).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldRejectConflictingCommittedBindingDuringReplay()
+    {
+        using var provider = BuildServiceProvider();
+        const string actorId = "nyxid-chat-profile-replay-conflict";
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = BuildSealedProfile("profile-v1") },
+            new AgentProfileBoundEvent { Profile = BuildSealedProfile("profile-v2") });
+        var agent = CreateAgent(provider, actorId);
+
+        var act = () => agent.ActivateAsync();
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot be replaced*");
+    }
+
     [Fact]
     public async Task Conversations_ShouldKeepIndependentProfileVersions()
     {
@@ -630,6 +696,25 @@ public class NyxIdChatGAgentTests
         Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actorId } },
         Propagation = new EnvelopePropagation { CorrelationId = Guid.NewGuid().ToString("N") },
     };
+
+    private static async Task AppendCommittedEventsAsync(
+        IServiceProvider provider,
+        string actorId,
+        params IMessage[] events)
+    {
+        var stateEvents = events.Select((evt, index) => new StateEvent
+        {
+            EventId = $"profile-binding-{index + 1}",
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Version = index + 1,
+            EventType = evt.Descriptor.FullName,
+            EventData = Any.Pack(evt),
+            AgentId = actorId,
+        });
+
+        await provider.GetRequiredService<IEventStore>()
+            .AppendAsync(actorId, stateEvents, expectedVersion: 0);
+    }
 
     private static ChatRouteResolver NewChatRouteResolver() =>
         new(new StaticChatRouteFallbackProvider(string.Empty));

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -82,6 +82,39 @@ public class NyxIdChatGAgentTests
         runtime.CreateCalls.Should().BeEmpty();
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CreateTargetResolver_ShouldRejectProfileRouteWithoutCompleteToolSetRef(
+        bool missingForwardToModel)
+    {
+        var runtime = new RecordingActorRuntime();
+        var source = new FixedAgentProfileSnapshotSource(BuildSealedProfile("profile-v1", "reviewed.route"));
+        var routeSnapshot = missingForwardToModel
+            ? null
+            : new ChatRoutePolicySnapshot(
+                new ChatRouteAction { ForwardToModel = new ForwardToModel() },
+                []);
+        var routeQueryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(routeSnapshot);
+        var routeResolver = missingForwardToModel
+            ? new ChatRouteResolver(new MissingForwardToModelFallbackProvider())
+            : NewChatRouteResolver();
+        var resolver = new NyxIdChatConversationCreateCommandTargetResolver(
+            runtime,
+            routeQueryPort,
+            routeResolver,
+            source);
+        var command = new NyxIdChatConversationCreateCommand { ScopeId = "scope-a" };
+
+        var result = await resolver.ResolveAsync(command);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
+        source.CallCount.Should().Be(1);
+        runtime.CreateCalls.Should().BeEmpty();
+        command.AgentProfile.Should().BeNull();
+    }
+
     [Fact]
     public async Task HandleCreateConversationAsync_ShouldBindProfileBeforeCreationAndRegistrationEvents()
     {
@@ -738,6 +771,17 @@ public class NyxIdChatGAgentTests
             {
                 ForwardToModel = new ForwardToModel { ModelName = modelName },
             },
+            MatchedRuleId = string.Empty,
+            UsedFallback = true,
+            ResolvedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+    }
+
+    private sealed class MissingForwardToModelFallbackProvider : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = new ChatRouteAction(),
             MatchedRuleId = string.Empty,
             UsedFallback = true,
             ResolvedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -3,12 +3,16 @@ using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgents.NyxidChat;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Google.Protobuf;
@@ -19,6 +23,214 @@ namespace Aevatar.AI.Tests;
 
 public class NyxIdChatGAgentTests
 {
+    [Fact]
+    public async Task CreateTargetResolver_ShouldCopySelectedProfileForMatchingDirectRoute()
+    {
+        var runtime = new RecordingActorRuntime();
+        var source = new FixedAgentProfileSnapshotSource(BuildSealedProfile("profile-v1", "profile.route"));
+        var routeQueryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel
+                {
+                    ToolSetRef = new ChatRouteToolSetRef { Name = "profile.route" },
+                },
+            },
+            []));
+        var resolver = new NyxIdChatConversationCreateCommandTargetResolver(
+            runtime,
+            routeQueryPort,
+            NewChatRouteResolver(),
+            source);
+        var command = new NyxIdChatConversationCreateCommand { ScopeId = "scope-a" };
+
+        var result = await resolver.ResolveAsync(command);
+
+        result.Succeeded.Should().BeTrue();
+        source.CallCount.Should().Be(1);
+        runtime.CreateCalls.Should().ContainSingle();
+        command.AgentProfile.Should().NotBeNull();
+        AgentProfileSnapshotCodec.ByteEquivalent(command.AgentProfile, source.Snapshot).Should().BeTrue();
+        command.AgentProfile.Should().NotBeSameAs(source.Snapshot);
+    }
+
+    [Fact]
+    public async Task CreateTargetResolver_ShouldRejectProfileRouteDriftBeforeCreatingActor()
+    {
+        var runtime = new RecordingActorRuntime();
+        var source = new FixedAgentProfileSnapshotSource(BuildSealedProfile("profile-v1", "reviewed.route"));
+        var routeQueryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel
+                {
+                    ToolSetRef = new ChatRouteToolSetRef { Name = "drifted.route" },
+                },
+            },
+            []));
+        var resolver = new NyxIdChatConversationCreateCommandTargetResolver(
+            runtime,
+            routeQueryPort,
+            NewChatRouteResolver(),
+            source);
+
+        var result = await resolver.ResolveAsync(new NyxIdChatConversationCreateCommand { ScopeId = "scope-a" });
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
+        source.CallCount.Should().Be(1);
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_ShouldBindProfileBeforeCreationAndRegistrationEvents()
+    {
+        var registry = new RecordingGAgentActorRegistryCommandPort();
+        using var provider = BuildServiceProvider(registry, new RecordingActorRuntime());
+        const string actorId = "nyxid-chat-profile-order";
+        var agent = CreateAgent(provider, actorId);
+
+        await agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            CreatedLocally = true,
+            AgentProfile = BuildSealedProfile("profile-v1"),
+        }));
+
+        var events = await provider.GetRequiredService<IEventStore>().GetEventsAsync(actorId);
+        events.Select(static stateEvent => stateEvent.EventData.TypeUrl).Should().Equal(
+            Any.Pack(new AgentProfileBoundEvent()).TypeUrl,
+            Any.Pack(new NyxIdChatConversationCreationStartedEvent()).TypeUrl,
+            Any.Pack(new NyxIdChatConversationRegistrationAcceptedEvent()).TypeUrl);
+        agent.State.AgentProfile.ProfileVersion.Should().Be("profile-v1");
+        registry.RegisteredActors.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_ShouldNotAppendEquivalentBindingTwice()
+    {
+        var registry = new RecordingGAgentActorRegistryCommandPort();
+        using var provider = BuildServiceProvider(registry, new RecordingActorRuntime());
+        const string actorId = "nyxid-chat-profile-repeat";
+        var agent = CreateAgent(provider, actorId);
+        var profile = BuildSealedProfile("profile-v1");
+
+        await agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            CreatedLocally = true,
+            AgentProfile = profile.Clone(),
+        }));
+        await agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            CreatedLocally = true,
+            AgentProfile = profile.Clone(),
+        }));
+
+        var events = await provider.GetRequiredService<IEventStore>().GetEventsAsync(actorId);
+        events.Count(static stateEvent => stateEvent.EventData.Is(AgentProfileBoundEvent.Descriptor))
+            .Should()
+            .Be(1);
+        registry.RegisteredActors.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_ShouldRejectDifferentOrMissingProfileAfterBinding()
+    {
+        var registry = new RecordingGAgentActorRegistryCommandPort();
+        using var provider = BuildServiceProvider(registry, new RecordingActorRuntime());
+        const string actorId = "nyxid-chat-profile-conflict";
+        var agent = CreateAgent(provider, actorId);
+
+        await agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            AgentProfile = BuildSealedProfile("profile-v1"),
+        }));
+
+        var replace = () => agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            AgentProfile = BuildSealedProfile("profile-v2"),
+        }));
+        var remove = () => agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+        }));
+
+        await replace.Should().ThrowAsync<InvalidOperationException>();
+        await remove.Should().ThrowAsync<InvalidOperationException>();
+        registry.RegisteredActors.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_ShouldRejectInvalidDigestBeforeRegistryIo()
+    {
+        var registry = new RecordingGAgentActorRegistryCommandPort();
+        using var provider = BuildServiceProvider(registry, new RecordingActorRuntime());
+        const string actorId = "nyxid-chat-profile-bad-digest";
+        var agent = CreateAgent(provider, actorId);
+        var profile = BuildSealedProfile("profile-v1");
+        profile.ProfileVersion = "tampered";
+
+        var act = () => agent.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            AgentProfile = profile,
+        }));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        registry.RegisteredActors.Should().BeEmpty();
+        (await provider.GetRequiredService<IEventStore>().GetEventsAsync(actorId)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldRestoreBoundProfileFromCommittedEvents()
+    {
+        var registry = new RecordingGAgentActorRegistryCommandPort();
+        using var provider = BuildServiceProvider(registry, new RecordingActorRuntime());
+        const string actorId = "nyxid-chat-profile-restart";
+        var first = CreateAgent(provider, actorId);
+        await first.ActivateAsync();
+        await first.HandleEventAsync(CreateEnvelope(actorId, new NyxIdChatConversationCreateCommand
+        {
+            ScopeId = "scope-a",
+            AgentProfile = BuildSealedProfile("profile-v1"),
+        }));
+        await first.DeactivateAsync();
+
+        var restored = CreateAgent(provider, actorId);
+        await restored.ActivateAsync();
+
+        restored.State.AgentProfile.Should().NotBeNull();
+        restored.State.AgentProfile.ProfileVersion.Should().Be("profile-v1");
+        AgentProfileSnapshotCodec.Verify(restored.State.AgentProfile).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Conversations_ShouldKeepIndependentProfileVersions()
+    {
+        var registry = new RecordingGAgentActorRegistryCommandPort();
+        using var provider = BuildServiceProvider(registry, new RecordingActorRuntime());
+        var agents = Enumerable.Range(1, 4)
+            .Select(index => CreateAgent(provider, $"nyxid-chat-profile-{index}"))
+            .ToArray();
+
+        for (var index = 0; index < agents.Length; index++)
+        {
+            await agents[index].HandleEventAsync(CreateEnvelope(agents[index].Id, new NyxIdChatConversationCreateCommand
+            {
+                ScopeId = "scope-a",
+                AgentProfile = BuildSealedProfile($"profile-v{index + 1}"),
+            }));
+        }
+
+        agents.Select(static agent => agent.State.AgentProfile.ProfileVersion)
+            .Should()
+            .Equal("profile-v1", "profile-v2", "profile-v3", "profile-v4");
+    }
+
     [Fact]
     public async Task ActivateAsync_ShouldPinNyxIdProviderOnFirstInitialization()
     {
@@ -419,6 +631,58 @@ public class NyxIdChatGAgentTests
         Propagation = new EnvelopePropagation { CorrelationId = Guid.NewGuid().ToString("N") },
     };
 
+    private static ChatRouteResolver NewChatRouteResolver() =>
+        new(new StaticChatRouteFallbackProvider(string.Empty));
+
+    private static AgentProfileSnapshot BuildSealedProfile(
+        string profileVersion,
+        string routeToolSetRef = "") =>
+        AgentProfileSnapshotCodec.Seal(new AgentProfileSnapshot
+        {
+            ProfileId = "profile-alpha",
+            ProfileVersion = profileVersion,
+            AgentKind = "nyxid.chat",
+            RouteToolSetRef = routeToolSetRef,
+        });
+
+    private sealed class StaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel { ModelName = modelName },
+            },
+            MatchedRuleId = string.Empty,
+            UsedFallback = true,
+            ResolvedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+    }
+
+    private sealed class StaticChatRoutePolicyQueryPort(ChatRoutePolicySnapshot? snapshot)
+        : IChatRoutePolicyQueryPort
+    {
+        public static StaticChatRoutePolicyQueryPort ForSnapshot(ChatRoutePolicySnapshot? snapshot) => new(snapshot);
+
+        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+            OwnerScope callerScope,
+            CancellationToken ct = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class FixedAgentProfileSnapshotSource(AgentProfileSnapshot snapshot)
+        : INyxIdChatAgentProfileSnapshotSource
+    {
+        public AgentProfileSnapshot Snapshot { get; } = snapshot;
+        public int CallCount { get; private set; }
+
+        public AgentProfileSnapshot? GetSnapshotForNewConversation()
+        {
+            CallCount++;
+            return Snapshot.Clone();
+        }
+    }
+
     private sealed class RecordingGAgentActorRegistryCommandPort : IGAgentActorRegistryCommandPort
     {
         public GAgentActorRegistryCommandStage RegisterStage { get; init; } =
@@ -507,17 +771,21 @@ public class NyxIdChatGAgentTests
 
     private sealed class RecordingActorRuntime : IActorRuntime
     {
+        public List<(System.Type Type, string? Id)> CreateCalls { get; } = [];
         public List<string> DestroyedActors { get; } = [];
 
         public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(new RecordingActor(id));
 
         public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
-            where TAgent : IAgent =>
-            Task.FromResult<IActor>(new RecordingActor(id ?? Guid.NewGuid().ToString("N")));
+            where TAgent : IAgent
+        {
+            CreateCalls.Add((typeof(TAgent), id));
+            return Task.FromResult<IActor>(new RecordingActor(id ?? Guid.NewGuid().ToString("N")));
+        }
 
         public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default)
         {
-            _ = agentType;
+            CreateCalls.Add((agentType, id));
             return Task.FromResult<IActor>(new RecordingActor(id ?? Guid.NewGuid().ToString("N")));
         }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
@@ -7,6 +7,7 @@ using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,18 @@ namespace Aevatar.AI.Tests;
 
 public sealed class NyxIdChatServiceCollectionExtensionsTests
 {
+    [Fact]
+    public void AddNyxIdChat_ShouldRegisterDefaultDisabledAgentProfileSource()
+    {
+        var services = new ServiceCollection();
+
+        services.AddNyxIdChat(new ConfigurationBuilder().Build());
+
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(INyxIdChatAgentProfileSnapshotSource) &&
+            descriptor.ImplementationType == typeof(DisabledNyxIdChatAgentProfileSnapshotSource));
+    }
+
     [Fact]
     public void AddNyxIdChat_ShouldNotRegisterRelayReplayGuard()
     {

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -36,7 +36,9 @@ using Aevatar.GAgents.Channel.NyxIdRelay.Outbound;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Device;
 using Aevatar.GAgents.Scheduled;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.GAgents.StatusDashboard.Executors;
+using Aevatar.Mainnet.Host.Api.AgentProfiles;
 using Aevatar.Mainnet.Host.Api.Hosting;
 using Aevatar.Mainnet.Host.Api.Responses;
 using Aevatar.Foundation.Abstractions.HumanInteraction;
@@ -55,6 +57,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -63,6 +66,53 @@ namespace Aevatar.Capabilities.Tests;
 [Collection(ProcessEnvSerialCollection.Name)]
 public sealed class MainnetHostCompositionTests
 {
+    [Fact]
+    public void AddAevatarMainnetHost_ShouldComposeDisabledProfileSourceWithEmptyReplaceableBaseline()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        var builder = CreateBuilder();
+
+        builder.AddAevatarMainnetHost(options =>
+        {
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+        });
+
+        using var app = builder.Build();
+        var profileOptions = app.Services.GetRequiredService<IOptions<NyxIdChatAgentProfileOptions>>().Value;
+        var baseline = app.Services.GetRequiredService<NyxIdChatAgentProfileValidationBaseline>();
+        var source = app.Services.GetRequiredService<INyxIdChatAgentProfileSnapshotSource>();
+
+        profileOptions.Enabled.Should().BeFalse();
+        profileOptions.ExternalReference.Should().Be(NyxIdChatAgentProfileOptions.StableExternalReference);
+        baseline.RequiredRecoveryToolNames.Should().BeEmpty();
+        baseline.DeniedLegacyToolNames.Should().BeEmpty();
+        source.Should().BeOfType<MainnetNyxIdChatAgentProfileSnapshotSource>();
+        source.GetSnapshotForNewConversation().Should().BeNull();
+    }
+
+    [Fact]
+    public void AddAevatarMainnetHost_ShouldAllowReviewedBaselineReplacementAtCompositionSeam()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        var builder = CreateBuilder();
+        builder.AddAevatarMainnetHost(options =>
+        {
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+        });
+        var reviewed = new NyxIdChatAgentProfileValidationBaseline(
+            ["recover_tool"],
+            ["legacy_tool"]);
+        builder.Services.Replace(ServiceDescriptor.Singleton(reviewed));
+
+        using var app = builder.Build();
+
+        app.Services.GetRequiredService<NyxIdChatAgentProfileValidationBaseline>()
+            .Should()
+            .BeSameAs(reviewed);
+    }
+
     [Fact]
     public async Task AddAevatarMainnetHost_WithInMemoryDependencies_ShouldBuildAndStartFullComposition()
     {

--- a/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
@@ -1,0 +1,351 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
+using Aevatar.Mainnet.Host.Api.AgentProfiles;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Capabilities.Tests;
+
+public sealed class NyxIdChatAgentProfileOptionsTests
+{
+    private const string CanonicalGuid = "550e8400-e29b-41d4-a716-446655440000";
+    private const string NonzeroVersionZeroGuid = "00000000-0000-0000-0000-000000000001";
+    private const string NilGuid = "00000000-0000-0000-0000-000000000000";
+
+    public static TheoryData<bool, string> ValidExactGuids => new()
+    {
+        { false, CanonicalGuid },
+        { true, CanonicalGuid },
+        { false, NonzeroVersionZeroGuid },
+        { true, NonzeroVersionZeroGuid },
+    };
+
+    public static TheoryData<bool, string> InvalidExactGuids => new()
+    {
+        { false, "" },
+        { true, "" },
+        { false, " " },
+        { true, " " },
+        { false, $" {CanonicalGuid}" },
+        { true, $"{CanonicalGuid} " },
+        { false, CanonicalGuid.ToUpperInvariant() },
+        { true, CanonicalGuid.ToUpperInvariant() },
+        { false, "550e8400e29b41d4a716446655440000" },
+        { true, "{550e8400-e29b-41d4-a716-446655440000}" },
+        { false, "(550e8400-e29b-41d4-a716-446655440000)" },
+        { true, "550e8400-e29b-41d4-a716-44665544000" },
+        { false, "550e8400-e29b-41d4-a716-44665544000z" },
+    };
+
+    [Fact]
+    public void Validate_ShouldAcceptDefaultDisabledSlotWithEmptyBaseline()
+    {
+        var result = CreateValidator(new NyxIdChatAgentProfileValidationBaseline([], []))
+            .Validate(null, new NyxIdChatAgentProfileOptions());
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldRejectDisabledProfilePayloadWithEmptyBaseline()
+    {
+        var result = CreateValidator(new NyxIdChatAgentProfileValidationBaseline([], []))
+            .Validate(null, new NyxIdChatAgentProfileOptions
+            {
+                Enabled = false,
+                Profile = BuildValidProfile(),
+            });
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("RequiredRecoveryToolNames", StringComparison.Ordinal));
+        result.Failures.Should().Contain(message => message.Contains("DeniedLegacyToolNames", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void Validate_ShouldRequireBothBaselineSetsForEnabledProfile(
+        bool emptyRequired,
+        bool emptyDenied)
+    {
+        var baseline = new NyxIdChatAgentProfileValidationBaseline(
+            emptyRequired ? [] : ["recover_tool"],
+            emptyDenied ? [] : ["legacy_tool"]);
+
+        var result = CreateValidator(baseline).Validate(null, EnabledOptions());
+
+        result.Failed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_ShouldAcceptReviewedBaselineAndCompleteProfile()
+    {
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, EnabledOptions());
+
+        result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+    }
+
+    [MemberData(nameof(ValidExactGuids))]
+    [Theory]
+    public void Validate_ShouldAcceptCanonicalNonzeroGuidForBothExactRefKinds(
+        bool skillsetRef,
+        string guid)
+    {
+        var options = EnabledOptions();
+        SetExactGuid(options.Profile!, skillsetRef, guid);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+    }
+
+    [MemberData(nameof(InvalidExactGuids))]
+    [Theory]
+    public void Validate_ShouldRejectNoncanonicalGuidForBothExactRefKinds(
+        bool skillsetRef,
+        string guid)
+    {
+        var options = EnabledOptions();
+        SetExactGuid(options.Profile!, skillsetRef, guid);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("nonzero canonical lowercase D GUID", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Validate_ShouldRejectNilGuidForBothExactRefKinds(bool skillsetRef)
+    {
+        var options = EnabledOptions();
+        SetExactGuid(options.Profile!, skillsetRef, NilGuid);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("nonzero canonical lowercase D GUID", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("1.0.0")]
+    [InlineData("latest")]
+    [InlineData("^1.0")]
+    [InlineData("01.0")]
+    public void Validate_ShouldRejectNonliteralOrnnVersion(string literalVersion)
+    {
+        var options = EnabledOptions();
+        options.Profile!.Members[0].SkillRef.LiteralVersion = literalVersion;
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("<major>.<minor>", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ShouldRejectMissingRequiredRecoveryTool()
+    {
+        var baseline = new NyxIdChatAgentProfileValidationBaseline(["missing_tool"], ["legacy_tool"]);
+
+        var result = CreateValidator(baseline).Validate(null, EnabledOptions());
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("missing from the maximum policy", StringComparison.Ordinal));
+        result.Failures.Should().Contain(message => message.Contains("missing from the recovery policy", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("maximum")]
+    [InlineData("recovery")]
+    [InlineData("member")]
+    public void Validate_ShouldRejectDeniedLegacyToolInEveryPolicy(string policy)
+    {
+        var options = EnabledOptions();
+        var target = policy switch
+        {
+            "maximum" => options.Profile!.MaximumToolPolicy,
+            "recovery" => options.Profile!.RecoveryToolPolicy,
+            _ => options.Profile!.Members[0].TaskToolPolicy,
+        };
+        target.ToolNames.Add("legacy_tool");
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("Denied legacy tool", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ShouldRejectNonNfcAliasAndDuplicateToolNamesIgnoringCase()
+    {
+        var options = EnabledOptions();
+        options.Profile!.Members[0].ExplicitTriggerAliases.Add("e\u0301");
+        options.Profile.MaximumToolPolicy.ToolNames.Add("RECOVER_TOOL");
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("Unicode NFC", StringComparison.Ordinal));
+        result.Failures.Should().Contain(message => message.Contains("duplicates ignoring case", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ShouldRejectUnknownRouteToolSetAndNonProperMemberPolicy()
+    {
+        var options = EnabledOptions();
+        options.Profile!.RouteToolSetRef = "missing.route";
+        options.Profile.Members[0].TaskToolPolicy = options.Profile.MaximumToolPolicy.Clone();
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message => message.Contains("unknown tool set", StringComparison.Ordinal));
+        result.Failures.Should().Contain(message => message.Contains("proper subset", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidationBaseline_ShouldDefensivelyCopyInputWithoutChangingComparerSemantics()
+    {
+        var required = new[] { "recover_tool" };
+        var denied = new[] { "legacy_tool" };
+        var baseline = new NyxIdChatAgentProfileValidationBaseline(required, denied);
+        required[0] = "mutated";
+        denied[0] = "mutated";
+
+        baseline.RequiredRecoveryToolNames.Should().Equal("recover_tool");
+        baseline.DeniedLegacyToolNames.Should().Equal("legacy_tool");
+    }
+
+    [Fact]
+    public void ValidationBaseline_ShouldRejectDuplicateNamesIgnoringCase()
+    {
+        var act = () => new NyxIdChatAgentProfileValidationBaseline(
+            ["recover_tool", "RECOVER_TOOL"],
+            ["legacy_tool"]);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ProductionSchemaScanner_ShouldAcceptAllThreeBoundedRoots()
+    {
+        AgentProfileProductionSchemaScanner.FindForbiddenNames().Should().BeEmpty();
+        typeof(NyxIdChatAgentProfileOptions).GetProperty(nameof(NyxIdChatAgentProfileOptions.Profile)).Should().NotBeNull();
+        typeof(NyxIdChatAgentProfileValidationBaseline)
+            .GetProperty(nameof(NyxIdChatAgentProfileValidationBaseline.RequiredRecoveryToolNames))
+            .Should()
+            .NotBeNull();
+    }
+
+    [Fact]
+    public void MainnetSnapshotSource_ShouldFreezeAndCloneEnabledProfile()
+    {
+        var configuredProfile = BuildValidProfile();
+        var source = new MainnetNyxIdChatAgentProfileSnapshotSource(
+            Options.Create(new NyxIdChatAgentProfileOptions
+            {
+                Enabled = true,
+                Profile = configuredProfile,
+            }));
+        configuredProfile.ProfileVersion = "mutated-after-startup";
+
+        var first = source.GetSnapshotForNewConversation();
+        var second = source.GetSnapshotForNewConversation();
+        first!.ProfileVersion = "caller-mutation";
+
+        second.Should().NotBeNull();
+        second!.ProfileVersion.Should().Be("profile-v1");
+        second.Should().NotBeSameAs(first);
+        AgentProfileSnapshotCodec.Verify(second).Should().BeTrue();
+    }
+
+    private static NyxIdChatAgentProfileOptionsValidator CreateValidator(
+        NyxIdChatAgentProfileValidationBaseline baseline) =>
+        new(new FixedToolSetRegistry(["profile.route"]), baseline);
+
+    private static NyxIdChatAgentProfileValidationBaseline ReviewedBaseline() =>
+        new(["recover_tool"], ["legacy_tool"]);
+
+    private static NyxIdChatAgentProfileOptions EnabledOptions() => new()
+    {
+        Enabled = true,
+        Profile = BuildValidProfile(),
+    };
+
+    private static AgentProfileSnapshot BuildValidProfile() => new()
+    {
+        ProfileId = "profile-alpha",
+        ProfileVersion = "profile-v1",
+        AgentKind = "nyxid.chat",
+        PolicyRevision = "revision-1",
+        SkillsetProvenance = new ExactRemoteSkillsetRef
+        {
+            Guid = CanonicalGuid,
+            LiteralVersion = "1.0",
+        },
+        RouteToolSetRef = "profile.route",
+        MaximumToolPolicy = new AgentProfileToolPolicy
+        {
+            ToolNames = { "recover_tool", "task_tool" },
+        },
+        RecoveryToolPolicy = new AgentProfileToolPolicy
+        {
+            ToolNames = { "recover_tool" },
+        },
+        Members =
+        {
+            new AgentProfileSkillMember
+            {
+                IntentId = "intent-alpha",
+                RoutingDescription = "Route alpha requests.",
+                SkillRef = new ExactRemoteSkillRef
+                {
+                    Guid = NonzeroVersionZeroGuid,
+                    LiteralVersion = "1.0",
+                },
+                ExplicitTriggerAliases = { "alpha" },
+                TaskToolPolicy = new AgentProfileToolPolicy
+                {
+                    ToolNames = { "task_tool" },
+                },
+                SideEffectClass = AgentProfileSideEffectClass.ReadOnly,
+                ExpectedSkillName = "skill-alpha",
+                ReviewedPublisherId = "publisher-alpha",
+            },
+        },
+        MaxPlanSteps = 4,
+        HandoffTtlSeconds = 900,
+        ClassifierTimeoutMs = 600,
+        ExactSkillFetchTimeoutMs = 1_500,
+        MaxSelectedSkillBytes = 24_576,
+        ActivationMode = AgentProfileActivationMode.Enforced,
+    };
+
+    private static void SetExactGuid(AgentProfileSnapshot profile, bool skillsetRef, string guid)
+    {
+        if (skillsetRef)
+            profile.SkillsetProvenance.Guid = guid;
+        else
+            profile.Members[0].SkillRef.Guid = guid;
+    }
+
+    private sealed class FixedToolSetRegistry(IReadOnlyList<string> names) : IToolSetRegistry
+    {
+        public IReadOnlyList<string> GetRegisteredNames() => names;
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+            names.Contains(toolSetRef?.Name, StringComparer.Ordinal)
+                ? ToolSetResolveResult.Success(toolSetRef!.Name, [])
+                : ToolSetResolveResult.Failure(new ToolSetResolveError(
+                    ToolSetResolveError.UnknownNameCode,
+                    toolSetRef?.Name ?? string.Empty,
+                    "Unknown test tool set.",
+                    names));
+    }
+}

--- a/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
@@ -138,6 +138,100 @@ public sealed class NyxIdChatAgentProfileOptionsTests
     }
 
     [Theory]
+    [InlineData(true, "SkillsetProvenance")]
+    [InlineData(false, "SkillRef")]
+    public void Validate_ShouldRejectMissingExactReference(bool skillsetRef, string expectedFailure)
+    {
+        var options = EnabledOptions();
+        if (skillsetRef)
+            options.Profile!.SkillsetProvenance = null;
+        else
+            options.Profile!.Members[0].SkillRef = null;
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(expectedFailure, StringComparison.Ordinal) &&
+            message.Contains("is required", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(true, "ProfileId")]
+    [InlineData(false, "IntentId")]
+    public void Validate_ShouldRejectNoncanonicalIdentifier(bool profileIdentifier, string expectedFailure)
+    {
+        var options = EnabledOptions();
+        if (profileIdentifier)
+            options.Profile!.ProfileId = "not canonical";
+        else
+            options.Profile!.Members[0].IntentId = "not canonical";
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(expectedFailure, StringComparison.Ordinal) &&
+            message.Contains("invalid canonical form", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(true, "RouteToolSetRef")]
+    [InlineData(false, "MaximumToolPolicy.ToolNames")]
+    public void Validate_ShouldRejectInvalidToolOrToolSetName(bool routeToolSet, string expectedFailure)
+    {
+        var options = EnabledOptions();
+        if (routeToolSet)
+            options.Profile!.RouteToolSetRef = "not a tool set";
+        else
+            options.Profile!.MaximumToolPolicy.ToolNames.Add("not a tool");
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(expectedFailure, StringComparison.Ordinal) &&
+            message.Contains("invalid tool or tool-set name", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("", "is required")]
+    [InlineData(" revision-1", "leading or trailing whitespace")]
+    [InlineData("revision-1 ", "leading or trailing whitespace")]
+    public void Validate_ShouldRejectMissingOrPaddedRequiredString(string policyRevision, string expectedFailure)
+    {
+        var options = EnabledOptions();
+        options.Profile!.PolicyRevision = policyRevision;
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(nameof(AgentProfileSnapshot.PolicyRevision), StringComparison.Ordinal) &&
+            message.Contains(expectedFailure, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void Validate_ShouldEnforceRequiredStringUtf8ByteBoundary(
+        bool appendAsciiByte,
+        bool expectedValid)
+    {
+        var options = EnabledOptions();
+        options.Profile!.PolicyRevision = new string('\u00e9', 64) + (appendAsciiByte ? "a" : string.Empty);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        if (expectedValid)
+            result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+        else
+            result.Failures.Should().Contain(message =>
+                message.Contains(nameof(AgentProfileSnapshot.PolicyRevision), StringComparison.Ordinal) &&
+                message.Contains("cannot exceed 128 UTF-8 bytes", StringComparison.Ordinal));
+    }
+
+    [Theory]
     [InlineData(0, false)]
     [InlineData(1, true)]
     [InlineData(32, true)]
@@ -557,6 +651,19 @@ public sealed class NyxIdChatAgentProfileOptionsTests
             .GetProperty(nameof(NyxIdChatAgentProfileValidationBaseline.RequiredRecoveryToolNames))
             .Should()
             .NotBeNull();
+    }
+
+    [Theory]
+    [InlineData("api_token", true)]
+    [InlineData("SkillPayload", true)]
+    [InlineData("ProfileVersion", false)]
+    public void ProductionSchemaScanner_ShouldDetectForbiddenIdentifierTokens(
+        string identifier,
+        bool expectedForbidden)
+    {
+        AgentProfileProductionSchemaScanner.IsForbiddenIdentifier(identifier)
+            .Should()
+            .Be(expectedForbidden);
     }
 
     [Fact]

--- a/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
@@ -5,6 +5,7 @@ using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.Mainnet.Host.Api.AgentProfiles;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Extensions.Options;
 
 namespace Aevatar.Capabilities.Tests;
@@ -86,6 +87,321 @@ public sealed class NyxIdChatAgentProfileOptionsTests
         var result = CreateValidator(ReviewedBaseline()).Validate(null, EnabledOptions());
 
         result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+    }
+
+    [Fact]
+    public void Validate_ShouldRejectExternalReferenceDrift()
+    {
+        var options = new NyxIdChatAgentProfileOptions
+        {
+            ExternalReference = "drifted-reference",
+        };
+
+        var result = CreateValidator(new NyxIdChatAgentProfileValidationBaseline([], []))
+            .Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(nameof(options.ExternalReference), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_ShouldRejectEnabledSlotWithoutProfilePayload()
+    {
+        var result = CreateValidator(ReviewedBaseline()).Validate(
+            null,
+            new NyxIdChatAgentProfileOptions { Enabled = true });
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains("requires a complete Profile payload", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("agent-kind", "AgentKind")]
+    [InlineData("preset-digest", "DeterministicPolicySha256")]
+    public void Validate_ShouldRejectInvalidConfigurationOwnedProfileFields(
+        string mutation,
+        string expectedFailure)
+    {
+        var options = EnabledOptions();
+        if (mutation == "agent-kind")
+            options.Profile!.AgentKind = "other.agent";
+        else
+            options.Profile!.DeterministicPolicySha256 = ByteString.CopyFrom(new byte[32]);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(expectedFailure, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(32, true)]
+    [InlineData(33, false)]
+    public void Validate_ShouldEnforceMemberCountBoundaries(int memberCount, bool expectedValid)
+    {
+        var options = EnabledOptions();
+        SetMemberCount(options.Profile!, memberCount);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        if (expectedValid)
+            result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+        else
+            result.Failures.Should().Contain(message =>
+                message.Contains("Members must contain between 1 and 32 entries", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(65_535, true)]
+    [InlineData(65_536, true)]
+    [InlineData(65_537, false)]
+    public void Validate_ShouldEnforceSealedSnapshotSizeBoundary(int sealedSize, bool expectedValid)
+    {
+        var options = EnabledOptions();
+        options.Profile = BuildProfileWithSealedSize(sealedSize);
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        if (expectedValid)
+            result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+        else
+            result.Failures.Should().Contain(message =>
+                message.Contains("sealed profile snapshot cannot exceed 65536 bytes", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("duplicate-intent", "IntentId", "unique within the profile")]
+    [InlineData("duplicate-ref", "SkillRef", "unique within the profile")]
+    [InlineData("duplicate-alias", "ExplicitTriggerAliases", "globally unique ignoring case")]
+    [InlineData("alias-limit", "ExplicitTriggerAliases", "cannot exceed 16 entries")]
+    [InlineData("side-effect", "SideEffectClass", "must be explicit")]
+    public void Validate_ShouldRejectInvalidMemberIdentityAndBounds(
+        string mutation,
+        string fieldName,
+        string reason)
+    {
+        var options = EnabledOptions();
+        var profile = options.Profile!;
+        switch (mutation)
+        {
+            case "duplicate-intent":
+            {
+                var duplicate = BuildMember(1);
+                duplicate.IntentId = profile.Members[0].IntentId;
+                profile.Members.Add(duplicate);
+                break;
+            }
+            case "duplicate-ref":
+            {
+                var duplicate = BuildMember(1);
+                duplicate.SkillRef = profile.Members[0].SkillRef.Clone();
+                profile.Members.Add(duplicate);
+                break;
+            }
+            case "duplicate-alias":
+            {
+                var duplicate = BuildMember(1);
+                duplicate.ExplicitTriggerAliases.Clear();
+                duplicate.ExplicitTriggerAliases.Add(
+                    profile.Members[0].ExplicitTriggerAliases[0].ToUpperInvariant());
+                profile.Members.Add(duplicate);
+                break;
+            }
+            case "alias-limit":
+                for (var index = 1; index <= 16; index++)
+                    profile.Members[0].ExplicitTriggerAliases.Add($"alias-{index}");
+                break;
+            default:
+                profile.Members[0].SideEffectClass = AgentProfileSideEffectClass.Unspecified;
+                break;
+        }
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(fieldName, StringComparison.Ordinal) &&
+            message.Contains(reason, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("MaxPlanSteps", 3, false)]
+    [InlineData("MaxPlanSteps", 4, true)]
+    [InlineData("MaxPlanSteps", 5, false)]
+    [InlineData("HandoffTtlSeconds", 899, false)]
+    [InlineData("HandoffTtlSeconds", 900, true)]
+    [InlineData("HandoffTtlSeconds", 901, false)]
+    [InlineData("ClassifierTimeoutMs", 599, false)]
+    [InlineData("ClassifierTimeoutMs", 600, true)]
+    [InlineData("ClassifierTimeoutMs", 601, false)]
+    [InlineData("ExactSkillFetchTimeoutMs", 1_499, false)]
+    [InlineData("ExactSkillFetchTimeoutMs", 1_500, true)]
+    [InlineData("ExactSkillFetchTimeoutMs", 1_501, false)]
+    [InlineData("MaxSelectedSkillBytes", 24_575, false)]
+    [InlineData("MaxSelectedSkillBytes", 24_576, true)]
+    [InlineData("MaxSelectedSkillBytes", 24_577, false)]
+    public void Validate_ShouldEnforceRuntimeParameterBoundaries(
+        string parameter,
+        int value,
+        bool expectedValid)
+    {
+        var options = EnabledOptions();
+        switch (parameter)
+        {
+            case "MaxPlanSteps":
+                options.Profile!.MaxPlanSteps = value;
+                break;
+            case "HandoffTtlSeconds":
+                options.Profile!.HandoffTtlSeconds = value;
+                break;
+            case "ClassifierTimeoutMs":
+                options.Profile!.ClassifierTimeoutMs = value;
+                break;
+            case "ExactSkillFetchTimeoutMs":
+                options.Profile!.ExactSkillFetchTimeoutMs = value;
+                break;
+            default:
+                options.Profile!.MaxSelectedSkillBytes = value;
+                break;
+        }
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        if (expectedValid)
+            result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+        else
+            result.Failures.Should().Contain(message =>
+                message.Contains(parameter, StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(599, false)]
+    [InlineData(600, false)]
+    [InlineData(601, true)]
+    public void Validate_ShouldRejectOnlyColdPreTurnBudgetsAboveMaximum(
+        int classifierTimeoutMs,
+        bool expectedBudgetFailure)
+    {
+        var options = EnabledOptions();
+        options.Profile!.ClassifierTimeoutMs = classifierTimeoutMs;
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+        var hasBudgetFailure = result.Failures?.Any(message =>
+            message.Contains("cold pre-turn budget", StringComparison.Ordinal)) == true;
+
+        hasBudgetFailure.Should().Be(expectedBudgetFailure);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(2, true)]
+    [InlineData(3, false)]
+    public void Validate_ShouldAcceptOnlyExplicitActivationModes(int activationMode, bool expectedValid)
+    {
+        var options = EnabledOptions();
+        options.Profile!.ActivationMode = (AgentProfileActivationMode)activationMode;
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        if (expectedValid)
+            result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+        else
+            result.Failures.Should().Contain(message =>
+                message.Contains("ActivationMode must be Shadow or Enforced", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("maximum", "MaximumToolPolicy")]
+    [InlineData("recovery", "RecoveryToolPolicy")]
+    [InlineData("member", "TaskToolPolicy")]
+    public void Validate_ShouldRejectMissingPolicy(string policy, string expectedFailure)
+    {
+        var options = EnabledOptions();
+        switch (policy)
+        {
+            case "maximum":
+                options.Profile!.MaximumToolPolicy = null;
+                break;
+            case "recovery":
+                options.Profile!.RecoveryToolPolicy = null;
+                break;
+            default:
+                options.Profile!.Members[0].TaskToolPolicy = null;
+                break;
+        }
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(expectedFailure, StringComparison.Ordinal) &&
+            message.Contains("is required", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false, 63, true)]
+    [InlineData(false, 64, true)]
+    [InlineData(false, 65, false)]
+    [InlineData(true, 63, true)]
+    [InlineData(true, 64, true)]
+    [InlineData(true, 65, false)]
+    public void Validate_ShouldEnforcePolicyEntryBoundaries(
+        bool toolSetRefs,
+        int entryCount,
+        bool expectedValid)
+    {
+        var options = EnabledOptions();
+        var registeredToolSets = new List<string> { "profile.route" };
+        if (toolSetRefs)
+        {
+            for (var index = 0; index < entryCount; index++)
+            {
+                var name = $"set.{index}";
+                options.Profile!.MaximumToolPolicy.ToolSetRefs.Add(name);
+                registeredToolSets.Add(name);
+            }
+        }
+        else
+        {
+            options.Profile!.MaximumToolPolicy.ToolNames.Clear();
+            options.Profile.MaximumToolPolicy.ToolNames.Add(["recover_tool", "task_tool"]);
+            for (var index = 2; index < entryCount; index++)
+                options.Profile.MaximumToolPolicy.ToolNames.Add($"tool_{index}");
+        }
+
+        var result = CreateValidator(ReviewedBaseline(), registeredToolSets).Validate(null, options);
+
+        if (expectedValid)
+            result.Succeeded.Should().BeTrue(string.Join(Environment.NewLine, result.Failures ?? []));
+        else
+            result.Failures.Should().Contain(message =>
+                message.Contains(toolSetRefs ? "ToolSetRefs" : "ToolNames", StringComparison.Ordinal) &&
+                message.Contains("cannot exceed 64 entries", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("duplicate", "duplicate values")]
+    [InlineData("unknown", "unknown tool set")]
+    public void Validate_ShouldRejectDuplicateOrUnknownPolicyToolSetRef(
+        string mutation,
+        string expectedFailure)
+    {
+        var options = EnabledOptions();
+        options.Profile!.MaximumToolPolicy.ToolSetRefs.Add("profile.route");
+        options.Profile.MaximumToolPolicy.ToolSetRefs.Add(
+            mutation == "duplicate" ? "profile.route" : "missing.route");
+
+        var result = CreateValidator(ReviewedBaseline()).Validate(null, options);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(message =>
+            message.Contains(expectedFailure, StringComparison.Ordinal));
     }
 
     [MemberData(nameof(ValidExactGuids))]
@@ -266,8 +582,9 @@ public sealed class NyxIdChatAgentProfileOptionsTests
     }
 
     private static NyxIdChatAgentProfileOptionsValidator CreateValidator(
-        NyxIdChatAgentProfileValidationBaseline baseline) =>
-        new(new FixedToolSetRegistry(["profile.route"]), baseline);
+        NyxIdChatAgentProfileValidationBaseline baseline,
+        IReadOnlyList<string>? registeredToolSets = null) =>
+        new(new FixedToolSetRegistry(registeredToolSets ?? ["profile.route"]), baseline);
 
     private static NyxIdChatAgentProfileValidationBaseline ReviewedBaseline() =>
         new(["recover_tool"], ["legacy_tool"]);
@@ -300,24 +617,7 @@ public sealed class NyxIdChatAgentProfileOptionsTests
         },
         Members =
         {
-            new AgentProfileSkillMember
-            {
-                IntentId = "intent-alpha",
-                RoutingDescription = "Route alpha requests.",
-                SkillRef = new ExactRemoteSkillRef
-                {
-                    Guid = NonzeroVersionZeroGuid,
-                    LiteralVersion = "1.0",
-                },
-                ExplicitTriggerAliases = { "alpha" },
-                TaskToolPolicy = new AgentProfileToolPolicy
-                {
-                    ToolNames = { "task_tool" },
-                },
-                SideEffectClass = AgentProfileSideEffectClass.ReadOnly,
-                ExpectedSkillName = "skill-alpha",
-                ReviewedPublisherId = "publisher-alpha",
-            },
+            BuildMember(0),
         },
         MaxPlanSteps = 4,
         HandoffTtlSeconds = 900,
@@ -326,6 +626,57 @@ public sealed class NyxIdChatAgentProfileOptionsTests
         MaxSelectedSkillBytes = 24_576,
         ActivationMode = AgentProfileActivationMode.Enforced,
     };
+
+    private static AgentProfileSkillMember BuildMember(int index) => new()
+    {
+        IntentId = $"intent-{index}",
+        RoutingDescription = $"Route intent {index} requests.",
+        SkillRef = new ExactRemoteSkillRef
+        {
+            Guid = $"00000000-0000-0000-0000-{index + 1:000000000000}",
+            LiteralVersion = "1.0",
+        },
+        ExplicitTriggerAliases = { $"alias-{index}" },
+        TaskToolPolicy = new AgentProfileToolPolicy
+        {
+            ToolNames = { "task_tool" },
+        },
+        SideEffectClass = AgentProfileSideEffectClass.ReadOnly,
+        ExpectedSkillName = $"skill-{index}",
+        ReviewedPublisherId = $"publisher-{index}",
+    };
+
+    private static void SetMemberCount(AgentProfileSnapshot profile, int memberCount)
+    {
+        profile.Members.Clear();
+        for (var index = 0; index < memberCount; index++)
+            profile.Members.Add(BuildMember(index));
+    }
+
+    private static AgentProfileSnapshot BuildProfileWithSealedSize(int targetSize)
+    {
+        var profile = BuildValidProfile();
+        var baselineSize = AgentProfileSnapshotCodec.Seal(profile).CalculateSize();
+        var firstPayloadLength = Math.Max(0, targetSize - baselineSize - 12);
+        var lastPayloadLength = targetSize - baselineSize;
+        for (var payloadLength = firstPayloadLength; payloadLength <= lastPayloadLength; payloadLength++)
+        {
+            using var stream = new MemoryStream();
+            stream.Write(profile.ToByteArray());
+            using (var output = new CodedOutputStream(stream, leaveOpen: true))
+            {
+                output.WriteTag(100, WireFormat.WireType.LengthDelimited);
+                output.WriteBytes(ByteString.CopyFrom(new byte[payloadLength]));
+                output.Flush();
+            }
+
+            var candidate = AgentProfileSnapshot.Parser.ParseFrom(stream.ToArray());
+            if (AgentProfileSnapshotCodec.Seal(candidate).CalculateSize() == targetSize)
+                return candidate;
+        }
+
+        throw new InvalidOperationException($"Could not construct a profile with sealed size {targetSize}.");
+    }
 
     private static void SetExactGuid(AgentProfileSnapshot profile, bool skillsetRef, string guid)
     {


### PR DESCRIPTION
## Changed files

- 新增 agent profile、exact remote skill/skillset ref 与一次性绑定事件的强类型 Protobuf 契约。
- Mainnet Host 增加独立 immutable validation baseline、三个 bounded schema roots、启动时 fail-closed 校验和冻结快照 source。
- NyxID Chat create resolver 在 actor 创建前核对 route tool set，并将完整 sealed snapshot 一次性提交给现有 actor；actor 负责幂等绑定和 durable state。
- 补充 codec、validator、Host composition、resolver、DI、actor replay/幂等行为测试及 canonical 文档。

## Test results

- AI 定向测试：1121/1121 通过。
- Capabilities 定向测试：476/476 通过。
- 全量 build 与原实现全量 test 通过，0 errors、0 failed；当前 rebase head 的 GitHub required checks 重新执行。
- architecture、test stability、query projection priming、文档索引与 lint 门禁全部通过。

## Deviations

- 无范围扩展；exact-ref value types 属于已接受的 #2815 r15 profile/binding scope。后续 meta-layer re-cluster 已关闭过期 #2813 standalone work，并明确把 exact-fetch Port/DI/runtime consumer 交给 #2816、release verifier/provisioning 交给 #2818；本 PR 不包含这些兄弟范围。
- 未增加 diagnostics、reload、backfill、create-time Ornn I/O 或公开 HTTP 合同；`docs/README.md` 按规定由索引生成器刷新。

Closes #2815

⟦AI:AUTO-LOOP⟧
