### PR TITLE
重构 NyxID 对话的请求级 Agent Profile 权限目录

### DIFF
--- a/agents/Aevatar.GAgents.ChatbotClassifier/ChatbotClassifierGAgent.cs
+++ b/agents/Aevatar.GAgents.ChatbotClassifier/ChatbotClassifierGAgent.cs
@@ -70,7 +70,12 @@ public sealed class ChatbotClassifierGAgent : RoleGAgent
             //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
             //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
             result = await ChatStreamContentAggregator.AggregateContentAsync(
-                ChatStreamAsync(request.Prompt, request.SessionId, metadata, CancellationToken.None),
+                ChatStreamAsync(
+                    request.Prompt,
+                    request.SessionId,
+                    turnCatalog: null,
+                    metadata: metadata,
+                    ct: CancellationToken.None),
                 ct: CancellationToken.None);
         }
         catch (Exception ex)

--- a/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
+++ b/agents/Aevatar.GAgents.Household/HouseholdEntity.cs
@@ -4,6 +4,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.TypeSystem;
@@ -77,7 +78,9 @@ public class HouseholdEntity : AIGAgentBase<HouseholdEntityState>
 
     // ─── Dynamic system prompt (inject environment, actions, memories) ───
 
-    protected override string DecorateSystemPrompt(string basePrompt)
+    protected override string DecorateSystemPrompt(
+        string basePrompt,
+        AgentProfileTurnCatalog? turnCatalog)
     {
         var sb = new StringBuilder(basePrompt);
 
@@ -273,7 +276,11 @@ public class HouseholdEntity : AIGAgentBase<HouseholdEntityState>
             //   Old pattern: household reasoning used the non-streaming chat shortcut as the main chain.
             //   New principle: household reasoning consumes the streaming chain and commits only its final text.
             var responseBuilder = new StringBuilder();
-            await foreach (var chunk in ChatStreamAsync(prompt, requestId: null, metadata))
+            await foreach (var chunk in ChatStreamAsync(
+                               prompt,
+                               requestId: null,
+                               turnCatalog: null,
+                               metadata: metadata))
             {
                 if (!string.IsNullOrEmpty(chunk.DeltaContent))
                     responseBuilder.Append(chunk.DeltaContent);

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -467,9 +467,7 @@ public sealed class AgentProfileTurnCatalogMaterializer
 
     private static bool MatchesAlias(string? userMessage, string? alias)
     {
-        if (string.IsNullOrWhiteSpace(userMessage))
-            return true;
-        if (string.IsNullOrWhiteSpace(alias))
+        if (string.IsNullOrWhiteSpace(userMessage) || string.IsNullOrWhiteSpace(alias))
             return false;
 
         var message = userMessage.Trim();

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -1,0 +1,477 @@
+using System.Text;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.Prompting;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.Skills;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
+using Aevatar.ChatRouting.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat.AgentProfiles;
+
+public sealed class AgentProfileTurnCatalogMaterializer
+{
+    private readonly IToolSetRegistry _toolSetRegistry;
+    private readonly IAgentProfileTurnClassifier _classifier;
+    private readonly IExactRemoteSkillFetcher? _exactRemoteSkillFetcher;
+    private readonly SkillFrontmatterParser _frontmatterParser;
+    private readonly ILogger<AgentProfileTurnCatalogMaterializer> _logger;
+
+    public AgentProfileTurnCatalogMaterializer(
+        IToolSetRegistry toolSetRegistry,
+        IAgentProfileTurnClassifier classifier,
+        IExactRemoteSkillFetcher? exactRemoteSkillFetcher = null,
+        SkillFrontmatterParser? frontmatterParser = null,
+        ILogger<AgentProfileTurnCatalogMaterializer>? logger = null)
+    {
+        _toolSetRegistry = toolSetRegistry ?? throw new ArgumentNullException(nameof(toolSetRegistry));
+        _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
+        _exactRemoteSkillFetcher = exactRemoteSkillFetcher;
+        _frontmatterParser = frontmatterParser ?? new SkillFrontmatterParser();
+        _logger = logger ?? NullLogger<AgentProfileTurnCatalogMaterializer>.Instance;
+    }
+
+    public async Task<AgentProfileTurnCatalog> MaterializeAsync(
+        AgentProfileSnapshot profile,
+        string userMessage,
+        string? accessToken,
+        IReadOnlyList<IAgentTool> registeredTools,
+        AgentToolExecutionContext toolContext,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(registeredTools);
+        ArgumentNullException.ThrowIfNull(toolContext);
+
+        var diagnostics = new List<AgentProfileTurnDiagnostic>();
+        if (!AgentProfileSnapshotCodec.Verify(profile))
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ProfileInvalid,
+                "snapshot_digest_invalid"));
+            return BuildCatalog(profile, [], null, null, null, diagnostics);
+        }
+
+        var routeTools = await DiscoverToolSetAsync(
+            profile.RouteToolSetRef,
+            toolContext,
+            AgentProfileTurnDiagnosticCode.RouteToolSetUnavailable,
+            diagnostics,
+            ct);
+        var registered = ToEligibleToolNames(registeredTools, toolContext, diagnostics);
+        var available = new HashSet<string>(routeTools.Names, StringComparer.OrdinalIgnoreCase);
+        available.IntersectWith(registered.Names);
+        available.RemoveWhere(name => !toolContext.ToolVisibility.Allows(name));
+
+        var maximum = await ResolvePolicyAsync(profile.MaximumToolPolicy, toolContext, diagnostics, ct);
+        available.IntersectWith(maximum.Names);
+        var recovery = await ResolvePolicyAsync(profile.RecoveryToolPolicy, toolContext, diagnostics, ct);
+        var recoveryNames = new HashSet<string>(available, StringComparer.OrdinalIgnoreCase);
+        recoveryNames.IntersectWith(recovery.Names);
+        if (routeTools.HadFailure || registered.HadFailure || maximum.HadFailure || recovery.HadFailure)
+            return BuildCatalog(profile, recoveryNames, null, null, null, diagnostics);
+
+        var candidate = await SelectCandidateAsync(profile, userMessage, diagnostics, ct);
+        if (candidate is null)
+            return BuildCatalog(profile, recoveryNames, null, null, null, diagnostics);
+
+        if (profile.ActivationMode != AgentProfileActivationMode.Enforced)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ShadowCandidate,
+                candidate.IntentId));
+            return BuildCatalog(profile, recoveryNames, null, candidate.IntentId, null, diagnostics);
+        }
+
+        var fetched = await FetchSelectedSkillAsync(profile, candidate, accessToken, diagnostics, ct);
+        if (fetched is null)
+            return BuildCatalog(profile, recoveryNames, null, candidate.IntentId, null, diagnostics);
+
+        var taskPolicy = await ResolvePolicyAsync(candidate.TaskToolPolicy, toolContext, diagnostics, ct);
+        if (taskPolicy.HadFailure)
+            return BuildCatalog(profile, recoveryNames, null, candidate.IntentId, null, diagnostics);
+
+        var selectedPolicy = new HashSet<string>(recovery.Names, StringComparer.OrdinalIgnoreCase);
+        selectedPolicy.UnionWith(taskPolicy.Names);
+        var finalNames = new HashSet<string>(available, StringComparer.OrdinalIgnoreCase);
+        finalNames.IntersectWith(selectedPolicy);
+
+        var selectedLayer = new SelectedSkillPromptLayer(
+            fetched,
+            new SelectedSkillPromptProvenance(
+                $"ornn:{candidate.SkillRef.Guid}@{candidate.SkillRef.LiteralVersion}"),
+            new PromptLayerBounds(profile.MaxSelectedSkillBytes, Math.Max(1, profile.MaxSelectedSkillBytes / 4)));
+        return BuildCatalog(
+            profile,
+            finalNames,
+            candidate.IntentId,
+            candidate.IntentId,
+            selectedLayer,
+            diagnostics);
+    }
+
+    private async Task<AgentProfileSkillMember?> SelectCandidateAsync(
+        AgentProfileSnapshot profile,
+        string userMessage,
+        List<AgentProfileTurnDiagnostic> diagnostics,
+        CancellationToken ct)
+    {
+        var aliasMatches = profile.Members
+            .Where(member => member.ExplicitTriggerAliases.Any(alias => MatchesAlias(userMessage, alias)))
+            .ToArray();
+        if (aliasMatches.Length == 1)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.AliasMatched,
+                aliasMatches[0].IntentId));
+            return aliasMatches[0];
+        }
+        if (aliasMatches.Length > 1)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ClassifierFailed,
+                "alias_collision"));
+            return null;
+        }
+
+        if (profile.Members.Count == 0 || profile.ClassifierTimeoutMs <= 0)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ClassifierFailed,
+                "classifier_not_configured"));
+            return null;
+        }
+
+        AgentProfileTurnClassificationResult result;
+        try
+        {
+            result = await _classifier.ClassifyAsync(
+                new AgentProfileTurnClassificationRequest(
+                    userMessage ?? string.Empty,
+                    profile.Members.Take(32)
+                        .Select(static member => new AgentProfileTurnClassificationCandidate(
+                            member.IntentId,
+                            member.RoutingDescription))
+                        .ToArray(),
+                    TimeSpan.FromMilliseconds(profile.ClassifierTimeoutMs)),
+                ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            result = AgentProfileTurnClassificationResult.Failed("classifier_exception");
+        }
+
+        if (result.Status == AgentProfileTurnClassificationStatus.NoMatch)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ClassifierNoMatch,
+                "no_match"));
+            return null;
+        }
+        if (result.Status != AgentProfileTurnClassificationStatus.Matched ||
+            string.IsNullOrWhiteSpace(result.IntentId))
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ClassifierFailed,
+                result.FailureCode ?? "failed"));
+            return null;
+        }
+
+        var member = profile.Members.SingleOrDefault(candidate =>
+            string.Equals(candidate.IntentId, result.IntentId, StringComparison.Ordinal));
+        if (member is null)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ClassifierFailed,
+                "unknown_intent"));
+            return null;
+        }
+
+        diagnostics.Add(new AgentProfileTurnDiagnostic(
+            AgentProfileTurnDiagnosticCode.ClassifierMatched,
+            member.IntentId));
+        return member;
+    }
+
+    private async Task<string?> FetchSelectedSkillAsync(
+        AgentProfileSnapshot profile,
+        AgentProfileSkillMember candidate,
+        string? accessToken,
+        List<AgentProfileTurnDiagnostic> diagnostics,
+        CancellationToken ct)
+    {
+        if (_exactRemoteSkillFetcher is null || string.IsNullOrWhiteSpace(accessToken) ||
+            candidate.SkillRef is null || profile.ExactSkillFetchTimeoutMs <= 0)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed,
+                "exact_fetch_unavailable"));
+            return null;
+        }
+
+        ExactRemoteSkillFetchResult fetchResult;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(profile.ExactSkillFetchTimeoutMs));
+        try
+        {
+            fetchResult = await _exactRemoteSkillFetcher.FetchAsync(
+                accessToken,
+                candidate.SkillRef,
+                timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed,
+                "timeout"));
+            return null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Exact remote skill fetch failed for intent {IntentId}.", candidate.IntentId);
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed,
+                "fetch_exception"));
+            return null;
+        }
+
+        if (!fetchResult.IsSuccess)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed,
+                fetchResult.FailureCode?.ToString() ?? "failed"));
+            return null;
+        }
+
+        if (!string.Equals(fetchResult.Guid, candidate.SkillRef.Guid, StringComparison.Ordinal) ||
+            !string.Equals(fetchResult.LiteralVersion, candidate.SkillRef.LiteralVersion, StringComparison.Ordinal) ||
+            !string.Equals(fetchResult.Name, candidate.ExpectedSkillName, StringComparison.Ordinal) ||
+            !string.Equals(fetchResult.PublisherId, candidate.ReviewedPublisherId, StringComparison.Ordinal) ||
+            string.IsNullOrWhiteSpace(fetchResult.SkillHash))
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ExactSkillIdentityMismatch,
+                candidate.IntentId));
+            return null;
+        }
+
+        var skillMarkdown = fetchResult.SkillMarkdown ?? string.Empty;
+        if (profile.MaxSelectedSkillBytes <= 0 ||
+            Encoding.UTF8.GetByteCount(skillMarkdown) > profile.MaxSelectedSkillBytes)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid,
+                "body_out_of_bounds"));
+            return null;
+        }
+
+        var parsed = _frontmatterParser.Parse(skillMarkdown);
+        if (string.IsNullOrWhiteSpace(parsed.Body) ||
+            (!string.IsNullOrWhiteSpace(parsed.Name) &&
+             !string.Equals(parsed.Name, candidate.ExpectedSkillName, StringComparison.Ordinal)))
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid,
+                "frontmatter_identity_invalid"));
+            return null;
+        }
+
+        return parsed.Body;
+    }
+
+    private async Task<ToolPolicyResolution> ResolvePolicyAsync(
+        AgentProfileToolPolicy? policy,
+        AgentToolExecutionContext toolContext,
+        List<AgentProfileTurnDiagnostic> diagnostics,
+        CancellationToken ct)
+    {
+        if (policy is null)
+            return new ToolPolicyResolution(
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                false);
+
+        var names = new HashSet<string>(
+            policy.ToolNames.Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        var hadFailure = false;
+        foreach (var toolSetRef in policy.ToolSetRefs)
+        {
+            var resolution = await DiscoverToolSetAsync(
+                toolSetRef,
+                toolContext,
+                AgentProfileTurnDiagnosticCode.ToolSetUnavailable,
+                diagnostics,
+                ct);
+            names.UnionWith(resolution.Names);
+            hadFailure |= resolution.HadFailure;
+        }
+
+        return new ToolPolicyResolution(names, hadFailure);
+    }
+
+    private async Task<ToolPolicyResolution> DiscoverToolSetAsync(
+        string? toolSetName,
+        AgentToolExecutionContext toolContext,
+        AgentProfileTurnDiagnosticCode unavailableCode,
+        List<AgentProfileTurnDiagnostic> diagnostics,
+        CancellationToken ct)
+    {
+        ToolSetResolveResult resolved;
+        try
+        {
+            resolved = _toolSetRegistry.Resolve(new ChatRouteToolSetRef { Name = toolSetName ?? string.Empty });
+        }
+        catch (Exception)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(unavailableCode, toolSetName ?? string.Empty));
+            return new ToolPolicyResolution(
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                true);
+        }
+
+        if (!resolved.IsSuccess)
+        {
+            diagnostics.Add(new AgentProfileTurnDiagnostic(
+                unavailableCode,
+                resolved.Error?.Code ?? "resolve_failed"));
+            return new ToolPolicyResolution(
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                true);
+        }
+
+        var discovered = new List<IAgentTool>();
+        foreach (var source in resolved.Sources)
+        {
+            try
+            {
+                discovered.AddRange(await source.DiscoverToolsAsync(ct));
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                diagnostics.Add(new AgentProfileTurnDiagnostic(
+                    AgentProfileTurnDiagnosticCode.ToolDiscoveryFailed,
+                    resolved.Name ?? string.Empty));
+                return new ToolPolicyResolution(
+                    new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                    true);
+            }
+        }
+
+        return ToEligibleToolNames(discovered, toolContext, diagnostics);
+    }
+
+    private static ToolPolicyResolution ToEligibleToolNames(
+        IReadOnlyList<IAgentTool> tools,
+        AgentToolExecutionContext toolContext,
+        List<AgentProfileTurnDiagnostic> diagnostics)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hadFailure = false;
+        foreach (var group in tools
+                     .Where(static tool => !string.IsNullOrWhiteSpace(tool.Name))
+                     .GroupBy(static tool => tool.Name.Trim(), StringComparer.OrdinalIgnoreCase))
+        {
+            if (group.Count() > 1)
+            {
+                hadFailure = true;
+                diagnostics.Add(new AgentProfileTurnDiagnostic(
+                    AgentProfileTurnDiagnosticCode.ToolNameCollision,
+                    group.Key));
+                continue;
+            }
+
+            var tool = group.Single();
+            if (!IsEligible(tool, toolContext))
+            {
+                hadFailure = true;
+                diagnostics.Add(new AgentProfileTurnDiagnostic(
+                    AgentProfileTurnDiagnosticCode.ToolCapabilityRejected,
+                    group.Key));
+                continue;
+            }
+
+            names.Add(group.Key);
+        }
+
+        return new ToolPolicyResolution(names, hadFailure);
+    }
+
+    private static bool IsEligible(IAgentTool tool, AgentToolExecutionContext toolContext)
+    {
+        if (tool is not IAgentToolCapabilityDescriptor descriptor)
+            return true;
+
+        if (descriptor.Capabilities.Contains(
+                AgentToolCapabilities.ExcludeFromDirectChannelChat,
+                StringComparer.Ordinal))
+        {
+            return false;
+        }
+
+        return !descriptor.Capabilities.Contains(
+                   AgentToolCapabilities.RequiresHumanSession,
+                   StringComparer.Ordinal) ||
+               !string.IsNullOrWhiteSpace(toolContext.Credentials.NyxIdAccessToken);
+    }
+
+    private static AgentProfileTurnCatalog BuildCatalog(
+        AgentProfileSnapshot profile,
+        IEnumerable<string> finalNames,
+        string? selectedIntentId,
+        string? candidateIntentId,
+        SelectedSkillPromptLayer? selectedSkillPromptLayer,
+        IReadOnlyList<AgentProfileTurnDiagnostic> diagnostics)
+    {
+        var profileText = new StringBuilder()
+            .Append("Agent profile: ").Append(profile.ProfileId)
+            .Append("\nProfile version: ").Append(profile.ProfileVersion)
+            .Append("\nPolicy revision: ").Append(profile.PolicyRevision);
+        if (!string.IsNullOrWhiteSpace(candidateIntentId))
+            profileText.Append("\nCandidate intent: ").Append(candidateIntentId);
+        if (!string.IsNullOrWhiteSpace(selectedIntentId))
+            profileText.Append("\nSelected intent: ").Append(selectedIntentId);
+
+        var profileLayer = new ProfileRoutingPromptLayer(
+            profileText.ToString(),
+            new ProfileRoutingPromptProvenance(
+                $"agent-profile:{profile.ProfileId}@{profile.ProfileVersion}"),
+            new PromptLayerBounds(8 * 1024, 2 * 1024));
+        return new AgentProfileTurnCatalog(
+            finalNames,
+            profileLayer,
+            selectedSkillPromptLayer,
+            selectedIntentId,
+            candidateIntentId,
+            diagnostics);
+    }
+
+    private static bool MatchesAlias(string? userMessage, string? alias)
+    {
+        if (string.IsNullOrWhiteSpace(userMessage) || string.IsNullOrWhiteSpace(alias))
+            return false;
+
+        var message = userMessage.Trim();
+        var normalizedAlias = alias.Trim();
+        return string.Equals(message, normalizedAlias, StringComparison.OrdinalIgnoreCase) ||
+               (message.StartsWith(normalizedAlias, StringComparison.OrdinalIgnoreCase) &&
+                message.Length > normalizedAlias.Length &&
+                char.IsWhiteSpace(message[normalizedAlias.Length]));
+    }
+
+    private sealed record ToolPolicyResolution(IReadOnlySet<string> Names, bool HadFailure);
+}

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -281,9 +281,7 @@ public sealed class AgentProfileTurnCatalogMaterializer
         }
 
         var parsed = _frontmatterParser.Parse(skillMarkdown);
-        if (string.IsNullOrWhiteSpace(parsed.Body) ||
-            (!string.IsNullOrWhiteSpace(parsed.Name) &&
-             !string.Equals(parsed.Name, candidate.ExpectedSkillName, StringComparison.Ordinal)))
+        if (profile.MaxSelectedSkillBytes < 0)
         {
             diagnostics.Add(new AgentProfileTurnDiagnostic(
                 AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid,

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -18,19 +18,22 @@ public sealed class AgentProfileTurnCatalogMaterializer
     private readonly IExactRemoteSkillFetcher? _exactRemoteSkillFetcher;
     private readonly SkillFrontmatterParser _frontmatterParser;
     private readonly ILogger<AgentProfileTurnCatalogMaterializer> _logger;
+    private readonly TimeProvider _timeProvider;
 
     public AgentProfileTurnCatalogMaterializer(
         IToolSetRegistry toolSetRegistry,
         IAgentProfileTurnClassifier classifier,
         IExactRemoteSkillFetcher? exactRemoteSkillFetcher = null,
         SkillFrontmatterParser? frontmatterParser = null,
-        ILogger<AgentProfileTurnCatalogMaterializer>? logger = null)
+        ILogger<AgentProfileTurnCatalogMaterializer>? logger = null,
+        TimeProvider? timeProvider = null)
     {
         _toolSetRegistry = toolSetRegistry ?? throw new ArgumentNullException(nameof(toolSetRegistry));
         _classifier = classifier ?? throw new ArgumentNullException(nameof(classifier));
         _exactRemoteSkillFetcher = exactRemoteSkillFetcher;
         _frontmatterParser = frontmatterParser ?? new SkillFrontmatterParser();
         _logger = logger ?? NullLogger<AgentProfileTurnCatalogMaterializer>.Instance;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<AgentProfileTurnCatalog> MaterializeAsync(
@@ -216,14 +219,16 @@ public sealed class AgentProfileTurnCatalogMaterializer
         }
 
         ExactRemoteSkillFetchResult fetchResult;
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(TimeSpan.FromMilliseconds(profile.ExactSkillFetchTimeoutMs));
+        using var timeoutCts = new CancellationTokenSource(
+            TimeSpan.FromMilliseconds(profile.ExactSkillFetchTimeoutMs),
+            _timeProvider);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
         try
         {
             fetchResult = await _exactRemoteSkillFetcher.FetchAsync(
                 accessToken,
                 candidate.SkillRef,
-                timeoutCts.Token);
+                linkedCts.Token);
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -281,7 +281,9 @@ public sealed class AgentProfileTurnCatalogMaterializer
         }
 
         var parsed = _frontmatterParser.Parse(skillMarkdown);
-        if (profile.MaxSelectedSkillBytes < 0)
+        if (string.IsNullOrWhiteSpace(parsed.Body) ||
+            (!string.IsNullOrWhiteSpace(parsed.Name) &&
+             !string.Equals(parsed.Name, candidate.ExpectedSkillName, StringComparison.Ordinal)))
         {
             diagnostics.Add(new AgentProfileTurnDiagnostic(
                 AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid,

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -467,7 +467,9 @@ public sealed class AgentProfileTurnCatalogMaterializer
 
     private static bool MatchesAlias(string? userMessage, string? alias)
     {
-        if (string.IsNullOrWhiteSpace(userMessage) || string.IsNullOrWhiteSpace(alias))
+        if (string.IsNullOrWhiteSpace(userMessage))
+            return true;
+        if (string.IsNullOrWhiteSpace(alias))
             return false;
 
         var message = userMessage.Trim();

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
@@ -66,7 +66,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
                 if (chunk.DeltaToolCall is not null)
                     return AgentProfileTurnClassificationResult.Failed("tool_call_not_allowed");
                 if (string.IsNullOrEmpty(chunk.DeltaContent))
-                    return AgentProfileTurnClassificationResult.Failed("empty_delta");
+                    continue;
 
                 outputBytes += Encoding.UTF8.GetByteCount(chunk.DeltaContent);
                 if (outputBytes > MaximumOutputUtf8Bytes)
@@ -80,7 +80,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
         }
         catch (JsonException)
         {
-            return AgentProfileTurnClassificationResult.Failed("provider_failure");
+            return AgentProfileTurnClassificationResult.Failed("malformed_output");
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -113,7 +113,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
             using var document = JsonDocument.Parse(output);
             var root = document.RootElement;
             if (root.ValueKind != JsonValueKind.Object)
-                return AgentProfileTurnClassificationResult.Failed("unknown_intent");
+                return AgentProfileTurnClassificationResult.Failed("malformed_output");
 
             foreach (var property in root.EnumerateObject())
             {
@@ -142,7 +142,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
                 !root.TryGetProperty("intent_id", out var intentProperty) ||
                 intentProperty.ValueKind != JsonValueKind.String)
             {
-                return AgentProfileTurnClassificationResult.Failed("unknown_intent");
+                return AgentProfileTurnClassificationResult.Failed("malformed_output");
             }
 
             var intentId = intentProperty.GetString();

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
@@ -66,7 +66,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
                 if (chunk.DeltaToolCall is not null)
                     return AgentProfileTurnClassificationResult.Failed("tool_call_not_allowed");
                 if (string.IsNullOrEmpty(chunk.DeltaContent))
-                    continue;
+                    return AgentProfileTurnClassificationResult.Failed("empty_delta");
 
                 outputBytes += Encoding.UTF8.GetByteCount(chunk.DeltaContent);
                 if (outputBytes > MaximumOutputUtf8Bytes)
@@ -80,7 +80,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
         }
         catch (JsonException)
         {
-            return AgentProfileTurnClassificationResult.Failed("malformed_output");
+            return AgentProfileTurnClassificationResult.Failed("provider_failure");
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -113,7 +113,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
             using var document = JsonDocument.Parse(output);
             var root = document.RootElement;
             if (root.ValueKind != JsonValueKind.Object)
-                return AgentProfileTurnClassificationResult.Failed("malformed_output");
+                return AgentProfileTurnClassificationResult.Failed("unknown_intent");
 
             foreach (var property in root.EnumerateObject())
             {
@@ -142,7 +142,7 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
                 !root.TryGetProperty("intent_id", out var intentProperty) ||
                 intentProperty.ValueKind != JsonValueKind.String)
             {
-                return AgentProfileTurnClassificationResult.Failed("malformed_output");
+                return AgentProfileTurnClassificationResult.Failed("unknown_intent");
             }
 
             var intentId = intentProperty.GetString();

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
@@ -1,0 +1,167 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core.AgentProfiles;
+
+namespace Aevatar.GAgents.NyxidChat.AgentProfiles;
+
+public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClassifier
+{
+    internal const int MaximumCandidates = 32;
+    internal const int MaximumInputUtf8Bytes = 16 * 1024;
+    internal const int MaximumOutputUtf8Bytes = 4 * 1024;
+
+    private readonly ILLMProviderFactory _providerFactory;
+
+    public StreamingAgentProfileTurnClassifier(ILLMProviderFactory providerFactory)
+    {
+        _providerFactory = providerFactory ?? throw new ArgumentNullException(nameof(providerFactory));
+    }
+
+    public async Task<AgentProfileTurnClassificationResult> ClassifyAsync(
+        AgentProfileTurnClassificationRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Candidates is not { Count: > 0 and <= MaximumCandidates })
+            return AgentProfileTurnClassificationResult.Failed("candidate_count_out_of_bounds");
+        if (request.Timeout <= TimeSpan.Zero)
+            return AgentProfileTurnClassificationResult.Failed("timeout_out_of_bounds");
+
+        var input = BuildInput(request);
+        if (Encoding.UTF8.GetByteCount(input) > MaximumInputUtf8Bytes)
+            return AgentProfileTurnClassificationResult.Failed("input_too_large");
+
+        var llmRequest = new LLMRequest
+        {
+            Messages =
+            [
+                ChatMessage.System(
+                    "Classify the user message against the supplied intent catalog. " +
+                    "Return only JSON with status 'matched' and intent_id, or status 'no_match'."),
+                ChatMessage.User(input),
+            ],
+            Tools = null,
+            ResponseFormat = LLMResponseFormat.ForJsonSchema<ClassificationPayload>(
+                "agent_profile_turn_classification"),
+            MaxTokens = 128,
+            Temperature = 0,
+        };
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(request.Timeout);
+        var output = new StringBuilder();
+        var outputBytes = 0;
+        try
+        {
+            await foreach (var chunk in _providerFactory.GetDefault()
+                               .ChatStreamAsync(llmRequest, timeoutCts.Token)
+                               .WithCancellation(timeoutCts.Token))
+            {
+                if (chunk.DeltaToolCall is not null)
+                    return AgentProfileTurnClassificationResult.Failed("tool_call_not_allowed");
+                if (string.IsNullOrEmpty(chunk.DeltaContent))
+                    continue;
+
+                outputBytes += Encoding.UTF8.GetByteCount(chunk.DeltaContent);
+                if (outputBytes > MaximumOutputUtf8Bytes)
+                    return AgentProfileTurnClassificationResult.Failed("output_too_large");
+                output.Append(chunk.DeltaContent);
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return AgentProfileTurnClassificationResult.Failed("timeout");
+        }
+        catch (JsonException)
+        {
+            return AgentProfileTurnClassificationResult.Failed("malformed_output");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return AgentProfileTurnClassificationResult.Failed("provider_failure");
+        }
+
+        return ParseOutput(output.ToString(), request.Candidates);
+    }
+
+    private static string BuildInput(AgentProfileTurnClassificationRequest request) =>
+        JsonSerializer.Serialize(new
+        {
+            user_message = request.UserMessage ?? string.Empty,
+            intents = request.Candidates.Select(static candidate => new
+            {
+                intent_id = candidate.IntentId,
+                routing_description = candidate.RoutingDescription,
+            }),
+        });
+
+    private static AgentProfileTurnClassificationResult ParseOutput(
+        string output,
+        IReadOnlyList<AgentProfileTurnClassificationCandidate> candidates)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return AgentProfileTurnClassificationResult.Failed("empty_output");
+
+        try
+        {
+            using var document = JsonDocument.Parse(output);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return AgentProfileTurnClassificationResult.Failed("malformed_output");
+
+            foreach (var property in root.EnumerateObject())
+            {
+                if (!property.NameEquals("status") && !property.NameEquals("intent_id"))
+                    return AgentProfileTurnClassificationResult.Failed("unexpected_output_field");
+            }
+
+            if (!root.TryGetProperty("status", out var statusProperty) ||
+                statusProperty.ValueKind != JsonValueKind.String)
+            {
+                return AgentProfileTurnClassificationResult.Failed("status_missing");
+            }
+
+            var status = statusProperty.GetString();
+            if (string.Equals(status, "no_match", StringComparison.Ordinal))
+            {
+                if (root.TryGetProperty("intent_id", out var noMatchIntent) &&
+                    noMatchIntent.ValueKind != JsonValueKind.Null)
+                {
+                    return AgentProfileTurnClassificationResult.Failed("unexpected_intent");
+                }
+
+                return AgentProfileTurnClassificationResult.NoMatch();
+            }
+            if (!string.Equals(status, "matched", StringComparison.Ordinal) ||
+                !root.TryGetProperty("intent_id", out var intentProperty) ||
+                intentProperty.ValueKind != JsonValueKind.String)
+            {
+                return AgentProfileTurnClassificationResult.Failed("malformed_output");
+            }
+
+            var intentId = intentProperty.GetString();
+            if (string.IsNullOrWhiteSpace(intentId) ||
+                !candidates.Any(candidate => string.Equals(candidate.IntentId, intentId, StringComparison.Ordinal)))
+            {
+                return AgentProfileTurnClassificationResult.Failed("unknown_intent");
+            }
+
+            return AgentProfileTurnClassificationResult.Matched(intentId);
+        }
+        catch (JsonException)
+        {
+            return AgentProfileTurnClassificationResult.Failed("malformed_output");
+        }
+    }
+
+    private sealed class ClassificationPayload
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; init; } = string.Empty;
+
+        [JsonPropertyName("intent_id")]
+        public string? IntentId { get; init; }
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/StreamingAgentProfileTurnClassifier.cs
@@ -13,10 +13,14 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
     internal const int MaximumOutputUtf8Bytes = 4 * 1024;
 
     private readonly ILLMProviderFactory _providerFactory;
+    private readonly TimeProvider _timeProvider;
 
-    public StreamingAgentProfileTurnClassifier(ILLMProviderFactory providerFactory)
+    public StreamingAgentProfileTurnClassifier(
+        ILLMProviderFactory providerFactory,
+        TimeProvider? timeProvider = null)
     {
         _providerFactory = providerFactory ?? throw new ArgumentNullException(nameof(providerFactory));
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<AgentProfileTurnClassificationResult> ClassifyAsync(
@@ -49,15 +53,15 @@ public sealed class StreamingAgentProfileTurnClassifier : IAgentProfileTurnClass
             Temperature = 0,
         };
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        timeoutCts.CancelAfter(request.Timeout);
+        using var timeoutCts = new CancellationTokenSource(request.Timeout, _timeProvider);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
         var output = new StringBuilder();
         var outputBytes = 0;
         try
         {
             await foreach (var chunk in _providerFactory.GetDefault()
-                               .ChatStreamAsync(llmRequest, timeoutCts.Token)
-                               .WithCancellation(timeoutCts.Token))
+                               .ChatStreamAsync(llmRequest, linkedCts.Token)
+                               .WithCancellation(linkedCts.Token))
             {
                 if (chunk.DeltaToolCall is not null)
                     return AgentProfileTurnClassificationResult.Failed("tool_call_not_allowed");

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -349,7 +349,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         initialMessages.Add(ChatMessage.User(input.Parts, input.Text));
 
         return new AgentRunReplyStepPlan(
-            runtime.CreateStepExecutor(),
+            runtime.CreateStepExecutor(turnCatalog: null),
             externalMetadata,
             replyPlan.PrimaryControl,
             effectiveToolContext,
@@ -429,7 +429,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 toolMiddlewares: BuildToolMiddlewaresForTurn(),
                 llmMiddlewares: _llmMiddlewares),
             hooks: null,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages =
                 [
@@ -465,6 +465,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                            activity.Id,
                            llmControl,
                            toolContext,
+                           turnCatalog: null,
                            externalMetadata,
                            ct))
         {
@@ -1084,7 +1085,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 toolMiddlewares: BuildToolMiddlewaresForTurn(),
                 llmMiddlewares: _llmMiddlewares),
             hooks: null,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages =
                 [

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
@@ -77,6 +77,8 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         _turnCatalogMaterializer = turnCatalogMaterializer;
     }
 
+    protected override TimeProvider ChatRequestTimeProvider => _timeProvider;
+
     // Refactor (iter47/issue-877-chat-endpoints-own-lifecycle-and-compensation):
     //   Old pattern: Chat endpoints owned actor lifecycle, registry compensation, participant orchestration, terminal-state recovery, and chat history command-port side effects.
     //   New principle: Endpoint is adapter-only (HTTP/SSE); typed command facade owns lifecycle; existing chat actors own compensation events and terminal-state publication.

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
@@ -17,6 +17,7 @@ using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -45,6 +46,7 @@ public sealed class NyxIdChatGAgent : RoleGAgent
     private readonly LocalSkillCatalog? _localSkillCatalog;
     private readonly NyxIdRelayOptions? _relayOptions;
     private readonly TimeProvider _timeProvider;
+    private readonly AgentProfileTurnCatalogMaterializer? _turnCatalogMaterializer;
     private int _systemSkillOverlayPromptLogCounter;
 
     public NyxIdChatGAgent(
@@ -60,7 +62,8 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         IRemoteToolApprovalPort? remoteToolApprovalPort = null,
         IRemoteToolApprovalNotificationPort? remoteToolApprovalNotificationPort = null,
         NyxIdRelayOptions? relayOptions = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        AgentProfileTurnCatalogMaterializer? turnCatalogMaterializer = null)
         : base(llmProviderFactory, additionalHooks, agentMiddlewares, toolMiddlewares, llmMiddlewares, toolSources,
                remoteToolApprovalPort: remoteToolApprovalPort,
                remoteToolApprovalNotificationPort: remoteToolApprovalNotificationPort)
@@ -71,6 +74,7 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         _localSkillCatalog = localSkillCatalog;
         _relayOptions = relayOptions;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _turnCatalogMaterializer = turnCatalogMaterializer;
     }
 
     // Refactor (iter47/issue-877-chat-endpoints-own-lifecycle-and-compensation):
@@ -291,7 +295,9 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         await base.OnActivateAsync(ct);
     }
 
-    protected override string DecorateSystemPrompt(string basePrompt)
+    protected override string DecorateSystemPrompt(
+        string basePrompt,
+        AgentProfileTurnCatalog? turnCatalog)
     {
         var runtimeFacts = new System.Text.StringBuilder();
         AppendRuntimeFact(
@@ -309,7 +315,7 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         }
 
         var decoratedKernel = new KernelPromptLayer(
-            base.DecorateSystemPrompt(basePrompt),
+            base.DecorateSystemPrompt(basePrompt, turnCatalog),
             NyxIdChatSystemPrompt.Value.Provenance);
         var builtInFloor = _builtInPromptFloorProvider.GetFloor();
         var global = _systemSkillOverlayProvider
@@ -323,8 +329,8 @@ public sealed class NyxIdChatGAgent : RoleGAgent
             decoratedKernel,
             builtInFloor,
             global,
-            profile: null,
-            selectedSkill: null,
+            turnCatalog?.ProfilePromptLayer,
+            turnCatalog?.SelectedSkillPromptLayer,
             runtime,
             conversation: null);
 
@@ -340,6 +346,56 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         }
 
         return result.Prompt;
+    }
+
+    protected override async Task<AgentProfileTurnCatalog?> MaterializeAgentProfileTurnCatalogAsync(
+        ChatRequestEvent request,
+        AgentToolExecutionContext toolContext,
+        CancellationToken ct)
+    {
+        if (State.AgentProfile is null)
+            return null;
+
+        if (_turnCatalogMaterializer is null)
+        {
+            return new AgentProfileTurnCatalog(
+                [],
+                profilePromptLayer: null,
+                selectedSkillPromptLayer: null,
+                selectedIntentId: null,
+                candidateIntentId: null,
+                [new AgentProfileTurnDiagnostic(
+                    AgentProfileTurnDiagnosticCode.ProfileInvalid,
+                    "materializer_unavailable")]);
+        }
+
+        try
+        {
+            return await _turnCatalogMaterializer.MaterializeAsync(
+                State.AgentProfile,
+                request.Prompt ?? string.Empty,
+                toolContext.Credentials.NyxIdAccessToken,
+                Tools.GetAll(),
+                toolContext,
+                ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Agent profile turn materialization failed closed.");
+            return new AgentProfileTurnCatalog(
+                [],
+                profilePromptLayer: null,
+                selectedSkillPromptLayer: null,
+                selectedIntentId: null,
+                candidateIntentId: null,
+                [new AgentProfileTurnDiagnostic(
+                    AgentProfileTurnDiagnosticCode.ProfileInvalid,
+                    "materialization_exception")]);
+        }
     }
 
     public override async Task HandleChatRequest(ChatRequestEvent request)

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
@@ -47,6 +49,7 @@ public static class ServiceCollectionExtensions
         services.AddAevatarAgentKindRegistry(builder => builder.ScanAssemblies(typeof(NyxIdChatGAgent).Assembly));
 
         services.AddCqrsCore();
+        services.AddToolSetRegistry();
         services.AddHttpClient();
         services.TryAddSingleton(provider => BindRelayOptions(configuration));
         services.TryAddSingleton<Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions>(
@@ -55,6 +58,16 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NyxIdRelayAuthValidator>();
         services.TryAddSingleton<INyxIdRelayIngressPort, NyxIdRelayIngressPort>();
         services.TryAddSingleton<INyxIdChatAgentProfileSnapshotSource, DisabledNyxIdChatAgentProfileSnapshotSource>();
+        services.TryAddSingleton<SkillFrontmatterParser>();
+        services.TryAddSingleton<StreamingAgentProfileTurnClassifier>();
+        services.TryAddSingleton<IAgentProfileTurnClassifier>(sp =>
+            sp.GetRequiredService<StreamingAgentProfileTurnClassifier>());
+        services.TryAddSingleton(sp => new AgentProfileTurnCatalogMaterializer(
+            sp.GetRequiredService<IToolSetRegistry>(),
+            sp.GetRequiredService<IAgentProfileTurnClassifier>(),
+            sp.GetService<IExactRemoteSkillFetcher>(),
+            sp.GetRequiredService<SkillFrontmatterParser>(),
+            sp.GetService<ILogger<AgentProfileTurnCatalogMaterializer>>()));
         services.TryAddSingleton<IChannelRelayTailTextSender, MissingChannelRelayTailTextSender>();
         services.TryAddSingleton<IChannelRelayProxyResponseClassifier, MissingChannelRelayProxyResponseClassifier>();
         services.TryAddSingleton<NyxIdChatLifecycleFacade>();

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -4,6 +4,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
@@ -766,6 +767,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                                requestId,
                                llmControl,
                                toolContext,
+                               turnCatalog: null,
                                metadata,
                                ct))
             {
@@ -1202,8 +1204,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }
     }
 
-    protected override string DecorateSystemPrompt(string basePrompt) =>
-        _systemPromptOverride ?? base.DecorateSystemPrompt(basePrompt);
+    protected override string DecorateSystemPrompt(
+        string basePrompt,
+        AgentProfileTurnCatalog? turnCatalog) =>
+        _systemPromptOverride ?? base.DecorateSystemPrompt(basePrompt, turnCatalog);
 
     private async Task<SkillRunnerExecutionPlan> BuildExecutionPlanAsync(CancellationToken ct)
     {
@@ -1540,6 +1544,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                                {
                                    Request = toolContext.Request with { RequestId = $"{requestId}:lark-docx", CallId = null },
                                },
+                               turnCatalog: null,
                                metadata,
                                timeoutCts.Token))
             {

--- a/docs/canon/nyxid-chat-agent-profile-binding.md
+++ b/docs/canon/nyxid-chat-agent-profile-binding.md
@@ -47,6 +47,6 @@ create resolver 继续以 `CHAT_SOURCE_KIND_DIRECT` 的 chat-route decision 为�
 
 NyxID materializer 先从 route-owned tool set、当前已注册工具、既有 typed visibility、maximum policy 和 recovery policy 取交集，再执行 alias 或 bounded streaming classifier。`ENFORCED` 只有在 exact GUID、literal version、expected name、reviewed publisher、hash evidence、唯一 `SKILL.md` 和 UTF-8 正文上限全部通过后，才加入 selected-skill prompt layer，并把 member task policy 与 recovery policy 的并集继续限制在上述交集内。Ornn adapter 只读取两个 version-pinned GUID endpoint，不按 name、latest 或 search 回退。
 
-非空 catalog 即使没有任何工具名，也表示 restricted-empty。`ChatRuntimeRequestBuilder` 让 main 与 step 共用同一份 `FinalAllowedToolNames`：一边过滤模型可见 schema，一边写入 executor admission 使用的 `AgentToolVisibilityScope`；既有 visibility 只会继续取交集，不能被 profile 扩大。模型伪造不可见 tool call 时，executor 在工具执行前拒绝。
+非空 catalog 即使没有任何工具名，也表示 restricted-empty。`ChatRuntimeRequestBuilder` 让 main 与 step 共用同一份 `FinalAllowedToolNames`：一边过滤模型可见 schema，一边写入 executor admission 使用的 `AgentToolVisibilityScope`；既有 visibility 只会继续取交集，不能被 profile 扩大。每次 LLM call 都在 middleware 运行前冻结该 request 的 schema 与 visibility 上限，并在调用 provider 前再次取交集，因此 middleware 只能继续缩权，不能恢复 catalog 外工具。模型伪造不可见 tool call 时，executor 在工具执行前拒绝。
 
 `SHADOW` 只保留当前请求的 candidate identity 与 bounded diagnostic，权限和 prompt body 固定为 recovery，不读取、解析或注入 candidate skill body，也不解析 candidate task tool set。profile digest、classifier、registry、tool discovery、collision、capability、exact fetch、identity、integrity或正文校验任一失败，都只能降为继续取交集后的 recovery；若交集为空则保持 restricted-empty，不能退回 unrestricted。

--- a/docs/canon/nyxid-chat-agent-profile-binding.md
+++ b/docs/canon/nyxid-chat-agent-profile-binding.md
@@ -40,3 +40,13 @@ create resolver 继续以 `CHAT_SOURCE_KIND_DIRECT` 的 chat-route decision 为�
 协议采用 additive tags：`RoleGAgentState.agent_profile = 12`，`NyxIdChatConversationCreateCommand.agent_profile = 3`。旧 bytes 的字段缺失值为空，因此旧会话保持未绑定；系统不 replay、backfill、lazy bind 或 hot-upgrade。配置和 validation baseline 变更都需要重新部署并重启，只影响之后创建的会话。
 
 本边界不增加公开 profile diagnostics、readmodel/query/API、create-time exact fetch、release verification或第二条 chat pipeline。具体 reviewed GUID、publisher、member、recovery/deny 名单和 enablement 属于发布配置，不属于本协议。
+
+## Turn-local materialization 与执行约束
+
+绑定 profile 的真实请求在 completed replay 判定之后只物化一次 immutable `AgentProfileTurnCatalog`。该值以无默认值的显式参数进入 main chat、step executor 和 prompt 组合；它不是 DI service、actor state、readmodel、cache 或进程级上下文。未绑定会话以及 Workflow、Studio、relay、Household、Scheduled 和 AgentRun 等非 profile consumer 必须显式传 `null`，只有这个值表示 unprofiled。
+
+NyxID materializer 先从 route-owned tool set、当前已注册工具、既有 typed visibility、maximum policy 和 recovery policy 取交集，再执行 alias 或 bounded streaming classifier。`ENFORCED` 只有在 exact GUID、literal version、expected name、reviewed publisher、hash evidence、唯一 `SKILL.md` 和 UTF-8 正文上限全部通过后，才加入 selected-skill prompt layer，并把 member task policy 与 recovery policy 的并集继续限制在上述交集内。Ornn adapter 只读取两个 version-pinned GUID endpoint，不按 name、latest 或 search 回退。
+
+非空 catalog 即使没有任何工具名，也表示 restricted-empty。`ChatRuntimeRequestBuilder` 让 main 与 step 共用同一份 `FinalAllowedToolNames`：一边过滤模型可见 schema，一边写入 executor admission 使用的 `AgentToolVisibilityScope`；既有 visibility 只会继续取交集，不能被 profile 扩大。模型伪造不可见 tool call 时，executor 在工具执行前拒绝。
+
+`SHADOW` 只保留当前请求的 candidate identity 与 bounded diagnostic，权限和 prompt body 固定为 recovery，不读取、解析或注入 candidate skill body，也不解析 candidate task tool set。profile digest、classifier、registry、tool discovery、collision、capability、exact fetch、identity、integrity或正文校验任一失败，都只能降为继续取交集后的 recovery；若交集为空则保持 restricted-empty，不能退回 unrestricted。

--- a/src/Aevatar.AI.Core/AIGAgentBase.cs
+++ b/src/Aevatar.AI.Core/AIGAgentBase.cs
@@ -4,6 +4,7 @@
 // ─────────────────────────────────────────────────────────────
 
 using Aevatar.AI.Core.Chat;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Hooks.BuiltIn;
 using Aevatar.AI.Core.Middleware;
@@ -201,34 +202,49 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
     //   Old pattern: protected ChatAsync helpers let GAgents call the non-streaming executor as a formal conversation path.
     //   New principle: GAgent subclasses use ChatStreamAsync; explicit offline aggregation is local to the caller that needs text.
     /// <summary>流式 Chat。</summary>
-    protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(string userMessage, CancellationToken ct = default)
+    protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+        string userMessage,
+        AgentProfileTurnCatalog? turnCatalog,
+        CancellationToken ct = default)
     {
         EnsureRuntime();
-        return _chat!.ChatStreamAsync([ContentPart.TextPart(userMessage)], EffectiveConfig.MaxToolRounds, ct);
+        return _chat!.ChatStreamAsync(
+            [ContentPart.TextPart(userMessage)],
+            EffectiveConfig.MaxToolRounds,
+            turnCatalog,
+            ct);
     }
 
     /// <summary>流式 Chat，显式传入稳定 request id 和 metadata。</summary>
     protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         string userMessage,
         string? requestId,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default)
     {
         EnsureRuntime();
         var maxRounds = ResolveMaxToolRounds(metadata);
-        return _chat!.ChatStreamAsync([ContentPart.TextPart(userMessage)], maxRounds, requestId, metadata, ct);
+        return _chat!.ChatStreamAsync(
+            [ContentPart.TextPart(userMessage)],
+            maxRounds,
+            requestId,
+            turnCatalog,
+            metadata,
+            ct);
     }
 
     /// <summary>流式 Chat（多模态内容），显式传入稳定 request id 和 metadata。</summary>
     protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         IReadOnlyList<ContentPart> userContent,
         string? requestId,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default)
     {
         EnsureRuntime();
         var maxRounds = ResolveMaxToolRounds(metadata);
-        return _chat!.ChatStreamAsync(userContent, maxRounds, requestId, metadata, ct);
+        return _chat!.ChatStreamAsync(userContent, maxRounds, requestId, turnCatalog, metadata, ct);
     }
 
     protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
@@ -236,6 +252,7 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
         string? requestId,
         LLMControlContext? llmControl,
         AgentToolExecutionContext? toolContext,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default)
     {
@@ -243,19 +260,35 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
         var maxRounds = llmControl?.MaxToolRoundsOverride
                         ?? toolContext?.Routing.MaxToolRoundsOverride
                         ?? EffectiveConfig.MaxToolRounds;
-        return _chat!.ChatStreamAsync(userContent, maxRounds, requestId, llmControl, toolContext, metadata, ct);
+        return _chat!.ChatStreamAsync(
+            userContent,
+            maxRounds,
+            requestId,
+            llmControl,
+            toolContext,
+            turnCatalog,
+            metadata,
+            ct);
     }
 
     protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         IReadOnlyList<ContentPart> userContent,
         string? requestId,
         AgentToolExecutionContext? toolContext,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default)
     {
         EnsureRuntime();
         var maxRounds = toolContext?.Routing.MaxToolRoundsOverride ?? ResolveMaxToolRounds(metadata);
-        return _chat!.ChatStreamAsync(userContent, maxRounds, requestId, toolContext, metadata, ct);
+        return _chat!.ChatStreamAsync(
+            userContent,
+            maxRounds,
+            requestId,
+            toolContext,
+            turnCatalog,
+            metadata,
+            ct);
     }
 
     /// <summary>
@@ -351,11 +384,13 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
     /// 装饰系统 prompt。子类可覆写以追加动态内容（如技能列表）。
     /// 默认实现直接返回原始 prompt。
     /// </summary>
-    protected virtual string DecorateSystemPrompt(string basePrompt) => basePrompt;
+    protected virtual string DecorateSystemPrompt(
+        string basePrompt,
+        AgentProfileTurnCatalog? turnCatalog) => basePrompt;
 
-    private LLMRequest BuildRequest() => new()
+    private LLMRequest BuildRequest(AgentProfileTurnCatalog? turnCatalog) => new()
     {
-        Messages = History.BuildMessages(DecorateSystemPrompt(EffectiveConfig.SystemPrompt)),
+        Messages = History.BuildMessages(DecorateSystemPrompt(EffectiveConfig.SystemPrompt, turnCatalog)),
         RequestId = null,
         Metadata = null,
         Tools = BuildValidTools(),

--- a/src/Aevatar.AI.Core/AgentProfiles/AgentProfileTurnCatalog.cs
+++ b/src/Aevatar.AI.Core/AgentProfiles/AgentProfileTurnCatalog.cs
@@ -1,0 +1,106 @@
+using System.Collections.Frozen;
+using System.Text;
+using Aevatar.AI.Abstractions.Prompting;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.Core.AgentProfiles;
+
+public enum AgentProfileTurnDiagnosticCode
+{
+    ProfileInvalid = 0,
+    RouteToolSetUnavailable = 1,
+    ToolSetUnavailable = 2,
+    ToolDiscoveryFailed = 3,
+    ToolNameCollision = 4,
+    ToolCapabilityRejected = 5,
+    AliasMatched = 6,
+    ClassifierMatched = 7,
+    ClassifierNoMatch = 8,
+    ClassifierFailed = 9,
+    ShadowCandidate = 10,
+    ExactSkillFetchFailed = 11,
+    ExactSkillIdentityMismatch = 12,
+    SelectedSkillBodyInvalid = 13,
+}
+
+public sealed record AgentProfileTurnDiagnostic(AgentProfileTurnDiagnosticCode Code, string Detail);
+
+public sealed class AgentProfileTurnCatalog
+{
+    public const int MaximumDiagnostics = 16;
+    private const int MaximumDiagnosticDetailUtf8Bytes = 256;
+
+    public AgentProfileTurnCatalog(
+        IEnumerable<string> finalAllowedToolNames,
+        ProfileRoutingPromptLayer? profilePromptLayer,
+        SelectedSkillPromptLayer? selectedSkillPromptLayer,
+        string? selectedIntentId,
+        string? candidateIntentId,
+        IReadOnlyList<AgentProfileTurnDiagnostic>? diagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(finalAllowedToolNames);
+
+        FinalAllowedToolNames = finalAllowedToolNames
+            .Where(static name => !string.IsNullOrWhiteSpace(name))
+            .Select(static name => name.Trim())
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        ToolVisibility = new AgentToolVisibilityScope(FinalAllowedToolNames);
+        ProfilePromptLayer = profilePromptLayer;
+        SelectedSkillPromptLayer = selectedSkillPromptLayer;
+        SelectedIntentId = Normalize(selectedIntentId);
+        CandidateIntentId = Normalize(candidateIntentId);
+        Diagnostics = CopyDiagnostics(diagnostics);
+    }
+
+    public IReadOnlySet<string> FinalAllowedToolNames { get; }
+
+    public AgentToolVisibilityScope ToolVisibility { get; }
+
+    public ProfileRoutingPromptLayer? ProfilePromptLayer { get; }
+
+    public SelectedSkillPromptLayer? SelectedSkillPromptLayer { get; }
+
+    public string? SelectedIntentId { get; }
+
+    public string? CandidateIntentId { get; }
+
+    public IReadOnlyList<AgentProfileTurnDiagnostic> Diagnostics { get; }
+
+    private static IReadOnlyList<AgentProfileTurnDiagnostic> CopyDiagnostics(
+        IReadOnlyList<AgentProfileTurnDiagnostic>? diagnostics)
+    {
+        if (diagnostics is null or { Count: 0 })
+            return [];
+
+        var bounded = diagnostics
+            .Take(MaximumDiagnostics)
+            .Select(static diagnostic => diagnostic with
+            {
+                Detail = TruncateUtf8(diagnostic.Detail ?? string.Empty, MaximumDiagnosticDetailUtf8Bytes),
+            })
+            .ToList();
+        return bounded.AsReadOnly();
+    }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string TruncateUtf8(string value, int maximumBytes)
+    {
+        if (Encoding.UTF8.GetByteCount(value) <= maximumBytes)
+            return value;
+
+        var builder = new StringBuilder();
+        var bytes = 0;
+        foreach (var rune in value.EnumerateRunes())
+        {
+            if (bytes + rune.Utf8SequenceLength > maximumBytes)
+                break;
+
+            builder.Append(rune);
+            bytes += rune.Utf8SequenceLength;
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Aevatar.AI.Core/AgentProfiles/IAgentProfileTurnClassifier.cs
+++ b/src/Aevatar.AI.Core/AgentProfiles/IAgentProfileTurnClassifier.cs
@@ -1,0 +1,39 @@
+namespace Aevatar.AI.Core.AgentProfiles;
+
+public sealed record AgentProfileTurnClassificationCandidate(
+    string IntentId,
+    string RoutingDescription);
+
+public sealed record AgentProfileTurnClassificationRequest(
+    string UserMessage,
+    IReadOnlyList<AgentProfileTurnClassificationCandidate> Candidates,
+    TimeSpan Timeout);
+
+public enum AgentProfileTurnClassificationStatus
+{
+    Matched = 0,
+    NoMatch = 1,
+    Failed = 2,
+}
+
+public sealed record AgentProfileTurnClassificationResult(
+    AgentProfileTurnClassificationStatus Status,
+    string? IntentId,
+    string? FailureCode)
+{
+    public static AgentProfileTurnClassificationResult Matched(string intentId) =>
+        new(AgentProfileTurnClassificationStatus.Matched, intentId, null);
+
+    public static AgentProfileTurnClassificationResult NoMatch() =>
+        new(AgentProfileTurnClassificationStatus.NoMatch, null, null);
+
+    public static AgentProfileTurnClassificationResult Failed(string failureCode) =>
+        new(AgentProfileTurnClassificationStatus.Failed, null, failureCode);
+}
+
+public interface IAgentProfileTurnClassifier
+{
+    Task<AgentProfileTurnClassificationResult> ClassifyAsync(
+        AgentProfileTurnClassificationRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.AI.Core/AgentProfiles/IExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.Core/AgentProfiles/IExactRemoteSkillFetcher.cs
@@ -1,0 +1,50 @@
+using Aevatar.AI.Abstractions;
+
+namespace Aevatar.AI.Core.AgentProfiles;
+
+public enum ExactRemoteSkillFetchFailureCode
+{
+    InvalidReference = 0,
+    AccessTokenMissing = 1,
+    NotFound = 2,
+    AccessDenied = 3,
+    Timeout = 4,
+    InvalidResponse = 5,
+    IdentityMismatch = 6,
+    IntegrityEvidenceMissing = 7,
+    Failed = 8,
+}
+
+public sealed record ExactRemoteSkillFetchResult(
+    bool IsSuccess,
+    string? Guid,
+    string? LiteralVersion,
+    string? Name,
+    string? PublisherId,
+    string? SkillHash,
+    string? SkillMarkdown,
+    ExactRemoteSkillFetchFailureCode? FailureCode,
+    string? FailureDetail)
+{
+    public static ExactRemoteSkillFetchResult Success(
+        string guid,
+        string literalVersion,
+        string name,
+        string publisherId,
+        string skillHash,
+        string skillMarkdown) =>
+        new(true, guid, literalVersion, name, publisherId, skillHash, skillMarkdown, null, null);
+
+    public static ExactRemoteSkillFetchResult Failed(
+        ExactRemoteSkillFetchFailureCode failureCode,
+        string? failureDetail = null) =>
+        new(false, null, null, null, null, null, null, failureCode, failureDetail);
+}
+
+public interface IExactRemoteSkillFetcher
+{
+    Task<ExactRemoteSkillFetchResult> FetchAsync(
+        string accessToken,
+        ExactRemoteSkillRef skillRef,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -393,10 +393,19 @@ public sealed class ChatRuntime
                 yield return new LLMStreamChunk { DeltaContent = "\n\n" };
             }
 
+            var authorizedToolContext = AgentToolExecutionContextMapper.FromRequest(baseRequest);
             var streamingExecutor = new StreamingToolExecutor(
                 _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
-                toolContext: AgentToolExecutionContextMapper.FromRequest(baseRequest));
+                toolContext: authorizedToolContext);
             using var streamingToolState = streamingExecutor.CreateExecutionState();
+
+            void BindAuthorizedRequest(LLMRequest authorizedRequest)
+            {
+                authorizedToolContext = AgentToolExecutionContextMapper.FromRequest(authorizedRequest);
+                streamingExecutor = new StreamingToolExecutor(
+                    _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
+                    toolContext: authorizedToolContext);
+            }
 
             List<ToolCall>? deferredToolCalls = _hooks != null ? [] : null;
 
@@ -434,7 +443,8 @@ public sealed class ChatRuntime
                                            deferredToolCalls.Add(toolCall);
                                        else
                                            streamingExecutor.AddTool(streamingToolState, toolCall);
-                                   }))
+                                   },
+                                   BindAuthorizedRequest))
                 {
                     roundChunks.Add(chunk);
                 }
@@ -449,7 +459,7 @@ public sealed class ChatRuntime
 
                 if (!roundCallsTools &&
                     await skillRecovery.TryRecoverFinalAnswerAsync(
-                        roundRequest.ToolContext,
+                        authorizedToolContext,
                         messages,
                         pendingHistoryMessages,
                         roundResult.Content,
@@ -487,7 +497,8 @@ public sealed class ChatRuntime
                                            deferredToolCalls.Add(toolCall);
                                        else
                                            streamingExecutor.AddTool(streamingToolState, toolCall);
-                                   }))
+                                   },
+                                   BindAuthorizedRequest))
                 {
                     wroteOutput = true;
                     yield return chunk;
@@ -548,7 +559,7 @@ public sealed class ChatRuntime
 
                         var textToolExecutor = new StreamingToolExecutor(
                             _toolLoop.Tools, _hooks, _toolLoop.ToolMiddlewares,
-                            toolContext: AgentToolExecutionContextMapper.FromRequest(roundRequest));
+                            toolContext: authorizedToolContext);
                         using var textToolState = textToolExecutor.CreateExecutionState();
                         foreach (var tc in parsed.ToolCalls)
                             textToolExecutor.AddTool(textToolState, tc);
@@ -578,7 +589,7 @@ public sealed class ChatRuntime
                 }
 
                 if (await skillRecovery.TryRecoverFinalAnswerAsync(
-                        roundRequest.ToolContext,
+                        authorizedToolContext,
                         messages,
                         pendingHistoryMessages,
                         roundResult.Content,
@@ -830,7 +841,8 @@ public sealed class ChatRuntime
         LLMRequest request,
         StreamingRoundScope roundScope,
         [EnumeratorCancellation] CancellationToken ct,
-        Action<ToolCall>? onToolCallCompleted = null)
+        Action<ToolCall>? onToolCallCompleted = null,
+        Action<LLMRequest>? onRequestAuthorized = null)
     {
         // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
         //   Old pattern: ChatRuntime.ChatStreamAsync 用 Task.Run + Channel<LLMStreamChunk>/ChannelWriter 在 actor turn 外跑 LLM/tool/hook/history 业务循环,违反 actor execution integrity
@@ -871,6 +883,7 @@ public sealed class ChatRuntime
         if (readyTask == coreTurnTask && !llmCallContext.Terminate)
         {
             llmCallContext.Request = authorizationFence.Apply(llmCallContext.Request);
+            onRequestAuthorized?.Invoke(llmCallContext.Request);
             var full = new StringBuilder();
             var fullReasoning = new StringBuilder();
             TokenUsage? usage = null;

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -838,6 +838,7 @@ public sealed class ChatRuntime
         var llmHookContext = new AIGAgentExecutionHookContext { LLMRequest = request };
         if (_hooks != null) await _hooks.RunLLMRequestStartAsync(llmHookContext, ct);
         var llmStartedAt = Stopwatch.GetTimestamp();
+        var authorizationFence = ChatRuntimeRequestBuilder.CaptureAuthorizationFence(request);
 
         var llmCallContext = new LLMCallContext
         {
@@ -867,6 +868,7 @@ public sealed class ChatRuntime
 
         if (readyTask == coreTurnTask && !llmCallContext.Terminate)
         {
+            llmCallContext.Request = authorizationFence.Apply(llmCallContext.Request);
             var full = new StringBuilder();
             var fullReasoning = new StringBuilder();
             TokenUsage? usage = null;

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -836,13 +836,15 @@ public sealed class ChatRuntime
         //   Old pattern: ChatRuntime.ChatStreamAsync 用 Task.Run + Channel<LLMStreamChunk>/ChannelWriter 在 actor turn 外跑 LLM/tool/hook/history 业务循环,违反 actor execution integrity
         //   New principle: ChatStreamAsync owns the stream flow directly; the Task.Run + Channel owned-stream loop and stream_buffer_capacity config were removed; middleware wrapping stays inside private bridge adapters.
         var authorizationFence = ChatRuntimeRequestBuilder.CaptureAuthorizationFence(request);
-        var llmHookContext = new AIGAgentExecutionHookContext { LLMRequest = request };
+        var hasRequestExtensionPoint = _hooks is not null || _llmMiddlewares.Count > 0;
+        var catalogBoundRequest = authorizationFence.Apply(request, forceCopy: hasRequestExtensionPoint);
+        var llmHookContext = new AIGAgentExecutionHookContext { LLMRequest = catalogBoundRequest };
         if (_hooks != null) await _hooks.RunLLMRequestStartAsync(llmHookContext, ct);
         var llmStartedAt = Stopwatch.GetTimestamp();
 
         var llmCallContext = new LLMCallContext
         {
-            Request = authorizationFence.Apply(request),
+            Request = authorizationFence.Apply(catalogBoundRequest),
             Provider = provider,
             CancellationToken = ct,
             IsStreaming = true,

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -8,6 +8,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Diagnostics;
@@ -43,7 +44,7 @@ public sealed class ChatRuntime
     private readonly ChatHistory _history;
     private readonly ToolCallLoop _toolLoop;
     private readonly AgentHookPipeline? _hooks;
-    private readonly Func<LLMRequest> _requestBuilder;
+    private readonly Func<AgentProfileTurnCatalog?, LLMRequest> _requestBuilder;
     private readonly IReadOnlyList<IAgentRunMiddleware> _agentMiddlewares;
     private readonly IReadOnlyList<ILLMCallMiddleware> _llmMiddlewares;
     private readonly string? _agentId;
@@ -57,7 +58,7 @@ public sealed class ChatRuntime
         ChatHistory history,
         ToolCallLoop toolLoop,
         AgentHookPipeline? hooks,
-        Func<LLMRequest> requestBuilder,
+        Func<AgentProfileTurnCatalog?, LLMRequest> requestBuilder,
         IReadOnlyList<IAgentRunMiddleware>? agentMiddlewares = null,
         IReadOnlyList<ILLMCallMiddleware>? llmMiddlewares = null,
         string? agentId = null,
@@ -80,48 +81,78 @@ public sealed class ChatRuntime
         _logger = logger ?? NullLogger.Instance;
     }
 
-    public ChatRuntimeStepExecutor CreateStepExecutor() =>
+    public ChatRuntimeStepExecutor CreateStepExecutor(AgentProfileTurnCatalog? turnCatalog) =>
         new(
             _providerFactory,
             _toolLoop,
             _hooks,
             _requestBuilder,
             _llmMiddlewares,
-            _history.Budget);
+            _history.Budget,
+            turnCatalog);
 
     /// <summary>流式 Chat，包裹 LLM Call Middleware。</summary>
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         string userMessage,
+        AgentProfileTurnCatalog? turnCatalog,
         CancellationToken ct = default) =>
-        ChatStreamAsync([ContentPart.TextPart(userMessage)], DefaultMaxToolRounds, requestId: null, metadata: null, ct);
+        ChatStreamAsync(
+            [ContentPart.TextPart(userMessage)],
+            DefaultMaxToolRounds,
+            requestId: null,
+            turnCatalog: turnCatalog,
+            metadata: null,
+            ct);
 
     /// <summary>流式 Chat（多模态内容）。</summary>
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         IReadOnlyList<ContentPart> userContent,
+        AgentProfileTurnCatalog? turnCatalog,
         CancellationToken ct = default) =>
-        ChatStreamAsync(userContent, DefaultMaxToolRounds, requestId: null, metadata: null, ct);
+        ChatStreamAsync(
+            userContent,
+            DefaultMaxToolRounds,
+            requestId: null,
+            turnCatalog: turnCatalog,
+            metadata: null,
+            ct);
 
     /// <summary>流式 Chat，允许显式控制 tool calling 轮数。</summary>
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         string userMessage,
         int maxToolRounds,
+        AgentProfileTurnCatalog? turnCatalog,
         CancellationToken ct = default) =>
-        ChatStreamAsync([ContentPart.TextPart(userMessage)], maxToolRounds, requestId: null, metadata: null, ct);
+        ChatStreamAsync(
+            [ContentPart.TextPart(userMessage)],
+            maxToolRounds,
+            requestId: null,
+            turnCatalog: turnCatalog,
+            metadata: null,
+            ct);
 
     /// <summary>流式 Chat（多模态内容），允许显式控制 tool calling 轮数。</summary>
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         IReadOnlyList<ContentPart> userContent,
         int maxToolRounds,
+        AgentProfileTurnCatalog? turnCatalog,
         CancellationToken ct = default) =>
-        ChatStreamAsync(userContent, maxToolRounds, requestId: null, metadata: null, ct);
+        ChatStreamAsync(
+            userContent,
+            maxToolRounds,
+            requestId: null,
+            turnCatalog: turnCatalog,
+            metadata: null,
+            ct);
 
     /// <summary>流式 Chat，显式传入稳定 request id 和 metadata（默认 tool 轮数）。</summary>
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         string userMessage,
         string? requestId,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default) =>
-        ChatStreamAsync([ContentPart.TextPart(userMessage)], DefaultMaxToolRounds, requestId, metadata, ct);
+        ChatStreamAsync([ContentPart.TextPart(userMessage)], DefaultMaxToolRounds, requestId, turnCatalog, metadata, ct);
 
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         IReadOnlyList<ContentPart> userContent,
@@ -129,24 +160,35 @@ public sealed class ChatRuntime
         string? requestId,
         LLMControlContext? llmControl,
         AgentToolExecutionContext? toolContext,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default) =>
-        ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, toolContext, llmControl, ct);
+        ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, toolContext, llmControl, turnCatalog, ct);
 
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         IReadOnlyList<ContentPart> userContent,
         int maxToolRounds,
         string? requestId,
         AgentToolExecutionContext? toolContext,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         CancellationToken ct = default) =>
-        ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, toolContext, llmControl: null, ct);
+        ChatStreamAsync(
+            userContent,
+            maxToolRounds,
+            requestId,
+            metadata,
+            toolContext,
+            llmControl: null,
+            turnCatalog: turnCatalog,
+            ct);
 
     /// <summary>流式 Chat，显式传入稳定 request id 和 metadata + tool 轮数。</summary>
     public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         string userMessage,
         int maxToolRounds,
         string? requestId,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -154,6 +196,7 @@ public sealed class ChatRuntime
                            [ContentPart.TextPart(userMessage)],
                            maxToolRounds,
                            requestId,
+                           turnCatalog,
                            metadata,
                            ct))
         {
@@ -166,6 +209,7 @@ public sealed class ChatRuntime
         IReadOnlyList<ContentPart> userContent,
         int maxToolRounds,
         string? requestId,
+        AgentProfileTurnCatalog? turnCatalog,
         IReadOnlyDictionary<string, string>? metadata = null,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -176,6 +220,7 @@ public sealed class ChatRuntime
                            metadata,
                            toolContext: null,
                            llmControl: null,
+                           turnCatalog: turnCatalog,
                            ct))
         {
             yield return chunk;
@@ -189,6 +234,7 @@ public sealed class ChatRuntime
         IReadOnlyDictionary<string, string>? metadata,
         AgentToolExecutionContext? toolContext,
         LLMControlContext? llmControl,
+        AgentProfileTurnCatalog? turnCatalog,
         [EnumeratorCancellation] CancellationToken ct)
     {
         var normalizedUserContent = NormalizeUserContent(userContent);
@@ -223,6 +269,7 @@ public sealed class ChatRuntime
                     metadata,
                     toolContext,
                     llmControl,
+                    turnCatalog,
                     runContext,
                     runToken)
                 .GetAsyncEnumerator(runToken);
@@ -263,6 +310,7 @@ public sealed class ChatRuntime
         IReadOnlyDictionary<string, string>? metadata,
         AgentToolExecutionContext? toolContext,
         LLMControlContext? llmControl,
+        AgentProfileTurnCatalog? turnCatalog,
         AgentRunContext runContext,
         [EnumeratorCancellation] CancellationToken runToken)
     {
@@ -280,6 +328,7 @@ public sealed class ChatRuntime
                            metadata,
                            toolContext,
                            llmControl,
+                           turnCatalog,
                            runContext,
                            pendingHistoryMessages,
                            wroteOutput,
@@ -296,6 +345,7 @@ public sealed class ChatRuntime
         IReadOnlyDictionary<string, string>? metadata,
         AgentToolExecutionContext? toolContext,
         LLMControlContext? llmControl,
+        AgentProfileTurnCatalog? turnCatalog,
         AgentRunContext runContext,
         List<ChatMessage> pendingHistoryMessages,
         bool wroteOutput,
@@ -309,7 +359,13 @@ public sealed class ChatRuntime
         //   New principle: ChatStreamAsync owns the stream flow directly; the Task.Run + Channel owned-stream loop and stream_buffer_capacity config were removed; middleware wrapping stays inside private bridge adapters.
         var userMsg = ChatMessage.User(normalizedUserContent, runContext.UserMessage);
         pendingHistoryMessages.Add(userMsg);
-        var baseRequest = ApplyRequestIdentity(_requestBuilder(), requestId, metadata, toolContext, llmControl);
+        var baseRequest = ChatRuntimeRequestBuilder.Build(
+            _requestBuilder(turnCatalog),
+            requestId,
+            metadata,
+            toolContext,
+            llmControl,
+            turnCatalog);
         var provider = _providerFactory();
         runContext.Items["gen_ai.provider.name"] = provider.Name;
         var messages = BuildMessagesWithPending(baseRequest, userMsg);
@@ -979,85 +1035,6 @@ public sealed class ChatRuntime
         messages.AddRange(ChatMessageToolCallTranscript.WithoutInvalidToolCallPairs(_history.Messages));
         messages.Add(pendingUserMessage);
         return messages;
-    }
-
-    private static LLMRequest ApplyRequestIdentity(
-        LLMRequest baseRequest,
-        string? requestId,
-        IReadOnlyDictionary<string, string>? metadata,
-        AgentToolExecutionContext? toolContext,
-        LLMControlContext? llmControl)
-    {
-        var effectiveLlmControl = llmControl ?? baseRequest.LlmControl;
-        var effectiveToolContext = toolContext is null
-            ? AgentToolExecutionContextMapper.FromRequest(baseRequest)
-            : AgentToolExecutionContextMapper.MergeExternalMetadata(
-                toolContext,
-                MergeMetadata(baseRequest.Metadata, metadata));
-        effectiveToolContext = effectiveLlmControl?.ToToolContext(effectiveToolContext) ?? effectiveToolContext;
-        if (!string.IsNullOrWhiteSpace(requestId))
-        {
-            effectiveToolContext = effectiveToolContext with
-            {
-                Request = effectiveToolContext.Request with { RequestId = requestId.Trim() },
-            };
-        }
-
-        return new LLMRequest
-        {
-            Messages = baseRequest.Messages,
-            RequestId = string.IsNullOrWhiteSpace(requestId) ? baseRequest.RequestId : requestId.Trim(),
-            Metadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(MergeMetadata(baseRequest.Metadata, metadata)),
-            CallerContext = baseRequest.CallerContext,
-            ToolContext = effectiveToolContext,
-            RoutingContext = effectiveLlmControl?.ToRoutingContext(baseRequest.RoutingContext) ?? baseRequest.RoutingContext,
-            LlmControl = effectiveLlmControl,
-            Tools = FilterVisibleTools(baseRequest.Tools, effectiveToolContext.ToolVisibility),
-            Model = baseRequest.Model,
-            Temperature = baseRequest.Temperature,
-            MaxTokens = baseRequest.MaxTokens,
-            ResponseFormat = baseRequest.ResponseFormat,
-        };
-    }
-
-    private static IReadOnlyList<IAgentTool>? FilterVisibleTools(
-        IReadOnlyList<IAgentTool>? tools,
-        AgentToolVisibilityScope visibility)
-    {
-        if (tools is not { Count: > 0 })
-            return null;
-
-        if (!visibility.IsRestricted)
-            return tools;
-
-        var visibleTools = tools.Where(tool => visibility.Allows(tool.Name)).ToList();
-        return visibleTools.Count > 0 ? visibleTools : null;
-    }
-
-    private static IReadOnlyDictionary<string, string>? MergeMetadata(
-        IReadOnlyDictionary<string, string>? baseMetadata,
-        IReadOnlyDictionary<string, string>? overrideMetadata)
-    {
-        if ((baseMetadata == null || baseMetadata.Count == 0) &&
-            (overrideMetadata == null || overrideMetadata.Count == 0))
-        {
-            return null;
-        }
-
-        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
-        if (baseMetadata != null)
-        {
-            foreach (var pair in baseMetadata)
-                merged[pair.Key] = pair.Value;
-        }
-
-        if (overrideMetadata != null)
-        {
-            foreach (var pair in overrideMetadata)
-                merged[pair.Key] = pair.Value;
-        }
-
-        return merged;
     }
 
     private static void AnnotateRequestIdentity(LLMCallContext context)

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -835,14 +835,14 @@ public sealed class ChatRuntime
         // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
         //   Old pattern: ChatRuntime.ChatStreamAsync 用 Task.Run + Channel<LLMStreamChunk>/ChannelWriter 在 actor turn 外跑 LLM/tool/hook/history 业务循环,违反 actor execution integrity
         //   New principle: ChatStreamAsync owns the stream flow directly; the Task.Run + Channel owned-stream loop and stream_buffer_capacity config were removed; middleware wrapping stays inside private bridge adapters.
+        var authorizationFence = ChatRuntimeRequestBuilder.CaptureAuthorizationFence(request);
         var llmHookContext = new AIGAgentExecutionHookContext { LLMRequest = request };
         if (_hooks != null) await _hooks.RunLLMRequestStartAsync(llmHookContext, ct);
         var llmStartedAt = Stopwatch.GetTimestamp();
-        var authorizationFence = ChatRuntimeRequestBuilder.CaptureAuthorizationFence(request);
 
         var llmCallContext = new LLMCallContext
         {
-            Request = request,
+            Request = authorizationFence.Apply(request),
             Provider = provider,
             CancellationToken = ct,
             IsStreaming = true,

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
@@ -80,7 +80,7 @@ internal static class ChatRuntimeRequestBuilder
         if (!existing.IsRestricted)
             return ceiling;
         if (!ceiling.IsRestricted)
-            return ceiling;
+            return existing;
 
         return AgentToolVisibilityScope.FromAllowedToolNames(
             ceiling.AllowedToolNames!.Where(existing.Allows));

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
@@ -1,0 +1,110 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
+
+namespace Aevatar.AI.Core.Chat;
+
+internal static class ChatRuntimeRequestBuilder
+{
+    public static LLMRequest Build(
+        LLMRequest baseRequest,
+        string? requestId,
+        IReadOnlyDictionary<string, string>? metadata,
+        AgentToolExecutionContext? toolContext,
+        LLMControlContext? llmControl,
+        AgentProfileTurnCatalog? turnCatalog)
+    {
+        ArgumentNullException.ThrowIfNull(baseRequest);
+
+        var mergedMetadata = MergeMetadata(baseRequest.Metadata, metadata);
+        var effectiveLlmControl = llmControl ?? baseRequest.LlmControl;
+        var effectiveToolContext = toolContext is null
+            ? AgentToolExecutionContextMapper.FromRequest(baseRequest)
+            : AgentToolExecutionContextMapper.MergeExternalMetadata(toolContext, mergedMetadata);
+        effectiveToolContext = effectiveLlmControl?.ToToolContext(effectiveToolContext) ?? effectiveToolContext;
+        if (!string.IsNullOrWhiteSpace(requestId))
+        {
+            effectiveToolContext = effectiveToolContext with
+            {
+                Request = effectiveToolContext.Request with { RequestId = requestId.Trim() },
+            };
+        }
+
+        if (turnCatalog is not null)
+        {
+            effectiveToolContext = effectiveToolContext with
+            {
+                ToolVisibility = IntersectVisibility(
+                    effectiveToolContext.ToolVisibility,
+                    turnCatalog.FinalAllowedToolNames),
+            };
+        }
+
+        return new LLMRequest
+        {
+            Messages = baseRequest.Messages,
+            RequestId = string.IsNullOrWhiteSpace(requestId) ? baseRequest.RequestId : requestId.Trim(),
+            Metadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(mergedMetadata),
+            CallerContext = baseRequest.CallerContext,
+            ToolContext = effectiveToolContext,
+            RoutingContext = effectiveLlmControl?.ToRoutingContext(baseRequest.RoutingContext) ?? baseRequest.RoutingContext,
+            LlmControl = effectiveLlmControl,
+            Tools = FilterVisibleTools(baseRequest.Tools, effectiveToolContext.ToolVisibility),
+            Model = baseRequest.Model,
+            Temperature = baseRequest.Temperature,
+            MaxTokens = baseRequest.MaxTokens,
+            ResponseFormat = baseRequest.ResponseFormat,
+        };
+    }
+
+    private static AgentToolVisibilityScope IntersectVisibility(
+        AgentToolVisibilityScope existing,
+        IReadOnlySet<string> profileAllowedNames)
+    {
+        if (!existing.IsRestricted)
+            return AgentToolVisibilityScope.FromAllowedToolNames(profileAllowedNames);
+
+        return AgentToolVisibilityScope.FromAllowedToolNames(
+            profileAllowedNames.Where(existing.Allows));
+    }
+
+    private static IReadOnlyList<IAgentTool>? FilterVisibleTools(
+        IReadOnlyList<IAgentTool>? tools,
+        AgentToolVisibilityScope visibility)
+    {
+        if (tools is not { Count: > 0 })
+            return null;
+
+        if (!visibility.IsRestricted)
+            return tools;
+
+        var visibleTools = tools.Where(tool => visibility.Allows(tool.Name)).ToList();
+        return visibleTools.Count > 0 ? visibleTools : null;
+    }
+
+    private static IReadOnlyDictionary<string, string>? MergeMetadata(
+        IReadOnlyDictionary<string, string>? baseMetadata,
+        IReadOnlyDictionary<string, string>? overrideMetadata)
+    {
+        if ((baseMetadata is null || baseMetadata.Count == 0) &&
+            (overrideMetadata is null || overrideMetadata.Count == 0))
+        {
+            return null;
+        }
+
+        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (baseMetadata is not null)
+        {
+            foreach (var pair in baseMetadata)
+                merged[pair.Key] = pair.Value;
+        }
+
+        if (overrideMetadata is not null)
+        {
+            foreach (var pair in overrideMetadata)
+                merged[pair.Key] = pair.Value;
+        }
+
+        return merged;
+    }
+}

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
@@ -80,7 +80,7 @@ internal static class ChatRuntimeRequestBuilder
         if (!existing.IsRestricted)
             return ceiling;
         if (!ceiling.IsRestricted)
-            return existing;
+            return ceiling;
 
         return AgentToolVisibilityScope.FromAllowedToolNames(
             ceiling.AllowedToolNames!.Where(existing.Allows));

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
@@ -57,15 +57,32 @@ internal static class ChatRuntimeRequestBuilder
         };
     }
 
+    internal static AuthorizationFence CaptureAuthorizationFence(LLMRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new AuthorizationFence(
+            request.Tools?.Select(static tool => tool.Name) ?? [],
+            (request.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(request)).ToolVisibility);
+    }
+
     private static AgentToolVisibilityScope IntersectVisibility(
         AgentToolVisibilityScope existing,
         IReadOnlySet<string> profileAllowedNames)
+        => IntersectVisibility(
+            existing,
+            AgentToolVisibilityScope.FromAllowedToolNames(profileAllowedNames));
+
+    private static AgentToolVisibilityScope IntersectVisibility(
+        AgentToolVisibilityScope existing,
+        AgentToolVisibilityScope ceiling)
     {
         if (!existing.IsRestricted)
-            return AgentToolVisibilityScope.FromAllowedToolNames(profileAllowedNames);
+            return ceiling;
+        if (!ceiling.IsRestricted)
+            return existing;
 
         return AgentToolVisibilityScope.FromAllowedToolNames(
-            profileAllowedNames.Where(existing.Allows));
+            ceiling.AllowedToolNames!.Where(existing.Allows));
     }
 
     private static IReadOnlyList<IAgentTool>? FilterVisibleTools(
@@ -106,5 +123,65 @@ internal static class ChatRuntimeRequestBuilder
         }
 
         return merged;
+    }
+
+    internal sealed class AuthorizationFence
+    {
+        private readonly IReadOnlySet<string> _schemaToolNames;
+        private readonly AgentToolVisibilityScope _toolVisibility;
+
+        public AuthorizationFence(
+            IEnumerable<string> schemaToolNames,
+            AgentToolVisibilityScope toolVisibility)
+        {
+            _schemaToolNames = new HashSet<string>(
+                schemaToolNames
+                    .Where(static name => !string.IsNullOrWhiteSpace(name))
+                    .Select(static name => name.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+            _toolVisibility = toolVisibility.IsRestricted
+                ? AgentToolVisibilityScope.FromAllowedToolNames(toolVisibility.AllowedToolNames)
+                : AgentToolVisibilityScope.Unrestricted;
+        }
+
+        public LLMRequest Apply(LLMRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            var toolContext = request.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(request);
+            var visibility = IntersectVisibility(toolContext.ToolVisibility, _toolVisibility);
+            var tools = request.Tools?
+                .Where(tool => _schemaToolNames.Contains(tool.Name.Trim()) && visibility.Allows(tool.Name))
+                .ToList();
+            var toolsWereAttenuated = (request.Tools?.Count ?? 0) != (tools?.Count ?? 0);
+            var visibilityWasAttenuated = !HasSameVisibility(toolContext.ToolVisibility, visibility);
+            if (!toolsWereAttenuated && !visibilityWasAttenuated && ReferenceEquals(request.ToolContext, toolContext))
+                return request;
+
+            return new LLMRequest
+            {
+                Messages = request.Messages,
+                RequestId = request.RequestId,
+                Metadata = request.Metadata,
+                CallerContext = request.CallerContext,
+                ToolContext = toolContext with { ToolVisibility = visibility },
+                RoutingContext = request.RoutingContext,
+                LlmControl = request.LlmControl,
+                Tools = tools is { Count: > 0 } ? tools : null,
+                Model = request.Model,
+                Temperature = request.Temperature,
+                MaxTokens = request.MaxTokens,
+                ResponseFormat = request.ResponseFormat,
+            };
+        }
+
+        private static bool HasSameVisibility(
+            AgentToolVisibilityScope left,
+            AgentToolVisibilityScope right)
+        {
+            if (left.IsRestricted != right.IsRestricted)
+                return false;
+
+            return !left.IsRestricted || left.AllowedToolNames!.SetEquals(right.AllowedToolNames!);
+        }
     }
 }

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeRequestBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.AgentProfiles;
@@ -134,28 +135,30 @@ internal static class ChatRuntimeRequestBuilder
             IEnumerable<string> schemaToolNames,
             AgentToolVisibilityScope toolVisibility)
         {
-            _schemaToolNames = new HashSet<string>(
-                schemaToolNames
-                    .Where(static name => !string.IsNullOrWhiteSpace(name))
-                    .Select(static name => name.Trim()),
-                StringComparer.OrdinalIgnoreCase);
-            _toolVisibility = toolVisibility.IsRestricted
-                ? AgentToolVisibilityScope.FromAllowedToolNames(toolVisibility.AllowedToolNames)
-                : AgentToolVisibilityScope.Unrestricted;
+            _schemaToolNames = schemaToolNames
+                .Where(static name => !string.IsNullOrWhiteSpace(name))
+                .Select(static name => name.Trim())
+                .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+            _toolVisibility = FreezeVisibility(toolVisibility);
         }
 
-        public LLMRequest Apply(LLMRequest request)
+        public LLMRequest Apply(LLMRequest request, bool forceCopy = false)
         {
             ArgumentNullException.ThrowIfNull(request);
             var toolContext = request.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(request);
-            var visibility = IntersectVisibility(toolContext.ToolVisibility, _toolVisibility);
+            var visibility = CopyVisibility(IntersectVisibility(toolContext.ToolVisibility, _toolVisibility));
             var tools = request.Tools?
                 .Where(tool => _schemaToolNames.Contains(tool.Name.Trim()) && visibility.Allows(tool.Name))
                 .ToList();
             var toolsWereAttenuated = (request.Tools?.Count ?? 0) != (tools?.Count ?? 0);
             var visibilityWasAttenuated = !HasSameVisibility(toolContext.ToolVisibility, visibility);
-            if (!toolsWereAttenuated && !visibilityWasAttenuated && ReferenceEquals(request.ToolContext, toolContext))
+            if (!forceCopy &&
+                !toolsWereAttenuated &&
+                !visibilityWasAttenuated &&
+                ReferenceEquals(request.ToolContext, toolContext))
+            {
                 return request;
+            }
 
             return new LLMRequest
             {
@@ -173,6 +176,17 @@ internal static class ChatRuntimeRequestBuilder
                 ResponseFormat = request.ResponseFormat,
             };
         }
+
+        private static AgentToolVisibilityScope FreezeVisibility(AgentToolVisibilityScope visibility) =>
+            visibility.IsRestricted
+                ? new AgentToolVisibilityScope(
+                    visibility.AllowedToolNames!.ToFrozenSet(StringComparer.OrdinalIgnoreCase))
+                : AgentToolVisibilityScope.Unrestricted;
+
+        private static AgentToolVisibilityScope CopyVisibility(AgentToolVisibilityScope visibility) =>
+            visibility.IsRestricted
+                ? AgentToolVisibilityScope.FromAllowedToolNames(visibility.AllowedToolNames)
+                : AgentToolVisibilityScope.Unrestricted;
 
         private static bool HasSameVisibility(
             AgentToolVisibilityScope left,

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
@@ -2,6 +2,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Tools;
 
@@ -12,17 +13,19 @@ public sealed class ChatRuntimeStepExecutor
     private readonly Func<ILLMProvider> _providerFactory;
     private readonly ToolCallLoop _toolLoop;
     private readonly AgentHookPipeline? _hooks;
-    private readonly Func<LLMRequest> _requestBuilder;
+    private readonly Func<AgentProfileTurnCatalog?, LLMRequest> _requestBuilder;
     private readonly IReadOnlyList<ILLMCallMiddleware> _llmMiddlewares;
     private readonly TokenBudgetTracker _budgetTracker;
+    private readonly AgentProfileTurnCatalog? _turnCatalog;
 
     internal ChatRuntimeStepExecutor(
         Func<ILLMProvider> providerFactory,
         ToolCallLoop toolLoop,
         AgentHookPipeline? hooks,
-        Func<LLMRequest> requestBuilder,
+        Func<AgentProfileTurnCatalog?, LLMRequest> requestBuilder,
         IReadOnlyList<ILLMCallMiddleware> llmMiddlewares,
-        TokenBudgetTracker budgetTracker)
+        TokenBudgetTracker budgetTracker,
+        AgentProfileTurnCatalog? turnCatalog)
     {
         _providerFactory = providerFactory;
         _toolLoop = toolLoop;
@@ -30,6 +33,7 @@ public sealed class ChatRuntimeStepExecutor
         _requestBuilder = requestBuilder;
         _llmMiddlewares = llmMiddlewares;
         _budgetTracker = budgetTracker;
+        _turnCatalog = turnCatalog;
     }
 
     public LLMRequest BuildBaseRequest(
@@ -37,7 +41,13 @@ public sealed class ChatRuntimeStepExecutor
         IReadOnlyDictionary<string, string>? metadata,
         AgentToolExecutionContext? toolContext,
         LLMControlContext? llmControl) =>
-        ApplyRequestIdentity(_requestBuilder(), requestId, metadata, toolContext, llmControl);
+        ChatRuntimeRequestBuilder.Build(
+            _requestBuilder(_turnCatalog),
+            requestId,
+            metadata,
+            toolContext,
+            llmControl,
+            _turnCatalog);
 
     public LLMRequest BuildLlmStepRequest(
         IReadOnlyList<ChatMessage> messages,
@@ -84,7 +94,7 @@ public sealed class ChatRuntimeStepExecutor
             new ChatHistory(),
             _toolLoop,
             _hooks,
-            () => request,
+            _ => request,
             llmMiddlewares: _llmMiddlewares);
         return ExecuteAsync(runtime, provider, request, onChunkAsync, ct);
 
@@ -113,6 +123,11 @@ public sealed class ChatRuntimeStepExecutor
         AgentToolExecutionContext? toolContext,
         CancellationToken ct)
     {
+        var baseRequest = BuildBaseRequest(
+            requestId: null,
+            metadata: requestMetadata,
+            toolContext: toolContext,
+            llmControl: null);
         var runtime = new ChatRuntime(
             _providerFactory,
             new ChatHistory(),
@@ -120,74 +135,16 @@ public sealed class ChatRuntimeStepExecutor
             _hooks,
             _requestBuilder,
             llmMiddlewares: _llmMiddlewares);
+        var executionToolContext = _turnCatalog is null
+            ? toolContext
+            : baseRequest.ToolContext;
         // Refactor (issue1574): Old pattern: core tool step accepted Metadata as a fallback control source.
         // New principle: metadata is retained for outer legacy planning only; core tool execution uses typed context.
-        return await runtime.ExecuteSingleToolStepAsync(toolCalls, toolContext, ct)
+        return await runtime.ExecuteSingleToolStepAsync(toolCalls, executionToolContext, ct)
             .ConfigureAwait(false);
     }
 
     public void RecordUsage(TokenUsage? usage) => _budgetTracker.RecordUsage(usage);
-
-    private static LLMRequest ApplyRequestIdentity(
-        LLMRequest baseRequest,
-        string? requestId,
-        IReadOnlyDictionary<string, string>? metadata,
-        AgentToolExecutionContext? toolContext,
-        LLMControlContext? llmControl)
-    {
-        var effectiveLlmControl = llmControl ?? baseRequest.LlmControl;
-        var effectiveToolContext = toolContext ?? baseRequest.ToolContext ?? AgentToolExecutionContextMapper.FromRequest(baseRequest);
-        effectiveToolContext = effectiveLlmControl?.ToToolContext(effectiveToolContext) ?? effectiveToolContext;
-        if (!string.IsNullOrWhiteSpace(requestId))
-        {
-            effectiveToolContext = effectiveToolContext with
-            {
-                Request = effectiveToolContext.Request with { RequestId = requestId.Trim() },
-            };
-        }
-
-        return new LLMRequest
-        {
-            Messages = baseRequest.Messages,
-            RequestId = string.IsNullOrWhiteSpace(requestId) ? baseRequest.RequestId : requestId.Trim(),
-            Metadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(MergeMetadata(baseRequest.Metadata, metadata)),
-            CallerContext = baseRequest.CallerContext,
-            ToolContext = effectiveToolContext,
-            RoutingContext = effectiveLlmControl?.ToRoutingContext(baseRequest.RoutingContext) ?? baseRequest.RoutingContext,
-            LlmControl = effectiveLlmControl,
-            Tools = baseRequest.Tools,
-            Model = baseRequest.Model,
-            Temperature = baseRequest.Temperature,
-            MaxTokens = baseRequest.MaxTokens,
-            ResponseFormat = baseRequest.ResponseFormat,
-        };
-    }
-
-    private static IReadOnlyDictionary<string, string>? MergeMetadata(
-        IReadOnlyDictionary<string, string>? baseMetadata,
-        IReadOnlyDictionary<string, string>? overrideMetadata)
-    {
-        if ((baseMetadata == null || baseMetadata.Count == 0) &&
-            (overrideMetadata == null || overrideMetadata.Count == 0))
-        {
-            return null;
-        }
-
-        var merged = new Dictionary<string, string>(StringComparer.Ordinal);
-        if (baseMetadata != null)
-        {
-            foreach (var pair in baseMetadata)
-                merged[pair.Key] = pair.Value;
-        }
-
-        if (overrideMetadata != null)
-        {
-            foreach (var pair in overrideMetadata)
-                merged[pair.Key] = pair.Value;
-        }
-
-        return merged;
-    }
 
     private static List<ChatMessage> BuildStepMessages(
         IReadOnlyList<ChatMessage> messages,

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
@@ -89,14 +89,21 @@ public sealed class ChatRuntimeStepExecutor
         Func<LLMStreamChunk, CancellationToken, Task>? onChunkAsync,
         CancellationToken ct)
     {
+        var catalogBoundRequest = ChatRuntimeRequestBuilder.Build(
+            request,
+            request.RequestId,
+            request.Metadata,
+            request.ToolContext,
+            request.LlmControl,
+            _turnCatalog);
         var runtime = new ChatRuntime(
             () => provider,
             new ChatHistory(),
             _toolLoop,
             _hooks,
-            _ => request,
+            _ => catalogBoundRequest,
             llmMiddlewares: _llmMiddlewares);
-        return ExecuteAsync(runtime, provider, request, onChunkAsync, ct);
+        return ExecuteAsync(runtime, provider, catalogBoundRequest, onChunkAsync, ct);
 
         static async Task<ChatRuntimeStepLlmResult> ExecuteAsync(
             ChatRuntime runtime,

--- a/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntimeStepExecutor.cs
@@ -89,13 +89,15 @@ public sealed class ChatRuntimeStepExecutor
         Func<LLMStreamChunk, CancellationToken, Task>? onChunkAsync,
         CancellationToken ct)
     {
-        var catalogBoundRequest = ChatRuntimeRequestBuilder.Build(
-            request,
-            request.RequestId,
-            request.Metadata,
-            request.ToolContext,
-            request.LlmControl,
-            _turnCatalog);
+        var catalogBoundRequest = _turnCatalog is null
+            ? request
+            : ChatRuntimeRequestBuilder.Build(
+                request,
+                request.RequestId,
+                request.Metadata,
+                request.ToolContext,
+                request.LlmControl,
+                _turnCatalog);
         var runtime = new ChatRuntime(
             () => provider,
             new ChatHistory(),

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -14,6 +14,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Chat;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Middleware;
 using Aevatar.Foundation.Abstractions.Attributes;
@@ -870,6 +871,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         var useWorkflowFailureMarker = timeoutMs > 0;
         using var timeoutCts = timeoutMs > 0 ? new CancellationTokenSource(timeoutMs) : null;
         var streamCt = timeoutCts?.Token ?? CancellationToken.None;
+        var llmControl = LLMControlContextMapper.FromPayload(request.LlmControl);
+        var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext));
+        var turnCatalog = await MaterializeAgentProfileTurnCatalogAsync(request, toolContext, streamCt);
 
         // ─── AG-UI: TEXT_MESSAGE_START ───
         await PublishAsync(new TextMessageStartEvent
@@ -881,7 +885,12 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         SessionReplayRecord replayRecord;
         try
         {
-            replayRecord = await ExecuteStreamingChatAsync(request, streamCt);
+            replayRecord = await ExecuteStreamingChatAsync(
+                request,
+                llmControl,
+                toolContext,
+                turnCatalog,
+                streamCt);
         }
         catch (OperationCanceledException) when (timeoutCts is { IsCancellationRequested: true })
         {
@@ -965,7 +974,18 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
     private static string SanitizeFailureMessage(string? message) =>
         string.IsNullOrWhiteSpace(message) ? "LLM request failed." : message.Trim();
 
-    private async Task<SessionReplayRecord> ExecuteStreamingChatAsync(ChatRequestEvent request, CancellationToken streamCt)
+    protected virtual Task<AgentProfileTurnCatalog?> MaterializeAgentProfileTurnCatalogAsync(
+        ChatRequestEvent request,
+        AgentToolExecutionContext toolContext,
+        CancellationToken ct) =>
+        Task.FromResult<AgentProfileTurnCatalog?>(null);
+
+    private async Task<SessionReplayRecord> ExecuteStreamingChatAsync(
+        ChatRequestEvent request,
+        LLMControlContext llmControl,
+        AgentToolExecutionContext toolContext,
+        AgentProfileTurnCatalog? turnCatalog,
+        CancellationToken streamCt)
     {
         // ─── AG-UI: TEXT_MESSAGE_CONTENT — streaming chunks ───
         var initialHistoryCount = History.Count;
@@ -980,14 +1000,19 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             ? AgentToolExecutionContextMapper.StripOwnedControlKeys(
                 new Dictionary<string, string>(request.Metadata, StringComparer.Ordinal))
             : null;
-        var llmControl = LLMControlContextMapper.FromPayload(request.LlmControl);
-        var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext));
         // Stash this turn's token for chartered direct-chat subclasses (System Skill Overlay seam).
         // Kept in memory only for the turn; never persisted or logged.
         _currentTurnNyxIdAccessToken = toolContext.Credentials.NyxIdAccessToken;
         var inputParts = ResolveRequestInputParts(request);
 
-        await foreach (var chunk in ChatStreamAsync(inputParts, request.SessionId, llmControl, toolContext, metadata, streamCt))
+        await foreach (var chunk in ChatStreamAsync(
+                           inputParts,
+                           request.SessionId,
+                           llmControl,
+                           toolContext,
+                           turnCatalog,
+                           metadata,
+                           streamCt))
         {
             if (chunk.Usage != null)
                 usage = chunk.Usage;

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -51,6 +51,8 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
     /// </summary>
     protected string? CurrentTurnNyxIdAccessToken => _currentTurnNyxIdAccessToken;
 
+    protected virtual TimeProvider ChatRequestTimeProvider => TimeProvider.System;
+
     public RoleGAgent(
         ILLMProviderFactory? llmProviderFactory = null,
         IEnumerable<IAIGAgentExecutionHook>? additionalHooks = null,
@@ -869,11 +871,12 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             requestSummary.InputPartCount);
         var timeoutMs = ResolveLlmTimeoutMs(request);
         var useWorkflowFailureMarker = timeoutMs > 0;
-        using var timeoutCts = timeoutMs > 0 ? new CancellationTokenSource(timeoutMs) : null;
+        using var timeoutCts = timeoutMs > 0
+            ? new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs), ChatRequestTimeProvider)
+            : null;
         var streamCt = timeoutCts?.Token ?? CancellationToken.None;
         var llmControl = LLMControlContextMapper.FromPayload(request.LlmControl);
         var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext));
-        var turnCatalog = await MaterializeAgentProfileTurnCatalogAsync(request, toolContext, streamCt);
 
         // ─── AG-UI: TEXT_MESSAGE_START ───
         await PublishAsync(new TextMessageStartEvent
@@ -885,6 +888,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         SessionReplayRecord replayRecord;
         try
         {
+            var turnCatalog = await MaterializeAgentProfileTurnCatalogAsync(request, toolContext, streamCt);
             replayRecord = await ExecuteStreamingChatAsync(
                 request,
                 llmControl,

--- a/src/Aevatar.AI.ToolProviders.Ornn/Aevatar.AI.ToolProviders.Ornn.csproj
+++ b/src/Aevatar.AI.ToolProviders.Ornn/Aevatar.AI.ToolProviders.Ornn.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
   </ItemGroup>

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
@@ -124,7 +124,7 @@ public sealed partial class OrnnExactRemoteSkillFetcher : IExactRemoteSkillFetch
                 readResult.FailureDetail),
             null => null,
             _ => ExactRemoteSkillFetchResult.Failed(
-                ExactRemoteSkillFetchFailureCode.InvalidResponse,
+                ExactRemoteSkillFetchFailureCode.Failed,
                 readResult.FailureDetail),
         };
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
@@ -32,16 +32,26 @@ public sealed partial class OrnnExactRemoteSkillFetcher : IExactRemoteSkillFetch
 
         try
         {
-            var detail = await _client.GetExactSkillDetailAsync(
+            var detailRead = await _client.GetExactSkillDetailAsync(
                 accessToken,
                 skillRef.Guid,
                 skillRef.LiteralVersion,
                 ct);
-            var skillJson = await _client.GetExactSkillJsonAsync(
+            var detailFailure = MapReadFailure(detailRead);
+            if (detailFailure is not null)
+                return detailFailure;
+
+            var skillJsonRead = await _client.GetExactSkillJsonAsync(
                 accessToken,
                 skillRef.Guid,
                 skillRef.LiteralVersion,
                 ct);
+            var skillJsonFailure = MapReadFailure(skillJsonRead);
+            if (skillJsonFailure is not null)
+                return skillJsonFailure;
+
+            var detail = detailRead.Value;
+            var skillJson = skillJsonRead.Value;
             if (detail is null || skillJson is null)
             {
                 return ExactRemoteSkillFetchResult.Failed(
@@ -101,6 +111,22 @@ public sealed partial class OrnnExactRemoteSkillFetcher : IExactRemoteSkillFetch
         Guid.TryParseExact(value, "D", out var parsed) &&
         parsed != Guid.Empty &&
         string.Equals(parsed.ToString("D"), value, StringComparison.Ordinal);
+
+    private static ExactRemoteSkillFetchResult? MapReadFailure<T>(OrnnExactSkillReadResult<T> readResult)
+        where T : class =>
+        readResult.ProxyStatus switch
+        {
+            403 => ExactRemoteSkillFetchResult.Failed(
+                ExactRemoteSkillFetchFailureCode.AccessDenied,
+                readResult.FailureDetail),
+            404 => ExactRemoteSkillFetchResult.Failed(
+                ExactRemoteSkillFetchFailureCode.NotFound,
+                readResult.FailureDetail),
+            null => null,
+            _ => ExactRemoteSkillFetchResult.Failed(
+                ExactRemoteSkillFetchFailureCode.InvalidResponse,
+                readResult.FailureDetail),
+        };
 
     [GeneratedRegex("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", RegexOptions.CultureInvariant)]
     private static partial Regex LiteralVersionPattern();

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
@@ -124,7 +124,7 @@ public sealed partial class OrnnExactRemoteSkillFetcher : IExactRemoteSkillFetch
                 readResult.FailureDetail),
             null => null,
             _ => ExactRemoteSkillFetchResult.Failed(
-                ExactRemoteSkillFetchFailureCode.Failed,
+                ExactRemoteSkillFetchFailureCode.InvalidResponse,
                 readResult.FailureDetail),
         };
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnExactRemoteSkillFetcher.cs
@@ -1,0 +1,107 @@
+using System.Text.RegularExpressions;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Core.AgentProfiles;
+
+namespace Aevatar.AI.ToolProviders.Ornn;
+
+public sealed partial class OrnnExactRemoteSkillFetcher : IExactRemoteSkillFetcher
+{
+    private readonly OrnnSkillClient _client;
+
+    public OrnnExactRemoteSkillFetcher(OrnnSkillClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public async Task<ExactRemoteSkillFetchResult> FetchAsync(
+        string accessToken,
+        ExactRemoteSkillRef skillRef,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(skillRef);
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            return ExactRemoteSkillFetchResult.Failed(
+                ExactRemoteSkillFetchFailureCode.AccessTokenMissing);
+        }
+        if (!IsCanonicalGuid(skillRef.Guid) || !LiteralVersionPattern().IsMatch(skillRef.LiteralVersion))
+        {
+            return ExactRemoteSkillFetchResult.Failed(
+                ExactRemoteSkillFetchFailureCode.InvalidReference);
+        }
+
+        try
+        {
+            var detail = await _client.GetExactSkillDetailAsync(
+                accessToken,
+                skillRef.Guid,
+                skillRef.LiteralVersion,
+                ct);
+            var skillJson = await _client.GetExactSkillJsonAsync(
+                accessToken,
+                skillRef.Guid,
+                skillRef.LiteralVersion,
+                ct);
+            if (detail is null || skillJson is null)
+            {
+                return ExactRemoteSkillFetchResult.Failed(
+                    ExactRemoteSkillFetchFailureCode.InvalidResponse);
+            }
+
+            if (!string.Equals(detail.Guid, skillRef.Guid, StringComparison.Ordinal) ||
+                !string.Equals(skillJson.Version, skillRef.LiteralVersion, StringComparison.Ordinal) ||
+                !string.Equals(detail.Name, skillJson.Name, StringComparison.Ordinal))
+            {
+                return ExactRemoteSkillFetchResult.Failed(
+                    ExactRemoteSkillFetchFailureCode.IdentityMismatch);
+            }
+            if (string.IsNullOrWhiteSpace(detail.Name) ||
+                string.IsNullOrWhiteSpace(detail.CreatedBy) ||
+                string.IsNullOrWhiteSpace(detail.SkillHash))
+            {
+                return ExactRemoteSkillFetchResult.Failed(
+                    ExactRemoteSkillFetchFailureCode.IntegrityEvidenceMissing);
+            }
+
+            var skillMarkdownEntries = (skillJson.Files ?? [])
+                .Where(static entry => string.Equals(entry.Key, "SKILL.md", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (skillMarkdownEntries.Length != 1 || string.IsNullOrWhiteSpace(skillMarkdownEntries[0].Value))
+            {
+                return ExactRemoteSkillFetchResult.Failed(
+                    ExactRemoteSkillFetchFailureCode.InvalidResponse,
+                    "unique_skill_markdown_required");
+            }
+
+            return ExactRemoteSkillFetchResult.Success(
+                skillRef.Guid,
+                skillRef.LiteralVersion,
+                detail.Name,
+                detail.CreatedBy,
+                detail.SkillHash,
+                skillMarkdownEntries[0].Value);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return ExactRemoteSkillFetchResult.Failed(ExactRemoteSkillFetchFailureCode.Timeout);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return ExactRemoteSkillFetchResult.Failed(
+                ExactRemoteSkillFetchFailureCode.Failed,
+                ex.GetType().Name);
+        }
+    }
+
+    private static bool IsCanonicalGuid(string? value) =>
+        Guid.TryParseExact(value, "D", out var parsed) &&
+        parsed != Guid.Empty &&
+        string.Equals(parsed.ToString("D"), value, StringComparison.Ordinal);
+
+    [GeneratedRegex("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", RegexOptions.CultureInvariant)]
+    private static partial Regex LiteralVersionPattern();
+}

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -138,6 +138,72 @@ public sealed class OrnnSkillClient
         }
     }
 
+    public Task<OrnnExactSkillDetail?> GetExactSkillDetailAsync(
+        string accessToken,
+        string guid,
+        string literalVersion,
+        CancellationToken ct = default) =>
+        GetExactAsync<OrnnExactSkillDetail>(
+            accessToken,
+            $"/api/v1/skills/{Uri.EscapeDataString(guid)}?version={Uri.EscapeDataString(literalVersion)}",
+            guid,
+            ct);
+
+    public Task<OrnnSkillJson?> GetExactSkillJsonAsync(
+        string accessToken,
+        string guid,
+        string literalVersion,
+        CancellationToken ct = default) =>
+        GetExactAsync<OrnnSkillJson>(
+            accessToken,
+            $"/api/v1/skills/{Uri.EscapeDataString(guid)}/json?version={Uri.EscapeDataString(literalVersion)}",
+            guid,
+            ct);
+
+    private async Task<T?> GetExactAsync<T>(
+        string accessToken,
+        string path,
+        string guid,
+        CancellationToken ct)
+        where T : class
+    {
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+        try
+        {
+            var response = await _nyxApi.ProxyRequestAsync(
+                token: accessToken,
+                slug: _options.NyxIdSlug,
+                path,
+                method: "GET",
+                body: null,
+                extraHeaders: null,
+                ct: linkedCts.Token);
+            if (TryUnwrapNyxIdProxyError(response, out _))
+                return default;
+
+            var envelope = JsonSerializer.Deserialize<OrnnApiResponse<T>>(response, JsonOptions);
+            return envelope?.Data;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "Ornn exact skill read exceeded {TimeoutSeconds}s per-call budget for guid '{Guid}'",
+                (int)_perCallTimeout.TotalSeconds,
+                guid);
+            return default;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Ornn exact skill read failed for guid '{Guid}'", guid);
+            return default;
+        }
+    }
+
     /// <summary>Fetch skill JSON including file contents.</summary>
     public async Task<OrnnSkillJson?> GetSkillJsonAsync(
         string accessToken,
@@ -487,6 +553,14 @@ public sealed class OrnnSkillSummary
     public OrnnSkillMetadata? Metadata { get; set; }
 }
 
+public sealed class OrnnExactSkillDetail
+{
+    public string? Guid { get; set; }
+    public string? Name { get; set; }
+    public string? SkillHash { get; set; }
+    public string? CreatedBy { get; set; }
+}
+
 public sealed class OrnnSkillMetadata
 {
     public string? Category { get; set; }
@@ -498,6 +572,7 @@ public sealed class OrnnSkillJson
 {
     public string? Name { get; set; }
     public string? Description { get; set; }
+    public string? Version { get; set; }
     public OrnnSkillMetadata? Metadata { get; set; }
     public Dictionary<string, string>? Files { get; set; }
 }

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -141,7 +141,7 @@ public sealed class OrnnSkillClient
         }
     }
 
-    public Task<OrnnExactSkillDetail?> GetExactSkillDetailAsync(
+    internal Task<OrnnExactSkillReadResult<OrnnExactSkillDetail>> GetExactSkillDetailAsync(
         string accessToken,
         string guid,
         string literalVersion,
@@ -152,7 +152,7 @@ public sealed class OrnnSkillClient
             guid,
             ct);
 
-    public Task<OrnnSkillJson?> GetExactSkillJsonAsync(
+    internal Task<OrnnExactSkillReadResult<OrnnSkillJson>> GetExactSkillJsonAsync(
         string accessToken,
         string guid,
         string literalVersion,
@@ -163,7 +163,7 @@ public sealed class OrnnSkillClient
             guid,
             ct);
 
-    private async Task<T?> GetExactAsync<T>(
+    private async Task<OrnnExactSkillReadResult<T>> GetExactAsync<T>(
         string accessToken,
         string path,
         string guid,
@@ -182,11 +182,11 @@ public sealed class OrnnSkillClient
                 body: null,
                 extraHeaders: null,
                 ct: linkedCts.Token);
-            if (TryUnwrapNyxIdProxyError(response, out _))
-                return default;
+            if (TryUnwrapNyxIdProxyError(response, out var proxyError))
+                return OrnnExactSkillReadResult<T>.ProxyFailure(proxyError.Status, proxyError.Detail);
 
             var envelope = JsonSerializer.Deserialize<OrnnApiResponse<T>>(response, JsonOptions);
-            return envelope?.Data;
+            return OrnnExactSkillReadResult<T>.Success(envelope?.Data);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -562,6 +562,15 @@ public sealed class OrnnExactSkillDetail
     public string? Name { get; set; }
     public string? SkillHash { get; set; }
     public string? CreatedBy { get; set; }
+}
+
+internal sealed record OrnnExactSkillReadResult<T>(T? Value, int? ProxyStatus, string? FailureDetail)
+    where T : class
+{
+    public static OrnnExactSkillReadResult<T> Success(T? value) => new(value, null, null);
+
+    public static OrnnExactSkillReadResult<T> ProxyFailure(int status, string detail) =>
+        new(null, status, detail);
 }
 
 public sealed class OrnnSkillMetadata

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -20,6 +20,7 @@ public sealed class OrnnSkillClient
     private readonly NyxIdApiClient _nyxApi;
     private readonly OrnnOptions _options;
     private readonly ILogger _logger;
+    private readonly TimeProvider _timeProvider;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -52,7 +53,8 @@ public sealed class OrnnSkillClient
         OrnnOptions options,
         NyxIdApiClient nyxApi,
         TimeSpan perCallTimeout,
-        ILogger<OrnnSkillClient>? logger = null)
+        ILogger<OrnnSkillClient>? logger = null,
+        TimeProvider? timeProvider = null)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _nyxApi = nyxApi ?? throw new ArgumentNullException(nameof(nyxApi));
@@ -60,6 +62,7 @@ public sealed class OrnnSkillClient
             throw new ArgumentOutOfRangeException(nameof(perCallTimeout), "Per-call timeout must be positive.");
         _perCallTimeout = perCallTimeout;
         _logger = logger ?? NullLogger<OrnnSkillClient>.Instance;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>Search skills.</summary>
@@ -91,7 +94,7 @@ public sealed class OrnnSkillClient
 
         var path = $"/api/v1/skill-search?query={Uri.EscapeDataString(query)}&mode={normalizedMode}&scope={Uri.EscapeDataString(normalizedScope)}&page={page}&pageSize={pageSize}";
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -94,7 +94,7 @@ public sealed class OrnnSkillClient
 
         var path = $"/api/v1/skill-search?query={Uri.EscapeDataString(query)}&mode={normalizedMode}&scope={Uri.EscapeDataString(normalizedScope)}&page={page}&pageSize={pageSize}";
 
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
 
         try
@@ -170,7 +170,7 @@ public sealed class OrnnSkillClient
         CancellationToken ct)
         where T : class
     {
-        using var timeoutCts = new CancellationTokenSource(_perCallTimeout);
+        using var timeoutCts = new CancellationTokenSource(_perCallTimeout, _timeProvider);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
         try
         {

--- a/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/OrnnSkillClient.cs
@@ -195,12 +195,12 @@ public sealed class OrnnSkillClient
                 "Ornn exact skill read exceeded {TimeoutSeconds}s per-call budget for guid '{Guid}'",
                 (int)_perCallTimeout.TotalSeconds,
                 guid);
-            return default;
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Ornn exact skill read failed for guid '{Guid}'", guid);
-            return default;
+            throw;
         }
     }
 

--- a/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Ornn/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.Publishing;
 using Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
@@ -63,6 +64,9 @@ public static class ServiceCollectionExtensions
                 sp.GetRequiredService<OrnnOptions>().PerCallTimeout,
                 sp.GetService<ILogger<OrnnSkillClient>>());
         });
+        services.TryAddSingleton<OrnnExactRemoteSkillFetcher>();
+        services.TryAddSingleton<IExactRemoteSkillFetcher>(sp =>
+            sp.GetRequiredService<OrnnExactRemoteSkillFetcher>());
         return services;
     }
 

--- a/src/Aevatar.Studio.Infrastructure/Authoring/ChatRuntimeStudioAuthoringLLMStreamPort.cs
+++ b/src/Aevatar.Studio.Infrastructure/Authoring/ChatRuntimeStudioAuthoringLLMStreamPort.cs
@@ -54,7 +54,7 @@ internal sealed class ChatRuntimeStudioAuthoringLLMStreamPort : IStudioAuthoring
                 toolMiddlewares: null,
                 llmMiddlewares: _llmMiddlewares),
             hooks: null,
-            requestBuilder: () => BuildRequest(config),
+            requestBuilder: _ => BuildRequest(config),
             agentMiddlewares: _agentMiddlewares,
             llmMiddlewares: _llmMiddlewares,
             agentId: BuildAgentName(request.Kind),
@@ -66,6 +66,7 @@ internal sealed class ChatRuntimeStudioAuthoringLLMStreamPort : IStudioAuthoring
                            request.RequestId,
                            request.LlmControl,
                            toolContext: null,
+                           turnCatalog: null,
                            request.Metadata,
                            ct))
         {

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -306,7 +306,14 @@ public class WorkflowRoleGAgent(
         var contentParts = new List<ContentPart>();
         TokenUsage? usage = null;
 
-        await foreach (var chunk in ChatStreamAsync(inputParts, request.SessionId, llmControl, toolContext, metadata, streamCt))
+        await foreach (var chunk in ChatStreamAsync(
+                           inputParts,
+                           request.SessionId,
+                           llmControl,
+                           toolContext,
+                           turnCatalog: null,
+                           metadata,
+                           streamCt))
         {
             if (chunk.Usage != null)
                 usage = chunk.Usage;

--- a/test/Aevatar.AI.Tests/AIGAgentBaseToolRefreshTests.cs
+++ b/test/Aevatar.AI.Tests/AIGAgentBaseToolRefreshTests.cs
@@ -120,7 +120,7 @@ public class AIGAgentBaseToolRefreshTests
         public async Task<IReadOnlyList<LLMStreamChunk>> StreamAsync(string userMessage)
         {
             var chunks = new List<LLMStreamChunk>();
-            await foreach (var chunk in ChatStreamAsync(userMessage))
+            await foreach (var chunk in ChatStreamAsync(userMessage, turnCatalog: null))
                 chunks.Add(chunk);
             return chunks;
         }

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -39,6 +39,64 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_DuplicateAlias_ShouldUseRecoveryWithoutFetching()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var profile = BuildProfile(withAlias: true);
+        var collidingMember = profile.Members[0].Clone();
+        collidingMember.IntentId = "intent-beta";
+        collidingMember.RoutingDescription = "Route beta requests.";
+        profile.Members.Add(collidingMember);
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch());
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(RegistryWithRoute(tools), classifier, fetcher)
+            .MaterializeAsync(
+                SealProfile(profile),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierFailed &&
+            diagnostic.Detail == "alias_collision");
+        classifier.CallCount.Should().Be(0);
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_AliasPrefixWithoutBoundary_ShouldUseClassifierAndRecovery()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch());
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(RegistryWithRoute(tools), classifier, fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alphabet",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierNoMatch);
+        classifier.CallCount.Should().Be(1);
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task MaterializeAsync_ClassifierMatch_ShouldSelectExactMember()
     {
         var tools = NewTools("recovery", "task", "extra");
@@ -178,6 +236,63 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
                 diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillIdentityMismatch ||
                 diagnostic.Code == AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid);
         }
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_EmptySelectedSkillBody_ShouldUseRecoveryWithoutPromptInjection()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var fetcher = new RecordingFetcher(SuccessfulFetch("---\nname: skill-alpha\n---\n   "));
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().Be("intent-alpha");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid &&
+            diagnostic.Detail == "frontmatter_identity_invalid");
+        fetcher.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_SelectedSkillFrontmatterNameMismatch_ShouldUseRecoveryWithoutPromptInjection()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var fetcher = new RecordingFetcher(SuccessfulFetch(
+            "---\nname: skill-beta\n---\nSelected instructions."));
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().Be("intent-alpha");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid &&
+            diagnostic.Detail == "frontmatter_identity_invalid");
+        fetcher.CallCount.Should().Be(1);
     }
 
     [Fact]
@@ -518,14 +633,14 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     private static AgentProfileSnapshot SealProfile(AgentProfileSnapshot profile) =>
         AgentProfileSnapshotCodec.Seal(profile);
 
-    private static ExactRemoteSkillFetchResult SuccessfulFetch() =>
+    private static ExactRemoteSkillFetchResult SuccessfulFetch(string skillMarkdown = SkillMarkdown) =>
         ExactRemoteSkillFetchResult.Success(
             SkillGuid,
             SkillVersion,
             SkillName,
             PublisherId,
             "hash-alpha",
-            SkillMarkdown);
+            skillMarkdown);
 
     private static AgentToolExecutionContext ToolContext(string? accessToken = "token") =>
         AgentToolExecutionContext.Empty with

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -181,6 +181,102 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_ExactFetcherUnavailable_ShouldUseRecoveryOnly()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher: null)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed &&
+            diagnostic.Detail == "exact_fetch_unavailable");
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_ExactFetchTimeout_ShouldUseRecoveryOnly()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var profile = BuildProfile(withAlias: true);
+        profile.ExactSkillFetchTimeoutMs = 20;
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                new CancellationBlockingFetcher())
+            .MaterializeAsync(
+                SealProfile(profile),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed &&
+            diagnostic.Detail == "timeout");
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_ExactFetcherException_ShouldUseRecoveryOnly()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                new ThrowingFetcher(new InvalidOperationException("fetch failed")))
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed &&
+            diagnostic.Detail == "fetch_exception");
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_CallerCancellationDuringExactFetch_ShouldPropagate()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        using var callerCts = new CancellationTokenSource();
+        callerCts.Cancel();
+
+        var act = async () => await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                new CancellationBlockingFetcher())
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                callerCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task MaterializeAsync_InvalidSnapshot_ShouldReturnRestrictedEmpty()
     {
         var tools = NewTools("recovery", "task", "extra");
@@ -315,7 +411,7 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     private static AgentProfileTurnCatalogMaterializer NewMaterializer(
         IToolSetRegistry registry,
         IAgentProfileTurnClassifier classifier,
-        IExactRemoteSkillFetcher fetcher) =>
+        IExactRemoteSkillFetcher? fetcher) =>
         new(registry, classifier, fetcher);
 
     private static AgentProfileSnapshot BuildProfile(bool withAlias = false)
@@ -417,6 +513,31 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
             CallCount++;
             return Task.FromResult(result);
         }
+    }
+
+    private sealed class CancellationBlockingFetcher : IExactRemoteSkillFetcher
+    {
+        public async Task<ExactRemoteSkillFetchResult> FetchAsync(
+            string accessToken,
+            ExactRemoteSkillRef skillRef,
+            CancellationToken ct = default)
+        {
+            var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = ct.Register(
+                static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(),
+                canceled);
+            await canceled.Task;
+            return SuccessfulFetch();
+        }
+    }
+
+    private sealed class ThrowingFetcher(Exception exception) : IExactRemoteSkillFetcher
+    {
+        public Task<ExactRemoteSkillFetchResult> FetchAsync(
+            string accessToken,
+            ExactRemoteSkillRef skillRef,
+            CancellationToken ct = default) =>
+            Task.FromException<ExactRemoteSkillFetchResult>(exception);
     }
 
     private sealed class RecordingToolSetRegistry : IToolSetRegistry

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -1,0 +1,474 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class AgentProfileTurnCatalogMaterializerTests
+{
+    private const string SkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string SkillVersion = "1.2";
+    private const string SkillName = "skill-alpha";
+    private const string PublisherId = "publisher-alpha";
+    private const string SkillMarkdown = "---\nname: skill-alpha\n---\nSelected instructions.";
+
+    [Fact]
+    public async Task MaterializeAsync_EnforcedAlias_ShouldSelectBodyAndAttenuatedPolicy()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var registry = RegistryWithRoute(tools);
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch());
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+        var profile = SealProfile(BuildProfile(withAlias: true));
+
+        var catalog = await NewMaterializer(registry, classifier, fetcher)
+            .MaterializeAsync(profile, "/alpha now", "token", tools, ToolContext(), CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery", "task");
+        catalog.SelectedIntentId.Should().Be("intent-alpha");
+        catalog.CandidateIntentId.Should().Be("intent-alpha");
+        catalog.SelectedSkillPromptLayer!.Content.Should().Be("Selected instructions.");
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.AliasMatched);
+        classifier.CallCount.Should().Be(0);
+        fetcher.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_ClassifierMatch_ShouldSelectExactMember()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha"));
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(RegistryWithRoute(tools), classifier, fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "classify me",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.SelectedIntentId.Should().Be("intent-alpha");
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierMatched);
+        classifier.CallCount.Should().Be(1);
+        classifier.LastRequest!.Candidates.Should().ContainSingle(candidate =>
+            candidate.IntentId == "intent-alpha" && candidate.RoutingDescription == "Route alpha requests.");
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_ClassifierNoMatch_ShouldUseRecoveryOnly()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "no route",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierNoMatch);
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_ClassifierException_ShouldFailClosedToRecovery()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var classifier = new RecordingClassifier(new InvalidOperationException("classifier failed"));
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                classifier,
+                new RecordingFetcher(SuccessfulFetch()))
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "classify",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierFailed &&
+            diagnostic.Detail == "classifier_exception");
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_Shadow_ShouldKeepCandidateDiagnosticWithoutFetchingOrResolvingTaskPolicy()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var registry = RegistryWithRoute(tools);
+        var profile = BuildProfile(withAlias: true);
+        profile.ActivationMode = AgentProfileActivationMode.Shadow;
+        profile.Members[0].TaskToolPolicy.ToolSetRefs.Add("candidate-only");
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                registry,
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(profile),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.CandidateIntentId.Should().Be("intent-alpha");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ShadowCandidate);
+        fetcher.CallCount.Should().Be(0);
+        registry.ResolveCalls.Should().NotContain("candidate-only");
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_ExactFetchIdentityOrBodyFailure_ShouldUseRecoveryOnly()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var failures = new[]
+        {
+            ExactRemoteSkillFetchResult.Failed(ExactRemoteSkillFetchFailureCode.NotFound),
+            ExactRemoteSkillFetchResult.Success(
+                SkillGuid, SkillVersion, "wrong-name", PublisherId, "hash", SkillMarkdown),
+            ExactRemoteSkillFetchResult.Success(
+                SkillGuid, SkillVersion, SkillName, PublisherId, "hash", new string('x', 300)),
+        };
+
+        foreach (var failure in failures)
+        {
+            var catalog = await NewMaterializer(
+                    RegistryWithRoute(tools),
+                    new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha")),
+                    new RecordingFetcher(failure))
+                .MaterializeAsync(
+                    SealProfile(BuildProfile()),
+                    "select",
+                    "token",
+                    tools,
+                    ToolContext(),
+                    CancellationToken.None);
+
+            catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+            catalog.SelectedSkillPromptLayer.Should().BeNull();
+            catalog.Diagnostics.Should().Contain(diagnostic =>
+                diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed ||
+                diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillIdentityMismatch ||
+                diagnostic.Code == AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid);
+        }
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_InvalidSnapshot_ShouldReturnRestrictedEmpty()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var profile = SealProfile(BuildProfile());
+        profile.PolicyRevision = "tampered";
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha")),
+                new RecordingFetcher(SuccessfulFetch()))
+            .MaterializeAsync(profile, "select", "token", tools, ToolContext(), CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.ToolVisibility.IsRestricted.Should().BeTrue();
+        catalog.Diagnostics.Should().ContainSingle(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ProfileInvalid);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_UnknownRouteToolSet_ShouldReturnRestrictedEmpty()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var registry = new RecordingToolSetRegistry();
+
+        var catalog = await NewMaterializer(
+                registry,
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                new RecordingFetcher(SuccessfulFetch()))
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "no route",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.RouteToolSetUnavailable);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_RouteDiscoveryFailure_ShouldReturnRestrictedEmpty()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var registry = new RecordingToolSetRegistry();
+        registry.Add("profile.route", new ThrowingToolSource());
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                registry,
+                new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha")),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "no route",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolDiscoveryFailed);
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_CollisionAndCapabilityRejection_ShouldNotGrantThoseNames()
+    {
+        var duplicateA = new TestTool("recovery");
+        var duplicateB = new TestTool("recovery");
+        var blocked = new CapabilityTool(
+            "task",
+            [AgentToolCapabilities.ExcludeFromDirectChannelChat]);
+        var routeTools = new IAgentTool[] { duplicateA, duplicateB, blocked };
+        var registry = RegistryWithRoute(routeTools);
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                registry,
+                new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha")),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "no route",
+                "token",
+                routeTools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolNameCollision &&
+            diagnostic.Detail == "recovery");
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolCapabilityRejected &&
+            diagnostic.Detail == "task");
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_TaskToolSetFailure_ShouldDiscardSelectionAndUseRecovery()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var registry = RegistryWithRoute(tools);
+        var profile = BuildProfile(withAlias: true);
+        profile.Members[0].TaskToolPolicy.ToolSetRefs.Add("missing.task");
+
+        var catalog = await NewMaterializer(
+                registry,
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                new RecordingFetcher(SuccessfulFetch()))
+            .MaterializeAsync(
+                SealProfile(profile),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().Be("intent-alpha");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolSetUnavailable);
+    }
+
+    private static AgentProfileTurnCatalogMaterializer NewMaterializer(
+        IToolSetRegistry registry,
+        IAgentProfileTurnClassifier classifier,
+        IExactRemoteSkillFetcher fetcher) =>
+        new(registry, classifier, fetcher);
+
+    private static AgentProfileSnapshot BuildProfile(bool withAlias = false)
+    {
+        var member = new AgentProfileSkillMember
+        {
+            IntentId = "intent-alpha",
+            RoutingDescription = "Route alpha requests.",
+            SkillRef = new ExactRemoteSkillRef { Guid = SkillGuid, LiteralVersion = SkillVersion },
+            TaskToolPolicy = new AgentProfileToolPolicy(),
+            SideEffectClass = AgentProfileSideEffectClass.ReadOnly,
+            ExpectedSkillName = SkillName,
+            ReviewedPublisherId = PublisherId,
+        };
+        member.TaskToolPolicy.ToolNames.Add("task");
+        if (withAlias)
+            member.ExplicitTriggerAliases.Add("/alpha");
+
+        var profile = new AgentProfileSnapshot
+        {
+            ProfileId = "profile-alpha",
+            ProfileVersion = "profile-v1",
+            AgentKind = "nyxid.chat",
+            PolicyRevision = "policy-v1",
+            RouteToolSetRef = "profile.route",
+            MaximumToolPolicy = new AgentProfileToolPolicy(),
+            RecoveryToolPolicy = new AgentProfileToolPolicy(),
+            ClassifierTimeoutMs = 600,
+            ExactSkillFetchTimeoutMs = 1_500,
+            MaxSelectedSkillBytes = 256,
+            ActivationMode = AgentProfileActivationMode.Enforced,
+        };
+        profile.MaximumToolPolicy.ToolNames.Add(["recovery", "task", "extra"]);
+        profile.RecoveryToolPolicy.ToolNames.Add("recovery");
+        profile.Members.Add(member);
+        return profile;
+    }
+
+    private static AgentProfileSnapshot SealProfile(AgentProfileSnapshot profile) =>
+        AgentProfileSnapshotCodec.Seal(profile);
+
+    private static ExactRemoteSkillFetchResult SuccessfulFetch() =>
+        ExactRemoteSkillFetchResult.Success(
+            SkillGuid,
+            SkillVersion,
+            SkillName,
+            PublisherId,
+            "hash-alpha",
+            SkillMarkdown);
+
+    private static AgentToolExecutionContext ToolContext() =>
+        AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials("token", null, null),
+        };
+
+    private static IReadOnlyList<IAgentTool> NewTools(params string[] names) =>
+        names.Select(static name => (IAgentTool)new TestTool(name)).ToArray();
+
+    private static RecordingToolSetRegistry RegistryWithRoute(IReadOnlyList<IAgentTool> tools)
+    {
+        var registry = new RecordingToolSetRegistry();
+        registry.Add("profile.route", new StaticToolSource(tools));
+        return registry;
+    }
+
+    private sealed class RecordingClassifier : IAgentProfileTurnClassifier
+    {
+        private readonly AgentProfileTurnClassificationResult? _result;
+        private readonly Exception? _exception;
+
+        public RecordingClassifier(AgentProfileTurnClassificationResult result) => _result = result;
+        public RecordingClassifier(Exception exception) => _exception = exception;
+
+        public int CallCount { get; private set; }
+        public AgentProfileTurnClassificationRequest? LastRequest { get; private set; }
+
+        public Task<AgentProfileTurnClassificationResult> ClassifyAsync(
+            AgentProfileTurnClassificationRequest request,
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            LastRequest = request;
+            return _exception is not null
+                ? Task.FromException<AgentProfileTurnClassificationResult>(_exception)
+                : Task.FromResult(_result!);
+        }
+    }
+
+    private sealed class RecordingFetcher(ExactRemoteSkillFetchResult result) : IExactRemoteSkillFetcher
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ExactRemoteSkillFetchResult> FetchAsync(
+            string accessToken,
+            ExactRemoteSkillRef skillRef,
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class RecordingToolSetRegistry : IToolSetRegistry
+    {
+        private readonly Dictionary<string, IReadOnlyList<IAgentToolSource>> _sources =
+            new(StringComparer.Ordinal);
+
+        public List<string> ResolveCalls { get; } = [];
+
+        public void Add(string name, params IAgentToolSource[] sources) =>
+            _sources.Add(name, sources);
+
+        public IReadOnlyList<string> GetRegisteredNames() => _sources.Keys.ToArray();
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        {
+            var name = toolSetRef?.Name ?? string.Empty;
+            ResolveCalls.Add(name);
+            return _sources.TryGetValue(name, out var sources)
+                ? ToolSetResolveResult.Success(name, sources)
+                : ToolSetResolveResult.Failure(new ToolSetResolveError(
+                    ToolSetResolveError.UnknownNameCode,
+                    name,
+                    "missing",
+                    GetRegisteredNames()));
+        }
+    }
+
+    private sealed class StaticToolSource(IReadOnlyList<IAgentTool> tools) : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromResult(tools);
+    }
+
+    private sealed class ThrowingToolSource : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromException<IReadOnlyList<IAgentTool>>(new InvalidOperationException("discovery failed"));
+    }
+
+    private class TestTool(string name) : IAgentTool
+    {
+        public string Name => name;
+        public string Description => name;
+        public string ParametersSchema => "{}";
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("{}");
+    }
+
+    private sealed class CapabilityTool(string name, IReadOnlyCollection<string> capabilities)
+        : TestTool(name), IAgentToolCapabilityDescriptor
+    {
+        public IReadOnlyCollection<string> Capabilities { get; } = capabilities;
+    }
+}

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -164,6 +164,32 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_BlankMessage_ShouldUseClassifierAndRecoveryWithoutFetching()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch());
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(RegistryWithRoute(tools), classifier, fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                " \t\n",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().ContainSingle(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierNoMatch);
+        classifier.CallCount.Should().Be(1);
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task MaterializeAsync_ClassifierMatch_ShouldSelectExactMember()
     {
         var tools = NewTools("recovery", "task", "extra");

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -381,6 +381,62 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_HumanSessionToolWithoutToken_ShouldBeRejected()
+    {
+        var humanSessionTool = new CapabilityTool(
+            "task",
+            [AgentToolCapabilities.RequiresHumanSession]);
+        var tools = new IAgentTool[] { humanSessionTool };
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                accessToken: null,
+                tools,
+                ToolContext(accessToken: null),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolCapabilityRejected &&
+            diagnostic.Detail == "task");
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_HumanSessionToolWithToken_ShouldBeAdmittedWhenPoliciesAllow()
+    {
+        var humanSessionTool = new CapabilityTool(
+            "task",
+            [AgentToolCapabilities.RequiresHumanSession]);
+        var tools = new IAgentTool[] { humanSessionTool };
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("task");
+        catalog.SelectedIntentId.Should().Be("intent-alpha");
+        catalog.Diagnostics.Should().NotContain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolCapabilityRejected);
+        fetcher.CallCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task MaterializeAsync_TaskToolSetFailure_ShouldDiscardSelectionAndUseRecovery()
     {
         var tools = NewTools("recovery", "task", "extra");
@@ -462,10 +518,10 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
             "hash-alpha",
             SkillMarkdown);
 
-    private static AgentToolExecutionContext ToolContext() =>
+    private static AgentToolExecutionContext ToolContext(string? accessToken = "token") =>
         AgentToolExecutionContext.Empty with
         {
-            Credentials = new AgentToolCredentials("token", null, null),
+            Credentials = new AgentToolCredentials(accessToken, null, null),
         };
 
     private static IReadOnlyList<IAgentTool> NewTools(params string[] names) =>

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -39,6 +39,73 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_PolicyToolSetRefs_ShouldOnlyAttenuateFinalAuthority()
+    {
+        var routeTools = NewTools(
+            "recovery-from-set",
+            "task-from-set",
+            "route-only",
+            "visibility-blocked");
+        var registeredTools = NewTools(
+            "recovery-from-set",
+            "task-from-set",
+            "route-only",
+            "visibility-blocked",
+            "registered-only");
+        var registry = new RecordingToolSetRegistry();
+        registry.Add("profile.route", new StaticToolSource(routeTools));
+        registry.Add("maximum.policy", new StaticToolSource(NewTools(
+            "recovery-from-set",
+            "task-from-set",
+            "maximum-only")));
+        registry.Add("recovery.policy", new StaticToolSource(NewTools(
+            "recovery-from-set",
+            "recovery-outside-maximum")));
+        registry.Add("task.policy", new StaticToolSource(NewTools(
+            "task-from-set",
+            "task-outside-maximum")));
+        var profile = BuildProfile(withAlias: true);
+        profile.MaximumToolPolicy.ToolNames.Clear();
+        profile.MaximumToolPolicy.ToolSetRefs.Add("maximum.policy");
+        profile.RecoveryToolPolicy.ToolNames.Clear();
+        profile.RecoveryToolPolicy.ToolSetRefs.Add("recovery.policy");
+        profile.Members[0].TaskToolPolicy.ToolNames.Clear();
+        profile.Members[0].TaskToolPolicy.ToolSetRefs.Add("task.policy");
+        var toolContext = ToolContext() with
+        {
+            ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(
+                ["recovery-from-set", "task-from-set", "route-only"]),
+        };
+
+        var catalog = await NewMaterializer(
+                registry,
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                new RecordingFetcher(SuccessfulFetch()))
+            .MaterializeAsync(
+                SealProfile(profile),
+                "/alpha",
+                "token",
+                registeredTools,
+                toolContext,
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery-from-set", "task-from-set");
+        catalog.FinalAllowedToolNames.Should().NotContain([
+            "route-only",
+            "visibility-blocked",
+            "registered-only",
+            "maximum-only",
+            "recovery-outside-maximum",
+            "task-outside-maximum",
+        ]);
+        registry.ResolveCalls.Should().Equal(
+            "profile.route",
+            "maximum.policy",
+            "recovery.policy",
+            "task.policy");
+    }
+
+    [Fact]
     public async Task MaterializeAsync_DuplicateAlias_ShouldUseRecoveryWithoutFetching()
     {
         var tools = NewTools("recovery", "task", "extra");

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -146,6 +146,90 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
         fetcher.CallCount.Should().Be(0);
     }
 
+    [Theory]
+    [InlineData(true, 600)]
+    [InlineData(false, 0)]
+    public async Task MaterializeAsync_ClassifierNotConfigured_ShouldUseRecoveryWithoutClassifierOrFetch(
+        bool removeMembers,
+        int classifierTimeoutMs)
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var profile = BuildProfile();
+        profile.ClassifierTimeoutMs = classifierTimeoutMs;
+        if (removeMembers)
+            profile.Members.Clear();
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha"));
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(RegistryWithRoute(tools), classifier, fetcher)
+            .MaterializeAsync(
+                SealProfile(profile),
+                "classify",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().ContainSingle(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierFailed &&
+            diagnostic.Detail == "classifier_not_configured");
+        classifier.CallCount.Should().Be(0);
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_CallerCancellationDuringClassification_ShouldPropagate()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        using var callerCts = new CancellationTokenSource();
+        callerCts.Cancel();
+        var classifier = new CancellationAwareClassifier();
+
+        var act = async () => await NewMaterializer(
+                RegistryWithRoute(tools),
+                classifier,
+                new RecordingFetcher(SuccessfulFetch()))
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "classify",
+                "token",
+                tools,
+                ToolContext(),
+                callerCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        classifier.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_CallerCancellationDuringToolDiscovery_ShouldPropagate()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var registry = new RecordingToolSetRegistry();
+        registry.Add("profile.route", new CancellationAwareToolSource());
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch());
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+        using var callerCts = new CancellationTokenSource();
+        callerCts.Cancel();
+
+        var act = async () => await NewMaterializer(registry, classifier, fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "classify",
+                "token",
+                tools,
+                ToolContext(),
+                callerCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        classifier.CallCount.Should().Be(0);
+        fetcher.CallCount.Should().Be(0);
+    }
+
     [Fact]
     public async Task MaterializeAsync_ClassifierException_ShouldFailClosedToRecovery()
     {
@@ -783,6 +867,19 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
         }
     }
 
+    private sealed class CancellationAwareClassifier : IAgentProfileTurnClassifier
+    {
+        public int CallCount { get; private set; }
+
+        public Task<AgentProfileTurnClassificationResult> ClassifyAsync(
+            AgentProfileTurnClassificationRequest request,
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            return Task.FromCanceled<AgentProfileTurnClassificationResult>(ct);
+        }
+    }
+
     private sealed class RecordingFetcher(ExactRemoteSkillFetchResult result) : IExactRemoteSkillFetcher
     {
         public int CallCount { get; private set; }
@@ -881,6 +978,12 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     {
         public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
             Task.FromException<IReadOnlyList<IAgentTool>>(new InvalidOperationException("discovery failed"));
+    }
+
+    private sealed class CancellationAwareToolSource : IAgentToolSource
+    {
+        public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+            Task.FromCanceled<IReadOnlyList<IAgentTool>>(ct);
     }
 
     private class TestTool(string name) : IAgentTool

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -209,12 +209,15 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     {
         var tools = NewTools("recovery", "task", "extra");
         var profile = BuildProfile(withAlias: true);
-        profile.ExactSkillFetchTimeoutMs = 20;
+        profile.ExactSkillFetchTimeoutMs = 1_000;
+        var timeProvider = new ManualDeadlineTimeProvider();
+        var fetcher = new CancellationBlockingFetcher();
 
-        var catalog = await NewMaterializer(
+        var materialization = NewMaterializer(
                 RegistryWithRoute(tools),
                 new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
-                new CancellationBlockingFetcher())
+                fetcher,
+                timeProvider)
             .MaterializeAsync(
                 SealProfile(profile),
                 "/alpha",
@@ -222,12 +225,17 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
                 tools,
                 ToolContext(),
                 CancellationToken.None);
+        await fetcher.Started;
+
+        timeProvider.Advance(TimeSpan.FromMilliseconds(profile.ExactSkillFetchTimeoutMs));
+        var catalog = await materialization;
 
         catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
         catalog.SelectedSkillPromptLayer.Should().BeNull();
         catalog.Diagnostics.Should().Contain(diagnostic =>
             diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillFetchFailed &&
             diagnostic.Detail == "timeout");
+        fetcher.CancellationObserved.Should().BeTrue();
     }
 
     [Fact]
@@ -467,8 +475,9 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     private static AgentProfileTurnCatalogMaterializer NewMaterializer(
         IToolSetRegistry registry,
         IAgentProfileTurnClassifier classifier,
-        IExactRemoteSkillFetcher? fetcher) =>
-        new(registry, classifier, fetcher);
+        IExactRemoteSkillFetcher? fetcher,
+        TimeProvider? timeProvider = null) =>
+        new(registry, classifier, fetcher, timeProvider: timeProvider);
 
     private static AgentProfileSnapshot BuildProfile(bool withAlias = false)
     {
@@ -573,17 +582,32 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
 
     private sealed class CancellationBlockingFetcher : IExactRemoteSkillFetcher
     {
+        private readonly TaskCompletionSource _started =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Started => _started.Task;
+        public bool CancellationObserved { get; private set; }
+
         public async Task<ExactRemoteSkillFetchResult> FetchAsync(
             string accessToken,
             ExactRemoteSkillRef skillRef,
             CancellationToken ct = default)
         {
+            _started.TrySetResult();
             var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using var registration = ct.Register(
                 static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(),
                 canceled);
-            await canceled.Task;
-            return SuccessfulFetch();
+            try
+            {
+                await canceled.Task;
+                return SuccessfulFetch();
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                CancellationObserved = true;
+                throw;
+            }
         }
     }
 

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -171,6 +171,35 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_ClassifierReturnsUnknownIntent_ShouldUseRecoveryWithoutFetching()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-outside-profile")),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "classify",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.FinalAllowedToolNames.Should().NotContain("task");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ClassifierFailed &&
+            diagnostic.Detail == "unknown_intent");
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task MaterializeAsync_Shadow_ShouldKeepCandidateDiagnosticWithoutFetchingOrResolvingTaskPolicy()
     {
         var tools = NewTools("recovery", "task", "extra");
@@ -236,6 +265,48 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
                 diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillIdentityMismatch ||
                 diagnostic.Code == AgentProfileTurnDiagnosticCode.SelectedSkillBodyInvalid);
         }
+    }
+
+    [Theory]
+    [InlineData("22222222-2222-2222-2222-222222222222", SkillVersion, PublisherId, "hash-alpha")]
+    [InlineData(SkillGuid, "9.9", PublisherId, "hash-alpha")]
+    [InlineData(SkillGuid, SkillVersion, "publisher-beta", "hash-alpha")]
+    [InlineData(SkillGuid, SkillVersion, PublisherId, " ")]
+    public async Task MaterializeAsync_ExactFetchIdentityMismatch_ShouldUseRecoveryOnly(
+        string fetchedGuid,
+        string fetchedVersion,
+        string fetchedPublisherId,
+        string fetchedSkillHash)
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var fetcher = new RecordingFetcher(ExactRemoteSkillFetchResult.Success(
+            fetchedGuid,
+            fetchedVersion,
+            SkillName,
+            fetchedPublisherId,
+            fetchedSkillHash,
+            SkillMarkdown));
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha")),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "select",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("recovery");
+        catalog.FinalAllowedToolNames.Should().NotContain("task");
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().Be("intent-alpha");
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ExactSkillIdentityMismatch);
+        fetcher.CallCount.Should().Be(1);
     }
 
     [Fact]
@@ -439,6 +510,37 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
         catalog.FinalAllowedToolNames.Should().BeEmpty();
         catalog.Diagnostics.Should().Contain(diagnostic =>
             diagnostic.Code == AgentProfileTurnDiagnosticCode.RouteToolSetUnavailable);
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_RouteToolSetResolveThrows_ShouldReturnRestrictedEmptyWithoutFetching()
+    {
+        var tools = NewTools("recovery", "task", "extra");
+        var classifier = new RecordingClassifier(AgentProfileTurnClassificationResult.Matched("intent-alpha"));
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                new ThrowingToolSetRegistry(),
+                classifier,
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile()),
+                "classify",
+                "token",
+                tools,
+                ToolContext(),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.ToolVisibility.IsRestricted.Should().BeTrue();
+        catalog.SelectedIntentId.Should().BeNull();
+        catalog.CandidateIntentId.Should().BeNull();
+        catalog.SelectedSkillPromptLayer.Should().BeNull();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.RouteToolSetUnavailable &&
+            diagnostic.Detail == "profile.route");
+        classifier.CallCount.Should().Be(0);
+        fetcher.CallCount.Should().Be(0);
     }
 
     [Fact]
@@ -759,6 +861,14 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
                     "missing",
                     GetRegisteredNames()));
         }
+    }
+
+    private sealed class ThrowingToolSetRegistry : IToolSetRegistry
+    {
+        public IReadOnlyList<string> GetRegisteredNames() => [];
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+            throw new InvalidOperationException("resolve failed");
     }
 
     private sealed class StaticToolSource(IReadOnlyList<IAgentTool> tools) : IAgentToolSource

--- a/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
@@ -1,0 +1,256 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.Core.Chat;
+using Aevatar.AI.Core.Tools;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class AgentProfileTurnRuntimeTests
+{
+    [Fact]
+    public void Catalog_ShouldFreezeNamesAndBoundDiagnostics()
+    {
+        var names = new List<string> { " alpha ", "BETA", "alpha" };
+        var diagnostics = Enumerable.Range(0, AgentProfileTurnCatalog.MaximumDiagnostics + 3)
+            .Select(index => new AgentProfileTurnDiagnostic(
+                AgentProfileTurnDiagnosticCode.ClassifierFailed,
+                $"{index}:{new string('\u754c', 200)}"))
+            .ToList();
+
+        var catalog = NewCatalog(names, diagnostics);
+        names.Clear();
+        diagnostics.Clear();
+
+        catalog.FinalAllowedToolNames.Should().BeEquivalentTo("alpha", "BETA");
+        catalog.ToolVisibility.IsRestricted.Should().BeTrue();
+        catalog.ToolVisibility.AllowedToolNames.Should().BeSameAs(catalog.FinalAllowedToolNames);
+        catalog.Diagnostics.Should().HaveCount(AgentProfileTurnCatalog.MaximumDiagnostics);
+        catalog.Diagnostics.Should().OnlyContain(diagnostic =>
+            Encoding.UTF8.GetByteCount(diagnostic.Detail) <= 256);
+    }
+
+    [Fact]
+    public async Task MainTurn_ShouldHideAndRejectToolsOutsideCatalog()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var provider = new ForgedToolProvider("hidden");
+        var runtime = NewRuntime(provider, tools);
+
+        await foreach (var _ in runtime.ChatStreamAsync("run", NewCatalog(["visible"])))
+        {
+        }
+
+        provider.Requests[0].Tools.Should().ContainSingle(tool => tool.Name == "visible");
+        provider.Requests[0].ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
+        provider.Requests[0].ToolContext!.ToolVisibility.Allows("hidden").Should().BeFalse();
+        visible.ExecuteCount.Should().Be(0);
+        hidden.ExecuteCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StepTurn_ShouldUseSameSchemaAndExecutionAdmission()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var runtime = NewRuntime(new RecordingProvider(), tools);
+        var executor = runtime.CreateStepExecutor(NewCatalog(["visible"]));
+
+        var request = executor.BuildBaseRequest(null, null, null, null);
+        await executor.ExecuteToolStepAsync(
+            [
+                new ToolCall { Id = "hidden-call", Name = "hidden", ArgumentsJson = "{}" },
+                new ToolCall { Id = "visible-call", Name = "visible", ArgumentsJson = "{}" },
+            ],
+            requestMetadata: null,
+            toolContext: null,
+            CancellationToken.None);
+
+        request.Tools.Should().ContainSingle(tool => tool.Name == "visible");
+        hidden.ExecuteCount.Should().Be(0);
+        visible.ExecuteCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void NonNullEmptyCatalog_ShouldRemainRestrictedEmpty()
+    {
+        var tools = NewToolManager(new CountingTool("visible"));
+        var runtime = NewRuntime(new RecordingProvider(), tools);
+
+        var request = runtime.CreateStepExecutor(NewCatalog([]))
+            .BuildBaseRequest(null, null, null, null);
+
+        request.Tools.Should().BeNull();
+        request.ToolContext!.ToolVisibility.IsRestricted.Should().BeTrue();
+        request.ToolContext.ToolVisibility.AllowedToolNames.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Catalog_ShouldIntersectExistingVisibilityInsteadOfExpandingIt()
+    {
+        var tools = NewToolManager(new CountingTool("alpha"), new CountingTool("beta"));
+        var runtime = NewRuntime(new RecordingProvider(), tools);
+        var existingContext = AgentToolExecutionContext.Empty with
+        {
+            ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(["alpha"]),
+        };
+
+        var request = runtime.CreateStepExecutor(NewCatalog(["alpha", "beta"]))
+            .BuildBaseRequest(null, null, existingContext, null);
+
+        request.Tools.Should().ContainSingle(tool => tool.Name == "alpha");
+        request.ToolContext!.ToolVisibility.Allows("alpha").Should().BeTrue();
+        request.ToolContext.ToolVisibility.Allows("beta").Should().BeFalse();
+    }
+
+    [Fact]
+    public void PublicRuntimeApi_ShouldRequireExplicitCatalogWithoutLegacyShapes()
+    {
+        typeof(ChatRuntime).GetConstructors()
+            .Should().ContainSingle(constructor => constructor.GetParameters().Any(parameter =>
+                parameter.ParameterType == typeof(Func<AgentProfileTurnCatalog?, LLMRequest>)));
+        typeof(ChatRuntime).GetConstructors()
+            .Should().NotContain(constructor => constructor.GetParameters().Any(parameter =>
+                parameter.ParameterType == typeof(Func<LLMRequest>)));
+
+        var streamMethods = typeof(ChatRuntime).GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(method => method.Name == nameof(ChatRuntime.ChatStreamAsync))
+            .ToArray();
+        streamMethods.Should().NotBeEmpty();
+        streamMethods.Should().OnlyContain(method => method.GetParameters().Any(parameter =>
+            parameter.ParameterType == typeof(AgentProfileTurnCatalog) &&
+            !parameter.HasDefaultValue));
+
+        var createStep = typeof(ChatRuntime).GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(method => method.Name == nameof(ChatRuntime.CreateStepExecutor))
+            .ToArray();
+        createStep.Should().ContainSingle();
+        createStep[0].GetParameters().Should().ContainSingle(parameter =>
+            parameter.ParameterType == typeof(AgentProfileTurnCatalog) &&
+            !parameter.HasDefaultValue);
+
+        typeof(AIGAgentBase<>).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(method => method.Name == "DecorateSystemPrompt")
+            .Should().ContainSingle(method => method.GetParameters().Length == 2 &&
+                method.GetParameters()[1].ParameterType == typeof(AgentProfileTurnCatalog));
+    }
+
+    [Fact]
+    public async Task ConsecutiveTurns_ShouldNotLeakCatalogAuthority()
+    {
+        var provider = new RecordingProvider();
+        var tools = NewToolManager(new CountingTool("alpha"), new CountingTool("beta"));
+        var runtime = NewRuntime(provider, tools);
+
+        await DrainAsync(runtime.ChatStreamAsync("first", NewCatalog(["alpha"])));
+        await DrainAsync(runtime.ChatStreamAsync("second", NewCatalog(["beta"])));
+
+        provider.Requests.Should().HaveCount(2);
+        provider.Requests[0].Tools.Should().ContainSingle(tool => tool.Name == "alpha");
+        provider.Requests[1].Tools.Should().ContainSingle(tool => tool.Name == "beta");
+    }
+
+    private static AgentProfileTurnCatalog NewCatalog(
+        IEnumerable<string> names,
+        IReadOnlyList<AgentProfileTurnDiagnostic>? diagnostics = null) =>
+        new(names, null, null, null, null, diagnostics);
+
+    private static ToolManager NewToolManager(params IAgentTool[] tools)
+    {
+        var manager = new ToolManager();
+        manager.Register(tools);
+        return manager;
+    }
+
+    private static ChatRuntime NewRuntime(ILLMProvider provider, ToolManager tools)
+    {
+        var history = new ChatHistory();
+        return new ChatRuntime(
+            () => provider,
+            history,
+            new ToolCallLoop(tools),
+            hooks: null,
+            requestBuilder: _ => new LLMRequest
+            {
+                Messages = history.BuildMessages("system"),
+                Tools = tools.GetAll(),
+            });
+    }
+
+    private static async Task DrainAsync(IAsyncEnumerable<LLMStreamChunk> stream)
+    {
+        await foreach (var _ in stream)
+        {
+        }
+    }
+
+    private sealed class CountingTool(string name) : IAgentTool
+    {
+        public int ExecuteCount { get; private set; }
+        public string Name => name;
+        public string Description => name;
+        public string ParametersSchema => "{}";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCount++;
+            return Task.FromResult("{}");
+        }
+    }
+
+    private sealed class RecordingProvider : ILLMProvider
+    {
+        public string Name => "recording";
+        public List<LLMRequest> Requests { get; } = [];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            await Task.Yield();
+            yield return new LLMStreamChunk { DeltaContent = "done" };
+            yield return new LLMStreamChunk { IsLast = true };
+        }
+    }
+
+    private sealed class ForgedToolProvider(string forgedToolName) : ILLMProvider
+    {
+        public string Name => "forged-tool";
+        public List<LLMRequest> Requests { get; } = [];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            await Task.Yield();
+            if (Requests.Count == 1)
+            {
+                yield return new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = "forged-call",
+                        Name = forgedToolName,
+                        ArgumentsJson = "{}",
+                    },
+                };
+            }
+            else
+            {
+                yield return new LLMStreamChunk { DeltaContent = "done" };
+            }
+
+            yield return new LLMStreamChunk { IsLast = true };
+        }
+    }
+}

--- a/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
 using Aevatar.AI.Core.AgentProfiles;
@@ -77,6 +78,59 @@ public sealed class AgentProfileTurnRuntimeTests
         request.Tools.Should().ContainSingle(tool => tool.Name == "visible");
         hidden.ExecuteCount.Should().Be(0);
         visible.ExecuteCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MainTurn_LlmMiddlewareShouldNotRestoreToolsOutsideCatalog()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var provider = new RecordingProvider();
+        var runtime = NewRuntime(
+            provider,
+            tools,
+            [new ExpandingRequestMiddleware(tools.GetAll())]);
+
+        await DrainAsync(runtime.ChatStreamAsync("run", NewCatalog(["visible"])));
+
+        var request = provider.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().ContainSingle(tool => tool.Name == "visible");
+        request.ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
+        request.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StepTurn_LlmMiddlewareShouldNotRestoreToolsOutsideCatalog()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var provider = new RecordingProvider();
+        var runtime = NewRuntime(
+            provider,
+            tools,
+            [new ExpandingRequestMiddleware(tools.GetAll())]);
+        var executor = runtime.CreateStepExecutor(NewCatalog(["visible"]));
+        var request = executor.BuildLlmStepRequest(
+            [ChatMessage.User("run")],
+            requestId: null,
+            metadata: null,
+            toolContext: null,
+            llmControl: null,
+            round: 0,
+            finalNoTools: false);
+
+        await executor.ExecuteLlmStepAsync(
+            provider,
+            request,
+            onChunkAsync: null,
+            CancellationToken.None);
+
+        var providerRequest = provider.Requests.Should().ContainSingle().Subject;
+        providerRequest.Tools.Should().ContainSingle(tool => tool.Name == "visible");
+        providerRequest.ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
+        providerRequest.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
     }
 
     [Fact]
@@ -170,7 +224,10 @@ public sealed class AgentProfileTurnRuntimeTests
         return manager;
     }
 
-    private static ChatRuntime NewRuntime(ILLMProvider provider, ToolManager tools)
+    private static ChatRuntime NewRuntime(
+        ILLMProvider provider,
+        ToolManager tools,
+        IReadOnlyList<ILLMCallMiddleware>? llmMiddlewares = null)
     {
         var history = new ChatHistory();
         return new ChatRuntime(
@@ -182,7 +239,8 @@ public sealed class AgentProfileTurnRuntimeTests
             {
                 Messages = history.BuildMessages("system"),
                 Tools = tools.GetAll(),
-            });
+            },
+            llmMiddlewares: llmMiddlewares);
     }
 
     private static async Task DrainAsync(IAsyncEnumerable<LLMStreamChunk> stream)
@@ -219,6 +277,20 @@ public sealed class AgentProfileTurnRuntimeTests
             await Task.Yield();
             yield return new LLMStreamChunk { DeltaContent = "done" };
             yield return new LLMStreamChunk { IsLast = true };
+        }
+    }
+
+    private sealed class ExpandingRequestMiddleware(IReadOnlyList<IAgentTool> tools) : ILLMCallMiddleware
+    {
+        public async Task InvokeAsync(LLMCallContext context, Func<Task> next)
+        {
+            context.Request = new LLMRequest
+            {
+                Messages = context.Request.Messages,
+                ToolContext = AgentToolExecutionContext.Empty,
+                Tools = tools,
+            };
+            await next();
         }
     }
 

--- a/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
@@ -130,6 +130,29 @@ public sealed class AgentProfileTurnRuntimeTests
     }
 
     [Fact]
+    public async Task UnprofiledTurn_LlmMiddlewareRestrictionShouldRemainEffectiveForProviderAndExecutor()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var provider = new ForgedToolProvider("hidden");
+        var runtime = NewRuntime(
+            provider,
+            tools,
+            [new RestrictingRequestMiddleware(visible)]);
+
+        await DrainAsync(runtime.ChatStreamAsync("run", turnCatalog: null));
+
+        var firstRequest = provider.Requests[0];
+        firstRequest.Tools.Should().ContainSingle().Which.Name.Should().Be("visible");
+        firstRequest.ToolContext!.ToolVisibility.IsRestricted.Should().BeTrue();
+        firstRequest.ToolContext.ToolVisibility.Allows("visible").Should().BeTrue();
+        firstRequest.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
+        visible.ExecuteCount.Should().Be(0);
+        hidden.ExecuteCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task StepTurn_LlmMiddlewareShouldNotRestoreToolsOutsideCatalog()
     {
         var visible = new CountingTool("visible");
@@ -346,6 +369,23 @@ public sealed class AgentProfileTurnRuntimeTests
                 Messages = context.Request.Messages,
                 ToolContext = AgentToolExecutionContext.Empty,
                 Tools = tools,
+            };
+            await next();
+        }
+    }
+
+    private sealed class RestrictingRequestMiddleware(IAgentTool visibleTool) : ILLMCallMiddleware
+    {
+        public async Task InvokeAsync(LLMCallContext context, Func<Task> next)
+        {
+            context.Request = new LLMRequest
+            {
+                Messages = context.Request.Messages,
+                ToolContext = AgentToolExecutionContext.Empty with
+                {
+                    ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames([visibleTool.Name]),
+                },
+                Tools = [visibleTool],
             };
             await next();
         }

--- a/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
@@ -75,7 +75,7 @@ public sealed class AgentProfileTurnRuntimeTests
             toolContext: null,
             CancellationToken.None);
 
-        request.Tools.Should().ContainSingle(tool => tool.Name == "visible");
+        request.Tools.Should().ContainSingle().Which.Name.Should().Be("visible");
         hidden.ExecuteCount.Should().Be(0);
         visible.ExecuteCount.Should().Be(1);
     }
@@ -128,7 +128,7 @@ public sealed class AgentProfileTurnRuntimeTests
             CancellationToken.None);
 
         var providerRequest = provider.Requests.Should().ContainSingle().Subject;
-        providerRequest.Tools.Should().ContainSingle(tool => tool.Name == "visible");
+        providerRequest.Tools.Should().ContainSingle().Which.Name.Should().Be("visible");
         providerRequest.ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
         providerRequest.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
     }
@@ -284,6 +284,12 @@ public sealed class AgentProfileTurnRuntimeTests
     {
         public async Task InvokeAsync(LLMCallContext context, Func<Task> next)
         {
+            if (context.Request.ToolContext?.ToolVisibility.AllowedToolNames is ISet<string> allowedToolNames)
+            {
+                foreach (var tool in tools)
+                    allowedToolNames.Add(tool.Name);
+            }
+
             context.Request = new LLMRequest
             {
                 Messages = context.Request.Messages,

--- a/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnRuntimeTests.cs
@@ -7,6 +7,7 @@ using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Chat;
+using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Tools;
 using FluentAssertions;
 
@@ -81,6 +82,34 @@ public sealed class AgentProfileTurnRuntimeTests
     }
 
     [Fact]
+    public async Task StepTurn_ForgedRequestShouldStillApplyCatalogBeforeProvider()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var provider = new RecordingProvider();
+        var executor = NewRuntime(provider, tools)
+            .CreateStepExecutor(NewCatalog(["visible"]));
+        var forgedRequest = new LLMRequest
+        {
+            Messages = [ChatMessage.User("run")],
+            Tools = tools.GetAll(),
+            ToolContext = AgentToolExecutionContext.Empty,
+        };
+
+        await executor.ExecuteLlmStepAsync(
+            provider,
+            forgedRequest,
+            onChunkAsync: null,
+            CancellationToken.None);
+
+        var providerRequest = provider.Requests.Should().ContainSingle().Subject;
+        providerRequest.Tools.Should().ContainSingle().Which.Name.Should().Be("visible");
+        providerRequest.ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
+        providerRequest.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
+    }
+
+    [Fact]
     public async Task MainTurn_LlmMiddlewareShouldNotRestoreToolsOutsideCatalog()
     {
         var visible = new CountingTool("visible");
@@ -131,6 +160,27 @@ public sealed class AgentProfileTurnRuntimeTests
         providerRequest.Tools.Should().ContainSingle().Which.Name.Should().Be("visible");
         providerRequest.ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
         providerRequest.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MainTurn_LlmStartHookShouldNotRestoreCatalogExcludedTool()
+    {
+        var visible = new CountingTool("visible");
+        var hidden = new CountingTool("hidden");
+        var tools = NewToolManager(visible, hidden);
+        var provider = new ForgedToolProvider("hidden");
+        var runtime = NewRuntime(
+            provider,
+            tools,
+            hooks: new AgentHookPipeline([new ExpandingRequestStartHook(hidden)]));
+
+        await DrainAsync(runtime.ChatStreamAsync("run", NewCatalog(["visible"])));
+
+        var firstRequest = provider.Requests[0];
+        firstRequest.Tools.Should().ContainSingle().Which.Name.Should().Be("visible");
+        firstRequest.ToolContext!.ToolVisibility.Allows("visible").Should().BeTrue();
+        firstRequest.ToolContext.ToolVisibility.Allows("hidden").Should().BeFalse();
+        hidden.ExecuteCount.Should().Be(0);
     }
 
     [Fact]
@@ -227,14 +277,15 @@ public sealed class AgentProfileTurnRuntimeTests
     private static ChatRuntime NewRuntime(
         ILLMProvider provider,
         ToolManager tools,
-        IReadOnlyList<ILLMCallMiddleware>? llmMiddlewares = null)
+        IReadOnlyList<ILLMCallMiddleware>? llmMiddlewares = null,
+        AgentHookPipeline? hooks = null)
     {
         var history = new ChatHistory();
         return new ChatRuntime(
             () => provider,
             history,
             new ToolCallLoop(tools),
-            hooks: null,
+            hooks,
             requestBuilder: _ => new LLMRequest
             {
                 Messages = history.BuildMessages("system"),
@@ -297,6 +348,20 @@ public sealed class AgentProfileTurnRuntimeTests
                 Tools = tools,
             };
             await next();
+        }
+    }
+
+    private sealed class ExpandingRequestStartHook(IAgentTool hiddenTool) : IAIGAgentExecutionHook
+    {
+        public string Name => "expanding-request-start";
+        public int Priority => 0;
+
+        public Task OnLLMRequestStartAsync(AIGAgentExecutionHookContext ctx, CancellationToken ct)
+        {
+            var request = ctx.LLMRequest.Should().BeOfType<LLMRequest>().Subject;
+            ((IList<IAgentTool>)request.Tools!).Add(hiddenTool);
+            ((ISet<string>)request.ToolContext!.ToolVisibility.AllowedToolNames!).Add(hiddenTool.Name);
+            return Task.CompletedTask;
         }
     }
 

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -5,6 +5,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Chat;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Tools;
 using FluentAssertions;
 
@@ -22,7 +23,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(provider);
 
         var output = new StringBuilder();
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
         {
             if (!string.IsNullOrEmpty(chunk.DeltaContent))
                 output.Append(chunk.DeltaContent);
@@ -63,7 +64,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(provider);
         var chunks = new List<LLMStreamChunk>();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().Contain(x => x.DeltaToolCall != null);
@@ -102,7 +103,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var captureMiddleware = new CaptureLLMResponseMiddleware();
         var runtime = CreateRuntime(provider, llmMiddlewares: [captureMiddleware]);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
         {
         }
 
@@ -130,7 +131,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(provider);
         var chunks = new List<LLMStreamChunk>();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().Contain(x => x.DeltaReasoningContent == "thinking step");
@@ -154,7 +155,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(
             provider,
             tools,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = [ChatMessage.System("system")],
                 RequestId = "base-request",
@@ -172,7 +173,7 @@ public sealed class ChatRuntimeStreamingBufferTests
                 ToolContext = baseToolContext,
                 Tools = [tool],
             });
-        var executor = runtime.CreateStepExecutor();
+        var executor = runtime.CreateStepExecutor(turnCatalog: null);
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [LLMRequestMetadataKeys.CallId] = "strip-call",
@@ -246,6 +247,7 @@ public sealed class ChatRuntimeStreamingBufferTests
                            requestId: "req-123",
                            llmControl,
                            toolContext: null,
+                           turnCatalog: null,
                            metadata,
                            CancellationToken.None))
         {
@@ -284,7 +286,7 @@ public sealed class ChatRuntimeStreamingBufferTests
     {
         var provider = new RecordingStepProvider();
         var runtime = CreateRuntime(provider);
-        var executor = runtime.CreateStepExecutor();
+        var executor = runtime.CreateStepExecutor(turnCatalog: null);
         var messages = new List<ChatMessage>
         {
             ChatMessage.System("system"),
@@ -311,7 +313,7 @@ public sealed class ChatRuntimeStreamingBufferTests
     {
         var provider = new RecordingStepProvider();
         var runtime = CreateRuntime(provider);
-        var executor = runtime.CreateStepExecutor();
+        var executor = runtime.CreateStepExecutor(turnCatalog: null);
         var messages = new List<ChatMessage>
         {
             ChatMessage.System("system"),
@@ -346,7 +348,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var tools = new ToolManager();
         tools.Register(tool);
         var runtime = CreateRuntime(provider, tools);
-        var executor = runtime.CreateStepExecutor();
+        var executor = runtime.CreateStepExecutor(turnCatalog: null);
         var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
@@ -372,7 +374,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var provider = new RecordingStepProvider();
         var runtime = CreateRuntime(
             provider,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = [],
                 RequestId = "base-request",
@@ -384,7 +386,7 @@ public sealed class ChatRuntimeStreamingBufferTests
                     [LLMRequestMetadataKeys.ModelOverride] = "base-model",
                 },
             });
-        var executor = runtime.CreateStepExecutor();
+        var executor = runtime.CreateStepExecutor(turnCatalog: null);
 
         var request = executor.BuildBaseRequest(
             " request-1 ",
@@ -433,7 +435,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(provider, tools: tools);
         var output = new StringBuilder();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello", maxToolRounds: 2))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", maxToolRounds: 2, turnCatalog: null))
         {
             if (!string.IsNullOrEmpty(chunk.DeltaContent))
                 output.Append(chunk.DeltaContent);
@@ -478,7 +480,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}"));
         var runtime = CreateRuntime(provider, tools: tools);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 2))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 2, turnCatalog: null))
         {
         }
 
@@ -518,7 +520,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}"));
         var runtime = CreateRuntime(provider, tools: tools);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 2))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 2, turnCatalog: null))
         {
         }
 
@@ -572,7 +574,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(provider, tools: tools);
 
         var output = new StringBuilder();
-        await foreach (var chunk in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
         {
             if (!string.IsNullOrEmpty(chunk.DeltaContent))
                 output.Append(chunk.DeltaContent);
@@ -627,7 +629,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}", isReadOnly: true));
         var runtime = CreateRuntime(provider, tools: tools);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
         {
         }
 
@@ -675,7 +677,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         tools.Register(new DelegateTool("write_config", args => $"RESULT:{args}"));
         var runtime = CreateRuntime(provider, tools: tools);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
         {
         }
 
@@ -713,7 +715,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         tools.Register(new DelegateTool("lookup", args => $"RESULT:{args}", isReadOnly: true));
         var runtime = CreateRuntime(provider, tools: tools);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
         {
         }
 
@@ -723,7 +725,7 @@ public sealed class ChatRuntimeStreamingBufferTests
                               message.Content?.Contains("no successful mutating tool execution") == true)
             .Should().ContainSingle();
 
-        await foreach (var _ in runtime.ChatStreamAsync("next", maxToolRounds: 1))
+        await foreach (var _ in runtime.ChatStreamAsync("next", maxToolRounds: 1, turnCatalog: null))
         {
         }
 
@@ -758,7 +760,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         tools.Register(new DelegateTool("write_config", args => $"RESULT:{args}"));
         var runtime = CreateRuntime(provider, tools: tools);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1, turnCatalog: null))
         {
         }
 
@@ -811,7 +813,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(
             provider,
             tools: tools,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = [],
                 ToolContext = AgentToolExecutionContext.Empty with
@@ -822,7 +824,11 @@ public sealed class ChatRuntimeStreamingBufferTests
                 },
             });
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", maxToolRounds: 1, requestId: "request-typed"))
+        await foreach (var _ in runtime.ChatStreamAsync(
+                           "hello",
+                           maxToolRounds: 1,
+                           requestId: "request-typed",
+                           turnCatalog: null))
         {
         }
 
@@ -842,7 +848,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var provider = new StreamingProvider(["A"]);
         var runtime = CreateRuntime(
             provider,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = [],
                 RequestId = "base-request",
@@ -859,7 +865,11 @@ public sealed class ChatRuntimeStreamingBufferTests
             ["workflow.run_id"] = "run-1",
         };
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", "session-42", providerMetadata))
+        await foreach (var _ in runtime.ChatStreamAsync(
+                           "hello",
+                           "session-42",
+                           turnCatalog: null,
+                           metadata: providerMetadata))
         {
         }
 
@@ -883,7 +893,11 @@ public sealed class ChatRuntimeStreamingBufferTests
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "metadata-token",
         };
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", "session-metadata-only", metadata))
+        await foreach (var _ in runtime.ChatStreamAsync(
+                           "hello",
+                           "session-metadata-only",
+                           turnCatalog: null,
+                           metadata: metadata))
         {
         }
 
@@ -900,7 +914,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var provider = new StreamingProvider(["A"]);
         var runtime = CreateRuntime(
             provider,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = [],
                 RoutingContext = new LLMRequestRoutingContext(
@@ -918,7 +932,7 @@ public sealed class ChatRuntimeStreamingBufferTests
                 },
             });
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello"))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", turnCatalog: null))
         {
         }
 
@@ -949,7 +963,8 @@ public sealed class ChatRuntimeStreamingBufferTests
                            maxToolRounds: 2,
                            requestId: "session-control",
                            llmControl: control,
-                           toolContext: null))
+                           toolContext: null,
+                           turnCatalog: null))
         {
         }
 
@@ -969,7 +984,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             provider,
             llmMiddlewares: [captureMiddleware]);
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello", "session-77"))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", "session-77", turnCatalog: null))
         {
         }
 
@@ -992,7 +1007,8 @@ public sealed class ChatRuntimeStreamingBufferTests
                 }),
             ]);
 
-        var result = await ChatStreamContentAggregator.AggregateContentAsync(runtime.ChatStreamAsync("hello"));
+        var result = await ChatStreamContentAggregator.AggregateContentAsync(
+            runtime.ChatStreamAsync("hello", turnCatalog: null));
 
         result.Should().Be("short-circuit");
         provider.StreamCallCount.Should().Be(0);
@@ -1016,7 +1032,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             ]);
         var output = new StringBuilder();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
         {
             if (!string.IsNullOrEmpty(chunk.DeltaContent))
                 output.Append(chunk.DeltaContent);
@@ -1036,7 +1052,8 @@ public sealed class ChatRuntimeStreamingBufferTests
         var provider = new StreamingProvider(["stream-", "answer"]);
         var runtime = CreateRuntime(provider);
 
-        var result = await ChatStreamContentAggregator.AggregateContentAsync(runtime.ChatStreamAsync("hello"));
+        var result = await ChatStreamContentAggregator.AggregateContentAsync(
+            runtime.ChatStreamAsync("hello", turnCatalog: null));
 
         result.Should().Be("stream-answer");
         provider.StreamCallCount.Should().Be(1);
@@ -1128,7 +1145,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             ]);
         var chunks = new List<LLMStreamChunk>();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().ContainSingle();
@@ -1165,7 +1182,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             ]);
         var chunks = new List<LLMStreamChunk>();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().Contain(x => x.DeltaContent == "middleware-content");
@@ -1195,7 +1212,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             ]);
         var chunks = new List<LLMStreamChunk>();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().Contain(x => x.DeltaReasoningContent == "thinking-step");
@@ -1216,7 +1233,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         var runtime = CreateRuntime(provider);
         var chunks = new List<LLMStreamChunk>();
 
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().BeEmpty();
@@ -1227,7 +1244,7 @@ public sealed class ChatRuntimeStreamingBufferTests
         ToolManager? tools = null,
         IReadOnlyList<IAgentRunMiddleware>? agentMiddlewares = null,
         IReadOnlyList<ILLMCallMiddleware>? llmMiddlewares = null,
-        Func<LLMRequest>? requestBuilder = null)
+        Func<AgentProfileTurnCatalog?, LLMRequest>? requestBuilder = null)
     {
         var history = new ChatHistory();
         var toolLoop = new ToolCallLoop(tools ?? new ToolManager());
@@ -1237,7 +1254,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             history: history,
             toolLoop: toolLoop,
             hooks: null,
-            requestBuilder: requestBuilder ?? (() => new LLMRequest { Messages = [] }),
+            requestBuilder: requestBuilder ?? (_ => new LLMRequest { Messages = [] }),
             agentMiddlewares: agentMiddlewares,
             llmMiddlewares: llmMiddlewares);
     }

--- a/test/Aevatar.AI.Tests/ContextCompressorTests.cs
+++ b/test/Aevatar.AI.Tests/ContextCompressorTests.cs
@@ -369,7 +369,7 @@ public class ContextCompressorTests
             history: history,
             toolLoop: toolLoop,
             hooks: pipeline,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = history.BuildMessages(null),
                 Tools = null,
@@ -377,7 +377,7 @@ public class ContextCompressorTests
             compressionConfig: compressionConfig);
 
         await ChatStreamContentAggregator.AggregateContentAsync(
-            chat.ChatStreamAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None),
+            chat.ChatStreamAsync("trigger", maxToolRounds: 1, turnCatalog: null, ct: CancellationToken.None),
             ct: CancellationToken.None);
 
         hook.CompactStartCount.Should().Be(1);
@@ -694,7 +694,7 @@ public class ContextCompressorTests
             history: history,
             toolLoop: toolLoop,
             hooks: pipeline,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = history.BuildMessages(null),
                 Tools = null,
@@ -702,7 +702,7 @@ public class ContextCompressorTests
             compressionConfig: compressionConfig);
 
         await ChatStreamContentAggregator.AggregateContentAsync(
-            chat.ChatStreamAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None),
+            chat.ChatStreamAsync("trigger", maxToolRounds: 1, turnCatalog: null, ct: CancellationToken.None),
             ct: CancellationToken.None);
 
         hook.CompactStartCount.Should().Be(0);
@@ -727,7 +727,7 @@ public class ContextCompressorTests
             history: history,
             toolLoop: toolLoop,
             hooks: pipeline,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = history.BuildMessages(null),
                 Tools = null,
@@ -735,7 +735,7 @@ public class ContextCompressorTests
             compressionConfig: compressionConfig);
 
         await ChatStreamContentAggregator.AggregateContentAsync(
-            chat.ChatStreamAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None),
+            chat.ChatStreamAsync("trigger", maxToolRounds: 1, turnCatalog: null, ct: CancellationToken.None),
             ct: CancellationToken.None);
 
         hook.CompactStartCount.Should().Be(0);

--- a/test/Aevatar.AI.Tests/MultimodalPipelineTests.cs
+++ b/test/Aevatar.AI.Tests/MultimodalPipelineTests.cs
@@ -177,7 +177,7 @@ public class MultimodalPipelineTests
         var runtime = CreateRuntime(provider);
 
         var chunks = new List<LLMStreamChunk>();
-        await foreach (var chunk in runtime.ChatStreamAsync("generate an image"))
+        await foreach (var chunk in runtime.ChatStreamAsync("generate an image", turnCatalog: null))
             chunks.Add(chunk);
 
         // The DeltaContentPart should be forwarded through
@@ -198,7 +198,7 @@ public class MultimodalPipelineTests
         var runtime = CreateRuntime(provider);
 
         var chunks = new List<LLMStreamChunk>();
-        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+        await foreach (var chunk in runtime.ChatStreamAsync("hello", turnCatalog: null))
             chunks.Add(chunk);
 
         chunks.Should().NotContain(c => c.DeltaContentPart != null);
@@ -220,7 +220,7 @@ public class MultimodalPipelineTests
                 ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(["search"]),
             });
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello"))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", turnCatalog: null))
         {
         }
 
@@ -243,7 +243,7 @@ public class MultimodalPipelineTests
                 ToolVisibility = AgentToolVisibilityScope.Empty,
             });
 
-        await foreach (var _ in runtime.ChatStreamAsync("hello"))
+        await foreach (var _ in runtime.ChatStreamAsync("hello", turnCatalog: null))
         {
         }
 
@@ -262,7 +262,7 @@ public class MultimodalPipelineTests
             history: history,
             toolLoop: toolLoop,
             hooks: null,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = history.BuildMessages("You are a helpful assistant."),
                 Tools = null,
@@ -281,7 +281,7 @@ public class MultimodalPipelineTests
             history: history,
             toolLoop: toolLoop,
             hooks: null,
-            requestBuilder: () => new LLMRequest
+            requestBuilder: _ => new LLMRequest
             {
                 Messages = history.BuildMessages("You are a helpful assistant."),
                 Tools = toolManager.GetAll(),

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -593,6 +593,26 @@ public class NyxIdChatGAgentTests
     }
 
     [Fact]
+    public async Task HandleChatRequest_BoundTurnWithoutMaterializer_ShouldRejectAllTools()
+    {
+        await AssertBoundTurnMaterializationFailureRejectsAllToolsAsync(
+            turnCatalogMaterializer: null,
+            "nyxid-chat-catalog-materializer-missing");
+    }
+
+    [Fact]
+    public async Task HandleChatRequest_BoundTurnWhenMaterializerThrows_ShouldRejectAllTools()
+    {
+        var materializer = new AgentProfileTurnCatalogMaterializer(
+            new ThrowingNameToolSetRegistry(),
+            new NoMatchClassifier());
+
+        await AssertBoundTurnMaterializationFailureRejectsAllToolsAsync(
+            materializer,
+            "nyxid-chat-catalog-materializer-throws");
+    }
+
+    [Fact]
     public async Task HandleChatRequest_UnboundTurn_ShouldNotMaterializeCatalog()
     {
         using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
@@ -895,6 +915,59 @@ public class NyxIdChatGAgentTests
             .GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)!;
         setId.Invoke(agent, [actorId]);
         return agent;
+    }
+
+    private static async Task AssertBoundTurnMaterializationFailureRejectsAllToolsAsync(
+        AgentProfileTurnCatalogMaterializer? turnCatalogMaterializer,
+        string actorId)
+    {
+        var executeCount = 0;
+        var tools = new IAgentTool[]
+        {
+            new DelegateTool("forged", _ =>
+            {
+                executeCount++;
+                return "must not execute";
+            }),
+        };
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
+        var llm = new StreamingToolLoopProviderFactory(
+        [
+            [new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall
+                {
+                    Id = "forged-call",
+                    Name = "forged",
+                    ArgumentsJson = "{}",
+                },
+            }],
+            [new LLMStreamChunk { DeltaContent = "done" }],
+        ]);
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = BuildSealedProfile("profile-v1", "profile.route") });
+        var agent = CreateAgent(
+            provider,
+            actorId,
+            llm,
+            [new StaticToolSource(tools)],
+            turnCatalogMaterializer: turnCatalogMaterializer);
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "run forged tool",
+            SessionId = $"{actorId}-session",
+        });
+
+        llm.StreamRequests.Should().HaveCount(2);
+        var firstRequest = llm.StreamRequests[0];
+        firstRequest.Tools.Should().BeNull();
+        firstRequest.ToolContext!.ToolVisibility.IsRestricted.Should().BeTrue();
+        firstRequest.ToolContext.ToolVisibility.Allows("forged").Should().BeFalse();
+        executeCount.Should().Be(0);
     }
 
     private static EventEnvelope CreateEnvelope(string actorId, IMessage payload) => new()
@@ -1246,6 +1319,25 @@ public class NyxIdChatGAgentTests
                     "missing",
                     GetRegisteredNames()));
         }
+    }
+
+    private sealed class ThrowingNameToolSetRegistry : IToolSetRegistry
+    {
+        public IReadOnlyList<string> GetRegisteredNames() => ["profile.route"];
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+            ToolSetResolveResult.Success(
+                toolSetRef?.Name ?? string.Empty,
+                [new StaticToolSource([new ThrowingNameTool()])]);
+    }
+
+    private sealed class ThrowingNameTool : IAgentTool
+    {
+        public string Name => throw new InvalidOperationException("tool name unavailable");
+        public string Description => "unreachable";
+        public string ParametersSchema => "{}";
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("{}");
     }
 
     private sealed class NoMatchClassifier : IAgentProfileTurnClassifier

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -24,6 +24,11 @@ namespace Aevatar.AI.Tests;
 
 public class NyxIdChatGAgentTests
 {
+    private const string ExactSkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string ExactSkillVersion = "1.2";
+    private const string ExactSkillName = "skill-alpha";
+    private const string ExactSkillPublisher = "publisher-alpha";
+
     [Fact]
     public async Task CreateTargetResolver_ShouldCopySelectedProfileForMatchingDirectRoute()
     {
@@ -507,6 +512,87 @@ public class NyxIdChatGAgentTests
     }
 
     [Fact]
+    public async Task HandleChatRequest_BoundTurn_ShouldPropagateTokenCatalogPromptAndAdmission()
+    {
+        const string turnToken = "turn-token-alpha";
+        var hiddenExecuteCount = 0;
+        var tools = new IAgentTool[]
+        {
+            new DelegateTool("recovery", _ => "recovered"),
+            new DelegateTool("task", _ => "task complete"),
+            new DelegateTool("hidden", _ =>
+            {
+                hiddenExecuteCount++;
+                return "must not execute";
+            }),
+        };
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
+        var llm = new StreamingToolLoopProviderFactory(
+        [
+            [new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall
+                {
+                    Id = "forged-hidden-call",
+                    Name = "hidden",
+                    ArgumentsJson = "{}",
+                },
+            }],
+            [new LLMStreamChunk { DeltaContent = "done" }],
+        ]);
+        var registry = new StaticProfileToolSetRegistry("profile.route", tools);
+        var fetcher = new RecordingExactFetcher(ExactRemoteSkillFetchResult.Success(
+            ExactSkillGuid,
+            ExactSkillVersion,
+            ExactSkillName,
+            ExactSkillPublisher,
+            "hash-alpha",
+            "---\nname: skill-alpha\n---\nSelected turn instructions."));
+        var materializer = new AgentProfileTurnCatalogMaterializer(
+            registry,
+            new NoMatchClassifier(),
+            fetcher);
+        const string actorId = "nyxid-chat-catalog-success";
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = BuildSealedEnforcedProfile() });
+        var agent = CreateAgent(
+            provider,
+            actorId,
+            llm,
+            [new StaticToolSource(tools)],
+            turnCatalogMaterializer: materializer);
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "/alpha run",
+            SessionId = "catalog-success-session",
+            ToolContext = new AgentToolExecutionContextPayload
+            {
+                Credentials = new AgentToolCredentialsPayload { NyxIdAccessToken = turnToken },
+            },
+        });
+
+        registry.ResolveCount.Should().Be(1);
+        fetcher.CallCount.Should().Be(1);
+        fetcher.AccessToken.Should().Be(turnToken);
+        fetcher.SkillRef.Should().BeEquivalentTo(new ExactRemoteSkillRef
+        {
+            Guid = ExactSkillGuid,
+            LiteralVersion = ExactSkillVersion,
+        });
+        llm.StreamRequests.Should().HaveCount(2);
+        var firstRequest = llm.StreamRequests[0];
+        firstRequest.Tools!.Select(static tool => tool.Name).Should().BeEquivalentTo("recovery", "task");
+        firstRequest.ToolContext!.ToolVisibility.Allows("hidden").Should().BeFalse();
+        firstRequest.Messages.Single(static message => message.Role == "system").Content
+            .Should().Contain("Selected turn instructions.");
+        hiddenExecuteCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task HandleChatRequest_UnboundTurn_ShouldNotMaterializeCatalog()
     {
         using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
@@ -853,6 +939,45 @@ public class NyxIdChatGAgentTests
             RouteToolSetRef = routeToolSetRef,
         });
 
+    private static AgentProfileSnapshot BuildSealedEnforcedProfile()
+    {
+        var member = new AgentProfileSkillMember
+        {
+            IntentId = "intent-alpha",
+            RoutingDescription = "Route alpha requests.",
+            SkillRef = new ExactRemoteSkillRef
+            {
+                Guid = ExactSkillGuid,
+                LiteralVersion = ExactSkillVersion,
+            },
+            TaskToolPolicy = new AgentProfileToolPolicy(),
+            SideEffectClass = AgentProfileSideEffectClass.ReadOnly,
+            ExpectedSkillName = ExactSkillName,
+            ReviewedPublisherId = ExactSkillPublisher,
+        };
+        member.ExplicitTriggerAliases.Add("/alpha");
+        member.TaskToolPolicy.ToolNames.Add("task");
+
+        var profile = new AgentProfileSnapshot
+        {
+            ProfileId = "profile-alpha",
+            ProfileVersion = "profile-v1",
+            AgentKind = "nyxid.chat",
+            PolicyRevision = "policy-v1",
+            RouteToolSetRef = "profile.route",
+            MaximumToolPolicy = new AgentProfileToolPolicy(),
+            RecoveryToolPolicy = new AgentProfileToolPolicy(),
+            ClassifierTimeoutMs = 600,
+            ExactSkillFetchTimeoutMs = 1_500,
+            MaxSelectedSkillBytes = 256,
+            ActivationMode = AgentProfileActivationMode.Enforced,
+        };
+        profile.MaximumToolPolicy.ToolNames.Add(["recovery", "task", "hidden"]);
+        profile.RecoveryToolPolicy.ToolNames.Add("recovery");
+        profile.Members.Add(member);
+        return AgentProfileSnapshotCodec.Seal(profile);
+    }
+
     private sealed class StaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
     {
         public ChatRouteDecision GetFallbackDecision() => new()
@@ -1102,12 +1227,51 @@ public class NyxIdChatGAgentTests
         }
     }
 
+    private sealed class StaticProfileToolSetRegistry(
+        string name,
+        IReadOnlyList<IAgentTool> tools) : IToolSetRegistry
+    {
+        public int ResolveCount { get; private set; }
+
+        public IReadOnlyList<string> GetRegisteredNames() => [name];
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        {
+            ResolveCount++;
+            return string.Equals(toolSetRef?.Name, name, StringComparison.Ordinal)
+                ? ToolSetResolveResult.Success(name, [new StaticToolSource(tools)])
+                : ToolSetResolveResult.Failure(new ToolSetResolveError(
+                    ToolSetResolveError.UnknownNameCode,
+                    toolSetRef?.Name ?? string.Empty,
+                    "missing",
+                    GetRegisteredNames()));
+        }
+    }
+
     private sealed class NoMatchClassifier : IAgentProfileTurnClassifier
     {
         public Task<AgentProfileTurnClassificationResult> ClassifyAsync(
             AgentProfileTurnClassificationRequest request,
             CancellationToken ct = default) =>
             Task.FromResult(AgentProfileTurnClassificationResult.NoMatch());
+    }
+
+    private sealed class RecordingExactFetcher(ExactRemoteSkillFetchResult result) : IExactRemoteSkillFetcher
+    {
+        public int CallCount { get; private set; }
+        public string? AccessToken { get; private set; }
+        public ExactRemoteSkillRef? SkillRef { get; private set; }
+
+        public Task<ExactRemoteSkillFetchResult> FetchAsync(
+            string accessToken,
+            ExactRemoteSkillRef skillRef,
+            CancellationToken ct = default)
+        {
+            CallCount++;
+            AccessToken = accessToken;
+            SkillRef = skillRef.Clone();
+            return Task.FromResult(result);
+        }
     }
 
     private sealed class DelegateTool(string name, Func<string, string> execute) : IAgentTool

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -512,6 +512,68 @@ public class NyxIdChatGAgentTests
     }
 
     [Fact]
+    public async Task HandleChatRequest_BoundTurnCatalogTimeout_ShouldCommitFailureAndPublishTerminalFrame()
+    {
+        const int timeoutMs = 1_000;
+        const string actorId = "nyxid-chat-catalog-timeout";
+        const string sessionId = "catalog-timeout-session";
+        var timeProvider = new ManualDeadlineTimeProvider();
+        var blockingSource = new ReleasableBlockingToolSource();
+        var registry = new BlockingProfileToolSetRegistry("profile.route", blockingSource);
+        var materializer = new AgentProfileTurnCatalogMaterializer(registry, new NoMatchClassifier());
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
+        var llm = new StreamingToolLoopProviderFactory(
+        [
+            [new LLMStreamChunk { DeltaContent = "must not run" }],
+        ]);
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = BuildSealedProfile("profile-v1", "profile.route") });
+        var agent = CreateAgent(
+            provider,
+            actorId,
+            llm,
+            timeProvider: timeProvider,
+            turnCatalogMaterializer: materializer);
+        var eventPublisher = new RecordingEventPublisher();
+        agent.EventPublisher = eventPublisher;
+
+        await agent.ActivateAsync();
+        var handling = agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "wait for catalog",
+            SessionId = sessionId,
+            TimeoutMs = timeoutMs,
+        });
+        await blockingSource.Started;
+
+        try
+        {
+            timeProvider.PendingTimerCount.Should().Be(1);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutMs));
+            await handling;
+        }
+        finally
+        {
+            blockingSource.Release();
+            await handling;
+        }
+
+        blockingSource.CancellationObserved.Should().BeTrue();
+        llm.StreamRequests.Should().BeEmpty();
+        var completion = (await provider.GetRequiredService<IEventStore>().GetEventsAsync(actorId))
+            .Where(stateEvent => stateEvent.EventData.Is(RoleChatSessionCompletedEvent.Descriptor))
+            .Should().ContainSingle().Subject.EventData.Unpack<RoleChatSessionCompletedEvent>();
+        completion.SessionId.Should().Be(sessionId);
+        completion.Content.Should().Contain($"LLM request timed out after {timeoutMs}ms");
+        eventPublisher.Published.OfType<TextMessageStartEvent>()
+            .Should().ContainSingle(start => start.SessionId == sessionId);
+        eventPublisher.Published.OfType<TextMessageEndEvent>()
+            .Should().ContainSingle(end => end.SessionId == sessionId && end.Content == completion.Content);
+    }
+
+    [Fact]
     public async Task HandleChatRequest_BoundTurn_ShouldPropagateTokenCatalogPromptAndAdmission()
     {
         const string turnToken = "turn-token-alpha";
@@ -1319,6 +1381,50 @@ public class NyxIdChatGAgentTests
                     "missing",
                     GetRegisteredNames()));
         }
+    }
+
+    private sealed class BlockingProfileToolSetRegistry(
+        string name,
+        IAgentToolSource source) : IToolSetRegistry
+    {
+        public IReadOnlyList<string> GetRegisteredNames() => [name];
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+            string.Equals(toolSetRef?.Name, name, StringComparison.Ordinal)
+                ? ToolSetResolveResult.Success(name, [source])
+                : ToolSetResolveResult.Failure(new ToolSetResolveError(
+                    ToolSetResolveError.UnknownNameCode,
+                    toolSetRef?.Name ?? string.Empty,
+                    "missing",
+                    GetRegisteredNames()));
+    }
+
+    private sealed class ReleasableBlockingToolSource : IAgentToolSource
+    {
+        private readonly TaskCompletionSource _started =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _released =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Started => _started.Task;
+        public bool CancellationObserved { get; private set; }
+
+        public async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+        {
+            _started.TrySetResult();
+            try
+            {
+                await _released.Task.WaitAsync(ct);
+                return [];
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                CancellationObserved = true;
+                throw;
+            }
+        }
+
+        public void Release() => _released.TrySetResult();
     }
 
     private sealed class ThrowingNameToolSetRegistry : IToolSetRegistry

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -4,6 +4,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.ToolSetRegistry;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
 using Aevatar.Foundation.Abstractions.Persistence;
@@ -477,6 +478,93 @@ public class NyxIdChatGAgentTests
     }
 
     [Fact]
+    public async Task HandleChatRequest_BoundTurn_ShouldMaterializeCatalogOnce()
+    {
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
+        var llm = new StreamingToolLoopProviderFactory(
+        [
+            [new LLMStreamChunk { DeltaContent = "done" }],
+        ]);
+        var registry = new CountingToolSetRegistry();
+        var materializer = new AgentProfileTurnCatalogMaterializer(registry, new NoMatchClassifier());
+        const string actorId = "nyxid-chat-catalog-bound";
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = BuildSealedProfile("profile-v1", "profile.route") });
+        var agent = CreateAgent(provider, actorId, llm, turnCatalogMaterializer: materializer);
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "hello",
+            SessionId = "catalog-bound-session",
+        });
+
+        registry.ResolveCount.Should().Be(1);
+        llm.StreamRequests.Should().ContainSingle();
+        llm.StreamRequests[0].ToolContext!.ToolVisibility.IsRestricted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleChatRequest_UnboundTurn_ShouldNotMaterializeCatalog()
+    {
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
+        var llm = new StreamingToolLoopProviderFactory(
+        [
+            [new LLMStreamChunk { DeltaContent = "done" }],
+        ]);
+        var registry = new CountingToolSetRegistry();
+        var materializer = new AgentProfileTurnCatalogMaterializer(registry, new NoMatchClassifier());
+        var agent = CreateAgent(
+            provider,
+            "nyxid-chat-catalog-unbound",
+            llm,
+            turnCatalogMaterializer: materializer);
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "hello",
+            SessionId = "catalog-unbound-session",
+        });
+
+        registry.ResolveCount.Should().Be(0);
+        llm.StreamRequests.Should().ContainSingle();
+        llm.StreamRequests[0].ToolContext!.ToolVisibility.IsRestricted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleChatRequest_CompletedReplay_ShouldNotRematerializeCatalog()
+    {
+        using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
+        var llm = new StreamingToolLoopProviderFactory(
+        [
+            [new LLMStreamChunk { DeltaContent = "done" }],
+        ]);
+        var registry = new CountingToolSetRegistry();
+        var materializer = new AgentProfileTurnCatalogMaterializer(registry, new NoMatchClassifier());
+        const string actorId = "nyxid-chat-catalog-replay";
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new AgentProfileBoundEvent { Profile = BuildSealedProfile("profile-v1", "profile.route") });
+        var agent = CreateAgent(provider, actorId, llm, turnCatalogMaterializer: materializer);
+        var request = new ChatRequestEvent
+        {
+            Prompt = "hello",
+            SessionId = "catalog-replay-session",
+        };
+
+        await agent.ActivateAsync();
+        await agent.HandleChatRequest(request);
+        await agent.HandleChatRequest(request.Clone());
+
+        registry.ResolveCount.Should().Be(1);
+        llm.StreamRequests.Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task ActivateAsync_ShouldUseConfiguredRelayCallbackUrlInSystemPrompt()
     {
         using var provider = BuildServiceProvider(historyCommandPort: new RecordingChatHistoryCommandPort());
@@ -702,14 +790,16 @@ public class NyxIdChatGAgentTests
         ILLMProviderFactory? llmProviderFactory = null,
         IEnumerable<IAgentToolSource>? toolSources = null,
         NyxIdRelayOptions? relayOptions = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        AgentProfileTurnCatalogMaterializer? turnCatalogMaterializer = null)
     {
         var agent = new NyxIdChatGAgent(
             new SystemSkillOverlayPromptInjectionTests.StubBuiltInPromptFloorProvider(),
             llmProviderFactory: llmProviderFactory,
             toolSources: toolSources,
             relayOptions: relayOptions,
-            timeProvider: timeProvider)
+            timeProvider: timeProvider,
+            turnCatalogMaterializer: turnCatalogMaterializer)
         {
             Services = provider,
             EventSourcingBehaviorFactory = provider.GetRequiredService<IEventSourcingBehaviorFactory<RoleGAgentState>>(),
@@ -992,6 +1082,32 @@ public class NyxIdChatGAgentTests
     {
         public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
             Task.FromResult(tools);
+    }
+
+    private sealed class CountingToolSetRegistry : IToolSetRegistry
+    {
+        public int ResolveCount { get; private set; }
+
+        public IReadOnlyList<string> GetRegisteredNames() => [];
+
+        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        {
+            ResolveCount++;
+            var name = toolSetRef?.Name ?? string.Empty;
+            return ToolSetResolveResult.Failure(new ToolSetResolveError(
+                ToolSetResolveError.UnknownNameCode,
+                name,
+                "missing",
+                []));
+        }
+    }
+
+    private sealed class NoMatchClassifier : IAgentProfileTurnClassifier
+    {
+        public Task<AgentProfileTurnClassificationResult> ClassifyAsync(
+            AgentProfileTurnClassificationRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(AgentProfileTurnClassificationResult.NoMatch());
     }
 
     private sealed class DelegateTool(string name, Func<string, string> execute) : IAgentTool

--- a/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Middleware;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
@@ -26,6 +27,22 @@ public sealed class NyxIdChatServiceCollectionExtensionsTests
         services.Should().ContainSingle(descriptor =>
             descriptor.ServiceType == typeof(INyxIdChatAgentProfileSnapshotSource) &&
             descriptor.ImplementationType == typeof(DisabledNyxIdChatAgentProfileSnapshotSource));
+    }
+
+    [Fact]
+    public void AddNyxIdChat_ShouldRegisterProfileConsumersWithoutServiceLevelCatalog()
+    {
+        var services = new ServiceCollection();
+
+        services.AddNyxIdChat(new ConfigurationBuilder().Build());
+
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(IAgentProfileTurnClassifier) &&
+            descriptor.ImplementationFactory != null);
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(AgentProfileTurnCatalogMaterializer));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(AgentProfileTurnCatalog));
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using Aevatar.AI.Abstractions.Prompting;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Prompting;
 using Aevatar.GAgents.NyxidChat;
 using FluentAssertions;
@@ -63,5 +66,40 @@ public class NyxIdChatSystemPromptTests
         prompt.Should().Contain("successful mutating tool result or typed success receipt");
         prompt.Should().Contain("Read-only checks, searches, observation, trigger/rerun requests");
         prompt.Should().Contain("genuine successful mutating tool receipt");
+    }
+
+    [Fact]
+    public void DecorateSystemPrompt_ShouldUseCatalogSlotsWithoutShadowCandidateBody()
+    {
+        var agent = new NyxIdChatGAgent(new SystemSkillOverlayPromptInjectionTests.StubBuiltInPromptFloorProvider());
+        var profileLayer = new ProfileRoutingPromptLayer(
+            "profile routing layer",
+            new ProfileRoutingPromptProvenance("profile-test"),
+            new PromptLayerBounds(1_024, 256));
+        var selectedLayer = new SelectedSkillPromptLayer(
+            "selected skill body",
+            new SelectedSkillPromptProvenance("selected-test"),
+            new PromptLayerBounds(1_024, 256));
+        var enforced = new AgentProfileTurnCatalog(
+            [], profileLayer, selectedLayer, "intent-alpha", "intent-alpha");
+        var shadow = new AgentProfileTurnCatalog(
+            [], profileLayer, null, null, "intent-shadow");
+
+        var enforcedPrompt = Decorate(agent, enforced);
+        var shadowPrompt = Decorate(agent, shadow);
+
+        enforcedPrompt.Should().Contain("profile routing layer");
+        enforcedPrompt.Should().Contain("<selected-skill-procedure>\nselected skill body");
+        shadowPrompt.Should().Contain("profile routing layer");
+        shadowPrompt.Should().NotContain("selected skill body");
+        shadowPrompt.Should().NotContain("selected-skill-procedure");
+    }
+
+    private static string Decorate(NyxIdChatGAgent agent, AgentProfileTurnCatalog catalog)
+    {
+        var method = typeof(NyxIdChatGAgent).GetMethod(
+            "DecorateSystemPrompt",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (string)method.Invoke(agent, ["kernel", catalog])!;
     }
 }

--- a/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
@@ -71,6 +71,54 @@ public sealed class StreamingAgentProfileTurnClassifierTests
     }
 
     [Fact]
+    public async Task ClassifyAsync_NonPositiveTimeout_ShouldFailBeforeCallingProvider()
+    {
+        var provider = new StubProvider([]);
+        var classifier = new StreamingAgentProfileTurnClassifier(new StubProviderFactory(provider));
+
+        var result = await classifier.ClassifyAsync(NewRequest() with { Timeout = TimeSpan.Zero });
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed("timeout_out_of_bounds"));
+        provider.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_InternalTimeout_ShouldFailClosed()
+    {
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new CancellationBlockingProvider()));
+
+        var result = await classifier.ClassifyAsync(
+            NewRequest() with { Timeout = TimeSpan.FromMilliseconds(20) });
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed("timeout"));
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_ProviderException_ShouldFailClosed()
+    {
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new ThrowingProvider(new InvalidOperationException("provider failed"))));
+
+        var result = await classifier.ClassifyAsync(NewRequest());
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed("provider_failure"));
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_CallerCancellation_ShouldPropagate()
+    {
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new CancellationBlockingProvider()));
+        using var callerCts = new CancellationTokenSource();
+        callerCts.Cancel();
+
+        var act = async () => await classifier.ClassifyAsync(NewRequest(), callerCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task ClassifyAsync_ShouldFailClosedForToolMalformedUnknownAndOversizedOutput()
     {
         var cases = new[]
@@ -142,6 +190,36 @@ public sealed class StreamingAgentProfileTurnClassifierTests
             }
 
             await Task.CompletedTask;
+        }
+    }
+
+    private sealed class CancellationBlockingProvider : ILLMProvider
+    {
+        public string Name => "blocking-classifier-test";
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = ct.Register(
+                static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(),
+                canceled);
+            await canceled.Task;
+            yield break;
+        }
+    }
+
+    private sealed class ThrowingProvider(Exception exception) : ILLMProvider
+    {
+        public string Name => "throwing-classifier-test";
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return await Task.FromException<LLMStreamChunk>(exception);
         }
     }
 }

--- a/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
@@ -277,6 +277,17 @@ internal sealed class ManualDeadlineTimeProvider : TimeProvider
         }
     }
 
+    public int PendingTimerCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _timers.Count;
+            }
+        }
+    }
+
     public void Advance(TimeSpan delta)
     {
         ManualTimer[] timers;

--- a/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
@@ -85,13 +85,21 @@ public sealed class StreamingAgentProfileTurnClassifierTests
     [Fact]
     public async Task ClassifyAsync_InternalTimeout_ShouldFailClosed()
     {
+        var timeProvider = new ManualDeadlineTimeProvider();
+        var provider = new CancellationBlockingProvider();
         var classifier = new StreamingAgentProfileTurnClassifier(
-            new StubProviderFactory(new CancellationBlockingProvider()));
+            new StubProviderFactory(provider),
+            timeProvider);
 
-        var result = await classifier.ClassifyAsync(
-            NewRequest() with { Timeout = TimeSpan.FromMilliseconds(20) });
+        var classification = classifier.ClassifyAsync(
+            NewRequest() with { Timeout = TimeSpan.FromSeconds(1) });
+        await provider.Started;
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        var result = await classification;
 
         result.Should().Be(AgentProfileTurnClassificationResult.Failed("timeout"));
+        provider.CancellationObserved.Should().BeTrue();
     }
 
     [Fact]
@@ -119,66 +127,60 @@ public sealed class StreamingAgentProfileTurnClassifierTests
     }
 
     [Fact]
-    public async Task ClassifyAsync_ShouldFailClosedForRejectedOutputShapes()
+    public async Task ClassifyAsync_ToolCallOutput_ShouldFailClosed()
     {
-        var cases = new[]
-        {
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new StubProvider(
+            [
+                new LLMStreamChunk
                 {
                     DeltaToolCall = new ToolCall { Id = "call", Name = "tool", ArgumentsJson = "{}" },
-                }],
-                Failure: "tool_call_not_allowed"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[],
-                Failure: "empty_output"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk { DeltaContent = " \t\n" }],
-                Failure: "empty_output"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk { DeltaContent = "not-json" }],
-                Failure: "malformed_output"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
-                {
-                    DeltaContent = "{\"status\":\"matched\",\"intent_id\":\"intent-a\",\"extra\":true}",
-                }],
-                Failure: "unexpected_output_field"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
-                {
-                    DeltaContent = "{\"intent_id\":\"intent-a\"}",
-                }],
-                Failure: "status_missing"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
-                {
-                    DeltaContent = "{\"status\":1,\"intent_id\":\"intent-a\"}",
-                }],
-                Failure: "status_missing"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
-                {
-                    DeltaContent = "{\"status\":\"matched\",\"intent_id\":\"unknown\"}",
-                }],
-                Failure: "unknown_intent"),
-            (
-                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                },
+            ])));
+
+        var result = await classifier.ClassifyAsync(NewRequest());
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed("tool_call_not_allowed"));
+    }
+
+    [Theory]
+    [InlineData(null, "empty_output")]
+    [InlineData(" \t\n", "empty_output")]
+    [InlineData("not-json", "malformed_output")]
+    [InlineData("{\"status\":\"matched\",\"intent_id\":\"intent-a\",\"extra\":true}", "unexpected_output_field")]
+    [InlineData("{\"intent_id\":\"intent-a\"}", "status_missing")]
+    [InlineData("{\"status\":1,\"intent_id\":\"intent-a\"}", "status_missing")]
+    [InlineData("{\"status\":\"matched\",\"intent_id\":\"unknown\"}", "unknown_intent")]
+    public async Task ClassifyAsync_RejectedTextOutput_ShouldFailClosed(
+        string? deltaContent,
+        string failureCode)
+    {
+        IReadOnlyList<LLMStreamChunk> chunks = deltaContent is null
+            ? []
+            : [new LLMStreamChunk { DeltaContent = deltaContent }];
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new StubProvider(chunks)));
+
+        var result = await classifier.ClassifyAsync(NewRequest());
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed(failureCode));
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_OversizedOutput_ShouldFailClosed()
+    {
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new StubProvider(
+            [
+                new LLMStreamChunk
                 {
                     DeltaContent = new string('x', StreamingAgentProfileTurnClassifier.MaximumOutputUtf8Bytes + 1),
-                }],
-                Failure: "output_too_large"),
-        };
+                },
+            ])));
 
-        foreach (var testCase in cases)
-        {
-            var classifier = new StreamingAgentProfileTurnClassifier(
-                new StubProviderFactory(new StubProvider(testCase.Chunks)));
+        var result = await classifier.ClassifyAsync(NewRequest());
 
-            var result = await classifier.ClassifyAsync(NewRequest());
-
-            result.Should().Be(AgentProfileTurnClassificationResult.Failed(testCase.Failure));
-        }
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed("output_too_large"));
     }
 
     private static AgentProfileTurnClassificationRequest NewRequest() =>
@@ -218,17 +220,31 @@ public sealed class StreamingAgentProfileTurnClassifierTests
 
     private sealed class CancellationBlockingProvider : ILLMProvider
     {
+        private readonly TaskCompletionSource _started =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public string Name => "blocking-classifier-test";
+        public Task Started => _started.Task;
+        public bool CancellationObserved { get; private set; }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
         {
+            _started.TrySetResult();
             var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             using var registration = ct.Register(
                 static state => ((TaskCompletionSource<bool>)state!).TrySetCanceled(),
                 canceled);
-            await canceled.Task;
+            try
+            {
+                await canceled.Task;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                CancellationObserved = true;
+                throw;
+            }
             yield break;
         }
     }
@@ -244,5 +260,125 @@ public sealed class StreamingAgentProfileTurnClassifierTests
             ct.ThrowIfCancellationRequested();
             yield return await Task.FromException<LLMStreamChunk>(exception);
         }
+    }
+}
+
+internal sealed class ManualDeadlineTimeProvider : TimeProvider
+{
+    private readonly object _gate = new();
+    private readonly List<ManualTimer> _timers = [];
+    private DateTimeOffset _utcNow = DateTimeOffset.UnixEpoch;
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        lock (_gate)
+        {
+            return _utcNow;
+        }
+    }
+
+    public void Advance(TimeSpan delta)
+    {
+        ManualTimer[] timers;
+        lock (_gate)
+        {
+            _utcNow = _utcNow.Add(delta);
+            timers = _timers.ToArray();
+        }
+
+        foreach (var timer in timers)
+            timer.FireIfDue();
+    }
+
+    public override ITimer CreateTimer(
+        TimerCallback callback,
+        object? state,
+        TimeSpan dueTime,
+        TimeSpan period)
+    {
+        var timer = new ManualTimer(this, callback, state, dueTime, period);
+        lock (_gate)
+        {
+            _timers.Add(timer);
+        }
+
+        timer.FireIfDue();
+        return timer;
+    }
+
+    private void Remove(ManualTimer timer)
+    {
+        lock (_gate)
+        {
+            _timers.Remove(timer);
+        }
+    }
+
+    private sealed class ManualTimer(
+        ManualDeadlineTimeProvider owner,
+        TimerCallback callback,
+        object? state,
+        TimeSpan dueTime,
+        TimeSpan period) : ITimer
+    {
+        private readonly object _gate = new();
+        private TimeSpan _period = period;
+        private DateTimeOffset? _dueAt = ResolveDueAt(owner.GetUtcNow(), dueTime);
+        private bool _disposed;
+
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return false;
+
+                _period = period;
+                _dueAt = ResolveDueAt(owner.GetUtcNow(), dueTime);
+            }
+
+            FireIfDue();
+            return true;
+        }
+
+        public void FireIfDue()
+        {
+            while (true)
+            {
+                lock (_gate)
+                {
+                    if (_disposed || !_dueAt.HasValue || owner.GetUtcNow() < _dueAt.Value)
+                        return;
+
+                    _dueAt = _period == Timeout.InfiniteTimeSpan
+                        ? null
+                        : owner.GetUtcNow().Add(_period);
+                }
+
+                callback(state);
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+            }
+
+            owner.Remove(this);
+        }
+
+        private static DateTimeOffset? ResolveDueAt(DateTimeOffset now, TimeSpan dueTime) =>
+            dueTime == Timeout.InfiniteTimeSpan ? null : now.Add(dueTime);
     }
 }

--- a/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
@@ -119,7 +119,7 @@ public sealed class StreamingAgentProfileTurnClassifierTests
     }
 
     [Fact]
-    public async Task ClassifyAsync_ShouldFailClosedForToolMalformedUnknownAndOversizedOutput()
+    public async Task ClassifyAsync_ShouldFailClosedForRejectedOutputShapes()
     {
         var cases = new[]
         {
@@ -130,8 +130,32 @@ public sealed class StreamingAgentProfileTurnClassifierTests
                 }],
                 Failure: "tool_call_not_allowed"),
             (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[],
+                Failure: "empty_output"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk { DeltaContent = " \t\n" }],
+                Failure: "empty_output"),
+            (
                 Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk { DeltaContent = "not-json" }],
                 Failure: "malformed_output"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                {
+                    DeltaContent = "{\"status\":\"matched\",\"intent_id\":\"intent-a\",\"extra\":true}",
+                }],
+                Failure: "unexpected_output_field"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                {
+                    DeltaContent = "{\"intent_id\":\"intent-a\"}",
+                }],
+                Failure: "status_missing"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                {
+                    DeltaContent = "{\"status\":1,\"intent_id\":\"intent-a\"}",
+                }],
+                Failure: "status_missing"),
             (
                 Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
                 {
@@ -153,8 +177,7 @@ public sealed class StreamingAgentProfileTurnClassifierTests
 
             var result = await classifier.ClassifyAsync(NewRequest());
 
-            result.Status.Should().Be(AgentProfileTurnClassificationStatus.Failed);
-            result.FailureCode.Should().Be(testCase.Failure);
+            result.Should().Be(AgentProfileTurnClassificationResult.Failed(testCase.Failure));
         }
     }
 

--- a/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
@@ -1,0 +1,147 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.GAgents.NyxidChat.AgentProfiles;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class StreamingAgentProfileTurnClassifierTests
+{
+    [Fact]
+    public async Task ClassifyAsync_ShouldUseSingleToolFreeBoundedStreamingRequest()
+    {
+        var provider = new StubProvider([
+            new LLMStreamChunk { DeltaContent = "{\"status\":\"matched\"," },
+            new LLMStreamChunk { DeltaContent = "\"intent_id\":\"intent-a\"}" },
+        ]);
+        var classifier = new StreamingAgentProfileTurnClassifier(new StubProviderFactory(provider));
+
+        var result = await classifier.ClassifyAsync(NewRequest());
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Matched("intent-a"));
+        provider.CallCount.Should().Be(1);
+        var request = provider.Requests.Should().ContainSingle().Subject;
+        request.Tools.Should().BeNull();
+        request.ResponseFormat.Should().NotBeNull();
+        request.MaxTokens.Should().Be(128);
+        request.Temperature.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_ShouldAcceptOnlyUnambiguousNoMatchOutput()
+    {
+        var noMatch = new StubProvider([
+            new LLMStreamChunk { DeltaContent = "{\"status\":\"no_match\",\"intent_id\":null}" },
+        ]);
+        var ambiguous = new StubProvider([
+            new LLMStreamChunk { DeltaContent = "{\"status\":\"no_match\",\"intent_id\":\"intent-a\"}" },
+        ]);
+
+        var accepted = await new StreamingAgentProfileTurnClassifier(new StubProviderFactory(noMatch))
+            .ClassifyAsync(NewRequest());
+        var rejected = await new StreamingAgentProfileTurnClassifier(new StubProviderFactory(ambiguous))
+            .ClassifyAsync(NewRequest());
+
+        accepted.Status.Should().Be(AgentProfileTurnClassificationStatus.NoMatch);
+        rejected.Should().Be(AgentProfileTurnClassificationResult.Failed("unexpected_intent"));
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_ShouldRejectOutOfBoundsInputBeforeCallingProvider()
+    {
+        var provider = new StubProvider([]);
+        var classifier = new StreamingAgentProfileTurnClassifier(new StubProviderFactory(provider));
+        var tooManyCandidates = Enumerable.Range(0, StreamingAgentProfileTurnClassifier.MaximumCandidates + 1)
+            .Select(index => new AgentProfileTurnClassificationCandidate($"intent-{index}", "route"))
+            .ToArray();
+
+        var countResult = await classifier.ClassifyAsync(new AgentProfileTurnClassificationRequest(
+            "message",
+            tooManyCandidates,
+            TimeSpan.FromSeconds(1)));
+        var sizeResult = await classifier.ClassifyAsync(new AgentProfileTurnClassificationRequest(
+            new string('x', StreamingAgentProfileTurnClassifier.MaximumInputUtf8Bytes + 1),
+            [new AgentProfileTurnClassificationCandidate("intent-a", "route")],
+            TimeSpan.FromSeconds(1)));
+
+        countResult.FailureCode.Should().Be("candidate_count_out_of_bounds");
+        sizeResult.FailureCode.Should().Be("input_too_large");
+        provider.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_ShouldFailClosedForToolMalformedUnknownAndOversizedOutput()
+    {
+        var cases = new[]
+        {
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall { Id = "call", Name = "tool", ArgumentsJson = "{}" },
+                }],
+                Failure: "tool_call_not_allowed"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk { DeltaContent = "not-json" }],
+                Failure: "malformed_output"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                {
+                    DeltaContent = "{\"status\":\"matched\",\"intent_id\":\"unknown\"}",
+                }],
+                Failure: "unknown_intent"),
+            (
+                Chunks: (IReadOnlyList<LLMStreamChunk>)[new LLMStreamChunk
+                {
+                    DeltaContent = new string('x', StreamingAgentProfileTurnClassifier.MaximumOutputUtf8Bytes + 1),
+                }],
+                Failure: "output_too_large"),
+        };
+
+        foreach (var testCase in cases)
+        {
+            var classifier = new StreamingAgentProfileTurnClassifier(
+                new StubProviderFactory(new StubProvider(testCase.Chunks)));
+
+            var result = await classifier.ClassifyAsync(NewRequest());
+
+            result.Status.Should().Be(AgentProfileTurnClassificationStatus.Failed);
+            result.FailureCode.Should().Be(testCase.Failure);
+        }
+    }
+
+    private static AgentProfileTurnClassificationRequest NewRequest() =>
+        new(
+            "please route this",
+            [new AgentProfileTurnClassificationCandidate("intent-a", "Route A")],
+            TimeSpan.FromSeconds(1));
+
+    private sealed class StubProviderFactory(ILLMProvider provider) : ILLMProviderFactory
+    {
+        public ILLMProvider GetProvider(string name) => provider;
+        public ILLMProvider GetDefault() => provider;
+        public IReadOnlyList<string> GetAvailableProviders() => [provider.Name];
+    }
+
+    private sealed class StubProvider(IReadOnlyList<LLMStreamChunk> chunks) : ILLMProvider
+    {
+        public string Name => "classifier-test";
+        public int CallCount { get; private set; }
+        public List<LLMRequest> Requests { get; } = [];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            CallCount++;
+            Requests.Add(request);
+            foreach (var chunk in chunks)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return chunk;
+            }
+
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingAgentProfileTurnClassifierTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.GAgents.NyxidChat.AgentProfiles;
@@ -114,6 +115,17 @@ public sealed class StreamingAgentProfileTurnClassifierTests
     }
 
     [Fact]
+    public async Task ClassifyAsync_ProviderJsonException_ShouldReturnMalformedOutput()
+    {
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new ThrowingProvider(new JsonException("malformed provider output"))));
+
+        var result = await classifier.ClassifyAsync(NewRequest());
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Failed("malformed_output"));
+    }
+
+    [Fact]
     public async Task ClassifyAsync_CallerCancellation_ShouldPropagate()
     {
         var classifier = new StreamingAgentProfileTurnClassifier(
@@ -143,13 +155,31 @@ public sealed class StreamingAgentProfileTurnClassifierTests
         result.Should().Be(AgentProfileTurnClassificationResult.Failed("tool_call_not_allowed"));
     }
 
+    [Fact]
+    public async Task ClassifyAsync_EmptyDeltaBeforeValidContent_ShouldStillMatch()
+    {
+        var classifier = new StreamingAgentProfileTurnClassifier(
+            new StubProviderFactory(new StubProvider(
+            [
+                new LLMStreamChunk { DeltaContent = string.Empty },
+                new LLMStreamChunk { DeltaContent = "{\"status\":\"matched\",\"intent_id\":\"intent-a\"}" },
+            ])));
+
+        var result = await classifier.ClassifyAsync(NewRequest());
+
+        result.Should().Be(AgentProfileTurnClassificationResult.Matched("intent-a"));
+    }
+
     [Theory]
     [InlineData(null, "empty_output")]
     [InlineData(" \t\n", "empty_output")]
     [InlineData("not-json", "malformed_output")]
+    [InlineData("[]", "malformed_output")]
     [InlineData("{\"status\":\"matched\",\"intent_id\":\"intent-a\",\"extra\":true}", "unexpected_output_field")]
     [InlineData("{\"intent_id\":\"intent-a\"}", "status_missing")]
     [InlineData("{\"status\":1,\"intent_id\":\"intent-a\"}", "status_missing")]
+    [InlineData("{\"status\":\"matched\"}", "malformed_output")]
+    [InlineData("{\"status\":\"matched\",\"intent_id\":1}", "malformed_output")]
     [InlineData("{\"status\":\"matched\",\"intent_id\":\"unknown\"}", "unknown_intent")]
     public async Task ClassifyAsync_RejectedTextOutput_ShouldFailClosed(
         string? deltaContent,

--- a/test/Aevatar.AI.Tests/SystemSkillOverlayPromptInjectionTests.cs
+++ b/test/Aevatar.AI.Tests/SystemSkillOverlayPromptInjectionTests.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.Prompting;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
@@ -27,7 +28,7 @@ public sealed class SystemSkillOverlayPromptInjectionTests
         var provider = new StubSystemSkillOverlayProvider(OverlayMarkdown);
         var agent = await CreateActivatedNyxIdChatAgentAsync(provider, "nyxid-chat-overlay");
 
-        var prompt = DecorateViaReflection(agent, "kernel invariant");
+        var prompt = DecorateViaReflection(agent, "kernel invariant", turnCatalog: null);
 
         prompt.Should().Contain("built-in prompt floor");
         prompt.IndexOf("kernel invariant", StringComparison.Ordinal).Should().BeLessThan(
@@ -44,8 +45,8 @@ public sealed class SystemSkillOverlayPromptInjectionTests
         var agent = await CreateActivatedNyxIdChatAgentAsync(
             new StubSystemSkillOverlayProvider("   "), "nyxid-chat-overlay-empty");
 
-        DecorateViaReflection(agent, "kernel invariant").Should().StartWith("kernel invariant");
-        DecorateViaReflection(agent, "kernel invariant").Should().NotContain(OverlayMarkdown);
+        DecorateViaReflection(agent, "kernel invariant", turnCatalog: null).Should().StartWith("kernel invariant");
+        DecorateViaReflection(agent, "kernel invariant", turnCatalog: null).Should().NotContain(OverlayMarkdown);
     }
 
     [Fact]
@@ -53,7 +54,7 @@ public sealed class SystemSkillOverlayPromptInjectionTests
     {
         var agent = await CreateActivatedNyxIdChatAgentAsync(overlayProvider: null, "nyxid-chat-overlay-none");
 
-        var prompt = DecorateViaReflection(agent, "kernel invariant");
+        var prompt = DecorateViaReflection(agent, "kernel invariant", turnCatalog: null);
         prompt.Should().Contain("kernel invariant");
         prompt.Should().Contain("built-in prompt floor");
     }
@@ -67,7 +68,7 @@ public sealed class SystemSkillOverlayPromptInjectionTests
         var provider = new StubSystemSkillOverlayProvider(OverlayMarkdown);
         var agent = await CreateActivatedAgentAsync(provider, "role-overlay-isolated");
 
-        agent.DecorateForTest("kernel invariant").Should().Be("kernel invariant");
+        agent.DecorateForTest("kernel invariant", turnCatalog: null).Should().Be("kernel invariant");
         provider.GetCurrentCalls.Should().Be(0, "the base role agent must not even consult the provider");
     }
 
@@ -87,7 +88,7 @@ public sealed class SystemSkillOverlayPromptInjectionTests
         AssignActorId(agent, "classifier-overlay-isolated");
         await agent.ActivateAsync();
 
-        var prompt = DecorateViaReflection(agent, "classifier kernel");
+        var prompt = DecorateViaReflection(agent, "classifier kernel", turnCatalog: null);
 
         prompt.Should().Be("classifier kernel");
         provider.GetCurrentCalls.Should().Be(0);
@@ -105,7 +106,7 @@ public sealed class SystemSkillOverlayPromptInjectionTests
         var replay = async () => await agent.PersistLegacyMaterializedEventAsync("## stale actor-state overlay");
         await replay.Should().NotThrowAsync();
 
-        agent.DecorateForTest("kernel invariant").Should().Be("kernel invariant");
+        agent.DecorateForTest("kernel invariant", turnCatalog: null).Should().Be("kernel invariant");
     }
 
     [Fact]
@@ -121,7 +122,7 @@ public sealed class SystemSkillOverlayPromptInjectionTests
             new SystemSkillOverlayRefreshFiredEvent { Attempt = 3 });
         await absorb.Should().NotThrowAsync();
 
-        agent.DecorateForTest("kernel invariant").Should().Be("kernel invariant");
+        agent.DecorateForTest("kernel invariant", turnCatalog: null).Should().Be("kernel invariant");
     }
 
     private static async Task<NyxIdChatGAgent> CreateActivatedNyxIdChatAgentAsync(
@@ -141,13 +142,16 @@ public sealed class SystemSkillOverlayPromptInjectionTests
         return agent;
     }
 
-    private static string DecorateViaReflection(RoleGAgent agent, string basePrompt)
+    private static string DecorateViaReflection(
+        RoleGAgent agent,
+        string basePrompt,
+        AgentProfileTurnCatalog? turnCatalog)
     {
         var decorate = agent.GetType().GetMethod(
             "DecorateSystemPrompt",
             BindingFlags.Instance | BindingFlags.NonPublic);
         decorate.Should().NotBeNull();
-        return (string)decorate!.Invoke(agent, [basePrompt])!;
+        return (string)decorate!.Invoke(agent, [basePrompt, turnCatalog])!;
     }
 
     private static async Task<TestRoleGAgent> CreateActivatedAgentAsync(
@@ -207,7 +211,8 @@ public sealed class SystemSkillOverlayPromptInjectionTests
                 },
             });
 
-        public string DecorateForTest(string basePrompt) => DecorateSystemPrompt(basePrompt);
+        public string DecorateForTest(string basePrompt, AgentProfileTurnCatalog? turnCatalog) =>
+            DecorateSystemPrompt(basePrompt, turnCatalog);
     }
 
     private sealed class StubSystemSkillOverlayProvider(string overlayMarkdown) : ISystemSkillOverlayProvider

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/Aevatar.AI.ToolProviders.Ornn.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Aevatar.AI.ToolProviders.Ornn.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Ornn\Aevatar.AI.ToolProviders.Ornn.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Scripting\Aevatar.AI.ToolProviders.Scripting.csproj" />

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -65,20 +65,27 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     }
 
     [Fact]
-    public async Task FetchAsync_IdentityMismatch_ShouldFailWithoutFallback()
+    public async Task FetchAsync_DetailGuidMismatch_ShouldFailWithoutFallback()
     {
-        var handler = new OrnnTestHttpMessageHandler(
-            _ => OrnnTestHttpMessageHandler.JsonResponse(DetailJson()),
-            _ => OrnnTestHttpMessageHandler.JsonResponse(SkillJson(version: "1.3")));
-        var fetcher = CreateFetcher(handler);
+        await AssertIdentityMismatchWithoutFallbackAsync(
+            DetailJson(guid: "22222222-2222-2222-2222-222222222222"),
+            SkillJson());
+    }
 
-        var result = await fetcher.FetchAsync("token", ExactRef());
+    [Fact]
+    public async Task FetchAsync_VersionMismatch_ShouldFailWithoutFallback()
+    {
+        await AssertIdentityMismatchWithoutFallbackAsync(
+            DetailJson(),
+            SkillJson(version: "1.3"));
+    }
 
-        result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.IdentityMismatch);
-        handler.Requests.Should().HaveCount(2);
-        handler.Requests.Should().OnlyContain(request =>
-            request.RequestUri!.Query == "?version=1.2" &&
-            !request.RequestUri.AbsoluteUri.Contains("latest", StringComparison.OrdinalIgnoreCase));
+    [Fact]
+    public async Task FetchAsync_DetailAndJsonNameMismatch_ShouldFailWithoutFallback()
+    {
+        await AssertIdentityMismatchWithoutFallbackAsync(
+            DetailJson(name: "skill-alpha"),
+            SkillJson(name: "skill-beta"));
     }
 
     [Fact]
@@ -208,17 +215,36 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     };
 
     private static string DetailJson(
+        string guid = SkillGuid,
+        string name = "skill-alpha",
         string publisher = "publisher-alpha",
         string hash = "hash-alpha") =>
-        "{\"data\":{\"guid\":\"" + SkillGuid +
-        "\",\"name\":\"skill-alpha\",\"skillHash\":\"" + hash +
+        "{\"data\":{\"guid\":\"" + guid +
+        "\",\"name\":\"" + name + "\",\"skillHash\":\"" + hash +
         "\",\"createdBy\":\"" + publisher + "\"}}";
 
     private static string SkillJson(
+        string name = "skill-alpha",
         string version = LiteralVersion,
         string filesJson = "{\"SKILL.md\":\"# Skill Alpha\\n\\nInstructions.\"}") =>
-        "{\"data\":{\"name\":\"skill-alpha\",\"version\":\"" + version +
+        "{\"data\":{\"name\":\"" + name + "\",\"version\":\"" + version +
         "\",\"files\":" + filesJson + "}}";
+
+    private static async Task AssertIdentityMismatchWithoutFallbackAsync(
+        string detailJson,
+        string skillJson)
+    {
+        var handler = new OrnnTestHttpMessageHandler(
+            _ => OrnnTestHttpMessageHandler.JsonResponse(detailJson),
+            _ => OrnnTestHttpMessageHandler.JsonResponse(skillJson));
+
+        var result = await CreateFetcher(handler).FetchAsync("token", ExactRef());
+
+        result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.IdentityMismatch);
+        handler.Requests.Select(request => request.RequestUri!.AbsoluteUri).Should().Equal(
+            $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}?version=1.2",
+            $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}/json?version=1.2");
+    }
 
     private sealed class CancellationObservingHttpMessageHandler : HttpMessageHandler
     {

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -2,6 +2,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.ToolProviders.NyxId;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aevatar.AI.ToolProviders.Ornn.Tests;
 
@@ -141,13 +142,18 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     [Fact]
     public async Task FetchAsync_InternalTimeout_ShouldReturnTypedTimeout()
     {
-        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled();
+        var handler = new CancellationObservingHttpMessageHandler();
+        var timeProvider = new FakeTimeProvider();
 
-        var result = await CreateFetcher(handler, TimeSpan.FromMilliseconds(20))
+        var fetch = CreateFetcher(handler, TimeSpan.FromSeconds(1), timeProvider)
             .FetchAsync("token", ExactRef());
+        await handler.Started;
+
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        var result = await fetch;
 
         result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.Timeout);
-        handler.Requests.Should().ContainSingle();
+        handler.CancellationObserved.Should().BeTrue();
     }
 
     [Fact]
@@ -181,15 +187,16 @@ public sealed class OrnnExactRemoteSkillFetcherTests
             _ => OrnnTestHttpMessageHandler.JsonResponse(SkillJson()));
 
     private static OrnnExactRemoteSkillFetcher CreateFetcher(
-        OrnnTestHttpMessageHandler handler,
-        TimeSpan? perCallTimeout = null)
+        HttpMessageHandler handler,
+        TimeSpan? perCallTimeout = null,
+        TimeProvider? timeProvider = null)
     {
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
             new HttpClient(handler));
         var options = new OrnnOptions { NyxIdSlug = "ornn" };
         var client = perCallTimeout.HasValue
-            ? new OrnnSkillClient(options, nyxClient, perCallTimeout.Value)
+            ? new OrnnSkillClient(options, nyxClient, perCallTimeout.Value, timeProvider: timeProvider)
             : new OrnnSkillClient(options, nyxClient);
         return new OrnnExactRemoteSkillFetcher(client);
     }
@@ -212,4 +219,35 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         string filesJson = "{\"SKILL.md\":\"# Skill Alpha\\n\\nInstructions.\"}") =>
         "{\"data\":{\"name\":\"skill-alpha\",\"version\":\"" + version +
         "\",\"files\":" + filesJson + "}}";
+
+    private sealed class CancellationObservingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _started =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Started => _started.Task;
+        public bool CancellationObserved { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _started.TrySetResult();
+            var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource)state!).TrySetCanceled(),
+                canceled);
+            try
+            {
+                await canceled.Task;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                CancellationObserved = true;
+                throw;
+            }
+
+            throw new InvalidOperationException("The cancellation-only handler completed without cancellation.");
+        }
+    }
 }

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -1,9 +1,9 @@
+using System.Net;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.ToolProviders.NyxId;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
-using System.Net;
 
 namespace Aevatar.AI.ToolProviders.Ornn.Tests;
 

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -1,0 +1,161 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Core.AgentProfiles;
+using Aevatar.AI.ToolProviders.NyxId;
+using FluentAssertions;
+
+namespace Aevatar.AI.ToolProviders.Ornn.Tests;
+
+public sealed class OrnnExactRemoteSkillFetcherTests
+{
+    private const string SkillGuid = "11111111-1111-1111-1111-111111111111";
+    private const string LiteralVersion = "1.2";
+
+    [Fact]
+    public async Task FetchAsync_ShouldReadOnlyVersionPinnedGuidDetailAndJson()
+    {
+        var handler = SuccessHandler();
+        var fetcher = CreateFetcher(handler);
+
+        var result = await fetcher.FetchAsync("token", ExactRef());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Should().BeEquivalentTo(ExactRemoteSkillFetchResult.Success(
+            SkillGuid,
+            LiteralVersion,
+            "skill-alpha",
+            "publisher-alpha",
+            "hash-alpha",
+            "# Skill Alpha\n\nInstructions."));
+        handler.Requests.Select(request => request.RequestUri!.AbsoluteUri).Should().Equal(
+            $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}?version=1.2",
+            $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}/json?version=1.2");
+        handler.Requests.Should().OnlyContain(request =>
+            request.Method == HttpMethod.Get && request.Authorization!.Parameter == "token");
+    }
+
+    [Fact]
+    public async Task FetchAsync_InvalidReferenceOrMissingToken_ShouldFailBeforeHttp()
+    {
+        var handler = SuccessHandler();
+        var fetcher = CreateFetcher(handler);
+
+        var missingToken = await fetcher.FetchAsync(" ", ExactRef());
+        var invalidGuid = await fetcher.FetchAsync("token", new ExactRemoteSkillRef
+        {
+            Guid = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+            LiteralVersion = LiteralVersion,
+        });
+        var emptyGuid = await fetcher.FetchAsync("token", new ExactRemoteSkillRef
+        {
+            Guid = Guid.Empty.ToString("D"),
+            LiteralVersion = LiteralVersion,
+        });
+        var invalidVersion = await fetcher.FetchAsync("token", new ExactRemoteSkillRef
+        {
+            Guid = SkillGuid,
+            LiteralVersion = "latest",
+        });
+
+        missingToken.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.AccessTokenMissing);
+        invalidGuid.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.InvalidReference);
+        emptyGuid.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.InvalidReference);
+        invalidVersion.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.InvalidReference);
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FetchAsync_IdentityMismatch_ShouldFailWithoutFallback()
+    {
+        var handler = new OrnnTestHttpMessageHandler(
+            _ => OrnnTestHttpMessageHandler.JsonResponse(DetailJson()),
+            _ => OrnnTestHttpMessageHandler.JsonResponse(SkillJson(version: "1.3")));
+        var fetcher = CreateFetcher(handler);
+
+        var result = await fetcher.FetchAsync("token", ExactRef());
+
+        result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.IdentityMismatch);
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests.Should().OnlyContain(request =>
+            request.RequestUri!.Query == "?version=1.2" &&
+            !request.RequestUri.AbsoluteUri.Contains("latest", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task FetchAsync_MissingPublisherOrHashEvidence_ShouldFailClosed()
+    {
+        var cases = new[]
+        {
+            DetailJson(publisher: ""),
+            DetailJson(hash: ""),
+        };
+
+        foreach (var detailJson in cases)
+        {
+            var handler = new OrnnTestHttpMessageHandler(
+                _ => OrnnTestHttpMessageHandler.JsonResponse(detailJson),
+                _ => OrnnTestHttpMessageHandler.JsonResponse(SkillJson()));
+
+            var result = await CreateFetcher(handler).FetchAsync("token", ExactRef());
+
+            result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.IntegrityEvidenceMissing);
+            handler.Requests.Should().HaveCount(2);
+        }
+    }
+
+    [Fact]
+    public async Task FetchAsync_MissingOrDuplicateSkillMarkdown_ShouldFailWithoutAlternateRead()
+    {
+        var skillJsonCases = new[]
+        {
+            SkillJson(filesJson: "{\"README.md\":\"readme\"}"),
+            SkillJson(filesJson: "{\"SKILL.md\":\"one\",\"skill.md\":\"two\"}"),
+        };
+
+        foreach (var skillJson in skillJsonCases)
+        {
+            var handler = new OrnnTestHttpMessageHandler(
+                _ => OrnnTestHttpMessageHandler.JsonResponse(DetailJson()),
+                _ => OrnnTestHttpMessageHandler.JsonResponse(skillJson));
+
+            var result = await CreateFetcher(handler).FetchAsync("token", ExactRef());
+
+            result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.InvalidResponse);
+            result.FailureDetail.Should().Be("unique_skill_markdown_required");
+            handler.Requests.Should().HaveCount(2);
+        }
+    }
+
+    private static OrnnTestHttpMessageHandler SuccessHandler() =>
+        new(
+            _ => OrnnTestHttpMessageHandler.JsonResponse(DetailJson()),
+            _ => OrnnTestHttpMessageHandler.JsonResponse(SkillJson()));
+
+    private static OrnnExactRemoteSkillFetcher CreateFetcher(OrnnTestHttpMessageHandler handler)
+    {
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(handler));
+        return new OrnnExactRemoteSkillFetcher(new OrnnSkillClient(
+            new OrnnOptions { NyxIdSlug = "ornn" },
+            nyxClient));
+    }
+
+    private static ExactRemoteSkillRef ExactRef() => new()
+    {
+        Guid = SkillGuid,
+        LiteralVersion = LiteralVersion,
+    };
+
+    private static string DetailJson(
+        string publisher = "publisher-alpha",
+        string hash = "hash-alpha") =>
+        "{\"data\":{\"guid\":\"" + SkillGuid +
+        "\",\"name\":\"skill-alpha\",\"skillHash\":\"" + hash +
+        "\",\"createdBy\":\"" + publisher + "\"}}";
+
+    private static string SkillJson(
+        string version = LiteralVersion,
+        string filesJson = "{\"SKILL.md\":\"# Skill Alpha\\n\\nInstructions.\"}") =>
+        "{\"data\":{\"name\":\"skill-alpha\",\"version\":\"" + version +
+        "\",\"files\":" + filesJson + "}}";
+}

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -125,19 +125,73 @@ public sealed class OrnnExactRemoteSkillFetcherTests
         }
     }
 
+    [Fact]
+    public async Task FetchAsync_NullExactResponses_ShouldFailClosed()
+    {
+        var handler = new OrnnTestHttpMessageHandler(
+            _ => OrnnTestHttpMessageHandler.JsonResponse("{}"),
+            _ => OrnnTestHttpMessageHandler.JsonResponse("{}"));
+
+        var result = await CreateFetcher(handler).FetchAsync("token", ExactRef());
+
+        result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.InvalidResponse);
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task FetchAsync_InternalTimeout_ShouldReturnTypedTimeout()
+    {
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled();
+
+        var result = await CreateFetcher(handler, TimeSpan.FromMilliseconds(20))
+            .FetchAsync("token", ExactRef());
+
+        result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.Timeout);
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task FetchAsync_InvalidJsonException_ShouldReturnTypedFailure()
+    {
+        var handler = OrnnTestHttpMessageHandler.ReturningJson("not-json");
+
+        var result = await CreateFetcher(handler).FetchAsync("token", ExactRef());
+
+        result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.Failed);
+        result.FailureDetail.Should().Be("JsonException");
+        handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task FetchAsync_CallerCancellation_ShouldPropagate()
+    {
+        var handler = OrnnTestHttpMessageHandler.HangingUntilCanceled();
+        using var callerCts = new CancellationTokenSource();
+        callerCts.Cancel();
+
+        var act = async () => await CreateFetcher(handler)
+            .FetchAsync("token", ExactRef(), callerCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private static OrnnTestHttpMessageHandler SuccessHandler() =>
         new(
             _ => OrnnTestHttpMessageHandler.JsonResponse(DetailJson()),
             _ => OrnnTestHttpMessageHandler.JsonResponse(SkillJson()));
 
-    private static OrnnExactRemoteSkillFetcher CreateFetcher(OrnnTestHttpMessageHandler handler)
+    private static OrnnExactRemoteSkillFetcher CreateFetcher(
+        OrnnTestHttpMessageHandler handler,
+        TimeSpan? perCallTimeout = null)
     {
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
             new HttpClient(handler));
-        return new OrnnExactRemoteSkillFetcher(new OrnnSkillClient(
-            new OrnnOptions { NyxIdSlug = "ornn" },
-            nyxClient));
+        var options = new OrnnOptions { NyxIdSlug = "ornn" };
+        var client = perCallTimeout.HasValue
+            ? new OrnnSkillClient(options, nyxClient, perCallTimeout.Value)
+            : new OrnnSkillClient(options, nyxClient);
+        return new OrnnExactRemoteSkillFetcher(client);
     }
 
     private static ExactRemoteSkillRef ExactRef() => new()

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -150,6 +150,8 @@ public sealed class OrnnExactRemoteSkillFetcherTests
     [Theory]
     [InlineData(true, HttpStatusCode.Forbidden, ExactRemoteSkillFetchFailureCode.AccessDenied)]
     [InlineData(false, HttpStatusCode.NotFound, ExactRemoteSkillFetchFailureCode.NotFound)]
+    [InlineData(true, HttpStatusCode.InternalServerError, ExactRemoteSkillFetchFailureCode.InvalidResponse)]
+    [InlineData(false, HttpStatusCode.ServiceUnavailable, ExactRemoteSkillFetchFailureCode.InvalidResponse)]
     public async Task FetchAsync_ExactEndpointProxyFailure_ShouldPreserveTypedFailureWithoutFallback(
         bool failDetailEndpoint,
         HttpStatusCode statusCode,

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/OrnnExactRemoteSkillFetcherTests.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.ToolProviders.NyxId;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
+using System.Net;
 
 namespace Aevatar.AI.ToolProviders.Ornn.Tests;
 
@@ -144,6 +145,37 @@ public sealed class OrnnExactRemoteSkillFetcherTests
 
         result.FailureCode.Should().Be(ExactRemoteSkillFetchFailureCode.InvalidResponse);
         handler.Requests.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData(true, HttpStatusCode.Forbidden, ExactRemoteSkillFetchFailureCode.AccessDenied)]
+    [InlineData(false, HttpStatusCode.NotFound, ExactRemoteSkillFetchFailureCode.NotFound)]
+    public async Task FetchAsync_ExactEndpointProxyFailure_ShouldPreserveTypedFailureWithoutFallback(
+        bool failDetailEndpoint,
+        HttpStatusCode statusCode,
+        ExactRemoteSkillFetchFailureCode expectedFailureCode)
+    {
+        var handler = failDetailEndpoint
+            ? new OrnnTestHttpMessageHandler(
+                _ => OrnnTestHttpMessageHandler.JsonResponse("{\"error\":\"denied\"}", statusCode))
+            : new OrnnTestHttpMessageHandler(
+                _ => OrnnTestHttpMessageHandler.JsonResponse(DetailJson()),
+                _ => OrnnTestHttpMessageHandler.JsonResponse("{\"error\":\"missing\"}", statusCode));
+
+        var result = await CreateFetcher(handler).FetchAsync("token", ExactRef());
+
+        result.FailureCode.Should().Be(expectedFailureCode);
+        var expectedUris = failDetailEndpoint
+            ? new[]
+            {
+                $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}?version=1.2",
+            }
+            : new[]
+            {
+                $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}?version=1.2",
+                $"https://nyx.example/api/v1/proxy/s/ornn/api/v1/skills/{SkillGuid}/json?version=1.2",
+            };
+        handler.Requests.Select(request => request.RequestUri!.AbsoluteUri).Should().Equal(expectedUris);
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.Ornn.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Ornn.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,9 @@
 using Aevatar.AI.Abstractions.Prompting;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn.SystemSkillOverlay;
+using Aevatar.AI.ToolProviders.Skills;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -115,6 +117,26 @@ public sealed class ServiceCollectionExtensionsTests
         sources.Count(x => x is OrnnAgentToolSource).Should().Be(1);
         sources.OfType<OrnnAgentToolSource>().Should().ContainSingle()
             .Which.Should().BeSameAs(provider.GetRequiredService<OrnnAgentToolSource>());
+    }
+
+    [Fact]
+    public void AddOrnnSkills_ShouldRegisterOneExactFetcherWithoutReplacingOrdinaryFetcher()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example" },
+            new HttpClient(new NotFoundHttpMessageHandler())));
+
+        services.AddOrnnSkills();
+        services.AddOrnnSkills();
+
+        using var provider = services.BuildServiceProvider();
+        var exactFetchers = provider.GetServices<IExactRemoteSkillFetcher>().ToArray();
+
+        exactFetchers.Should().ContainSingle()
+            .Which.Should().BeSameAs(provider.GetRequiredService<OrnnExactRemoteSkillFetcher>());
+        provider.GetRequiredService<IRemoteSkillFetcher>()
+            .Should().BeOfType<OrnnRemoteSkillFetcher>();
     }
 
     private sealed class StubFloorProvider : IBuiltInPromptFloorProvider

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorSenderTokenTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorSenderTokenTests.cs
@@ -373,9 +373,9 @@ public sealed class AgentRunReplyGenerationExecutorSenderTokenTests
                 history: new ChatHistory(),
                 toolLoop: new ToolCallLoop(new ToolManager()),
                 hooks: null,
-                requestBuilder: static () => new LLMRequest { Messages = [] });
+                requestBuilder: static _ => new LLMRequest { Messages = [] });
             var plan = new AgentRunReplyStepPlan(
-                runtime.CreateStepExecutor(),
+                runtime.CreateStepExecutor(turnCatalog: null),
                 new Dictionary<string, string>(metadata, StringComparer.Ordinal),
                 control,
                 projectedToolContext,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
@@ -163,9 +163,9 @@ public sealed class AgentRunReplyGenerationExecutorTests
             history: new ChatHistory(),
             toolLoop: new ToolCallLoop(new ToolManager()),
             hooks: null,
-            requestBuilder: static () => new LLMRequest { Messages = [] });
+            requestBuilder: static _ => new LLMRequest { Messages = [] });
         var plan = new AgentRunReplyStepPlan(
-            runtime.CreateStepExecutor(),
+            runtime.CreateStepExecutor(turnCatalog: null),
             new Dictionary<string, string>(),
             LLMControlContext.Empty,
             AgentToolExecutionContext.Empty,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunToolStepInteractiveReplyTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunToolStepInteractiveReplyTests.cs
@@ -84,8 +84,8 @@ public sealed class AgentRunToolStepInteractiveReplyTests
             history: new Aevatar.AI.Core.Chat.ChatHistory(),
             toolLoop: new ToolCallLoop(tools),
             hooks: null,
-            requestBuilder: static () => new LLMRequest { Messages = [] });
-        return runtime.CreateStepExecutor();
+            requestBuilder: static _ => new LLMRequest { Messages = [] });
+        return runtime.CreateStepExecutor(turnCatalog: null);
     }
 
     private static AgentRunReplyStepExecutionRequest BuildToolStepWorkItem(bool relay)


### PR DESCRIPTION
## Changed files

引入不可变的请求级 `AgentProfileTurnCatalog`，以无默认值参数贯穿 main、step 和 prompt 调用链。main 与 step 共用 `ChatRuntimeRequestBuilder`，同一 `FinalAllowedToolNames` 同时约束模型可见 schema 和执行器准入。NyxID 增加有界流式分类与 materializer，Ornn 增加 GUID + literal version 的 exact fetch adapter，并同步迁移全部显式 `null` 调用方、DI、测试和 canonical 文档。

## Test results

全量 restore/build/test 通过；AI、Ornn、ChannelRuntime、Workflow、Studio 定向测试均通过。architecture、test stability、query projection priming 和 docs lint 门禁全部通过。

## Deviations

未扩展冻结的 40 个文件范围，未修改 schema/protocol，未新增兼容入口。仓库既有 NuGet/analyzer 告警和外部基础设施集成 skip 保持不变。

Closes #2846

⟦AI:AUTO-LOOP⟧
