### PR TITLE
[codex] Reduce YAML stale conflict prompts

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -1369,10 +1369,13 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           ? `missing:${route.scopeId}:${route.memberId}`
           : "";
   latestSourceKeyRef.current = sourceKey;
+  const yamlEditBaseIsCurrent =
+    yamlEditBaseRevision === draftRevision &&
+    yamlEditBaseSourceKey === sourceKey;
   const yamlEditHasConflict = Boolean(
     yamlPanelOpen &&
-      (yamlEditBaseRevision !== draftRevision ||
-        yamlEditBaseSourceKey !== sourceKey),
+      yamlEditHasUnappliedChanges &&
+      !yamlEditBaseIsCurrent,
   );
 
   React.useEffect(() => {
@@ -1393,6 +1396,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     ) {
       suppressedSourceSignatureRef.current = null;
       appliedSourceKeyRef.current = sourceKey;
+      if (yamlPanelOpen && !yamlEditHasUnappliedChanges) {
+        setYamlEditBaseSourceKey(sourceKey);
+      }
       return;
     }
 
@@ -1429,6 +1435,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     workflowDraftTitle,
     workflowQuery.data?.layout,
     closeDraftRunPanel,
+    yamlPanelOpen,
     yamlEditHasUnappliedChanges,
   ]);
 
@@ -1956,6 +1963,29 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     editableDocument,
     routeFallbackTitle,
     workflowTitle,
+  ]);
+  React.useEffect(() => {
+    if (
+      !yamlPanelOpen ||
+      yamlEditHasUnappliedChanges ||
+      yamlEditPending ||
+      yamlEditApplying ||
+      yamlEditBaseIsCurrent ||
+      yamlEditBaseSourceKey !== sourceKey
+    ) {
+      return;
+    }
+
+    void openYamlEditor();
+  }, [
+    openYamlEditor,
+    sourceKey,
+    yamlEditApplying,
+    yamlEditBaseIsCurrent,
+    yamlEditBaseSourceKey,
+    yamlEditHasUnappliedChanges,
+    yamlEditPending,
+    yamlPanelOpen,
   ]);
   const applyYamlEdit = React.useCallback(async () => {
     if (yamlEditApplyingRef.current) {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -5150,7 +5150,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
   });
 
-  it("blocks an unchanged YAML buffer after the draft revision advances", async () => {
+  it("refreshes an unchanged YAML buffer after the draft revision advances", async () => {
     window.history.replaceState(
       {},
       "",
@@ -5162,7 +5162,6 @@ describe("TeamMemberWorkflowStudioPage", () => {
     const titleInput = await screen.findByLabelText("Workflow title");
     clickYamlAction("Edit YAML");
     const editor = await screen.findByLabelText("Workflow YAML editor");
-    const originalYaml = (editor as HTMLTextAreaElement).value;
     const applyButton = screen.getByRole("button", { name: "Apply to draft" });
     await waitFor(() => {
       expect(applyButton).toBeEnabled();
@@ -5173,7 +5172,45 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
 
     await waitFor(() => {
-      expect(editor).toHaveValue(originalYaml);
+      expect((editor as HTMLTextAreaElement).value).toContain(
+        "name: Renamed member",
+      );
+      expect(applyButton).toBeEnabled();
+      expect(
+        screen.queryByText(
+          "This YAML buffer is stale because the canvas or source draft changed.",
+        ),
+      ).toBeNull();
+    });
+    expect(titleInput).toHaveValue("Renamed member");
+  });
+
+  it("blocks edited YAML after the draft revision advances", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/new/workflow",
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    const titleInput = await screen.findByLabelText("Workflow title");
+    clickYamlAction("Edit YAML");
+    const editor = await screen.findByLabelText("Workflow YAML editor");
+    fireEvent.change(editor, {
+      target: { value: "name: YAML title\nsteps:\n" },
+    });
+    const applyButton = screen.getByRole("button", { name: "Apply to draft" });
+    await waitFor(() => {
+      expect(applyButton).toBeEnabled();
+    });
+
+    fireEvent.change(titleInput, {
+      target: { value: "Canvas title" },
+    });
+
+    await waitFor(() => {
+      expect(editor).toHaveValue("name: YAML title\nsteps:\n");
       expect(applyButton).toBeDisabled();
       expect(
         screen.getByText(
@@ -5181,7 +5218,6 @@ describe("TeamMemberWorkflowStudioPage", () => {
         ),
       ).toBeTruthy();
     });
-    expect(titleInput).toHaveValue("Renamed member");
   });
 
   it("keeps a declined source refresh pending until YAML edits are discarded", async () => {


### PR DESCRIPTION
## Problem

The Workflow Studio treated every YAML base revision change as a user-facing conflict. This showed the stale-buffer error even when the YAML buffer was unchanged and the canvas changed through title edits, layout updates, or same-source save refreshes.

## Solution

- Only report a YAML conflict when the buffer has unapplied edits and its base revision or source is stale.
- Automatically reserialize unchanged YAML from the current canvas after a local draft revision advances.
- Rebase the YAML source key when a saved draft refresh matches the locally saved source.
- Keep blocking edited YAML when a newer canvas or source draft would otherwise be overwritten.

## Impact

Users should see substantially fewer stale YAML warnings during normal Studio editing. Real concurrent edit conflicts remain protected and still disable applying the stale YAML.

## Validation

- `npm --prefix apps/aevatar-console-web test -- --runInBand src/pages/team-member-workflow-studio/index.test.tsx` (81 passed)
- `npm --prefix apps/aevatar-console-web run tsc`
- `npx @biomejs/biome lint src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts src/pages/team-member-workflow-studio/index.test.tsx`
- `npm --prefix apps/aevatar-console-web run build`
- `bash tools/ci/test_stability_guards.sh`

No architecture documentation changes are required because this only refines frontend transactional editor state handling.
