### PR TITLE
Improve YAML editor loading feedback

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioYamlPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioYamlPanel.tsx
@@ -13,6 +13,7 @@ type WorkflowStudioYamlPanelProps = {
   readonly hasBlockingFindings: boolean;
   readonly hasConflict: boolean;
   readonly hasUnappliedChanges: boolean;
+  readonly editorLoading: boolean;
   readonly loading: boolean;
   readonly onApply: () => Promise<void>;
   readonly onBufferChange: (yaml: string) => void;
@@ -188,6 +189,7 @@ const WorkflowStudioYamlPanel: React.FC<WorkflowStudioYamlPanelProps> = ({
   hasBlockingFindings,
   hasConflict,
   hasUnappliedChanges,
+  editorLoading,
   loading,
   onApply,
   onBufferChange,
@@ -198,6 +200,7 @@ const WorkflowStudioYamlPanel: React.FC<WorkflowStudioYamlPanelProps> = ({
   const [messageApi, contextHolder] = message.useMessage();
   const gutterRef = React.useRef<HTMLDivElement | null>(null);
   const lineCount = Math.max(1, buffer.split("\n").length);
+  const showEditorLoading = Boolean(editorLoading && !buffer.trim() && !error);
   const applyDisabled = Boolean(
     applying ||
       loading ||
@@ -318,35 +321,47 @@ const WorkflowStudioYamlPanel: React.FC<WorkflowStudioYamlPanelProps> = ({
           })}
         </div>
       ) : null}
-      <div style={editorShellStyle}>
-        <div aria-hidden="true" ref={gutterRef} style={lineNumberGutterStyle}>
-          {Array.from({ length: lineCount }, (_, index) => (
-            <div key={index + 1}>{index + 1}</div>
-          ))}
+      {showEditorLoading ? (
+        <div
+          style={{
+            ...editorShellStyle,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Spin />
         </div>
-        <textarea
-          aria-label={t(
-            "teamMemberWorkflowStudio.yamlPanel.editorAria",
-            "Workflow YAML editor",
-          )}
-          autoFocus
-          onChange={(event) => {
-            if (!applying) {
-              onBufferChange(event.target.value);
-            }
-          }}
-          onScroll={(event) => {
-            if (gutterRef.current) {
-              gutterRef.current.scrollTop = event.currentTarget.scrollTop;
-            }
-          }}
-          readOnly={applying}
-          spellCheck={false}
-          style={textareaStyle}
-          value={buffer}
-          wrap="off"
-        />
-      </div>
+      ) : (
+        <div style={editorShellStyle}>
+          <div aria-hidden="true" ref={gutterRef} style={lineNumberGutterStyle}>
+            {Array.from({ length: lineCount }, (_, index) => (
+              <div key={index + 1}>{index + 1}</div>
+            ))}
+          </div>
+          <textarea
+            aria-label={t(
+              "teamMemberWorkflowStudio.yamlPanel.editorAria",
+              "Workflow YAML editor",
+            )}
+            autoFocus
+            onChange={(event) => {
+              if (!applying) {
+                onBufferChange(event.target.value);
+              }
+            }}
+            onScroll={(event) => {
+              if (gutterRef.current) {
+                gutterRef.current.scrollTop = event.currentTarget.scrollTop;
+              }
+            }}
+            readOnly={applying}
+            spellCheck={false}
+            style={textareaStyle}
+            value={buffer}
+            wrap="off"
+          />
+        </div>
+      )}
       <footer style={{ flex: "0 0 auto" }}>
         <Space align="center" style={{ justifyContent: "flex-end", width: "100%" }}>
           <Button disabled={applying} onClick={onClose}>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -250,6 +250,7 @@ type TeamMemberWorkflowStudioState = {
   readonly yamlEditHasBlockingFindings: boolean;
   readonly yamlEditHasConflict: boolean;
   readonly yamlEditHasUnappliedChanges: boolean;
+  readonly yamlEditOpening: boolean;
   readonly yamlEditPending: boolean;
   readonly yamlPanelOpen: boolean;
 };
@@ -1100,6 +1101,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     StudioValidationFinding[]
   >([]);
   const [yamlEditError, setYamlEditError] = React.useState("");
+  const [yamlEditOpening, setYamlEditOpening] = React.useState(false);
   const [yamlEditPending, setYamlEditPending] = React.useState(false);
   const [yamlEditApplying, setYamlEditApplying] = React.useState(false);
   const yamlEditApplyingRef = React.useRef(false);
@@ -1149,7 +1151,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       return false;
     }
 
+    yamlEditRequestIdRef.current += 1;
+    yamlEditValidationRequestIdRef.current += 1;
     setYamlPanelOpen(false);
+    setYamlEditOpening(false);
+    setYamlEditPending(false);
     setYamlEditError("");
     return true;
   }, [yamlEditHasUnappliedChanges]);
@@ -1419,7 +1425,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     setSelectedEdgeId("");
     setSelectedNodeId("");
     closeDraftRunPanel();
+    yamlEditRequestIdRef.current += 1;
+    yamlEditValidationRequestIdRef.current += 1;
     setYamlPanelOpen(false);
+    setYamlEditOpening(false);
+    setYamlEditPending(false);
     setYamlEditBufferState("");
     setYamlEditSnapshot("");
     setYamlEditDiagnostics([]);
@@ -1916,7 +1926,20 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlEditRequestIdRef.current = requestId;
     const baseRevision = draftRevisionRef.current;
     const baseSourceKey = appliedSourceKeyRef.current;
-    setYamlEditPending(true);
+    const shouldResetEditor = !yamlPanelOpen;
+    yamlEditValidationRequestIdRef.current += 1;
+    setYamlEditOpening(true);
+    setYamlEditPending(false);
+    if (shouldResetEditor) {
+      setYamlEditBufferState("");
+      setYamlEditSnapshot("");
+      setYamlEditDiagnostics([]);
+      setYamlEditParsedDocument(null);
+      setYamlEditValidatedBuffer("");
+    }
+    setYamlEditBaseRevision(baseRevision);
+    setYamlEditBaseSourceKey(baseSourceKey);
+    setYamlPanelOpen(true);
 
     try {
       const serialized = await studioApi.serializeYaml({
@@ -1943,7 +1966,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       setYamlEditBaseRevision(baseRevision);
       setYamlEditBaseSourceKey(baseSourceKey);
       setYamlEditError("");
-      setYamlPanelOpen(true);
     } catch (error) {
       if (yamlEditRequestIdRef.current === requestId) {
         setYamlEditError(
@@ -1955,19 +1977,21 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
     } finally {
       if (yamlEditRequestIdRef.current === requestId) {
-        setYamlEditPending(false);
+        setYamlEditOpening(false);
       }
     }
   }, [
     closeDraftRunPanel,
     editableDocument,
     routeFallbackTitle,
+    yamlPanelOpen,
     workflowTitle,
   ]);
   React.useEffect(() => {
     if (
       !yamlPanelOpen ||
       yamlEditHasUnappliedChanges ||
+      yamlEditOpening ||
       yamlEditPending ||
       yamlEditApplying ||
       yamlEditBaseIsCurrent ||
@@ -1984,6 +2008,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlEditBaseIsCurrent,
     yamlEditBaseSourceKey,
     yamlEditHasUnappliedChanges,
+    yamlEditOpening,
     yamlEditPending,
     yamlPanelOpen,
   ]);
@@ -2091,7 +2116,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlEditValidatedBuffer,
   ]);
   React.useEffect(() => {
-    if (!yamlPanelOpen) {
+    if (!yamlPanelOpen || yamlEditOpening) {
       return;
     }
 
@@ -2174,7 +2199,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     return () => {
       window.clearTimeout(timerId);
     };
-  }, [yamlEditBuffer, yamlPanelOpen]);
+  }, [yamlEditBuffer, yamlEditOpening, yamlPanelOpen]);
   const currentDraftRunMutation = useMutation({
     mutationFn: async ({
       document,
@@ -3290,6 +3315,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlEditHasBlockingFindings,
     yamlEditHasConflict,
     yamlEditHasUnappliedChanges,
+    yamlEditOpening,
     yamlEditPending,
     yamlPanelOpen,
   };

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1384,11 +1384,13 @@ describe("TeamMemberWorkflowStudioPage", () => {
       document: mockWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     });
-    (studioApi.serializeYaml as jest.Mock).mockResolvedValueOnce({
-      document: mockWorkflowDocument,
-      findings: [],
-      yaml: "name: Serialized Workflow Alpha\nsteps:\n  - id: triage\n    type: llm_call\n",
-    });
+    let resolveSerialize: ((value: unknown) => void) | null = null;
+    (studioApi.serializeYaml as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSerialize = resolve;
+        }),
+    );
 
     renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
 
@@ -1397,23 +1399,35 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
     clickYamlAction("Edit YAML");
 
+    expect(await screen.findByLabelText("Workflow YAML panel")).toBeTruthy();
+    expect(screen.queryByLabelText("Workflow YAML editor")).toBeNull();
+    expect(screen.getByRole("button", { name: "Apply to draft" })).toBeDisabled();
+    expect(studioApi.serializeYaml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        availableStepTypes: expect.any(Array),
+        document: expect.objectContaining({
+          name: "Workflow Alpha",
+          steps: expect.arrayContaining([
+            expect.objectContaining({ id: "triage", type: "llm_call" }),
+          ]),
+        }),
+      }),
+    );
+
+    await act(async () => {
+      resolveSerialize?.({
+        document: mockWorkflowDocument,
+        findings: [],
+        yaml: "name: Serialized Workflow Alpha\nsteps:\n  - id: triage\n    type: llm_call\n",
+      });
+    });
+
     const yamlView = await screen.findByLabelText("Workflow YAML editor");
     await waitFor(() => {
       const yamlValue = (yamlView as HTMLTextAreaElement).value;
       expect(yamlValue).toContain("Serialized Workflow Alpha");
       expect(yamlValue).toContain("id: triage");
       expect(yamlValue).not.toContain("Stale Workflow Alpha");
-      expect(studioApi.serializeYaml).toHaveBeenCalledWith(
-        expect.objectContaining({
-          availableStepTypes: expect.any(Array),
-          document: expect.objectContaining({
-            name: "Workflow Alpha",
-            steps: expect.arrayContaining([
-              expect.objectContaining({ id: "triage", type: "llm_call" }),
-            ]),
-          }),
-        }),
-      );
     });
     expect(yamlView.tagName).toBe("TEXTAREA");
     expect((yamlView as HTMLTextAreaElement).wrap).toBe("off");

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -392,7 +392,8 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
           hasBlockingFindings={studio.yamlEditHasBlockingFindings}
           hasConflict={studio.yamlEditHasConflict}
           hasUnappliedChanges={studio.yamlEditHasUnappliedChanges}
-          loading={studio.yamlEditPending}
+          editorLoading={studio.yamlEditOpening}
+          loading={studio.yamlEditOpening || studio.yamlEditPending}
           onApply={studio.applyYamlEdit}
           onBufferChange={studio.setYamlEditBuffer}
           onClose={studio.closeYamlPanel}


### PR DESCRIPTION
## Summary

- Open the YAML side panel immediately when Edit YAML is clicked, with an editor loading state while YAML serialization is in flight.
- Split initial YAML opening state from YAML validation pending state so validation does not block itself.
- Preserve the mounted editor during unchanged-buffer auto-refreshes after draft revision changes.

## Validation

- pnpm --dir apps/aevatar-console-web tsc
- pnpm --dir apps/aevatar-console-web test:ui --runTestsByPath src/pages/team-member-workflow-studio/index.test.tsx --runInBand
- pnpm --dir apps/aevatar-console-web test:ui
- pnpm --dir apps/aevatar-console-web build
- bash tools/ci/test_stability_guards.sh

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2866
- Worktree: /Users/pottersun/Desktop/sbt_projects/aevatar/.worktrees/issue-2866-yaml-panel-loading
- Branch: fix/2026-07-20_yaml-panel-loading
- Operator: potter-sun
- Freshness: Issue #2866 was created from current YAML editor click feedback on 2026-07-20.

Closes #2866

⟦AI:FKST⟧