### PR TITLE
Add revisioned content artifacts

### DIFF
--- a/aevatar.slnx
+++ b/aevatar.slnx
@@ -23,6 +23,7 @@
     <Project Path="agents/Aevatar.GAgents.StudioMember/Aevatar.GAgents.StudioMember.csproj" />
     <Project Path="agents/Aevatar.GAgents.StudioTeam/Aevatar.GAgents.StudioTeam.csproj" />
     <Project Path="agents/Aevatar.GAgents.WorkOrder/Aevatar.GAgents.WorkOrder.csproj" />
+    <Project Path="agents/Aevatar.GAgents.ContentArtifacts/Aevatar.GAgents.ContentArtifacts.csproj" />
     <Project Path="agents/Aevatar.GAgents.ChatRouting/Aevatar.GAgents.ChatRouting.csproj" />
   </Folder>
   <Folder Name="/docs/">
@@ -44,6 +45,7 @@
     <Project Path="tools/secret-store/Aevatar.SecretStore.Tools.csproj" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/Aevatar.ContentArtifacts.Abstractions/Aevatar.ContentArtifacts.Abstractions.csproj" />
     <Project Path="src/Aevatar.Audit.Abstractions/Aevatar.Audit.Abstractions.csproj" />
     <Project Path="src/Aevatar.Audit.Core/Aevatar.Audit.Core.csproj" />
     <Project Path="src/Aevatar.AI.ToolProviders.Binding/Aevatar.AI.ToolProviders.Binding.csproj" />

--- a/agents/Aevatar.GAgents.ContentArtifacts/Aevatar.GAgents.ContentArtifacts.csproj
+++ b/agents/Aevatar.GAgents.ContentArtifacts/Aevatar.GAgents.ContentArtifacts.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Aevatar.GAgents.ContentArtifacts</AssemblyName>
+    <RootNamespace>Aevatar.GAgents.ContentArtifacts</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.ContentArtifacts.Abstractions\Aevatar.ContentArtifacts.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactConventions.cs
+++ b/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactConventions.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Aevatar.GAgents.ContentArtifacts;
+
+public static class ContentArtifactConventions
+{
+    public const string ActorIdPrefix = "content-artifact";
+    public const int MaxInlineContentBytes = 64 * 1024;
+
+    public static string BuildArtifactId(string scopeId, string dedupKey)
+    {
+        var normalizedScopeId = NormalizeScopeId(scopeId);
+        var normalizedDedupKey = NormalizeRequired(dedupKey, nameof(dedupKey));
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes($"{normalizedScopeId}\n{normalizedDedupKey}"));
+        return $"artifact-{Convert.ToHexStringLower(digest)}";
+    }
+
+    public static string BuildActorId(string scopeId, string artifactId) =>
+        $"{ActorIdPrefix}:{NormalizeScopeId(scopeId)}:{NormalizeArtifactId(artifactId)}";
+
+    public static string BuildRevisionId(string artifactId, long revisionNumber)
+    {
+        if (revisionNumber <= 0)
+            throw new ArgumentOutOfRangeException(nameof(revisionNumber), "revisionNumber must be positive.");
+        return $"{NormalizeArtifactId(artifactId)}-revision-{revisionNumber}";
+    }
+
+    public static string NormalizeScopeId(string? scopeId)
+    {
+        var normalized = NormalizeRequired(scopeId, nameof(scopeId));
+        if (normalized.Contains(':'))
+            throw new ArgumentException("scopeId must not contain ':' (it is the actor-id separator).", nameof(scopeId));
+        return normalized;
+    }
+
+    public static string NormalizeArtifactId(string? artifactId)
+    {
+        var normalized = NormalizeRequired(artifactId, nameof(artifactId));
+        if (normalized.Contains(':'))
+            throw new ArgumentException("artifactId must not contain ':' (it is the actor-id separator).", nameof(artifactId));
+        return normalized;
+    }
+
+    public static string NormalizeRequired(string? value, string parameterName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException($"{parameterName} is required.", parameterName);
+        return normalized;
+    }
+}

--- a/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
+++ b/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
@@ -1,0 +1,575 @@
+using System.Buffers;
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.TypeSystem;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.ContentArtifacts;
+
+/// <summary>
+/// Authority actor for one durable content artifact and its immutable revisions.
+/// </summary>
+[GAgent("studio.content-artifact")]
+public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IProjectedActor
+{
+    private readonly IContentArtifactBackingContentPort? _backingContentPort;
+
+    public static string ProjectionKind => "content-artifact";
+
+    public ContentArtifactGAgent(IContentArtifactBackingContentPort? backingContentPort = null)
+    {
+        _backingContentPort = backingContentPort;
+    }
+
+    [EventHandler(EndpointName = "createContentArtifact")]
+    public async Task HandleCreateAsync(CreateContentArtifact command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        await ValidateCreateAsync(command);
+
+        if (!string.IsNullOrWhiteSpace(State.ArtifactId))
+        {
+            if (!string.Equals(State.CreationRequestHash, HashCreateRequest(command), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    "ContentArtifact logical identity already exists with a different request.");
+            }
+            return;
+        }
+
+        var createdAt = command.RequestedAtUtc?.Clone()
+                        ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var request = command.Clone();
+        request.RequestedAtUtc = createdAt.Clone();
+        request.FirstRevision.CreatedAtUtc ??= createdAt.Clone();
+        request.FirstRevision.Availability = ContentArtifactRevisionAvailability.Available;
+        await PersistDomainEventAsync(new ContentArtifactCreatedEvent
+        {
+            Request = request,
+            CreatedAtUtc = createdAt,
+        });
+    }
+
+    [EventHandler(EndpointName = "appendContentArtifactRevision")]
+    public async Task HandleAppendRevisionAsync(AppendContentArtifactRevision command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureActiveArtifact(command.ArtifactId);
+        ArgumentNullException.ThrowIfNull(command.Revision);
+
+        if (State.Revisions.TryGetValue(command.Revision.RevisionId, out var existingRevision))
+        {
+            if (!RevisionsEqualForAppend(existingRevision, command.Revision))
+                throw new InvalidOperationException("ContentArtifact revision identity already exists with different facts.");
+            return;
+        }
+
+        EnsureWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
+        await ValidateRevisionAsync(command.Revision, firstRevision: false);
+        var appendedAt = command.RequestedAtUtc?.Clone()
+                         ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var revision = command.Revision.Clone();
+        revision.CreatedAtUtc ??= appendedAt.Clone();
+        revision.Availability = ContentArtifactRevisionAvailability.Available;
+        await PersistDomainEventAsync(new ContentArtifactRevisionAppendedEvent
+        {
+            Revision = revision,
+            AppendedAtUtc = appendedAt,
+        });
+    }
+
+    [EventHandler(EndpointName = "advanceContentArtifactCurrentRevision")]
+    public async Task HandleAdvanceCurrentRevisionAsync(AdvanceContentArtifactCurrentRevision command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureActiveArtifact(command.ArtifactId);
+        var revisionId = ContentArtifactConventions.NormalizeRequired(command.RevisionId, "revisionId");
+        if (string.Equals(State.CurrentRevisionId, revisionId, StringComparison.Ordinal))
+            return;
+
+        EnsureWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
+        if (!State.Revisions.TryGetValue(revisionId, out var revision))
+            throw new InvalidOperationException($"ContentArtifact revision '{revisionId}' does not exist.");
+        if (revision.Availability != ContentArtifactRevisionAvailability.Available)
+            throw new InvalidOperationException($"ContentArtifact revision '{revisionId}' is not available.");
+
+        await PersistDomainEventAsync(new ContentArtifactCurrentRevisionAdvancedEvent
+        {
+            RevisionId = revisionId,
+            AdvancedAtUtc = ResolveRequestedAt(command.RequestedAtUtc),
+        });
+    }
+
+    [EventHandler(EndpointName = "redactContentArtifactRevision")]
+    public async Task HandleRedactRevisionAsync(RedactContentArtifactRevision command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureActiveArtifact(command.ArtifactId);
+        var revision = GetRevision(command.RevisionId);
+        var reason = ContentArtifactConventions.NormalizeRequired(command.Reason, "reason");
+        if (revision.Availability == ContentArtifactRevisionAvailability.Redacted)
+        {
+            if (!string.Equals(revision.RedactionReason, reason, StringComparison.Ordinal))
+                throw new InvalidOperationException("ContentArtifact revision is already redacted for a different reason.");
+            return;
+        }
+
+        EnsureWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
+        await PersistDomainEventAsync(new ContentArtifactRevisionRedactedEvent
+        {
+            RevisionId = revision.RevisionId,
+            Reason = reason,
+            RedactedAtUtc = ResolveRequestedAt(command.RequestedAtUtc),
+        });
+    }
+
+    [EventHandler(EndpointName = "expireContentArtifactRevision")]
+    public async Task HandleExpireRevisionAsync(ExpireContentArtifactRevision command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureActiveArtifact(command.ArtifactId);
+        var revision = GetRevision(command.RevisionId);
+        if (revision.Availability == ContentArtifactRevisionAvailability.RetentionExpired)
+            return;
+        if (revision.Availability == ContentArtifactRevisionAvailability.Redacted)
+            throw new InvalidOperationException("A redacted ContentArtifact revision cannot transition to retention-expired.");
+
+        EnsureWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
+        await PersistDomainEventAsync(new ContentArtifactRevisionExpiredEvent
+        {
+            RevisionId = revision.RevisionId,
+            ExpiredAtUtc = ResolveRequestedAt(command.RequestedAtUtc),
+        });
+    }
+
+    [EventHandler(EndpointName = "tombstoneContentArtifact")]
+    public async Task HandleTombstoneAsync(TombstoneContentArtifact command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        EnsureArtifactIdentity(command.ArtifactId);
+        var reason = ContentArtifactConventions.NormalizeRequired(command.Reason, "reason");
+        if (State.LifecycleStatus == ContentArtifactLifecycleStatus.Tombstoned)
+        {
+            if (!string.Equals(State.TombstoneReason, reason, StringComparison.Ordinal))
+                throw new InvalidOperationException("ContentArtifact is already tombstoned for a different reason.");
+            return;
+        }
+
+        EnsureOwner(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
+        await PersistDomainEventAsync(new ContentArtifactTombstonedEvent
+        {
+            Reason = reason,
+            TombstonedAtUtc = ResolveRequestedAt(command.RequestedAtUtc),
+        });
+    }
+
+    protected override ContentArtifactState TransitionState(ContentArtifactState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<ContentArtifactCreatedEvent>(ApplyCreated)
+            .On<ContentArtifactRevisionAppendedEvent>(ApplyRevisionAppended)
+            .On<ContentArtifactCurrentRevisionAdvancedEvent>(ApplyCurrentRevisionAdvanced)
+            .On<ContentArtifactRevisionRedactedEvent>(ApplyRevisionRedacted)
+            .On<ContentArtifactRevisionExpiredEvent>(ApplyRevisionExpired)
+            .On<ContentArtifactTombstonedEvent>(ApplyTombstoned)
+            .OrCurrent();
+
+    private async Task ValidateCreateAsync(CreateContentArtifact command)
+    {
+        var scopeId = ContentArtifactConventions.NormalizeScopeId(command.ScopeId);
+        var dedupKey = ContentArtifactConventions.NormalizeRequired(command.DedupKey, "dedupKey");
+        var artifactId = ContentArtifactConventions.BuildArtifactId(scopeId, dedupKey);
+        if (!string.Equals(command.ArtifactId, artifactId, StringComparison.Ordinal) ||
+            !string.Equals(Id, ContentArtifactConventions.BuildActorId(scopeId, artifactId), StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "ContentArtifact canonical actor and artifact identities must be derived from scope_id and dedup_key.");
+        }
+        if (command.ExpectedConcurrencyVersion != 0)
+            throw new InvalidOperationException("ContentArtifact create expected_concurrency_version must be 0.");
+        if (command.Kind == ContentArtifactKind.Unspecified)
+            throw new InvalidOperationException("kind is required.");
+        ContentArtifactConventions.NormalizeRequired(command.Title, "title");
+        ArgumentNullException.ThrowIfNull(command.AccessPolicy);
+        ValidatePrincipal(command.AccessPolicy.Owner, "access_policy.owner");
+        ArgumentNullException.ThrowIfNull(command.FirstRevision);
+        var firstRevisionId = ContentArtifactConventions.BuildRevisionId(artifactId, 1);
+        if (!string.Equals(command.FirstRevision.RevisionId, firstRevisionId, StringComparison.Ordinal))
+            throw new InvalidOperationException("First ContentArtifact revision_id is not canonical for its artifact.");
+        await ValidateRevisionAsync(command.FirstRevision, firstRevision: true);
+        if (!string.Equals(command.FirstRevision.Provenance.ScopeId, scopeId, StringComparison.Ordinal))
+            throw new InvalidOperationException("First revision provenance scope_id must match the artifact scope.");
+        if (!string.Equals(command.FirstRevision.Provenance.TeamId ?? string.Empty, command.TeamId ?? string.Empty, StringComparison.Ordinal))
+            throw new InvalidOperationException("First revision provenance team_id must match the artifact team.");
+    }
+
+    private async Task ValidateRevisionAsync(ContentArtifactRevision revision, bool firstRevision)
+    {
+        ContentArtifactConventions.NormalizeRequired(revision.RevisionId, "revision.revisionId");
+        ContentArtifactConventions.NormalizeRequired(revision.DedupKey, "revision.dedupKey");
+        ContentArtifactConventions.NormalizeRequired(revision.MediaType, "revision.mediaType");
+        ValidateSha256(revision.ContentHash, "revision.content_hash");
+        ArgumentNullException.ThrowIfNull(revision.Content);
+        ArgumentNullException.ThrowIfNull(revision.Provenance);
+
+        if (firstRevision)
+        {
+            if (revision.RevisionNumber != 1 || !string.IsNullOrWhiteSpace(revision.ParentRevisionId))
+                throw new InvalidOperationException("First ContentArtifact revision must be revision 1 without a parent.");
+        }
+        else
+        {
+            var highestRevisionNumber = State.Revisions.Values.Max(static item => item.RevisionNumber);
+            if (revision.RevisionNumber <= highestRevisionNumber)
+                throw new InvalidOperationException("ContentArtifact revision_number must increase monotonically.");
+            if (!string.IsNullOrWhiteSpace(revision.ParentRevisionId) &&
+                !State.Revisions.ContainsKey(revision.ParentRevisionId))
+            {
+                throw new InvalidOperationException(
+                    $"ContentArtifact parent revision '{revision.ParentRevisionId}' does not exist.");
+            }
+        }
+
+        if (!firstRevision &&
+            !string.Equals(
+                revision.RevisionId,
+                ContentArtifactConventions.BuildRevisionId(State.ArtifactId, revision.RevisionNumber),
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("ContentArtifact revision_id is not canonical for its artifact and revision number.");
+        }
+
+        ValidateProvenance(revision.Provenance, firstRevision ? revision.Provenance.ScopeId : State.ScopeId, firstRevision ? revision.Provenance.TeamId : State.TeamId);
+        foreach (var citation in revision.Citations)
+            ValidateCitation(citation);
+        await VerifyContentAsync(revision);
+    }
+
+    private async Task VerifyContentAsync(ContentArtifactRevision revision)
+    {
+        switch (revision.Content.LocationCase)
+        {
+            case ContentArtifactRevisionContent.LocationOneofCase.InlineContent:
+                if (revision.Content.InlineContent.Length > ContentArtifactConventions.MaxInlineContentBytes)
+                    throw new InvalidOperationException("inline_content exceeds the ContentArtifact inline content limit.");
+                VerifyLengthAndHash(revision, revision.Content.InlineContent.Span);
+                return;
+            case ContentArtifactRevisionContent.LocationOneofCase.BackingObject:
+            {
+                if (_backingContentPort == null)
+                    throw new InvalidOperationException("ContentArtifact backing content port is not registered.");
+                var reference = revision.Content.BackingObject;
+                ContentArtifactConventions.NormalizeRequired(reference.Provider, "backing_object.provider");
+                ContentArtifactConventions.NormalizeRequired(reference.ObjectKey, "backing_object.objectKey");
+                var request = new ContentArtifactBackingContentRequest(
+                    reference,
+                    revision.Provenance.ScopeId,
+                    string.IsNullOrWhiteSpace(revision.Provenance.RunId) ? null : revision.Provenance.RunId);
+                var descriptor = await _backingContentPort.DescribeAsync(request);
+                await using var stream = await _backingContentPort.OpenReadAsync(request);
+                var verified = await MeasureAndHashAsync(stream);
+                if (descriptor.ByteLength != verified.ByteLength ||
+                    !string.Equals(descriptor.ContentHash, verified.ContentHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException("ContentArtifact backing content descriptor does not match its content.");
+                }
+                if (revision.ByteLength != verified.ByteLength ||
+                    !string.Equals(revision.ContentHash, verified.ContentHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException("ContentArtifact content_hash or byte_length does not match backing content.");
+                }
+                return;
+            }
+            default:
+                throw new InvalidOperationException("ContentArtifact revision content location is required.");
+        }
+    }
+
+    private static ContentArtifactState ApplyCreated(ContentArtifactState state, ContentArtifactCreatedEvent evt)
+    {
+        var request = evt.Request ?? throw new InvalidOperationException("ContentArtifact created event request is required.");
+        var createdAt = evt.CreatedAtUtc?.Clone() ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var revision = request.FirstRevision.Clone();
+        revision.CreatedAtUtc ??= createdAt.Clone();
+        revision.Availability = ContentArtifactRevisionAvailability.Available;
+        var next = new ContentArtifactState
+        {
+            ArtifactId = request.ArtifactId,
+            DedupKey = request.DedupKey,
+            ScopeId = request.ScopeId,
+            TeamId = request.TeamId,
+            Kind = request.Kind,
+            Title = request.Title,
+            Classification = request.Classification,
+            AccessPolicy = request.AccessPolicy?.Clone(),
+            RetentionPolicy = request.RetentionPolicy?.Clone(),
+            WorkOrderId = request.WorkOrderId,
+            CurrentRevisionId = revision.RevisionId,
+            ConcurrencyVersion = 1,
+            LifecycleStatus = ContentArtifactLifecycleStatus.Active,
+            CreatedAtUtc = createdAt.Clone(),
+            UpdatedAtUtc = createdAt.Clone(),
+            CreationRequestHash = HashCreateRequest(request),
+        };
+        next.Revisions.Add(revision.RevisionId, revision);
+        return next;
+    }
+
+    private static ContentArtifactState ApplyRevisionAppended(ContentArtifactState state, ContentArtifactRevisionAppendedEvent evt)
+    {
+        var next = state.Clone();
+        var revision = evt.Revision?.Clone() ?? throw new InvalidOperationException("Appended revision is required.");
+        next.Revisions.Add(revision.RevisionId, revision);
+        AdvanceVersion(next, evt.AppendedAtUtc);
+        return next;
+    }
+
+    private static ContentArtifactState ApplyCurrentRevisionAdvanced(ContentArtifactState state, ContentArtifactCurrentRevisionAdvancedEvent evt)
+    {
+        var next = state.Clone();
+        next.CurrentRevisionId = evt.RevisionId;
+        AdvanceVersion(next, evt.AdvancedAtUtc);
+        return next;
+    }
+
+    private static ContentArtifactState ApplyRevisionRedacted(ContentArtifactState state, ContentArtifactRevisionRedactedEvent evt)
+    {
+        var next = state.Clone();
+        var revision = next.Revisions[evt.RevisionId].Clone();
+        revision.Content = new ContentArtifactRevisionContent();
+        revision.Availability = ContentArtifactRevisionAvailability.Redacted;
+        revision.RedactionReason = evt.Reason;
+        revision.RedactedAtUtc = evt.RedactedAtUtc?.Clone();
+        next.Revisions[revision.RevisionId] = revision;
+        AdvanceVersion(next, evt.RedactedAtUtc);
+        return next;
+    }
+
+    private static ContentArtifactState ApplyRevisionExpired(ContentArtifactState state, ContentArtifactRevisionExpiredEvent evt)
+    {
+        var next = state.Clone();
+        var revision = next.Revisions[evt.RevisionId].Clone();
+        revision.Content = new ContentArtifactRevisionContent();
+        revision.Availability = ContentArtifactRevisionAvailability.RetentionExpired;
+        revision.RetentionExpiredAtUtc = evt.ExpiredAtUtc?.Clone();
+        next.Revisions[revision.RevisionId] = revision;
+        AdvanceVersion(next, evt.ExpiredAtUtc);
+        return next;
+    }
+
+    private static ContentArtifactState ApplyTombstoned(ContentArtifactState state, ContentArtifactTombstonedEvent evt)
+    {
+        var next = state.Clone();
+        next.LifecycleStatus = ContentArtifactLifecycleStatus.Tombstoned;
+        next.CurrentRevisionId = string.Empty;
+        next.TombstoneReason = evt.Reason;
+        next.TombstonedAtUtc = evt.TombstonedAtUtc?.Clone();
+        foreach (var revisionId in next.Revisions.Keys.ToArray())
+        {
+            var revision = next.Revisions[revisionId].Clone();
+            revision.Content = new ContentArtifactRevisionContent();
+            if (revision.Availability == ContentArtifactRevisionAvailability.Available)
+            {
+                revision.Availability = ContentArtifactRevisionAvailability.RetentionExpired;
+                revision.RetentionExpiredAtUtc = evt.TombstonedAtUtc?.Clone();
+            }
+            next.Revisions[revisionId] = revision;
+        }
+        AdvanceVersion(next, evt.TombstonedAtUtc);
+        return next;
+    }
+
+    private void EnsureActiveArtifact(string artifactId)
+    {
+        EnsureArtifactIdentity(artifactId);
+        if (State.LifecycleStatus != ContentArtifactLifecycleStatus.Active)
+            throw new InvalidOperationException("ContentArtifact is tombstoned.");
+    }
+
+    private void EnsureArtifactIdentity(string artifactId)
+    {
+        if (string.IsNullOrWhiteSpace(State.ArtifactId))
+            throw new InvalidOperationException("ContentArtifact has not been created.");
+        if (!string.Equals(State.ArtifactId, artifactId?.Trim(), StringComparison.Ordinal))
+            throw new InvalidOperationException($"ContentArtifact actor '{Id}' cannot mutate artifact '{artifactId}'.");
+    }
+
+    private void EnsureConcurrencyVersion(long expected)
+    {
+        if (State.ConcurrencyVersion != expected)
+        {
+            throw new InvalidOperationException(
+                $"ContentArtifact concurrency version is {State.ConcurrencyVersion}, not {expected}.");
+        }
+    }
+
+    private void EnsureWriter(ContentArtifactPrincipal? principal)
+    {
+        ValidatePrincipal(principal, "requested_by");
+        if (PrincipalEquals(State.AccessPolicy.Owner, principal!) ||
+            State.AccessPolicy.WriterPrincipalIds.Contains(principal!.PrincipalId))
+        {
+            return;
+        }
+        throw new InvalidOperationException("ContentArtifact principal is not authorized to write.");
+    }
+
+    private void EnsureOwner(ContentArtifactPrincipal? principal)
+    {
+        ValidatePrincipal(principal, "requested_by");
+        if (!PrincipalEquals(State.AccessPolicy.Owner, principal!))
+            throw new InvalidOperationException("Only the ContentArtifact owner can tombstone it.");
+    }
+
+    private ContentArtifactRevision GetRevision(string revisionId)
+    {
+        var normalized = ContentArtifactConventions.NormalizeRequired(revisionId, "revisionId");
+        if (!State.Revisions.TryGetValue(normalized, out var revision))
+            throw new InvalidOperationException($"ContentArtifact revision '{normalized}' does not exist.");
+        return revision;
+    }
+
+    private static void ValidateProvenance(ContentArtifactExecutionProvenance provenance, string scopeId, string teamId)
+    {
+        if (!string.Equals(provenance.ScopeId, scopeId, StringComparison.Ordinal))
+            throw new InvalidOperationException("ContentArtifact revision provenance scope_id must match the artifact scope.");
+        if (!string.Equals(provenance.TeamId ?? string.Empty, teamId ?? string.Empty, StringComparison.Ordinal))
+            throw new InvalidOperationException("ContentArtifact revision provenance team_id must match the artifact team.");
+        var hasRun = !string.IsNullOrWhiteSpace(provenance.RunId);
+        var hasService = !string.IsNullOrWhiteSpace(provenance.PublishedServiceId);
+        if (hasRun != hasService)
+            throw new InvalidOperationException("Execution provenance requires both run_id and published_service_id.");
+    }
+
+    private static void ValidateCitation(ContentArtifactCitation citation)
+    {
+        ContentArtifactConventions.NormalizeRequired(citation.CitationId, "citation.citationId");
+        switch (citation.SourceCase)
+        {
+            case ContentArtifactCitation.SourceOneofCase.ArtifactRevision:
+                var reference = citation.ArtifactRevision?.Reference;
+                if (reference == null || string.IsNullOrWhiteSpace(reference.ArtifactId))
+                    throw new InvalidOperationException("citation artifact_id is required.");
+                if (string.IsNullOrWhiteSpace(reference.RevisionId))
+                    throw new InvalidOperationException("citation revision_id is required.");
+                ValidateSha256(reference.ContentHash, "citation content_hash");
+                ContentArtifactConventions.NormalizeRequired(reference.MediaType, "citation.mediaType");
+                break;
+            case ContentArtifactCitation.SourceOneofCase.ExternalSource:
+                var source = citation.ExternalSource;
+                if (source == null ||
+                    string.IsNullOrWhiteSpace(source.SourceUri) && string.IsNullOrWhiteSpace(source.StableExternalId))
+                {
+                    throw new InvalidOperationException("citation external source requires source_uri or stable_external_id.");
+                }
+                break;
+            default:
+                throw new InvalidOperationException("citation source is required.");
+        }
+
+        var locator = citation.Locator;
+        if (locator != null &&
+            (locator.StartOffset < 0 || locator.EndOffset < 0 ||
+             locator.EndOffset > 0 && locator.EndOffset < locator.StartOffset))
+        {
+            throw new InvalidOperationException("citation locator offsets are invalid.");
+        }
+    }
+
+    private static void ValidatePrincipal(ContentArtifactPrincipal? principal, string fieldName)
+    {
+        if (principal == null || string.IsNullOrWhiteSpace(principal.PrincipalId) || string.IsNullOrWhiteSpace(principal.PrincipalKind))
+            throw new InvalidOperationException($"{fieldName} principal_id and principal_kind are required.");
+    }
+
+    private static bool PrincipalEquals(ContentArtifactPrincipal? left, ContentArtifactPrincipal right) =>
+        left != null &&
+        string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal) &&
+        string.Equals(left.PrincipalKind, right.PrincipalKind, StringComparison.Ordinal);
+
+    private static void VerifyLengthAndHash(ContentArtifactRevision revision, ReadOnlySpan<byte> content)
+    {
+        var hash = Convert.ToHexStringLower(SHA256.HashData(content));
+        if (revision.ByteLength != content.Length ||
+            !string.Equals(revision.ContentHash, hash, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("ContentArtifact content_hash or byte_length does not match inline content.");
+        }
+    }
+
+    private static async Task<ContentArtifactBackingContentDescriptor> MeasureAndHashAsync(Stream stream)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        long length = 0;
+        try
+        {
+            int read;
+            while ((read = await stream.ReadAsync(buffer.AsMemory())) > 0)
+            {
+                hash.AppendData(buffer, 0, read);
+                length += read;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+        return new ContentArtifactBackingContentDescriptor(
+            length,
+            Convert.ToHexStringLower(hash.GetHashAndReset()));
+    }
+
+    private static void ValidateSha256(string value, string fieldName)
+    {
+        if (value?.Length != 64)
+            throw new InvalidOperationException($"{fieldName} must be a SHA-256 hex digest.");
+        try
+        {
+            _ = Convert.FromHexString(value);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException($"{fieldName} must be a SHA-256 hex digest.", ex);
+        }
+    }
+
+    private static string HashCreateRequest(CreateContentArtifact command)
+    {
+        var semantic = command.Clone();
+        semantic.RequestedAtUtc = null;
+        if (semantic.FirstRevision != null)
+            semantic.FirstRevision.CreatedAtUtc = null;
+        return Convert.ToHexStringLower(SHA256.HashData(semantic.ToByteArray()));
+    }
+
+    private static bool RevisionsEqualForAppend(ContentArtifactRevision left, ContentArtifactRevision right)
+    {
+        var normalizedLeft = left.Clone();
+        var normalizedRight = right.Clone();
+        normalizedLeft.CreatedAtUtc = null;
+        normalizedRight.CreatedAtUtc = null;
+        normalizedLeft.Availability = ContentArtifactRevisionAvailability.Available;
+        normalizedRight.Availability = ContentArtifactRevisionAvailability.Available;
+        return normalizedLeft.Equals(normalizedRight);
+    }
+
+    private static void AdvanceVersion(ContentArtifactState state, Timestamp? updatedAt)
+    {
+        state.ConcurrencyVersion++;
+        state.UpdatedAtUtc = updatedAt?.Clone() ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+    }
+
+    private static Timestamp ResolveRequestedAt(Timestamp? requestedAt) =>
+        requestedAt?.Clone() ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+}

--- a/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
+++ b/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
@@ -30,8 +30,6 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     public async Task HandleCreateAsync(CreateContentArtifact command)
     {
         ArgumentNullException.ThrowIfNull(command);
-        await ValidateCreateAsync(command);
-
         if (!string.IsNullOrWhiteSpace(State.ArtifactId))
         {
             if (!string.Equals(State.CreationRequestHash, HashCreateRequest(command), StringComparison.Ordinal))
@@ -41,6 +39,8 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
             }
             return;
         }
+
+        await ValidateCreateAsync(command);
 
         var createdAt = command.RequestedAtUtc?.Clone()
                         ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
@@ -59,24 +59,31 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     public async Task HandleAppendRevisionAsync(AppendContentArtifactRevision command)
     {
         ArgumentNullException.ThrowIfNull(command);
-        EnsureActiveArtifact(command.ArtifactId);
         ArgumentNullException.ThrowIfNull(command.Revision);
+        EnsureWriter(command.RequestedBy);
+        EnsureActiveArtifact(command.ArtifactId);
+        var dedupKey = ContentArtifactConventions.NormalizeRequired(
+            command.Revision.DedupKey,
+            "revision.dedupKey");
 
-        if (State.Revisions.TryGetValue(command.Revision.RevisionId, out var existingRevision))
+        var existingRevision = State.Revisions.Values.FirstOrDefault(revision =>
+            string.Equals(revision.DedupKey, dedupKey, StringComparison.Ordinal));
+        if (existingRevision != null)
         {
             if (!RevisionsEqualForAppend(existingRevision, command.Revision))
-                throw new InvalidOperationException("ContentArtifact revision identity already exists with different facts.");
+                throw new InvalidOperationException("ContentArtifact revision dedup_key already exists with different facts.");
             return;
         }
 
-        EnsureWriter(command.RequestedBy);
-        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
-        await ValidateRevisionAsync(command.Revision, firstRevision: false);
         var appendedAt = command.RequestedAtUtc?.Clone()
                          ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
         var revision = command.Revision.Clone();
+        revision.RevisionNumber = checked(
+            State.Revisions.Values.Select(static item => item.RevisionNumber).DefaultIfEmpty().Max() + 1);
+        revision.RevisionId = ContentArtifactConventions.BuildRevisionId(State.ArtifactId, revision.RevisionNumber);
         revision.CreatedAtUtc ??= appendedAt.Clone();
         revision.Availability = ContentArtifactRevisionAvailability.Available;
+        await ValidateRevisionAsync(revision, firstRevision: false);
         await PersistDomainEventAsync(new ContentArtifactRevisionAppendedEvent
         {
             Revision = revision,
@@ -416,8 +423,9 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     private void EnsureWriter(ContentArtifactPrincipal? principal)
     {
         ValidatePrincipal(principal, "requested_by");
-        if (PrincipalEquals(State.AccessPolicy.Owner, principal!) ||
-            State.AccessPolicy.WriterPrincipalIds.Contains(principal!.PrincipalId))
+        if (State.AccessPolicy != null &&
+            (PrincipalEquals(State.AccessPolicy.Owner, principal!) ||
+             State.AccessPolicy.WriterPrincipalIds.Contains(principal!.PrincipalId)))
         {
             return;
         }
@@ -549,7 +557,10 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
         var semantic = command.Clone();
         semantic.RequestedAtUtc = null;
         if (semantic.FirstRevision != null)
+        {
             semantic.FirstRevision.CreatedAtUtc = null;
+            semantic.FirstRevision.Availability = ContentArtifactRevisionAvailability.Available;
+        }
         return Convert.ToHexStringLower(SHA256.HashData(semantic.ToByteArray()));
     }
 
@@ -559,6 +570,10 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
         var normalizedRight = right.Clone();
         normalizedLeft.CreatedAtUtc = null;
         normalizedRight.CreatedAtUtc = null;
+        normalizedLeft.RevisionId = string.Empty;
+        normalizedRight.RevisionId = string.Empty;
+        normalizedLeft.RevisionNumber = 0;
+        normalizedRight.RevisionNumber = 0;
         normalizedLeft.Availability = ContentArtifactRevisionAvailability.Available;
         normalizedRight.Availability = ContentArtifactRevisionAvailability.Available;
         return normalizedLeft.Equals(normalizedRight);

--- a/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
+++ b/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
@@ -95,13 +95,13 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     public async Task HandleAdvanceCurrentRevisionAsync(AdvanceContentArtifactCurrentRevision command)
     {
         ArgumentNullException.ThrowIfNull(command);
+        EnsureReaderWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         EnsureActiveArtifact(command.ArtifactId);
         var revisionId = ContentArtifactConventions.NormalizeRequired(command.RevisionId, "revisionId");
         if (string.Equals(State.CurrentRevisionId, revisionId, StringComparison.Ordinal))
             return;
 
-        EnsureWriter(command.RequestedBy);
-        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         if (!State.Revisions.TryGetValue(revisionId, out var revision))
             throw new InvalidOperationException($"ContentArtifact revision '{revisionId}' does not exist.");
         if (revision.Availability != ContentArtifactRevisionAvailability.Available)
@@ -118,6 +118,8 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     public async Task HandleRedactRevisionAsync(RedactContentArtifactRevision command)
     {
         ArgumentNullException.ThrowIfNull(command);
+        EnsureReaderWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         EnsureActiveArtifact(command.ArtifactId);
         var revision = GetRevision(command.RevisionId);
         var reason = ContentArtifactConventions.NormalizeRequired(command.Reason, "reason");
@@ -128,8 +130,6 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
             return;
         }
 
-        EnsureWriter(command.RequestedBy);
-        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         await PersistDomainEventAsync(new ContentArtifactRevisionRedactedEvent
         {
             RevisionId = revision.RevisionId,
@@ -142,6 +142,8 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     public async Task HandleExpireRevisionAsync(ExpireContentArtifactRevision command)
     {
         ArgumentNullException.ThrowIfNull(command);
+        EnsureReaderWriter(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         EnsureActiveArtifact(command.ArtifactId);
         var revision = GetRevision(command.RevisionId);
         if (revision.Availability == ContentArtifactRevisionAvailability.RetentionExpired)
@@ -149,8 +151,6 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
         if (revision.Availability == ContentArtifactRevisionAvailability.Redacted)
             throw new InvalidOperationException("A redacted ContentArtifact revision cannot transition to retention-expired.");
 
-        EnsureWriter(command.RequestedBy);
-        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         await PersistDomainEventAsync(new ContentArtifactRevisionExpiredEvent
         {
             RevisionId = revision.RevisionId,
@@ -162,6 +162,8 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     public async Task HandleTombstoneAsync(TombstoneContentArtifact command)
     {
         ArgumentNullException.ThrowIfNull(command);
+        EnsureOwner(command.RequestedBy);
+        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         EnsureArtifactIdentity(command.ArtifactId);
         var reason = ContentArtifactConventions.NormalizeRequired(command.Reason, "reason");
         if (State.LifecycleStatus == ContentArtifactLifecycleStatus.Tombstoned)
@@ -171,8 +173,6 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
             return;
         }
 
-        EnsureOwner(command.RequestedBy);
-        EnsureConcurrencyVersion(command.ExpectedConcurrencyVersion);
         await PersistDomainEventAsync(new ContentArtifactTombstonedEvent
         {
             Reason = reason,
@@ -435,8 +435,21 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     private void EnsureOwner(ContentArtifactPrincipal? principal)
     {
         ValidatePrincipal(principal, "requested_by");
-        if (!PrincipalEquals(State.AccessPolicy.Owner, principal!))
+        if (State.AccessPolicy == null || !PrincipalEquals(State.AccessPolicy.Owner, principal!))
             throw new InvalidOperationException("Only the ContentArtifact owner can tombstone it.");
+    }
+
+    private void EnsureReaderWriter(ContentArtifactPrincipal? principal)
+    {
+        ValidatePrincipal(principal, "requested_by");
+        if (State.AccessPolicy != null &&
+            (PrincipalEquals(State.AccessPolicy.Owner, principal!) ||
+             State.AccessPolicy.ReaderPrincipalIds.Contains(principal!.PrincipalId) &&
+             State.AccessPolicy.WriterPrincipalIds.Contains(principal.PrincipalId)))
+        {
+            return;
+        }
+        throw new InvalidOperationException("ContentArtifact principal is not authorized to read and write.");
     }
 
     private ContentArtifactRevision GetRevision(string revisionId)
@@ -502,8 +515,7 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
 
     private static bool PrincipalEquals(ContentArtifactPrincipal? left, ContentArtifactPrincipal right) =>
         left != null &&
-        string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal) &&
-        string.Equals(left.PrincipalKind, right.PrincipalKind, StringComparison.Ordinal);
+        string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal);
 
     private static void VerifyLengthAndHash(ContentArtifactRevision revision, ReadOnlySpan<byte> content)
     {

--- a/docs/canon/content-artifacts.md
+++ b/docs/canon/content-artifacts.md
@@ -1,0 +1,135 @@
+---
+title: "Content Artifacts"
+status: active
+owner: eanzhao
+---
+
+# Content Artifacts
+
+A `ContentArtifact` is the durable platform resource for attributable text,
+Markdown, structured documents, and other content-oriented execution results.
+It preserves exact immutable revisions and provenance while exposing one small,
+mutable current-revision pointer. It is not chat history, a workflow input-file
+transport, a generic binary step output, or a current-state projection used as
+the source of truth.
+
+## Authority And Identity
+
+`ContentArtifactGAgent` is the only authority for one artifact. Its committed
+Protobuf events and `ContentArtifactState` own the artifact metadata, access
+policy, retention policy, immutable revisions, current pointer, redaction facts,
+and tombstone. `ContentArtifactCurrentStateDocument` is an actor-scoped query
+replica; it never advances lifecycle or revision state.
+
+The identities remain separate:
+
+| Identity | Meaning |
+|---|---|
+| `artifactId` | Stable logical identity derived from canonical `scopeId + dedupKey`. |
+| actor id | Opaque address derived from Scope and artifact identity. |
+| `revisionId` | Stable identity derived from artifact identity and the server-assigned monotonic revision number. |
+| concurrency version | Actor-owned compare-and-swap version for mutable commands; it is not a revision number. |
+| `runId`, `workflowId`, `publishedServiceId`, `memberId` | Execution provenance identities; none is an artifact identity. |
+| `workOrderId` | Optional durable-intent link; it remains a WorkOrder identity. |
+
+Scope ownership is required. Team ownership is optional. When `teamId` is
+present, creation validates that the Team exists and is active in the same
+Scope. A scope-owned artifact without a Team stores no invented Team identity.
+
+## Immutable Revisions And CAS
+
+Creation commits revision 1 and makes it current. Append assigns the next
+revision number from the authoritative revision history. Append never changes a
+prior revision's content, hash, provenance, citations, creation time, or
+supersession reason. Advancing the current pointer is a separate command.
+
+Append, pointer advance, redaction, expiry, and tombstone carry the expected
+artifact concurrency version. The Actor checks that version immediately before
+committing. Pointer changes and lifecycle operations may advance the concurrency
+version without creating a revision, so revision numbering must never be derived
+from the CAS version.
+
+Each revision contains media type, byte length, SHA-256 content hash, exact
+execution provenance, typed citations, and exactly one content location. A
+citation identifies either an exact `artifactId + revisionId + contentHash +
+mediaType` tuple or a stable external identity. Its locator remains structured
+as section, offsets, and selector.
+
+## Content Storage And Integrity
+
+Inline content is bounded to 64 KiB. The Actor hashes and measures inline bytes
+before commit. Larger or provider-owned content uses
+`IContentArtifactBackingContentPort`; the Actor describes and streams the object,
+then verifies both provider descriptor and actual bytes against the revision's
+length and SHA-256 hash. Reads stream the object again and verify the exact
+committed revision hash before returning content.
+
+The Studio Host provides the `workflow-file` backing adapter:
+
+| ContentArtifact field | Workflow file mapping |
+|---|---|
+| `backingObject.provider` | Literal `workflow-file`. |
+| `backingObject.objectKey` | The stable `FileArtifactRef.ArtifactId`, for example `workflow-file://wf-file-...`; never a filesystem path or credential-bearing URL. |
+| revision provenance `scopeId` | Required `FileArtifactRef.OwnerScopeId`. |
+| revision provenance `runId` | Exact `FileArtifactRef.OwnerRunId`, or both absent for a non-Run artifact. |
+
+The adapter goes through `IFileArtifactReadPort`; it does not open provider files
+or URLs directly. Descriptor ownership must exactly match the revision
+provenance. A mismatch, unsupported provider, missing object, invalid descriptor,
+or unavailable provider fails closed.
+
+This mapping does not change workflow-file lifecycle semantics. Local/testing
+files and production `External` providers retain their configured expiry and
+cleanup behavior. If backing content later expires or disappears, the exact
+ContentArtifact revision metadata and provenance remain, while the content API
+returns an explicit unavailable result. Applications needing retention beyond a
+workflow file's lifetime must copy bytes into a backing provider whose retention
+contract covers that period and register that provider at the Host boundary.
+
+## Authorization And Lifecycle
+
+The access policy has one typed owner plus explicit reader and writer principal
+ids. Scope authorization is checked at the HTTP boundary. The application
+service checks artifact access against the current read model, and the content
+query checks the same principal again against the exact snapshot used for the
+physical read. Backing access additionally checks Scope and Run ownership.
+
+Writers may append, advance, redact, or expire revisions. Only the owner may
+tombstone the artifact. Redaction and retention expiry clear the content
+location while preserving identity, hash, provenance, citations, and the typed
+reason/time facts. Tombstone clears the current pointer and all surviving
+content locations without rewriting the historical provenance.
+
+## Run And WorkOrder Interoperability
+
+`ServiceRunGAgent` owns typed result attachments. Its state and current-state
+read model carry only `ContentArtifactReference` values containing artifact id,
+revision id, content hash, and media type. Full content is never embedded in a
+ServiceRun current-state read model. Attachment uses actor-owned CAS through the
+narrow `IServiceRunResultArtifactAttachmentPort`; an accepted receipt does not
+claim read-model visibility.
+
+WorkOrder references keep their existing contract. A ContentArtifact may be
+represented without changing WorkOrder semantics as follows:
+
+| `WorkOrderArtifactReference` field | Mapping |
+|---|---|
+| `artifact_id` | `ContentArtifactReference.artifact_id`. |
+| `artifact_kind` | Literal `content-artifact`. |
+| `revision_id` | `ContentArtifactReference.revision_id`. |
+| `uri` | Optional same-Scope metadata path `/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions/{revisionId}`. |
+
+The WorkOrder remains the authority for intent, assignment, approval, and its
+declared input/result references. The ContentArtifact remains the authority for
+content, revision history, provenance, citations, access, and lifecycle.
+
+## HTTP Surface
+
+The canonical resource root is `/api/scopes/{scopeId}/content-artifacts`.
+Endpoints create and list artifacts; read artifact metadata, one exact revision,
+the current revision, or verified content; append a revision; advance current;
+redact, expire, or tombstone; and attach exact references to a Service Run.
+
+Mutation responses are `202 Accepted` dispatch receipts. Clients observe
+committed state through the current-state query surface and its authoritative
+`stateVersion`; no endpoint implies query freshness from command acceptance.

--- a/docs/canon/content-artifacts.md
+++ b/docs/canon/content-artifacts.md
@@ -35,6 +35,7 @@ The identities remain separate:
 Scope ownership is required. Team ownership is optional. When `teamId` is
 present, creation validates that the Team exists and is active in the same
 Scope. A scope-owned artifact without a Team stores no invented Team identity.
+Team ownership records resource context; it grants no implicit artifact access.
 
 ## Immutable Revisions And CAS
 
@@ -43,11 +44,17 @@ revision number from the authoritative revision history. Append never changes a
 prior revision's content, hash, provenance, citations, creation time, or
 supersession reason. Advancing the current pointer is a separate command.
 
-Append, pointer advance, redaction, expiry, and tombstone carry the expected
-artifact concurrency version. The Actor checks that version immediately before
-committing. Pointer changes and lifecycle operations may advance the concurrency
-version without creating a revision, so revision numbering must never be derived
-from the CAS version.
+Append carries no expected concurrency version. Its client-supplied revision
+`dedupKey` is the idempotency key: an authorized retry with identical facts is a
+no-op, while the same key with different facts fails closed. The Actor assigns
+the revision number and id from authoritative state.
+
+Pointer advance, redaction, expiry, and tombstone carry an expected artifact
+concurrency version. The Actor authorizes first, then checks CAS before duplicate
+or no-op classification. Application read-model version checks are advisory only.
+Pointer changes and lifecycle operations may advance the concurrency version
+without creating a revision, so neither revision identity nor any other write
+fact may be derived from the read model or CAS version.
 
 Each revision contains media type, byte length, SHA-256 content hash, exact
 execution provenance, typed citations, and exactly one content location. A
@@ -80,25 +87,36 @@ or unavailable provider fails closed.
 
 This mapping does not change workflow-file lifecycle semantics. Local/testing
 files and production `External` providers retain their configured expiry and
-cleanup behavior. If backing content later expires or disappears, the exact
-ContentArtifact revision metadata and provenance remain, while the content API
-returns an explicit unavailable result. Applications needing retention beyond a
-workflow file's lifetime must copy bytes into a backing provider whose retention
-contract covers that period and register that provider at the Host boundary.
+cleanup behavior. If backing content later disappears, the exact revision
+metadata and provenance remain, while the content read fails closed as a backing
+storage failure. HTTP 410 is reserved for committed redaction, retention expiry,
+or tombstone facts. Applications needing retention beyond a workflow file's
+lifetime must copy bytes into a backing provider whose retention contract covers
+that period and register that provider at the Host boundary.
 
 ## Authorization And Lifecycle
 
 The access policy has one typed owner plus explicit reader and writer principal
-ids. Scope authorization is checked at the HTTP boundary. The application
-service checks artifact access against the current read model, and the content
-query checks the same principal again against the exact snapshot used for the
-physical read. Backing access additionally checks Scope and Run ownership.
+ids. `principalId` is the ACL identity; `principalKind` is descriptive and never
+changes a match. Scope authorization is checked at the HTTP boundary. The
+application checks artifact access against the current read model, and the
+content query checks the same principal again against the exact snapshot used
+for the physical read. Backing access additionally checks Scope and Run
+ownership.
 
-Writers may append, advance, redact, or expire revisions. Only the owner may
-tombstone the artifact. Redaction and retention expiry clear the content
-location while preserving identity, hash, provenance, citations, and the typed
+The owner can read, append, advance, redact, expire, and tombstone. Explicit
+readers can read and discover. A writer-only principal has one append-only
+capability: it can append and blindly retry without CAS, but cannot read, list,
+advance, redact, expire, attach to a Run, or tombstone. Advance, redaction, and
+expiry require owner authority or membership in both reader and writer lists.
+Only the owner may tombstone. Redaction and retention expiry clear the content
+location while preserving identity, hash, provenance, citations, and typed
 reason/time facts. Tombstone clears the current pointer and all surviving
-content locations without rewriting the historical provenance.
+content locations without rewriting historical provenance.
+
+List membership is `owner == caller OR readerPrincipalIds contains caller`. The
+projection store applies that ACL together with all user filters before cursor
+paging; Host, Application, and query ports do not post-filter materialized pages.
 
 ## Run And WorkOrder Interoperability
 
@@ -133,3 +151,12 @@ redact, expire, or tombstone; and attach exact references to a Service Run.
 Mutation responses are `202 Accepted` dispatch receipts. Clients observe
 committed state through the current-state query surface and its authoritative
 `stateVersion`; no endpoint implies query freshness from command acceptance.
+
+Artifact absence and artifact-level ACL denial both return HTTP 404 on reads,
+mutations, and Run attachment. A missing revision is also 404. The shared
+`scopeId + dedupKey` namespace is intentionally observable only as occupancy:
+cross-principal create collision returns HTTP 409 without exposing the occupying
+artifact's facts. HTTP 410 is reachable only after read authorization and only
+for committed redacted, retention-expired, or tombstoned content. Malformed
+requests and readable lifecycle/CAS conflicts remain HTTP 400; missing
+authentication and Scope denial remain HTTP 401 and 403.

--- a/docs/canon/work-orders.md
+++ b/docs/canon/work-orders.md
@@ -220,6 +220,13 @@ No process-local dictionary, query-time event replay, query-time projection
 priming, compatibility endpoint, deprecated message, or parallel old/new
 contract participates in the WorkOrder path.
 
+ContentArtifact interoperability preserves the existing WorkOrder reference
+shape. `artifact_kind="content-artifact"` identifies the resource family,
+`artifact_id` and `revision_id` retain the exact ContentArtifact identities, and
+the optional `uri` may use the same-Scope revision metadata path. WorkOrder does
+not copy the ContentArtifact hash, content, provenance, citations, or lifecycle
+into its own authority. See [Content Artifacts](content-artifacts.md).
+
 ## Non-Goals
 
 A WorkOrder is not a project-management ticket, recurring schedule, approval

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -203,6 +203,15 @@ Runtime boundary:
 - Host composition must fail closed for production/external backends. `WorkflowFileArtifacts:Backend=External` requires explicit registrations for ingress/read/ownership/cleanup ports; production policy rejects the implicit filesystem backend.
 - The filesystem backend is the local/test concrete backend. Its cleanup removes expired descriptor-committed artifacts and stale staged directories without introducing a process-local artifact registry.
 
+Workflow files can back a revisioned ContentArtifact without becoming the
+ContentArtifact authority. The Host adapter accepts only
+`backingObject.provider=workflow-file`, maps `objectKey` to the stable workflow
+`FileArtifactRef.ArtifactId`, and requires descriptor Scope/Run ownership to
+match the ContentArtifact revision provenance. Workflow file expiry and cleanup
+remain unchanged; a missing file makes content unavailable while immutable
+ContentArtifact metadata and provenance survive. See
+[Content Artifacts](content-artifacts.md).
+
 ### Webhook Ingress API
 
 `POST /api/workflow-webhooks/{routeKey}` 是 workflow 的第四个 start-run 入口。它和 `/api/chat` 复用同一条 `WorkflowChatRunRequest` accepted-only command dispatch 主干；它不是 workflow YAML 顶级 trigger，也不复用 channel inbound 或 `WorkflowSignalCommand`。

--- a/docs/superpowers/plans/2026-07-28-content-artifact-authority-semantics.md
+++ b/docs/superpowers/plans/2026-07-28-content-artifact-authority-semantics.md
@@ -1,0 +1,309 @@
+# ContentArtifact Authority Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete issue #3011 on PR #2870 so ContentArtifact authorization, idempotency, query visibility, HTTP errors, and provider behavior match the confirmed product contract.
+
+**Architecture:** Keep `ContentArtifactGAgent` as the sole write authority and current-state projection documents as the sole query source. Append becomes actor-numbered and `dedup_key`-idempotent without CAS; the other mutations remain actor-CAS guarded and require read capability. Projection stores perform ACL filtering before cursor paging, while Application maps artifact ACL denial to typed not-found results.
+
+**Tech Stack:** .NET 10, C# 13, Protobuf, xUnit, FluentAssertions, ASP.NET Core minimal APIs, Aevatar CQRS projection stores.
+
+## Global Constraints
+
+- Preserve `Domain / Application / Infrastructure / Host` layering; HTTP endpoints only adapt typed Application outcomes.
+- `ContentArtifactGAgent` owns artifact facts and write decisions; no write fact may be derived from a read model.
+- Queries read current-state read models only; no event replay, projection priming, query-time materialization, or second ACL index.
+- Internal persisted and transported contracts remain Protobuf.
+- Principal ACL identity is `principal_id`; `principal_kind` remains descriptive and must not change matching.
+- Append-only writers can append and retry blindly but cannot read, list, advance, redact, expire, tombstone, or attach to a run.
+- The synchronous command receipt remains accepted-only.
+- Store filtering precedes cursor paging; no in-process page membership post-filter is allowed.
+- Do not add compatibility shims for the removed append CAS/revision-number inputs.
+- Update ContentArtifact canon and run all architecture, projection, test-stability, and docs guards required by `AGENTS.md`.
+
+---
+
+### Task 1: Projection filter parity
+
+**Files:**
+- Modify: `src/Aevatar.CQRS.Projection.Providers.InMemory/Stores/InMemoryProjectionDocumentStore.cs`
+- Modify: `test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs`
+
+**Interfaces:**
+- Consumes: `ProjectionDocumentFilter.FieldPath`, Protobuf `IMessage.Descriptor`, and repeated `IEnumerable` values.
+- Produces: InMemory `Eq` semantics matching Elasticsearch `term`: snake_case proto paths resolve and a scalar equals any repeated-field element.
+
+- [ ] **Step 1: Add failing provider tests**
+
+Add one test that filters `TestStoreReadModel` by `actor_id`, and one that filters its repeated `tags` field by scalar equality:
+
+```csharp
+new ProjectionDocumentFilter
+{
+    FieldPath = "actor_id",
+    Operator = ProjectionDocumentFilterOperator.Eq,
+    Value = ProjectionDocumentValue.FromString("actor-1"),
+}
+
+new ProjectionDocumentFilter
+{
+    FieldPath = "tags",
+    Operator = ProjectionDocumentFilterOperator.Eq,
+    Value = ProjectionDocumentValue.FromString("reader-1"),
+}
+```
+
+- [ ] **Step 2: Verify the tests fail for the intended reasons**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.CQRS.Projection.Core.Tests/Aevatar.CQRS.Projection.Core.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~InMemoryProjectionDocumentStoreBehaviorTests'
+```
+
+Expected: the snake_case and repeated-element tests return no items.
+
+- [ ] **Step 3: Resolve proto field names and repeated scalar equality**
+
+In `ResolveFieldValue`, when `current is IMessage`, resolve each segment through `message.Descriptor.FindFieldByName(segment)` before CLR reflection and read it through the field accessor. In `MatchesFilter`, compare scalar operators against every element when `actualValue` is a non-string `IEnumerable`; keep scalar behavior unchanged.
+
+- [ ] **Step 4: Verify provider behavior**
+
+Run the Task 1 command. Expected: all InMemory behavior tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Aevatar.CQRS.Projection.Providers.InMemory/Stores/InMemoryProjectionDocumentStore.cs test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
+git commit -m "Fix projection filter parity"
+```
+
+### Task 2: Actor-safe create and append semantics
+
+**Files:**
+- Modify: `src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto`
+- Modify: `agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactCommandPort.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs`
+- Modify: `src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs`
+
+**Interfaces:**
+- Produces: `AppendContentArtifactRevisionRequest(ContentArtifactRevisionWriteRequest Revision)`.
+- Produces: `IContentArtifactCommandPort.AppendRevisionAsync(string scopeId, string artifactId, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)`.
+- Produces: `AppendContentArtifactRevision` with reserved protobuf field 2 and no expected concurrency version.
+- Consumes: client revision `dedup_key`; the actor assigns `revision_number`, `revision_id`, `created_at_utc`, and `availability`.
+
+- [ ] **Step 1: Add failing Actor regression tests**
+
+Cover these observable behaviors:
+
+```csharp
+await unauthorizedRetry.Should().ThrowAsync<InvalidOperationException>()
+    .WithMessage("*not authorized*");
+agent.State.Revisions.Should().HaveCount(2);
+agent.State.Revisions.Values.Should().ContainSingle(x => x.DedupKey == "revision-two");
+```
+
+The tests must show: authorization precedes append duplicate detection; a writer-only principal appends without CAS; retrying the same `dedup_key` and facts emits no new event; conflicting facts under the same key fail; and actor-assigned revision identity is monotonic.
+
+- [ ] **Step 2: Add the failing create retry test**
+
+Create from backing content, make the backing port throw on subsequent reads, then retry the same logical create with different server-assigned timestamp/availability fields. Assert the retry succeeds and the port's open count does not increase. A changed title or content fact must still fail as a logical identity conflict.
+
+- [ ] **Step 3: Verify Actor tests fail**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~ContentArtifactGAgentTests'
+```
+
+Expected: failures expose pre-authorization no-ops, backing re-open, CAS-coupled append, and caller-assigned revision identity.
+
+- [ ] **Step 4: Make create canonicalization retry-stable**
+
+Add one canonicalizer used by both first commit and retry hashing. It clones `CreateContentArtifact`, clears `requested_at_utc` and `first_revision.created_at_utc`, and forces `first_revision.availability` to `AVAILABLE`. In `HandleCreateAsync`, if state exists, compare this hash before `ValidateCreateAsync`; only first creation validates and reads backing content.
+
+- [ ] **Step 5: Make append actor-numbered and dedup-key idempotent**
+
+Reserve protobuf field 2, remove append CAS from DTOs/ports/dispatcher, and send revision facts without a revision id/number. In the Actor: authorize first; then validate artifact lifecycle; locate duplicates by normalized `revision.dedup_key`; compare only client-controlled semantic facts; otherwise set the next number and canonical id from authoritative state immediately before validation and commit.
+
+- [ ] **Step 6: Remove Application write-fact side reads**
+
+`ContentArtifactService.AppendRevisionAsync` may normalize and advisory-check provenance, but must neither require readable current state nor derive `Max(RevisionNumber) + 1`. Dispatch directly with the normalized route scope/artifact id and requester so a writer-only principal can append.
+
+- [ ] **Step 7: Update command/service tests and verify**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~ContentArtifactGAgentTests|FullyQualifiedName~ContentArtifactCommandServiceTests|FullyQualifiedName~ContentArtifactServiceTests'
+```
+
+Expected: all selected tests pass and no append test supplies expected CAS or revision number.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Aevatar.ContentArtifacts.Abstractions agents/Aevatar.GAgents.ContentArtifacts src/Aevatar.Studio.Application/Studio src/Aevatar.Studio.Projection/CommandServices test/Aevatar.Studio.Tests/ContentArtifacts
+git commit -m "Enforce content artifact write authority"
+```
+
+### Task 3: Read-capable mutation and store-side list ACL
+
+**Files:**
+- Modify: `agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs`
+- Modify: `src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `ProjectionDocumentQuery.Filters` for scope/user filters and `AnyOfFilters` for owner-or-reader ACL.
+- Produces: advance/redact/expire authority = owner or a principal present in both writer and reader lists; tombstone remains owner-only.
+
+- [ ] **Step 1: Add failing mutation authorization/CAS tests**
+
+For advance, redact, expire, and tombstone, assert authorization occurs before lifecycle/revision/no-op probes and that even an exact duplicate with a stale expected version fails. Add writer-only denials and writer+reader success for advance/redact/expire.
+
+- [ ] **Step 2: Add failing list ACL and paging tests**
+
+Assert the generated query contains required `scope_id` and user filters in `Filters`, plus exactly these OR filters in `AnyOfFilters`:
+
+```csharp
+Equal("owner_principal_id", requesterPrincipalId)
+Equal("reader_principal_ids", requesterPrincipalId)
+```
+
+Use the real InMemory store with owner, reader, writer-only, unrelated, and tombstoned documents. Request page size 1 and prove page 2 returns the other readable document rather than advancing past an inaccessible row.
+
+- [ ] **Step 3: Verify the selected tests fail**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~ContentArtifactGAgentTests|FullyQualifiedName~ContentArtifactProjectionTests|FullyQualifiedName~ContentArtifactServiceTests'
+```
+
+- [ ] **Step 4: Enforce authorization before probes and CAS before no-op**
+
+For each non-create mutation, validate `requested_by` against authoritative ACL before calling `EnsureActiveArtifact`, `GetRevision`, or checking duplicates. Advance/redact/expire require owner or writer+reader; then check the expected actor concurrency version before classifying an exact no-op. Tombstone authorizes owner and checks CAS before its duplicate branch.
+
+- [ ] **Step 5: Move list membership entirely into the store query**
+
+Build owner and repeated-reader membership as `AnyOfFilters`, retain scope and caller filters in `Filters`, and return `result.Items.Select(ToResponse)` directly. Delete `MatchesQuery` and its helper-only predicates so cursor membership has one source of truth.
+
+- [ ] **Step 6: Align Application mutation pre-checks**
+
+Treat writer-only as append-only. Advance/redact/expire advisory pre-checks require both write and read capability; tombstone requires owner. Convert artifact ACL denial to typed not-found in Task 4 rather than exposing the authorization reason.
+
+- [ ] **Step 7: Verify and commit**
+
+Run the Task 3 test command, then:
+
+```bash
+git add agents/Aevatar.GAgents.ContentArtifacts src/Aevatar.Studio.Application/Studio/Services src/Aevatar.Studio.Projection/QueryPorts test/Aevatar.Studio.Tests/ContentArtifacts
+git commit -m "Align content artifact ACL semantics"
+```
+
+### Task 4: Typed non-leaking Application and HTTP outcomes
+
+**Files:**
+- Modify: `src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs`
+- Modify: `src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs`
+- Modify: `src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs`
+
+**Interfaces:**
+- Produces: artifact ACL denial and nonexistent revision as `ContentArtifactNotFoundException`.
+- Produces: `ContentArtifactIdentityConflictException` for occupied `scope + dedupKey` with a different logical create request.
+- Keeps: `ContentArtifactContentUnavailableException` exclusively for authorized redacted, expired, or tombstoned content.
+
+- [ ] **Step 1: Add failing service and endpoint status tests**
+
+Cover 404 for ACL denial on metadata, revision, content, append, advance, redact, expire, tombstone, and attach-to-run. Cover 404 for an authorized reader's nonexistent revision and 410 only for redacted/expired/tombstoned content. Retain 401 for missing authentication and 403 for scope denial. Assert denied error bodies contain neither lifecycle facts nor concurrency versions.
+
+- [ ] **Step 2: Add the create occupancy conflict test**
+
+Seed the deterministic artifact id in the query port. A create by a different principal must throw `ContentArtifactIdentityConflictException` before dispatch; an exact same-owner retry may still dispatch so the Actor decides semantic equality. Endpoint mapping returns a typed conflict response containing only dedup-key occupancy.
+
+- [ ] **Step 3: Verify status tests fail**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~ContentArtifactServiceTests|FullyQualifiedName~ContentArtifactProjectionTests|FullyQualifiedName~ContentArtifactEndpointsTests'
+```
+
+- [ ] **Step 4: Implement typed translations at the narrow boundaries**
+
+Use `ContentArtifactNotFoundException` whenever the caller cannot read the artifact. `FindRevision` throws not-found rather than unavailable. The projection content reader authorizes before availability checks and also maps ACL denial to not-found. Add the advisory deterministic-id occupancy read in `CreateAsync` without replaying, priming, or querying actor state.
+
+- [ ] **Step 5: Map HTTP responses uniformly**
+
+Catch not-found before generic invalid requests on every read/command/attach handler. Catch unavailable as 410 in any handler where it can surface. Catch the typed occupancy conflict as HTTP 409 with a stable code and a message that reveals only key occupancy. Leave malformed requests and readable state/CAS conflicts as 400.
+
+- [ ] **Step 6: Verify and commit**
+
+Run the Task 4 command, then:
+
+```bash
+git add src/Aevatar.Studio.Application/Studio src/Aevatar.Studio.Projection/QueryPorts src/Aevatar.Studio.Hosting/Endpoints test/Aevatar.Studio.Tests/ContentArtifacts
+git commit -m "Hide content artifact ACL existence"
+```
+
+### Task 5: Canon, regression, and integration delivery
+
+**Files:**
+- Modify: `docs/canon/content-artifacts.md`
+- Verify: all changed production and test files
+
+**Interfaces:**
+- Documents: Team ownership versus ACL; append-only writer; Actor CAS versus advisory read-model checks; shared dedup namespace versus protected artifact facts; store-side ACL paging.
+
+- [ ] **Step 1: Update canon**
+
+State explicitly that append has no CAS and is `dedup_key` idempotent, writer-only is append-only, advance/redact/expire require read+write, tombstone is owner-only, create collisions expose occupancy only, and list filtering/paging occurs in the projection provider.
+
+- [ ] **Step 2: Run focused tests**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~ContentArtifact'
+dotnet test test/Aevatar.CQRS.Projection.Core.Tests/Aevatar.CQRS.Projection.Core.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~InMemoryProjectionDocumentStoreBehaviorTests|FullyQualifiedName~ElasticsearchProjectionDocumentStoreBehaviorTests'
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --no-restore --filter 'FullyQualifiedName~ContentArtifact'
+```
+
+- [ ] **Step 3: Run required guards**
+
+```bash
+bash tools/ci/test_stability_guards.sh
+bash tools/ci/query_projection_priming_guard.sh
+bash tools/ci/projection_state_version_guard.sh
+bash tools/ci/projection_state_mirror_current_state_guard.sh
+bash tools/ci/projection_route_mapping_guard.sh
+bash tools/ci/workflow_binding_boundary_guard.sh
+bash tools/docs/lint.sh
+bash tools/ci/architecture_guards.sh
+git diff --check
+```
+
+- [ ] **Step 4: Run fresh full verification**
+
+```bash
+dotnet restore aevatar.slnx --nologo
+dotnet build aevatar.slnx --nologo --no-restore
+dotnet test aevatar.slnx --nologo --no-restore
+```
+
+- [ ] **Step 5: Commit canon and final test adjustments**
+
+```bash
+git add docs/canon/content-artifacts.md test src agents
+git commit -m "Document content artifact authority semantics"
+```
+
+- [ ] **Step 6: Rebase, re-run affected verification, and deliver through PR #2870**
+
+Fetch `origin/feature/integrate`, rebase the PR branch if it advanced, re-run focused tests and required guards, push the PR branch with an explicit force-with-lease if rebased, wait for required CI, and merge PR #2870. Confirm `origin/feature/integrate` contains the merged head. Do not push directly around branch protection or required review policy.

--- a/src/Aevatar.CQRS.Projection.Providers.InMemory/Stores/InMemoryProjectionDocumentStore.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.InMemory/Stores/InMemoryProjectionDocumentStore.cs
@@ -358,6 +358,12 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
                 continue;
             }
 
+            if (current is IMessage message && message.Descriptor.FindFieldByName(segment) is { } field)
+            {
+                current = field.Accessor.GetValue(message);
+                continue;
+            }
+
             var property = current.GetType().GetProperty(
                 segment,
                 BindingFlags.Instance | BindingFlags.Public);
@@ -415,9 +421,9 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
         return filter.Operator switch
         {
             ProjectionDocumentFilterOperator.Exists => actualValue != null,
-            ProjectionDocumentFilterOperator.Eq => CompareNormalizedValues(actualValue, GetScalarValue(filter.Value)) == 0,
+            ProjectionDocumentFilterOperator.Eq => EqualsFilterValue(actualValue, GetScalarValue(filter.Value)),
             ProjectionDocumentFilterOperator.EqOrMissing =>
-                actualValue == null || CompareNormalizedValues(actualValue, GetScalarValue(filter.Value)) == 0,
+                actualValue == null || EqualsFilterValue(actualValue, GetScalarValue(filter.Value)),
             ProjectionDocumentFilterOperator.In => GetCollectionValues(filter.Value)
                 .Any(expected => CompareNormalizedValues(actualValue, expected) == 0),
             ProjectionDocumentFilterOperator.Gt => CompareNormalizedValues(actualValue, GetScalarValue(filter.Value)) > 0,
@@ -427,6 +433,12 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
             _ => false,
         };
     }
+
+    private static bool EqualsFilterValue(object? actualValue, object? expectedValue) =>
+        actualValue is IEnumerable values and not string
+            ? values.Cast<object?>().Any(value =>
+                CompareNormalizedValues(NormalizeComparableValue(value), expectedValue) == 0)
+            : CompareNormalizedValues(actualValue, expectedValue) == 0;
 
     private static object? GetScalarValue(ProjectionDocumentValue value)
     {

--- a/src/Aevatar.ContentArtifacts.Abstractions/Aevatar.ContentArtifacts.Abstractions.csproj
+++ b/src/Aevatar.ContentArtifacts.Abstractions/Aevatar.ContentArtifacts.Abstractions.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Aevatar.ContentArtifacts.Abstractions</AssemblyName>
+    <RootNamespace>Aevatar.ContentArtifacts.Abstractions</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="content_artifact_messages.proto" GrpcServices="None" />
+  </ItemGroup>
+</Project>

--- a/src/Aevatar.ContentArtifacts.Abstractions/IContentArtifactBackingContentPort.cs
+++ b/src/Aevatar.ContentArtifacts.Abstractions/IContentArtifactBackingContentPort.cs
@@ -1,0 +1,21 @@
+namespace Aevatar.ContentArtifacts.Abstractions;
+
+public sealed record ContentArtifactBackingContentDescriptor(
+    long ByteLength,
+    string ContentHash);
+
+public sealed record ContentArtifactBackingContentRequest(
+    ContentArtifactBackingObjectReference Reference,
+    string ScopeId,
+    string? RunId = null);
+
+public interface IContentArtifactBackingContentPort
+{
+    Task<ContentArtifactBackingContentDescriptor> DescribeAsync(
+        ContentArtifactBackingContentRequest request,
+        CancellationToken ct = default);
+
+    Task<Stream> OpenReadAsync(
+        ContentArtifactBackingContentRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto
+++ b/src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto
@@ -160,7 +160,7 @@ message CreateContentArtifact {
 
 message AppendContentArtifactRevision {
   string artifact_id = 1;
-  int64 expected_concurrency_version = 2;
+  reserved 2;
   ContentArtifactPrincipal requested_by = 3;
   ContentArtifactRevision revision = 4;
   google.protobuf.Timestamp requested_at_utc = 5;

--- a/src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto
+++ b/src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto
@@ -1,0 +1,231 @@
+syntax = "proto3";
+
+package aevatar.content_artifacts;
+option csharp_namespace = "Aevatar.ContentArtifacts.Abstractions";
+
+import "google/protobuf/timestamp.proto";
+
+enum ContentArtifactKind {
+  CONTENT_ARTIFACT_KIND_UNSPECIFIED = 0;
+  CONTENT_ARTIFACT_KIND_TEXT = 1;
+  CONTENT_ARTIFACT_KIND_MARKDOWN = 2;
+  CONTENT_ARTIFACT_KIND_STRUCTURED_DOCUMENT = 3;
+  CONTENT_ARTIFACT_KIND_OTHER_CONTENT = 4;
+}
+
+enum ContentArtifactLifecycleStatus {
+  CONTENT_ARTIFACT_LIFECYCLE_STATUS_UNSPECIFIED = 0;
+  CONTENT_ARTIFACT_LIFECYCLE_STATUS_ACTIVE = 1;
+  CONTENT_ARTIFACT_LIFECYCLE_STATUS_TOMBSTONED = 2;
+}
+
+enum ContentArtifactRevisionAvailability {
+  CONTENT_ARTIFACT_REVISION_AVAILABILITY_UNSPECIFIED = 0;
+  CONTENT_ARTIFACT_REVISION_AVAILABILITY_AVAILABLE = 1;
+  CONTENT_ARTIFACT_REVISION_AVAILABILITY_REDACTED = 2;
+  CONTENT_ARTIFACT_REVISION_AVAILABILITY_RETENTION_EXPIRED = 3;
+}
+
+message ContentArtifactPrincipal {
+  string principal_id = 1;
+  string principal_kind = 2;
+}
+
+message ContentArtifactReference {
+  string artifact_id = 1;
+  string revision_id = 2;
+  string content_hash = 3;
+  string media_type = 4;
+}
+
+message ContentArtifactAccessPolicy {
+  ContentArtifactPrincipal owner = 1;
+  repeated string reader_principal_ids = 2;
+  repeated string writer_principal_ids = 3;
+}
+
+message ContentArtifactRetentionPolicy {
+  string policy_id = 1;
+  google.protobuf.Timestamp expires_at_utc = 2;
+}
+
+message ContentArtifactBackingObjectReference {
+  string provider = 1;
+  string object_key = 2;
+}
+
+message ContentArtifactRevisionContent {
+  oneof location {
+    bytes inline_content = 1;
+    ContentArtifactBackingObjectReference backing_object = 2;
+  }
+}
+
+message ContentArtifactExecutionProvenance {
+  string scope_id = 1;
+  string team_id = 2;
+  string member_id = 3;
+  string workflow_id = 4;
+  string published_service_id = 5;
+  string run_id = 6;
+  string work_order_id = 7;
+}
+
+message ContentArtifactCitationLocator {
+  string section = 1;
+  int64 start_offset = 2;
+  int64 end_offset = 3;
+  string selector = 4;
+}
+
+message ContentArtifactRevisionCitationSource {
+  ContentArtifactReference reference = 1;
+}
+
+message ContentArtifactExternalCitationSource {
+  string source_uri = 1;
+  string stable_external_id = 2;
+  string document_revision = 3;
+  string content_hash = 4;
+  google.protobuf.Timestamp published_at_utc = 5;
+  google.protobuf.Timestamp fetched_at_utc = 6;
+}
+
+message ContentArtifactCitation {
+  string citation_id = 1;
+  string label = 2;
+  ContentArtifactCitationLocator locator = 3;
+  oneof source {
+    ContentArtifactRevisionCitationSource artifact_revision = 4;
+    ContentArtifactExternalCitationSource external_source = 5;
+  }
+}
+
+message ContentArtifactRevision {
+  string revision_id = 1;
+  int64 revision_number = 2;
+  string dedup_key = 3;
+  string parent_revision_id = 4;
+  string media_type = 5;
+  int64 byte_length = 6;
+  string content_hash = 7;
+  ContentArtifactRevisionContent content = 8;
+  ContentArtifactExecutionProvenance provenance = 9;
+  repeated ContentArtifactCitation citations = 10;
+  google.protobuf.Timestamp created_at_utc = 11;
+  ContentArtifactRevisionAvailability availability = 12;
+  string redaction_reason = 13;
+  google.protobuf.Timestamp redacted_at_utc = 14;
+  google.protobuf.Timestamp retention_expired_at_utc = 15;
+  string supersession_reason = 16;
+}
+
+message ContentArtifactState {
+  string artifact_id = 1;
+  string dedup_key = 2;
+  string scope_id = 3;
+  string team_id = 4;
+  ContentArtifactKind kind = 5;
+  string title = 6;
+  string classification = 7;
+  ContentArtifactAccessPolicy access_policy = 8;
+  ContentArtifactRetentionPolicy retention_policy = 9;
+  string work_order_id = 10;
+  map<string, ContentArtifactRevision> revisions = 11;
+  string current_revision_id = 12;
+  int64 concurrency_version = 13;
+  ContentArtifactLifecycleStatus lifecycle_status = 14;
+  google.protobuf.Timestamp created_at_utc = 15;
+  google.protobuf.Timestamp updated_at_utc = 16;
+  string tombstone_reason = 17;
+  google.protobuf.Timestamp tombstoned_at_utc = 18;
+  string creation_request_hash = 19;
+}
+
+message CreateContentArtifact {
+  string artifact_id = 1;
+  string dedup_key = 2;
+  string scope_id = 3;
+  string team_id = 4;
+  ContentArtifactKind kind = 5;
+  string title = 6;
+  string classification = 7;
+  ContentArtifactAccessPolicy access_policy = 8;
+  ContentArtifactRetentionPolicy retention_policy = 9;
+  string work_order_id = 10;
+  ContentArtifactRevision first_revision = 11;
+  int64 expected_concurrency_version = 12;
+  google.protobuf.Timestamp requested_at_utc = 13;
+}
+
+message AppendContentArtifactRevision {
+  string artifact_id = 1;
+  int64 expected_concurrency_version = 2;
+  ContentArtifactPrincipal requested_by = 3;
+  ContentArtifactRevision revision = 4;
+  google.protobuf.Timestamp requested_at_utc = 5;
+}
+
+message AdvanceContentArtifactCurrentRevision {
+  string artifact_id = 1;
+  int64 expected_concurrency_version = 2;
+  ContentArtifactPrincipal requested_by = 3;
+  string revision_id = 4;
+  google.protobuf.Timestamp requested_at_utc = 5;
+}
+
+message RedactContentArtifactRevision {
+  string artifact_id = 1;
+  int64 expected_concurrency_version = 2;
+  ContentArtifactPrincipal requested_by = 3;
+  string revision_id = 4;
+  string reason = 5;
+  google.protobuf.Timestamp requested_at_utc = 6;
+}
+
+message ExpireContentArtifactRevision {
+  string artifact_id = 1;
+  int64 expected_concurrency_version = 2;
+  ContentArtifactPrincipal requested_by = 3;
+  string revision_id = 4;
+  google.protobuf.Timestamp requested_at_utc = 5;
+}
+
+message TombstoneContentArtifact {
+  string artifact_id = 1;
+  int64 expected_concurrency_version = 2;
+  ContentArtifactPrincipal requested_by = 3;
+  string reason = 4;
+  google.protobuf.Timestamp requested_at_utc = 5;
+}
+
+message ContentArtifactCreatedEvent {
+  CreateContentArtifact request = 1;
+  google.protobuf.Timestamp created_at_utc = 2;
+}
+
+message ContentArtifactRevisionAppendedEvent {
+  ContentArtifactRevision revision = 1;
+  google.protobuf.Timestamp appended_at_utc = 2;
+}
+
+message ContentArtifactCurrentRevisionAdvancedEvent {
+  string revision_id = 1;
+  google.protobuf.Timestamp advanced_at_utc = 2;
+}
+
+message ContentArtifactRevisionRedactedEvent {
+  string revision_id = 1;
+  string reason = 2;
+  google.protobuf.Timestamp redacted_at_utc = 3;
+}
+
+message ContentArtifactRevisionExpiredEvent {
+  string revision_id = 1;
+  google.protobuf.Timestamp expired_at_utc = 2;
+}
+
+message ContentArtifactTombstonedEvent {
+  string reason = 1;
+  google.protobuf.Timestamp tombstoned_at_utc = 2;
+}

--- a/src/Aevatar.Studio.Application/Aevatar.Studio.Application.csproj
+++ b/src/Aevatar.Studio.Application/Aevatar.Studio.Application.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\Aevatar.Studio.Application.Abstractions\Aevatar.Studio.Application.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.ContentArtifacts.Abstractions\Aevatar.ContentArtifacts.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Studio.Domain\Aevatar.Studio.Domain.csproj" />
     <ProjectReference Include="..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Configuration\Aevatar.Configuration.csproj" />
@@ -21,6 +22,7 @@
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Core\Aevatar.Workflow.Core.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.WorkOrder\Aevatar.GAgents.WorkOrder.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.ContentArtifacts\Aevatar.GAgents.ContentArtifacts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactCommandPort.cs
@@ -1,0 +1,50 @@
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Abstractions;
+
+public interface IContentArtifactCommandPort
+{
+    Task<ContentArtifactAcceptedReceipt> CreateAsync(
+        string scopeId,
+        CreateContentArtifactRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(
+        string scopeId,
+        string artifactId,
+        long revisionNumber,
+        AppendContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(
+        string scopeId,
+        string artifactId,
+        AdvanceContentArtifactCurrentRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        RedactContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ExpireContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactAcceptedReceipt> TombstoneAsync(
+        string scopeId,
+        string artifactId,
+        TombstoneContentArtifactRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactCommandPort.cs
@@ -13,7 +13,6 @@ public interface IContentArtifactCommandPort
     Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(
         string scopeId,
         string artifactId,
-        long revisionNumber,
         AppendContentArtifactRevisionRequest request,
         ContentArtifactPrincipalContract requester,
         CancellationToken ct = default);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactQueryPort.cs
@@ -6,7 +6,7 @@ public interface IContentArtifactQueryPort
 {
     Task<ContentArtifactListResponse> ListAsync(
         string scopeId,
-        string ownerPrincipalId,
+        string requesterPrincipalId,
         ContentArtifactQueryRequest query,
         CancellationToken ct = default);
 

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactQueryPort.cs
@@ -1,0 +1,24 @@
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Abstractions;
+
+public interface IContentArtifactQueryPort
+{
+    Task<ContentArtifactListResponse> ListAsync(
+        string scopeId,
+        string ownerPrincipalId,
+        ContentArtifactQueryRequest query,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactCurrentStateResponse?> GetAsync(
+        string scopeId,
+        string artifactId,
+        CancellationToken ct = default);
+
+    Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactQueryPort.cs
@@ -15,6 +15,11 @@ public interface IContentArtifactQueryPort
         string artifactId,
         CancellationToken ct = default);
 
+    Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(
+        string scopeId,
+        string dedupKey,
+        CancellationToken ct = default);
+
     Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
         string scopeId,
         string artifactId,

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IContentArtifactService.cs
@@ -1,0 +1,19 @@
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Abstractions;
+
+public interface IContentArtifactService
+{
+    Task<ContentArtifactAcceptedReceipt> CreateAsync(string scopeId, CreateContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactListResponse> ListAsync(string scopeId, ContentArtifactQueryRequest query, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactCurrentStateResponse> GetAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactRevisionResponse> GetRevisionAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactRevisionResponse> GetCurrentRevisionAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+    Task<ContentArtifactRunAttachmentReceipt> AttachToRunAsync(string scopeId, AttachContentArtifactsToRunRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default);
+}

--- a/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
@@ -94,7 +94,6 @@ public sealed record CreateContentArtifactRequest(
     string? WorkOrderId = null);
 
 public sealed record AppendContentArtifactRevisionRequest(
-    long ExpectedConcurrencyVersion,
     ContentArtifactRevisionWriteRequest Revision);
 
 public sealed record AdvanceContentArtifactCurrentRevisionRequest(

--- a/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
@@ -1,0 +1,213 @@
+namespace Aevatar.Studio.Application.Studio.Contracts;
+
+public static class ContentArtifactCommandStageNames
+{
+    public const string DispatchAccepted = "dispatch_accepted";
+}
+
+public static class ContentArtifactLifecycleStatusNames
+{
+    public const string Active = "active";
+    public const string Tombstoned = "tombstoned";
+}
+
+public static class ContentArtifactRevisionAvailabilityNames
+{
+    public const string Available = "available";
+    public const string Redacted = "redacted";
+    public const string RetentionExpired = "retention_expired";
+}
+
+public sealed record ContentArtifactPrincipalContract(
+    string PrincipalId,
+    string PrincipalKind);
+
+public sealed record ContentArtifactReferenceContract(
+    string ArtifactId,
+    string RevisionId,
+    string ContentHash,
+    string MediaType);
+
+public sealed record ContentArtifactAccessPolicyContract(
+    IReadOnlyList<string>? ReaderPrincipalIds = null,
+    IReadOnlyList<string>? WriterPrincipalIds = null);
+
+public sealed record ContentArtifactRetentionPolicyContract(
+    string PolicyId,
+    DateTimeOffset? ExpiresAtUtc = null);
+
+public sealed record ContentArtifactBackingObjectContract(
+    string Provider,
+    string ObjectKey);
+
+public sealed record ContentArtifactExecutionProvenanceContract(
+    string ScopeId,
+    string? TeamId = null,
+    string? MemberId = null,
+    string? WorkflowId = null,
+    string? PublishedServiceId = null,
+    string? RunId = null,
+    string? WorkOrderId = null);
+
+public sealed record ContentArtifactCitationLocatorContract(
+    string? Section = null,
+    long? StartOffset = null,
+    long? EndOffset = null,
+    string? Selector = null);
+
+public sealed record ContentArtifactExternalCitationSourceContract(
+    string? SourceUri = null,
+    string? StableExternalId = null,
+    string? DocumentRevision = null,
+    string? ContentHash = null,
+    DateTimeOffset? PublishedAtUtc = null,
+    DateTimeOffset? FetchedAtUtc = null);
+
+public sealed record ContentArtifactCitationContract(
+    string CitationId,
+    string? Label = null,
+    ContentArtifactCitationLocatorContract? Locator = null,
+    ContentArtifactReferenceContract? ArtifactRevision = null,
+    ContentArtifactExternalCitationSourceContract? ExternalSource = null);
+
+public sealed record ContentArtifactRevisionWriteRequest(
+    string DedupKey,
+    string MediaType,
+    string ContentHash,
+    long ByteLength,
+    ContentArtifactExecutionProvenanceContract Provenance,
+    byte[]? InlineContent = null,
+    ContentArtifactBackingObjectContract? BackingObject = null,
+    string? ParentRevisionId = null,
+    IReadOnlyList<ContentArtifactCitationContract>? Citations = null,
+    string? SupersessionReason = null);
+
+public sealed record CreateContentArtifactRequest(
+    string? TeamId,
+    string Kind,
+    string Title,
+    string Classification,
+    string DedupKey,
+    ContentArtifactRevisionWriteRequest FirstRevision,
+    ContentArtifactAccessPolicyContract? AccessPolicy = null,
+    ContentArtifactRetentionPolicyContract? RetentionPolicy = null,
+    string? WorkOrderId = null);
+
+public sealed record AppendContentArtifactRevisionRequest(
+    long ExpectedConcurrencyVersion,
+    ContentArtifactRevisionWriteRequest Revision);
+
+public sealed record AdvanceContentArtifactCurrentRevisionRequest(
+    long ExpectedConcurrencyVersion,
+    string RevisionId);
+
+public sealed record RedactContentArtifactRevisionRequest(
+    long ExpectedConcurrencyVersion,
+    string Reason);
+
+public sealed record ExpireContentArtifactRevisionRequest(
+    long ExpectedConcurrencyVersion);
+
+public sealed record TombstoneContentArtifactRequest(
+    long ExpectedConcurrencyVersion,
+    string Reason);
+
+public sealed record AttachContentArtifactsToRunRequest(
+    string PublishedServiceId,
+    string RunId,
+    long ExpectedRunStateVersion,
+    IReadOnlyList<ContentArtifactReferenceContract> Artifacts);
+
+public sealed record ContentArtifactAcceptedReceipt(
+    string ArtifactId,
+    string CommandId,
+    string CorrelationId,
+    string Stage,
+    DateTimeOffset? AcceptedAtUtc = null);
+
+public sealed record ContentArtifactRevisionResponse(
+    string RevisionId,
+    long RevisionNumber,
+    string? ParentRevisionId,
+    string MediaType,
+    long ByteLength,
+    string ContentHash,
+    string Availability,
+    bool HasInlineContent,
+    bool HasBackingContent,
+    ContentArtifactExecutionProvenanceContract Provenance,
+    IReadOnlyList<ContentArtifactCitationContract> Citations,
+    DateTimeOffset CreatedAtUtc,
+    string? RedactionReason = null,
+    DateTimeOffset? RedactedAtUtc = null,
+    DateTimeOffset? RetentionExpiredAtUtc = null,
+    string? SupersessionReason = null);
+
+public sealed record ContentArtifactCurrentStateResponse(
+    string ArtifactId,
+    string ScopeId,
+    string? TeamId,
+    string Kind,
+    string Title,
+    string Classification,
+    string LifecycleStatus,
+    string? CurrentRevisionId,
+    long ConcurrencyVersion,
+    long StateVersion,
+    ContentArtifactPrincipalContract Owner,
+    IReadOnlyList<string> ReaderPrincipalIds,
+    IReadOnlyList<string> WriterPrincipalIds,
+    ContentArtifactRetentionPolicyContract? RetentionPolicy,
+    string? WorkOrderId,
+    IReadOnlyList<ContentArtifactRevisionResponse> Revisions,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc,
+    string? TombstoneReason = null,
+    DateTimeOffset? TombstonedAtUtc = null);
+
+public sealed record ContentArtifactListResponse(
+    string ScopeId,
+    IReadOnlyList<ContentArtifactCurrentStateResponse> Artifacts,
+    string? NextPageToken = null);
+
+public sealed record ContentArtifactQueryRequest(
+    int? PageSize = null,
+    string? PageToken = null,
+    string? TeamId = null,
+    string? Kind = null,
+    string? LifecycleStatus = null,
+    string? WorkOrderId = null,
+    string? RunId = null);
+
+public sealed record ContentArtifactRevisionContentResponse(
+    ContentArtifactReferenceContract Reference,
+    byte[] Content);
+
+public sealed record ContentArtifactRunAttachmentReceipt(
+    string RunId,
+    string CommandId,
+    string CorrelationId,
+    string Stage,
+    DateTimeOffset? AcceptedAtUtc = null);
+
+public sealed class ContentArtifactNotFoundException : InvalidOperationException
+{
+    public ContentArtifactNotFoundException(string scopeId, string artifactId)
+        : base($"ContentArtifact '{artifactId}' was not found in scope '{scopeId}'.")
+    {
+        ScopeId = scopeId;
+        ArtifactId = artifactId;
+    }
+
+    public string ScopeId { get; }
+
+    public string ArtifactId { get; }
+}
+
+public sealed class ContentArtifactContentUnavailableException : InvalidOperationException
+{
+    public ContentArtifactContentUnavailableException(string artifactId, string revisionId, string reason)
+        : base($"ContentArtifact '{artifactId}' revision '{revisionId}' content is unavailable: {reason}")
+    {
+    }
+}

--- a/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
@@ -203,6 +203,17 @@ public sealed class ContentArtifactNotFoundException : InvalidOperationException
     public string ArtifactId { get; }
 }
 
+public sealed class ContentArtifactIdentityConflictException : InvalidOperationException
+{
+    public ContentArtifactIdentityConflictException(string dedupKey)
+        : base($"ContentArtifact dedup key '{dedupKey}' is already occupied in this scope.")
+    {
+        DedupKey = dedupKey;
+    }
+
+    public string DedupKey { get; }
+}
+
 public sealed class ContentArtifactContentUnavailableException : InvalidOperationException
 {
     public ContentArtifactContentUnavailableException(string artifactId, string revisionId, string reason)

--- a/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
@@ -52,6 +52,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IWorkOrderExecutionScheduler>(provider =>
             provider.GetRequiredService<WorkOrderExecutionScheduler>());
         services.TryAddSingleton<WorkOrderExecutionService>();
+        services.TryAddSingleton<IContentArtifactService, ContentArtifactService>();
         services.TryAddSingleton<IWorkOrderService, WorkOrderService>();
         services.TryAddSingleton<IStudioTeamProvisioningPort, StudioTeamProvisioningPort>();
         services.TryAddSingleton<IStudioMemberProvisioningPort, StudioMemberProvisioningPort>();

--- a/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
@@ -1,0 +1,577 @@
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Services;
+
+public sealed class ContentArtifactService : IContentArtifactService
+{
+    private readonly IStudioTeamQueryPort _teamQueryPort;
+    private readonly IContentArtifactCommandPort _commandPort;
+    private readonly IContentArtifactQueryPort _queryPort;
+    private readonly IServiceRunQueryPort _serviceRunQueryPort;
+    private readonly IServiceRunResultArtifactAttachmentPort _serviceRunResultArtifactAttachmentPort;
+
+    public ContentArtifactService(
+        IStudioTeamQueryPort teamQueryPort,
+        IContentArtifactCommandPort commandPort,
+        IContentArtifactQueryPort queryPort,
+        IServiceRunQueryPort serviceRunQueryPort,
+        IServiceRunResultArtifactAttachmentPort serviceRunResultArtifactAttachmentPort)
+    {
+        _teamQueryPort = teamQueryPort ?? throw new ArgumentNullException(nameof(teamQueryPort));
+        _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _serviceRunQueryPort = serviceRunQueryPort ?? throw new ArgumentNullException(nameof(serviceRunQueryPort));
+        _serviceRunResultArtifactAttachmentPort = serviceRunResultArtifactAttachmentPort
+                                                  ?? throw new ArgumentNullException(nameof(serviceRunResultArtifactAttachmentPort));
+    }
+
+    public async Task<ContentArtifactAcceptedReceipt> CreateAsync(
+        string scopeId,
+        CreateContentArtifactRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var normalizedRequester = NormalizePrincipal(requester);
+        var normalizedRequest = NormalizeCreateRequest(normalizedScopeId, request);
+        if (normalizedRequest.TeamId != null)
+            await EnsureActiveTeamAsync(normalizedScopeId, normalizedRequest.TeamId, ct);
+        await ValidateExecutionProvenanceAsync(normalizedRequest.FirstRevision.Provenance, ct);
+        return await _commandPort.CreateAsync(
+            normalizedScopeId,
+            normalizedRequest,
+            normalizedRequester,
+            ct);
+    }
+
+    public Task<ContentArtifactListResponse> ListAsync(
+        string scopeId,
+        ContentArtifactQueryRequest query,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default) =>
+        _queryPort.ListAsync(
+            NormalizeRequired(scopeId, nameof(scopeId)),
+            NormalizePrincipal(requester).PrincipalId,
+            NormalizeQuery(query),
+            ct);
+
+    public async Task<ContentArtifactCurrentStateResponse> GetAsync(
+        string scopeId,
+        string artifactId,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default) =>
+        await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+
+    public async Task<ContentArtifactRevisionResponse> GetRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+        return FindRevision(current, revisionId);
+    }
+
+    public async Task<ContentArtifactRevisionResponse> GetCurrentRevisionAsync(
+        string scopeId,
+        string artifactId,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+        if (string.IsNullOrWhiteSpace(current.CurrentRevisionId))
+        {
+            throw new ContentArtifactContentUnavailableException(
+                current.ArtifactId,
+                string.Empty,
+                "artifact has no current revision");
+        }
+        return FindRevision(current, current.CurrentRevisionId);
+    }
+
+    public async Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+        var revision = FindRevision(current, revisionId);
+        if (!string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
+        {
+            throw new ContentArtifactContentUnavailableException(
+                current.ArtifactId,
+                revision.RevisionId,
+                "artifact is tombstoned");
+        }
+        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+        {
+            throw new ContentArtifactContentUnavailableException(
+                current.ArtifactId,
+                revision.RevisionId,
+                revision.Availability);
+        }
+        return await _queryPort.GetRevisionContentAsync(
+            current.ScopeId,
+            current.ArtifactId,
+            revision.RevisionId,
+            NormalizePrincipal(requester),
+            ct);
+    }
+
+    public async Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(
+        string scopeId,
+        string artifactId,
+        AppendContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var current = await GetCurrentForMutationAsync(
+            scopeId,
+            artifactId,
+            request.ExpectedConcurrencyVersion,
+            requester,
+            ownerOnly: false,
+            ct);
+        var normalizedRevision = NormalizeRevisionWrite(
+            request.Revision,
+            current.ScopeId,
+            current.TeamId);
+        var revisionNumber = checked(
+            current.Revisions.Select(static revision => revision.RevisionNumber).DefaultIfEmpty().Max() + 1);
+        await ValidateExecutionProvenanceAsync(normalizedRevision.Provenance, ct);
+        return await _commandPort.AppendRevisionAsync(
+            current.ScopeId,
+            current.ArtifactId,
+            revisionNumber,
+            request with { Revision = normalizedRevision },
+            NormalizePrincipal(requester),
+            ct);
+    }
+
+    public async Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(
+        string scopeId,
+        string artifactId,
+        AdvanceContentArtifactCurrentRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var current = await GetCurrentForMutationAsync(
+            scopeId,
+            artifactId,
+            request.ExpectedConcurrencyVersion,
+            requester,
+            ownerOnly: false,
+            ct);
+        var revisionId = NormalizeRequired(request.RevisionId, nameof(request.RevisionId));
+        var revision = FindRevision(current, revisionId);
+        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+            throw new InvalidOperationException("Only an available ContentArtifact revision can become current.");
+        return await _commandPort.AdvanceCurrentRevisionAsync(
+            current.ScopeId,
+            current.ArtifactId,
+            request with { RevisionId = revisionId },
+            NormalizePrincipal(requester),
+            ct);
+    }
+
+    public async Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        RedactContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var current = await GetCurrentForMutationAsync(
+            scopeId,
+            artifactId,
+            request.ExpectedConcurrencyVersion,
+            requester,
+            ownerOnly: false,
+            ct);
+        var normalizedRevisionId = FindRevision(current, revisionId).RevisionId;
+        return await _commandPort.RedactRevisionAsync(
+            current.ScopeId,
+            current.ArtifactId,
+            normalizedRevisionId,
+            request with { Reason = NormalizeRequired(request.Reason, nameof(request.Reason)) },
+            NormalizePrincipal(requester),
+            ct);
+    }
+
+    public async Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ExpireContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var current = await GetCurrentForMutationAsync(
+            scopeId,
+            artifactId,
+            request.ExpectedConcurrencyVersion,
+            requester,
+            ownerOnly: false,
+            ct);
+        var normalizedRevisionId = FindRevision(current, revisionId).RevisionId;
+        return await _commandPort.ExpireRevisionAsync(
+            current.ScopeId,
+            current.ArtifactId,
+            normalizedRevisionId,
+            request,
+            NormalizePrincipal(requester),
+            ct);
+    }
+
+    public async Task<ContentArtifactAcceptedReceipt> TombstoneAsync(
+        string scopeId,
+        string artifactId,
+        TombstoneContentArtifactRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var current = await GetCurrentForMutationAsync(
+            scopeId,
+            artifactId,
+            request.ExpectedConcurrencyVersion,
+            requester,
+            ownerOnly: true,
+            ct);
+        return await _commandPort.TombstoneAsync(
+            current.ScopeId,
+            current.ArtifactId,
+            request with { Reason = NormalizeRequired(request.Reason, nameof(request.Reason)) },
+            NormalizePrincipal(requester),
+            ct);
+    }
+
+    public async Task<ContentArtifactRunAttachmentReceipt> AttachToRunAsync(
+        string scopeId,
+        AttachContentArtifactsToRunRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var serviceId = NormalizeRequired(request.PublishedServiceId, nameof(request.PublishedServiceId));
+        var runId = NormalizeRequired(request.RunId, nameof(request.RunId));
+        var principal = NormalizePrincipal(requester);
+        var run = await _serviceRunQueryPort.GetByRunIdAsync(normalizedScopeId, serviceId, runId, ct)
+                  ?? throw new InvalidOperationException("Service Run was not found in the requested Scope and published service.");
+        if (!string.Equals(run.ScopeId, normalizedScopeId, StringComparison.Ordinal) ||
+            !string.Equals(run.ServiceId, serviceId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Service Run was not found in the requested Scope and published service.");
+        }
+        if (run.StateVersion != request.ExpectedRunStateVersion)
+        {
+            throw new InvalidOperationException(
+                $"Service Run state version is {run.StateVersion}, not {request.ExpectedRunStateVersion}.");
+        }
+        if (request.Artifacts == null || request.Artifacts.Count == 0)
+            throw new InvalidOperationException("At least one ContentArtifact reference is required.");
+
+        var references = new List<ContentArtifactReference>(request.Artifacts.Count);
+        foreach (var requestedReference in request.Artifacts)
+        {
+            var current = await GetAuthorizedCurrentAsync(
+                normalizedScopeId,
+                requestedReference.ArtifactId,
+                principal,
+                requireWrite: false,
+                ct);
+            var revision = FindRevision(current, requestedReference.RevisionId);
+            if (!string.Equals(revision.ContentHash, requestedReference.ContentHash, StringComparison.OrdinalIgnoreCase) ||
+                !string.Equals(revision.MediaType, requestedReference.MediaType, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("ContentArtifact reference does not match the exact stored revision.");
+            }
+            if (!string.Equals(revision.Provenance.ScopeId, normalizedScopeId, StringComparison.Ordinal) ||
+                !string.Equals(revision.Provenance.PublishedServiceId, serviceId, StringComparison.Ordinal) ||
+                !string.Equals(revision.Provenance.RunId, runId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("ContentArtifact revision provenance does not match the target Service Run.");
+            }
+            references.Add(new ContentArtifactReference
+            {
+                ArtifactId = current.ArtifactId,
+                RevisionId = revision.RevisionId,
+                ContentHash = revision.ContentHash,
+                MediaType = revision.MediaType,
+            });
+        }
+
+        var result = await _serviceRunResultArtifactAttachmentPort.AttachResultArtifactsAsync(
+            run.ActorId,
+            run.RunId,
+            request.ExpectedRunStateVersion,
+            references,
+            ct);
+        return new ContentArtifactRunAttachmentReceipt(
+            result.RunId,
+            result.CommandId,
+            result.CorrelationId,
+            ContentArtifactCommandStageNames.DispatchAccepted,
+            result.AcceptedAtUtc);
+    }
+
+    private async Task<ContentArtifactCurrentStateResponse> GetCurrentForMutationAsync(
+        string scopeId,
+        string artifactId,
+        long expectedConcurrencyVersion,
+        ContentArtifactPrincipalContract requester,
+        bool ownerOnly,
+        CancellationToken ct)
+    {
+        var current = await GetAuthorizedCurrentAsync(
+            scopeId,
+            artifactId,
+            requester,
+            requireWrite: !ownerOnly,
+            ct);
+        var principal = NormalizePrincipal(requester);
+        if (ownerOnly && !PrincipalEquals(current.Owner, principal))
+            throw new InvalidOperationException("Only the ContentArtifact owner can perform this command.");
+        if (!string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
+            throw new InvalidOperationException("ContentArtifact is tombstoned.");
+        if (current.ConcurrencyVersion != expectedConcurrencyVersion)
+        {
+            throw new InvalidOperationException(
+                $"ContentArtifact concurrency version is {current.ConcurrencyVersion}, not {expectedConcurrencyVersion}.");
+        }
+        return current;
+    }
+
+    private async Task<ContentArtifactCurrentStateResponse> GetAuthorizedCurrentAsync(
+        string scopeId,
+        string artifactId,
+        ContentArtifactPrincipalContract requester,
+        bool requireWrite,
+        CancellationToken ct)
+    {
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var normalizedArtifactId = NormalizeRequired(artifactId, nameof(artifactId));
+        var principal = NormalizePrincipal(requester);
+        var current = await _queryPort.GetAsync(normalizedScopeId, normalizedArtifactId, ct)
+                      ?? throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
+        if (!string.Equals(current.ScopeId, normalizedScopeId, StringComparison.Ordinal))
+            throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
+        var authorized = PrincipalEquals(current.Owner, principal) ||
+                         (requireWrite
+                             ? current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal)
+                             : current.ReaderPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal));
+        if (!authorized)
+        {
+            throw new InvalidOperationException(
+                $"ContentArtifact principal is not authorized to {(requireWrite ? "write" : "read")}.");
+        }
+        return current;
+    }
+
+    private async Task EnsureActiveTeamAsync(string scopeId, string teamId, CancellationToken ct)
+    {
+        var team = await _teamQueryPort.GetAsync(scopeId, teamId, ct);
+        if (team == null ||
+            !string.Equals(team.ScopeId, scopeId, StringComparison.Ordinal) ||
+            !string.Equals(team.TeamId, teamId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Team was not found in the requested Scope.");
+        }
+        if (!string.Equals(team.LifecycleStage, TeamLifecycleStageNames.Active, StringComparison.Ordinal))
+            throw new InvalidOperationException("ContentArtifacts can only be created for an active Team.");
+    }
+
+    private async Task ValidateExecutionProvenanceAsync(
+        ContentArtifactExecutionProvenanceContract provenance,
+        CancellationToken ct)
+    {
+        var hasRun = !string.IsNullOrWhiteSpace(provenance.RunId);
+        var hasService = !string.IsNullOrWhiteSpace(provenance.PublishedServiceId);
+        if (hasRun != hasService)
+            throw new InvalidOperationException("Execution provenance requires both Run and published service identities.");
+        if (!hasRun)
+            return;
+        var run = await _serviceRunQueryPort.GetByRunIdAsync(
+            provenance.ScopeId,
+            provenance.PublishedServiceId!,
+            provenance.RunId!,
+            ct);
+        if (run == null ||
+            !string.Equals(run.ScopeId, provenance.ScopeId, StringComparison.Ordinal) ||
+            !string.Equals(run.ServiceId, provenance.PublishedServiceId, StringComparison.Ordinal) ||
+            !string.Equals(run.RunId, provenance.RunId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Execution provenance does not identify a Service Run in the artifact Scope.");
+        }
+    }
+
+    private static CreateContentArtifactRequest NormalizeCreateRequest(
+        string scopeId,
+        CreateContentArtifactRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var teamId = NormalizeOptional(request.TeamId);
+        var kind = NormalizeKind(request.Kind);
+        return request with
+        {
+            TeamId = teamId,
+            Kind = kind,
+            Title = NormalizeRequired(request.Title, nameof(request.Title)),
+            Classification = NormalizeRequired(request.Classification, nameof(request.Classification)),
+            DedupKey = NormalizeRequired(request.DedupKey, nameof(request.DedupKey)),
+            FirstRevision = NormalizeRevisionWrite(request.FirstRevision, scopeId, teamId),
+            AccessPolicy = new ContentArtifactAccessPolicyContract(
+                NormalizeIds(request.AccessPolicy?.ReaderPrincipalIds),
+                NormalizeIds(request.AccessPolicy?.WriterPrincipalIds)),
+            RetentionPolicy = request.RetentionPolicy == null
+                ? null
+                : new ContentArtifactRetentionPolicyContract(
+                    NormalizeRequired(request.RetentionPolicy.PolicyId, "retentionPolicy.policyId"),
+                    request.RetentionPolicy.ExpiresAtUtc),
+            WorkOrderId = NormalizeOptional(request.WorkOrderId),
+        };
+    }
+
+    private static ContentArtifactRevisionWriteRequest NormalizeRevisionWrite(
+        ContentArtifactRevisionWriteRequest request,
+        string scopeId,
+        string? teamId)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.InlineContent != null && request.BackingObject != null)
+            throw new InvalidOperationException("A ContentArtifact revision cannot contain both inline and backing content.");
+        if (request.InlineContent == null && request.BackingObject == null)
+            throw new InvalidOperationException("A ContentArtifact revision content location is required.");
+
+        var contentHash = NormalizeRequired(request.ContentHash, "revision.contentHash").ToLowerInvariant();
+        var byteLength = request.ByteLength;
+        byte[]? inlineContent = null;
+        if (request.InlineContent != null)
+        {
+            inlineContent = request.InlineContent.ToArray();
+            var verifiedHash = Convert.ToHexStringLower(SHA256.HashData(inlineContent));
+            if (byteLength != inlineContent.LongLength ||
+                !string.Equals(contentHash, verifiedHash, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("ContentArtifact inline content hash or byte length is invalid.");
+            }
+        }
+
+        var provenance = request.Provenance ?? throw new InvalidOperationException("revision.provenance is required.");
+        return request with
+        {
+            DedupKey = NormalizeRequired(request.DedupKey, "revision.dedupKey"),
+            MediaType = NormalizeRequired(request.MediaType, "revision.mediaType"),
+            ContentHash = contentHash,
+            ByteLength = byteLength,
+            InlineContent = inlineContent,
+            BackingObject = request.BackingObject == null
+                ? null
+                : new ContentArtifactBackingObjectContract(
+                    NormalizeRequired(request.BackingObject.Provider, "revision.backingObject.provider").ToLowerInvariant(),
+                    NormalizeRequired(request.BackingObject.ObjectKey, "revision.backingObject.objectKey")),
+            ParentRevisionId = NormalizeOptional(request.ParentRevisionId),
+            Provenance = new ContentArtifactExecutionProvenanceContract(
+                scopeId,
+                teamId,
+                NormalizeOptional(provenance.MemberId),
+                NormalizeOptional(provenance.WorkflowId),
+                NormalizeOptional(provenance.PublishedServiceId),
+                NormalizeOptional(provenance.RunId),
+                NormalizeOptional(provenance.WorkOrderId)),
+            Citations = request.Citations?.Select(NormalizeCitation).ToArray(),
+            SupersessionReason = NormalizeOptional(request.SupersessionReason),
+        };
+    }
+
+    private static ContentArtifactCitationContract NormalizeCitation(ContentArtifactCitationContract citation)
+    {
+        ArgumentNullException.ThrowIfNull(citation);
+        return citation with
+        {
+            CitationId = NormalizeRequired(citation.CitationId, "citation.citationId"),
+            Label = NormalizeOptional(citation.Label),
+        };
+    }
+
+    private static ContentArtifactQueryRequest NormalizeQuery(ContentArtifactQueryRequest? query)
+    {
+        query ??= new ContentArtifactQueryRequest();
+        return query with
+        {
+            PageToken = NormalizeOptional(query.PageToken),
+            TeamId = NormalizeOptional(query.TeamId),
+            Kind = query.Kind == null ? null : NormalizeKind(query.Kind),
+            LifecycleStatus = NormalizeOptional(query.LifecycleStatus),
+            WorkOrderId = NormalizeOptional(query.WorkOrderId),
+            RunId = NormalizeOptional(query.RunId),
+        };
+    }
+
+    private static ContentArtifactRevisionResponse FindRevision(
+        ContentArtifactCurrentStateResponse current,
+        string revisionId)
+    {
+        var normalizedRevisionId = NormalizeRequired(revisionId, nameof(revisionId));
+        return current.Revisions.FirstOrDefault(revision =>
+                   string.Equals(revision.RevisionId, normalizedRevisionId, StringComparison.Ordinal))
+               ?? throw new ContentArtifactContentUnavailableException(
+                   current.ArtifactId,
+                   normalizedRevisionId,
+                   "revision was not found");
+    }
+
+    private static ContentArtifactPrincipalContract NormalizePrincipal(ContentArtifactPrincipalContract principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+        return new ContentArtifactPrincipalContract(
+            NormalizeRequired(principal.PrincipalId, "principal.principalId"),
+            NormalizeRequired(principal.PrincipalKind, "principal.principalKind"));
+    }
+
+    private static bool PrincipalEquals(
+        ContentArtifactPrincipalContract left,
+        ContentArtifactPrincipalContract right) =>
+        string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal) &&
+        string.Equals(left.PrincipalKind, right.PrincipalKind, StringComparison.Ordinal);
+
+    private static IReadOnlyList<string> NormalizeIds(IReadOnlyList<string>? values) =>
+        (values ?? [])
+            .Select(value => NormalizeRequired(value, "principalId"))
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+    private static string NormalizeKind(string value) => value.Trim().ToLowerInvariant() switch
+    {
+        "text" => "text",
+        "markdown" => "markdown",
+        "structured_document" => "structured_document",
+        "other_content" => "other_content",
+        _ => throw new InvalidOperationException($"Unsupported ContentArtifact kind '{value}'."),
+    };
+
+    private static string NormalizeRequired(string? value, string parameterName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException($"{parameterName} is required.", parameterName);
+        return normalized;
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
@@ -38,6 +38,12 @@ public sealed class ContentArtifactService : IContentArtifactService
         var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
         var normalizedRequester = NormalizePrincipal(requester);
         var normalizedRequest = NormalizeCreateRequest(normalizedScopeId, request);
+        var occupied = await _queryPort.GetByDedupKeyAsync(
+            normalizedScopeId,
+            normalizedRequest.DedupKey,
+            ct);
+        if (occupied != null && !PrincipalEquals(occupied.Owner, normalizedRequester))
+            throw new ContentArtifactIdentityConflictException(normalizedRequest.DedupKey);
         if (normalizedRequest.TeamId != null)
             await EnsureActiveTeamAsync(normalizedScopeId, normalizedRequest.TeamId, ct);
         await ValidateExecutionProvenanceAsync(normalizedRequest.FirstRevision.Provenance, ct);
@@ -64,7 +70,7 @@ public sealed class ContentArtifactService : IContentArtifactService
         string artifactId,
         ContentArtifactPrincipalContract requester,
         CancellationToken ct = default) =>
-        await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+        await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, ct);
 
     public async Task<ContentArtifactRevisionResponse> GetRevisionAsync(
         string scopeId,
@@ -73,7 +79,7 @@ public sealed class ContentArtifactService : IContentArtifactService
         ContentArtifactPrincipalContract requester,
         CancellationToken ct = default)
     {
-        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, ct);
         return FindRevision(current, revisionId);
     }
 
@@ -83,14 +89,16 @@ public sealed class ContentArtifactService : IContentArtifactService
         ContentArtifactPrincipalContract requester,
         CancellationToken ct = default)
     {
-        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
-        if (string.IsNullOrWhiteSpace(current.CurrentRevisionId))
+        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, ct);
+        if (string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Tombstoned, StringComparison.Ordinal))
         {
             throw new ContentArtifactContentUnavailableException(
                 current.ArtifactId,
                 string.Empty,
-                "artifact has no current revision");
+                "artifact is tombstoned");
         }
+        if (string.IsNullOrWhiteSpace(current.CurrentRevisionId))
+            throw new ContentArtifactNotFoundException(current.ScopeId, current.ArtifactId);
         return FindRevision(current, current.CurrentRevisionId);
     }
 
@@ -101,22 +109,25 @@ public sealed class ContentArtifactService : IContentArtifactService
         ContentArtifactPrincipalContract requester,
         CancellationToken ct = default)
     {
-        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, requireWrite: false, ct);
+        var current = await GetAuthorizedCurrentAsync(scopeId, artifactId, requester, ct);
         var revision = FindRevision(current, revisionId);
-        if (!string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
+        if (string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Tombstoned, StringComparison.Ordinal))
         {
             throw new ContentArtifactContentUnavailableException(
                 current.ArtifactId,
                 revision.RevisionId,
                 "artifact is tombstoned");
         }
-        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+        if (revision.Availability is ContentArtifactRevisionAvailabilityNames.Redacted or
+            ContentArtifactRevisionAvailabilityNames.RetentionExpired)
         {
             throw new ContentArtifactContentUnavailableException(
                 current.ArtifactId,
                 revision.RevisionId,
                 revision.Availability);
         }
+        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+            throw new InvalidOperationException("ContentArtifact revision availability is invalid.");
         return await _queryPort.GetRevisionContentAsync(
             current.ScopeId,
             current.ArtifactId,
@@ -292,7 +303,6 @@ public sealed class ContentArtifactService : IContentArtifactService
                 normalizedScopeId,
                 requestedReference.ArtifactId,
                 principal,
-                requireWrite: false,
                 ct);
             var revision = FindRevision(current, requestedReference.RevisionId);
             if (!string.Equals(revision.ContentHash, requestedReference.ContentHash, StringComparison.OrdinalIgnoreCase) ||
@@ -341,18 +351,17 @@ public sealed class ContentArtifactService : IContentArtifactService
             scopeId,
             artifactId,
             requester,
-            requireWrite: false,
             ct);
         var principal = NormalizePrincipal(requester);
         var isOwner = PrincipalEquals(current.Owner, principal);
         if (ownerOnly)
         {
             if (!isOwner)
-                throw new InvalidOperationException("Only the ContentArtifact owner can perform this command.");
+                throw new ContentArtifactNotFoundException(current.ScopeId, current.ArtifactId);
         }
         else if (!isOwner && !current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal))
         {
-            throw new InvalidOperationException("ContentArtifact principal is not authorized to write.");
+            throw new ContentArtifactNotFoundException(current.ScopeId, current.ArtifactId);
         }
         if (!string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
             throw new InvalidOperationException("ContentArtifact is tombstoned.");
@@ -368,7 +377,6 @@ public sealed class ContentArtifactService : IContentArtifactService
         string scopeId,
         string artifactId,
         ContentArtifactPrincipalContract requester,
-        bool requireWrite,
         CancellationToken ct)
     {
         var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
@@ -379,14 +387,9 @@ public sealed class ContentArtifactService : IContentArtifactService
         if (!string.Equals(current.ScopeId, normalizedScopeId, StringComparison.Ordinal))
             throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
         var authorized = PrincipalEquals(current.Owner, principal) ||
-                         (requireWrite
-                             ? current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal)
-                             : current.ReaderPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal));
+                         current.ReaderPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal);
         if (!authorized)
-        {
-            throw new InvalidOperationException(
-                $"ContentArtifact principal is not authorized to {(requireWrite ? "write" : "read")}.");
-        }
+            throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
         return current;
     }
 
@@ -537,10 +540,9 @@ public sealed class ContentArtifactService : IContentArtifactService
         var normalizedRevisionId = NormalizeRequired(revisionId, nameof(revisionId));
         return current.Revisions.FirstOrDefault(revision =>
                    string.Equals(revision.RevisionId, normalizedRevisionId, StringComparison.Ordinal))
-               ?? throw new ContentArtifactContentUnavailableException(
-                   current.ArtifactId,
-                   normalizedRevisionId,
-                   "revision was not found");
+               ?? throw new ContentArtifactNotFoundException(
+                   current.ScopeId,
+                   current.ArtifactId);
     }
 
     private static ContentArtifactPrincipalContract NormalizePrincipal(ContentArtifactPrincipalContract principal)

--- a/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
@@ -133,26 +133,27 @@ public sealed class ContentArtifactService : IContentArtifactService
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var current = await GetCurrentForMutationAsync(
-            scopeId,
-            artifactId,
-            request.ExpectedConcurrencyVersion,
-            requester,
-            ownerOnly: false,
-            ct);
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var normalizedArtifactId = NormalizeRequired(artifactId, nameof(artifactId));
+        var principal = NormalizePrincipal(requester);
+        var current = await _queryPort.GetAsync(normalizedScopeId, normalizedArtifactId, ct);
+        if (current != null)
+        {
+            var canWrite = PrincipalEquals(current.Owner, principal) ||
+                           current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal);
+            if (!string.Equals(current.ScopeId, normalizedScopeId, StringComparison.Ordinal) || !canWrite)
+                throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
+        }
         var normalizedRevision = NormalizeRevisionWrite(
             request.Revision,
-            current.ScopeId,
-            current.TeamId);
-        var revisionNumber = checked(
-            current.Revisions.Select(static revision => revision.RevisionNumber).DefaultIfEmpty().Max() + 1);
+            normalizedScopeId,
+            current?.TeamId ?? NormalizeOptional(request.Revision.Provenance?.TeamId));
         await ValidateExecutionProvenanceAsync(normalizedRevision.Provenance, ct);
         return await _commandPort.AppendRevisionAsync(
-            current.ScopeId,
-            current.ArtifactId,
-            revisionNumber,
+            normalizedScopeId,
+            normalizedArtifactId,
             request with { Revision = normalizedRevision },
-            NormalizePrincipal(requester),
+            principal,
             ct);
     }
 

--- a/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
@@ -341,11 +341,19 @@ public sealed class ContentArtifactService : IContentArtifactService
             scopeId,
             artifactId,
             requester,
-            requireWrite: !ownerOnly,
+            requireWrite: false,
             ct);
         var principal = NormalizePrincipal(requester);
-        if (ownerOnly && !PrincipalEquals(current.Owner, principal))
-            throw new InvalidOperationException("Only the ContentArtifact owner can perform this command.");
+        var isOwner = PrincipalEquals(current.Owner, principal);
+        if (ownerOnly)
+        {
+            if (!isOwner)
+                throw new InvalidOperationException("Only the ContentArtifact owner can perform this command.");
+        }
+        else if (!isOwner && !current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException("ContentArtifact principal is not authorized to write.");
+        }
         if (!string.Equals(current.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
             throw new InvalidOperationException("ContentArtifact is tombstoned.");
         if (current.ConcurrencyVersion != expectedConcurrencyVersion)
@@ -546,8 +554,7 @@ public sealed class ContentArtifactService : IContentArtifactService
     private static bool PrincipalEquals(
         ContentArtifactPrincipalContract left,
         ContentArtifactPrincipalContract right) =>
-        string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal) &&
-        string.Equals(left.PrincipalKind, right.PrincipalKind, StringComparison.Ordinal);
+        string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal);
 
     private static IReadOnlyList<string> NormalizeIds(IReadOnlyList<string>? values) =>
         (values ?? [])

--- a/src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj
+++ b/src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Aevatar.ContentArtifacts.Abstractions\Aevatar.ContentArtifacts.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.CQRS.Projection.Providers.Elasticsearch\Aevatar.CQRS.Projection.Providers.Elasticsearch.csproj" />
     <ProjectReference Include="..\Aevatar.CQRS.Projection.Providers.InMemory\Aevatar.CQRS.Projection.Providers.InMemory.csproj" />
     <ProjectReference Include="..\Aevatar.Studio.Infrastructure\Aevatar.Studio.Infrastructure.csproj" />

--- a/src/Aevatar.Studio.Hosting/ContentArtifacts/WorkflowFileContentArtifactBackingContentPort.cs
+++ b/src/Aevatar.Studio.Hosting/ContentArtifacts/WorkflowFileContentArtifactBackingContentPort.cs
@@ -1,0 +1,105 @@
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+
+namespace Aevatar.Studio.Hosting.ContentArtifacts;
+
+internal sealed class WorkflowFileContentArtifactBackingContentPort(
+    IFileArtifactReadPort? workflowFileArtifactReadPort = null)
+    : IContentArtifactBackingContentPort
+{
+    public const string Provider = "workflow-file";
+
+    public async Task<ContentArtifactBackingContentDescriptor> DescribeAsync(
+        ContentArtifactBackingContentRequest request,
+        CancellationToken ct = default)
+    {
+        var fileRef = ToFileArtifactRef(request);
+        var descriptor = await GetReadPort().DescribeAsync(fileRef, ct);
+        ValidateDescriptor(request, descriptor);
+        return new ContentArtifactBackingContentDescriptor(
+            descriptor.SizeBytes,
+            descriptor.Sha256!);
+    }
+
+    public async Task<Stream> OpenReadAsync(
+        ContentArtifactBackingContentRequest request,
+        CancellationToken ct = default)
+    {
+        var fileRef = ToFileArtifactRef(request);
+        var content = await GetReadPort().OpenReadAsync(fileRef, ct);
+        ValidateDescriptor(request, content.FileRef);
+        return content.Content;
+    }
+
+    private IFileArtifactReadPort GetReadPort() =>
+        workflowFileArtifactReadPort
+        ?? throw new InvalidOperationException("Workflow file backing content provider is unavailable.");
+
+    private static FileArtifactRef ToFileArtifactRef(ContentArtifactBackingContentRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Reference);
+        if (!string.Equals(request.Reference.Provider?.Trim(), Provider, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Unsupported ContentArtifact backing provider '{request.Reference.Provider}'.");
+        }
+
+        var objectKey = NormalizeRequired(request.Reference.ObjectKey, "backing object key");
+        var scopeId = NormalizeRequired(request.ScopeId, "backing content scope id");
+        return new FileArtifactRef
+        {
+            ArtifactId = objectKey,
+            OwnerScopeId = scopeId,
+            OwnerRunId = NormalizeOptional(request.RunId),
+        };
+    }
+
+    private static void ValidateDescriptor(
+        ContentArtifactBackingContentRequest request,
+        FileArtifactRef descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        var requestedScopeId = NormalizeRequired(request.ScopeId, "backing content scope id");
+        if (!string.Equals(descriptor.OwnerScopeId, requestedScopeId, StringComparison.Ordinal))
+            throw new InvalidOperationException("Workflow file backing content does not belong to the ContentArtifact Scope.");
+
+        if (!string.Equals(
+                NormalizeOptional(descriptor.OwnerRunId),
+                NormalizeOptional(request.RunId),
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Workflow file backing content does not belong to the ContentArtifact Run.");
+        }
+        if (descriptor.SizeBytes < 0)
+            throw new InvalidOperationException("Workflow file backing content has an invalid byte length.");
+        ValidateSha256(descriptor.Sha256);
+    }
+
+    private static void ValidateSha256(string? value)
+    {
+        if (value?.Length != 64)
+            throw new InvalidOperationException("Workflow file backing content must expose a SHA-256 hash.");
+        try
+        {
+            _ = Convert.FromHexString(value);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException(
+                "Workflow file backing content must expose a SHA-256 hash.",
+                ex);
+        }
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new InvalidOperationException($"ContentArtifact {fieldName} is required.");
+        return normalized;
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs
@@ -42,6 +42,14 @@ internal static class ContentArtifactEndpoints
             var receipt = await service.CreateAsync(scopeId, request, principal, ct);
             return Results.Accepted(BuildLocation(scopeId, receipt.ArtifactId), receipt);
         }
+        catch (ContentArtifactIdentityConflictException ex)
+        {
+            return Results.Conflict(new
+            {
+                code = "CONTENT_ARTIFACT_DEDUP_KEY_OCCUPIED",
+                message = ex.Message,
+            });
+        }
         catch (InvalidOperationException ex)
         {
             return BadRequest("INVALID_CONTENT_ARTIFACT_REQUEST", ex.Message);
@@ -237,6 +245,10 @@ internal static class ContentArtifactEndpoints
         {
             return NotFound(ex.Message);
         }
+        catch (ContentArtifactContentUnavailableException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status410Gone);
+        }
         catch (InvalidOperationException ex)
         {
             return BadRequest("INVALID_CONTENT_ARTIFACT_COMMAND", ex.Message);
@@ -284,6 +296,10 @@ internal static class ContentArtifactEndpoints
         catch (ContentArtifactNotFoundException ex)
         {
             return NotFound(ex.Message);
+        }
+        catch (ContentArtifactContentUnavailableException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status410Gone);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/ContentArtifactEndpoints.cs
@@ -1,0 +1,337 @@
+using System.Security.Claims;
+using Aevatar.Capabilities;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+namespace Aevatar.Studio.Hosting.Endpoints;
+
+internal static class ContentArtifactEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts", HandleCreateAsync).WithTags("ContentArtifacts");
+        app.MapGet("/api/scopes/{scopeId}/content-artifacts", HandleListAsync).WithTags("ContentArtifacts");
+        app.MapGet("/api/scopes/{scopeId}/content-artifacts/{artifactId}", HandleGetAsync).WithTags("ContentArtifacts");
+        app.MapGet("/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions/current", HandleGetCurrentRevisionAsync).WithTags("ContentArtifacts");
+        app.MapGet("/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions/{revisionId}", HandleGetRevisionAsync).WithTags("ContentArtifacts");
+        app.MapGet("/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions/{revisionId}/content", HandleGetRevisionContentAsync).WithTags("ContentArtifacts");
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions", HandleAppendRevisionAsync).WithTags("ContentArtifacts");
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts/{artifactId}:advance-current", HandleAdvanceCurrentRevisionAsync).WithTags("ContentArtifacts");
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions/{revisionId}:redact", HandleRedactRevisionAsync).WithTags("ContentArtifacts");
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts/{artifactId}/revisions/{revisionId}:expire", HandleExpireRevisionAsync).WithTags("ContentArtifacts");
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts/{artifactId}:tombstone", HandleTombstoneAsync).WithTags("ContentArtifacts");
+        app.MapPost("/api/scopes/{scopeId}/content-artifacts:attach-to-run", HandleAttachToRunAsync).WithTags("ContentArtifacts");
+    }
+
+    internal static async Task<IResult> HandleCreateAsync(
+        HttpContext http,
+        string scopeId,
+        CreateContentArtifactRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct)
+    {
+        if (!TryAuthorize(http, scopeId, out var principal, out var denied))
+            return denied;
+        try
+        {
+            var receipt = await service.CreateAsync(scopeId, request, principal, ct);
+            return Results.Accepted(BuildLocation(scopeId, receipt.ArtifactId), receipt);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_CONTENT_ARTIFACT_REQUEST", ex.Message);
+        }
+    }
+
+    internal static async Task<IResult> HandleListAsync(
+        HttpContext http,
+        string scopeId,
+        [FromServices] IContentArtifactService service,
+        int? pageSize,
+        string? pageToken,
+        string? teamId,
+        string? kind,
+        string? lifecycleStatus,
+        string? workOrderId,
+        string? runId,
+        CancellationToken ct)
+    {
+        if (!TryAuthorize(http, scopeId, out var principal, out var denied))
+            return denied;
+        try
+        {
+            return Results.Ok(await service.ListAsync(
+                scopeId,
+                new ContentArtifactQueryRequest(
+                    pageSize,
+                    pageToken,
+                    teamId,
+                    kind,
+                    lifecycleStatus,
+                    workOrderId,
+                    runId),
+                principal,
+                ct));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_CONTENT_ARTIFACT_QUERY", ex.Message);
+        }
+    }
+
+    internal static Task<IResult> HandleGetAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleReadAsync(
+            http,
+            scopeId,
+            principal => service.GetAsync(scopeId, artifactId, principal, ct));
+
+    internal static Task<IResult> HandleGetRevisionAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleReadAsync(
+            http,
+            scopeId,
+            principal => service.GetRevisionAsync(scopeId, artifactId, revisionId, principal, ct));
+
+    internal static Task<IResult> HandleGetCurrentRevisionAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleReadAsync(
+            http,
+            scopeId,
+            principal => service.GetCurrentRevisionAsync(scopeId, artifactId, principal, ct));
+
+    internal static async Task<IResult> HandleGetRevisionContentAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct)
+    {
+        if (!TryAuthorize(http, scopeId, out var principal, out var denied))
+            return denied;
+        try
+        {
+            var content = await service.GetRevisionContentAsync(
+                scopeId,
+                artifactId,
+                revisionId,
+                principal,
+                ct);
+            return Results.File(content.Content, content.Reference.MediaType);
+        }
+        catch (ContentArtifactNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (ContentArtifactContentUnavailableException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status410Gone);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_CONTENT_ARTIFACT_REQUEST", ex.Message);
+        }
+    }
+
+    internal static Task<IResult> HandleAppendRevisionAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        AppendContentArtifactRevisionRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleCommandAsync(
+            http,
+            scopeId,
+            artifactId,
+            principal => service.AppendRevisionAsync(scopeId, artifactId, request, principal, ct));
+
+    internal static Task<IResult> HandleAdvanceCurrentRevisionAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        AdvanceContentArtifactCurrentRevisionRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleCommandAsync(
+            http,
+            scopeId,
+            artifactId,
+            principal => service.AdvanceCurrentRevisionAsync(scopeId, artifactId, request, principal, ct));
+
+    internal static Task<IResult> HandleRedactRevisionAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        RedactContentArtifactRevisionRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleCommandAsync(
+            http,
+            scopeId,
+            artifactId,
+            principal => service.RedactRevisionAsync(scopeId, artifactId, revisionId, request, principal, ct));
+
+    internal static Task<IResult> HandleExpireRevisionAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ExpireContentArtifactRevisionRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleCommandAsync(
+            http,
+            scopeId,
+            artifactId,
+            principal => service.ExpireRevisionAsync(scopeId, artifactId, revisionId, request, principal, ct));
+
+    internal static Task<IResult> HandleTombstoneAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        TombstoneContentArtifactRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct) =>
+        HandleCommandAsync(
+            http,
+            scopeId,
+            artifactId,
+            principal => service.TombstoneAsync(scopeId, artifactId, request, principal, ct));
+
+    internal static async Task<IResult> HandleAttachToRunAsync(
+        HttpContext http,
+        string scopeId,
+        AttachContentArtifactsToRunRequest request,
+        [FromServices] IContentArtifactService service,
+        CancellationToken ct)
+    {
+        if (!TryAuthorize(http, scopeId, out var principal, out var denied))
+            return denied;
+        try
+        {
+            return Results.Accepted(
+                value: await service.AttachToRunAsync(scopeId, request, principal, ct));
+        }
+        catch (ContentArtifactNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_CONTENT_ARTIFACT_COMMAND", ex.Message);
+        }
+    }
+
+    private static async Task<IResult> HandleReadAsync<T>(
+        HttpContext http,
+        string scopeId,
+        Func<ContentArtifactPrincipalContract, Task<T>> read)
+    {
+        if (!TryAuthorize(http, scopeId, out var principal, out var denied))
+            return denied;
+        try
+        {
+            return Results.Ok(await read(principal));
+        }
+        catch (ContentArtifactNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (ContentArtifactContentUnavailableException ex)
+        {
+            return Results.Problem(ex.Message, statusCode: StatusCodes.Status410Gone);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_CONTENT_ARTIFACT_REQUEST", ex.Message);
+        }
+    }
+
+    private static async Task<IResult> HandleCommandAsync(
+        HttpContext http,
+        string scopeId,
+        string artifactId,
+        Func<ContentArtifactPrincipalContract, Task<ContentArtifactAcceptedReceipt>> command)
+    {
+        if (!TryAuthorize(http, scopeId, out var principal, out var denied))
+            return denied;
+        try
+        {
+            var receipt = await command(principal);
+            return Results.Accepted(BuildLocation(scopeId, receipt.ArtifactId), receipt);
+        }
+        catch (ContentArtifactNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_CONTENT_ARTIFACT_COMMAND", ex.Message);
+        }
+    }
+
+    private static bool TryAuthorize(
+        HttpContext http,
+        string scopeId,
+        out ContentArtifactPrincipalContract principal,
+        out IResult denied)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out denied))
+        {
+            principal = null!;
+            return false;
+        }
+        if (!TryResolvePrincipal(http.User, out principal))
+        {
+            denied = Results.Unauthorized();
+            return false;
+        }
+        denied = null!;
+        return true;
+    }
+
+    private static bool TryResolvePrincipal(
+        ClaimsPrincipal user,
+        out ContentArtifactPrincipalContract principal)
+    {
+        var subject = user.FindFirst(ClaimTypes.NameIdentifier)?.Value?.Trim()
+                      ?? user.FindFirst("sub")?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            principal = null!;
+            return false;
+        }
+        principal = new ContentArtifactPrincipalContract(subject, "user");
+        return true;
+    }
+
+    private static string BuildLocation(string scopeId, string artifactId) =>
+        $"/api/scopes/{Uri.EscapeDataString(scopeId)}/content-artifacts/{Uri.EscapeDataString(artifactId)}";
+
+    private static IResult BadRequest(string code, string message) =>
+        Results.BadRequest(new { code, message });
+
+    private static IResult NotFound(string message) =>
+        Results.NotFound(new { code = "CONTENT_ARTIFACT_NOT_FOUND", message });
+}

--- a/src/Aevatar.Studio.Hosting/StudioCapabilityExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioCapabilityExtensions.cs
@@ -47,6 +47,7 @@ public static class StudioCapabilityExtensions
                 StudioMemberAutomationEndpoints.Map(app);
                 StudioProvisioningEndpoints.Map(app);
                 StudioTeamEndpoints.Map(app);
+                ContentArtifactEndpoints.Map(app);
                 WorkOrderEndpoints.Map(app);
                 NyxIdLoginFinalizationEndpoints.Map(app);
                 Controllers.ChatHistoryEndpoints.MapChatHistoryEndpoints(app);

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.ContentArtifacts.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
 using Aevatar.GAgentService.Hosting.DependencyInjection;
@@ -7,6 +9,7 @@ using Aevatar.Studio.Application.Studio.DependencyInjection;
 using Aevatar.Studio.Application.Studio.Services;
 using Aevatar.Studio.Application.Studio.WorkflowBoards;
 using Aevatar.Studio.Hosting.Controllers;
+using Aevatar.Studio.Hosting.ContentArtifacts;
 using Aevatar.Studio.Hosting.Endpoints;
 using Aevatar.Studio.Hosting.WorkflowBoards;
 using Aevatar.Studio.Hosting.WorkOrders;
@@ -44,6 +47,9 @@ internal static class StudioHostingServiceCollectionExtensions
         services.AddHttpContextAccessor();
         services.AddHttpClient();
         services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<
+            IContentArtifactBackingContentPort,
+            WorkflowFileContentArtifactBackingContentPort>();
         services.AddSingleton<IAppScopeResolver, DefaultAppScopeResolver>();
         services.AddStudioApplication();
         AddWorkOrderExecutionWorker(services, configuration);

--- a/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
@@ -1,9 +1,11 @@
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.ContentArtifacts.Abstractions;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgents.ChatHistory;
+using Aevatar.GAgents.ContentArtifacts;
 using Aevatar.GAgents.ConnectorCatalog;
 using Aevatar.GAgents.Registry;
 using Aevatar.GAgents.RoleCatalog;
@@ -78,6 +80,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             services.TryAddSingleton<
                 IStudioWorkspaceVersionRegressionRepairService,
                 StudioWorkspaceVersionRegressionRepairService>();
+            RegisterElasticsearch<ContentArtifactCurrentStateDocument>(services, configuration);
             RegisterElasticsearch<WorkOrderCurrentStateDocument>(services, configuration);
         }
         else
@@ -101,6 +104,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             RegisterInMemory<StudioMemberBindingRunCurrentStateDocument>(services);
             RegisterInMemory<StudioTeamCurrentStateDocument>(services);
             RegisterInMemory<StudioWorkspaceCurrentStateDocument>(services);
+            RegisterInMemory<ContentArtifactCurrentStateDocument>(services);
             RegisterInMemory<WorkOrderCurrentStateDocument>(services);
         }
 
@@ -179,6 +183,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
                && HasDocumentReaderForProvider<StudioMemberBindingRunCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<StudioTeamCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<StudioWorkspaceCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ContentArtifactCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<WorkOrderCurrentStateDocument>(services, providerKind);
     }
 
@@ -229,6 +234,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             StudioMemberBindingRunState.Descriptor,
             StudioTeamState.Descriptor,
             StudioWorkspaceState.Descriptor,
+            ContentArtifactState.Descriptor,
             WorkOrderState.Descriptor);
     }
 

--- a/src/Aevatar.Studio.Projection/Aevatar.Studio.Projection.csproj
+++ b/src/Aevatar.Studio.Projection/Aevatar.Studio.Projection.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Aevatar.Audit.Abstractions\Aevatar.Audit.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Audit.Core\Aevatar.Audit.Core.csproj" />
     <ProjectReference Include="..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.ContentArtifacts.Abstractions\Aevatar.ContentArtifacts.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.CQRS.Core\Aevatar.CQRS.Core.csproj" />
     <ProjectReference Include="..\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
@@ -30,6 +31,7 @@
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.StudioMember\Aevatar.GAgents.StudioMember.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.StudioTeam\Aevatar.GAgents.StudioTeam.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.WorkOrder\Aevatar.GAgents.WorkOrder.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.ContentArtifacts\Aevatar.GAgents.ContentArtifacts.csproj" />
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Abstractions\Aevatar.Workflow.Abstractions.csproj" />
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Core\Aevatar.Workflow.Core.csproj" />
     <ProjectReference Include="..\workflow\Aevatar.Workflow.Studio\Aevatar.Workflow.Studio.csproj" />

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs
@@ -1,0 +1,400 @@
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.GAgents.ContentArtifacts;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Projection.CommandServices;
+
+internal sealed class ActorDispatchContentArtifactCommandService : IContentArtifactCommandPort
+{
+    private const string PublisherId = "aevatar.studio.projection.content-artifact";
+
+    private readonly IStudioActorBootstrap _bootstrap;
+    private readonly StudioProjectionActorCommandDispatch _commandDispatch;
+
+    public ActorDispatchContentArtifactCommandService(
+        IStudioActorBootstrap bootstrap,
+        StudioProjectionActorCommandDispatch commandDispatch)
+    {
+        _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
+        _commandDispatch = commandDispatch ?? throw new ArgumentNullException(nameof(commandDispatch));
+    }
+
+    public Task<ContentArtifactAcceptedReceipt> CreateAsync(
+        string scopeId,
+        CreateContentArtifactRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var artifactId = ContentArtifactConventions.BuildArtifactId(scopeId, request.DedupKey);
+        var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var command = new CreateContentArtifact
+        {
+            ArtifactId = artifactId,
+            DedupKey = request.DedupKey,
+            ScopeId = scopeId,
+            TeamId = request.TeamId ?? string.Empty,
+            Kind = ToKind(request.Kind),
+            Title = request.Title,
+            Classification = request.Classification,
+            AccessPolicy = ToAccessPolicy(request.AccessPolicy, requester),
+            WorkOrderId = request.WorkOrderId ?? string.Empty,
+            FirstRevision = ToRevision(
+                artifactId,
+                revisionNumber: 1,
+                request.FirstRevision,
+                now),
+            ExpectedConcurrencyVersion = 0,
+            RequestedAtUtc = now,
+        };
+        if (ToRetentionPolicy(request.RetentionPolicy) is { } retentionPolicy)
+            command.RetentionPolicy = retentionPolicy;
+        return DispatchAsync(scopeId, artifactId, command, "create", 0, ct);
+    }
+
+    public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(
+        string scopeId,
+        string artifactId,
+        long revisionNumber,
+        AppendContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        return DispatchAsync(
+            scopeId,
+            artifactId,
+            new AppendContentArtifactRevision
+            {
+                ArtifactId = artifactId,
+                ExpectedConcurrencyVersion = request.ExpectedConcurrencyVersion,
+                RequestedBy = ToPrincipal(requester),
+                Revision = ToRevision(artifactId, revisionNumber, request.Revision, now),
+                RequestedAtUtc = now,
+            },
+            "append",
+            request.ExpectedConcurrencyVersion,
+            ct);
+    }
+
+    public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(
+        string scopeId,
+        string artifactId,
+        AdvanceContentArtifactCurrentRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default) =>
+        DispatchAsync(
+            scopeId,
+            artifactId,
+            new AdvanceContentArtifactCurrentRevision
+            {
+                ArtifactId = artifactId,
+                ExpectedConcurrencyVersion = request.ExpectedConcurrencyVersion,
+                RequestedBy = ToPrincipal(requester),
+                RevisionId = request.RevisionId,
+                RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+            "advance",
+            request.ExpectedConcurrencyVersion,
+            ct);
+
+    public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        RedactContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default) =>
+        DispatchAsync(
+            scopeId,
+            artifactId,
+            new RedactContentArtifactRevision
+            {
+                ArtifactId = artifactId,
+                ExpectedConcurrencyVersion = request.ExpectedConcurrencyVersion,
+                RequestedBy = ToPrincipal(requester),
+                RevisionId = revisionId,
+                Reason = request.Reason,
+                RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+            "redact",
+            request.ExpectedConcurrencyVersion,
+            ct);
+
+    public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ExpireContentArtifactRevisionRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default) =>
+        DispatchAsync(
+            scopeId,
+            artifactId,
+            new ExpireContentArtifactRevision
+            {
+                ArtifactId = artifactId,
+                ExpectedConcurrencyVersion = request.ExpectedConcurrencyVersion,
+                RequestedBy = ToPrincipal(requester),
+                RevisionId = revisionId,
+                RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+            "expire",
+            request.ExpectedConcurrencyVersion,
+            ct);
+
+    public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(
+        string scopeId,
+        string artifactId,
+        TombstoneContentArtifactRequest request,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default) =>
+        DispatchAsync(
+            scopeId,
+            artifactId,
+            new TombstoneContentArtifact
+            {
+                ArtifactId = artifactId,
+                ExpectedConcurrencyVersion = request.ExpectedConcurrencyVersion,
+                RequestedBy = ToPrincipal(requester),
+                Reason = request.Reason,
+                RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+            "tombstone",
+            request.ExpectedConcurrencyVersion,
+            ct);
+
+    private async Task<ContentArtifactAcceptedReceipt> DispatchAsync(
+        string scopeId,
+        string artifactId,
+        IMessage payload,
+        string operation,
+        long expectedConcurrencyVersion,
+        CancellationToken ct)
+    {
+        var normalizedScopeId = ContentArtifactConventions.NormalizeScopeId(scopeId);
+        var normalizedArtifactId = ContentArtifactConventions.NormalizeArtifactId(artifactId);
+        var commandId = BuildCommandId(operation, normalizedArtifactId, expectedConcurrencyVersion, payload);
+        var actorId = ContentArtifactConventions.BuildActorId(normalizedScopeId, normalizedArtifactId);
+        var actor = await _bootstrap.EnsureAsync<ContentArtifactGAgent>(actorId, ct);
+        var receipt = await _commandDispatch.DispatchAsync(
+            actor,
+            payload,
+            PublisherId,
+            commandId,
+            commandId,
+            commandId,
+            ct);
+        return new ContentArtifactAcceptedReceipt(
+            normalizedArtifactId,
+            receipt.CommandId,
+            receipt.CorrelationId,
+            ContentArtifactCommandStageNames.DispatchAccepted,
+            receipt.AckedAt);
+    }
+
+    private static ContentArtifactRevision ToRevision(
+        string artifactId,
+        long revisionNumber,
+        ContentArtifactRevisionWriteRequest request,
+        Timestamp createdAt)
+    {
+        var revision = new ContentArtifactRevision
+        {
+            RevisionId = ContentArtifactConventions.BuildRevisionId(artifactId, revisionNumber),
+            RevisionNumber = revisionNumber,
+            DedupKey = request.DedupKey,
+            ParentRevisionId = request.ParentRevisionId ?? string.Empty,
+            MediaType = request.MediaType,
+            ByteLength = request.ByteLength,
+            ContentHash = request.ContentHash.ToLowerInvariant(),
+            Content = ToContent(request),
+            Provenance = ToProvenance(request.Provenance),
+            CreatedAtUtc = createdAt.Clone(),
+            Availability = ContentArtifactRevisionAvailability.Available,
+            SupersessionReason = request.SupersessionReason ?? string.Empty,
+        };
+        revision.Citations.Add((request.Citations ?? []).Select(ToCitation));
+        return revision;
+    }
+
+    private static ContentArtifactRevisionContent ToContent(ContentArtifactRevisionWriteRequest request)
+    {
+        if (request.InlineContent != null && request.BackingObject != null)
+            throw new InvalidOperationException("A ContentArtifact revision cannot contain both inline and backing content.");
+        if (request.InlineContent != null)
+            return new ContentArtifactRevisionContent { InlineContent = ByteString.CopyFrom(request.InlineContent) };
+        if (request.BackingObject != null)
+        {
+            return new ContentArtifactRevisionContent
+            {
+                BackingObject = new ContentArtifactBackingObjectReference
+                {
+                    Provider = request.BackingObject.Provider,
+                    ObjectKey = request.BackingObject.ObjectKey,
+                },
+            };
+        }
+        throw new InvalidOperationException("A ContentArtifact revision content location is required.");
+    }
+
+    private static ContentArtifactExecutionProvenance ToProvenance(
+        ContentArtifactExecutionProvenanceContract provenance) =>
+        new()
+        {
+            ScopeId = provenance.ScopeId,
+            TeamId = provenance.TeamId ?? string.Empty,
+            MemberId = provenance.MemberId ?? string.Empty,
+            WorkflowId = provenance.WorkflowId ?? string.Empty,
+            PublishedServiceId = provenance.PublishedServiceId ?? string.Empty,
+            RunId = provenance.RunId ?? string.Empty,
+            WorkOrderId = provenance.WorkOrderId ?? string.Empty,
+        };
+
+    private static ContentArtifactCitation ToCitation(ContentArtifactCitationContract citation)
+    {
+        var result = new ContentArtifactCitation
+        {
+            CitationId = citation.CitationId,
+            Label = citation.Label ?? string.Empty,
+        };
+        if (citation.Locator != null)
+        {
+            result.Locator = new ContentArtifactCitationLocator
+            {
+                Section = citation.Locator.Section ?? string.Empty,
+                StartOffset = citation.Locator.StartOffset ?? 0,
+                EndOffset = citation.Locator.EndOffset ?? 0,
+                Selector = citation.Locator.Selector ?? string.Empty,
+            };
+        }
+        if (citation.ArtifactRevision != null)
+        {
+            result.ArtifactRevision = new ContentArtifactRevisionCitationSource
+            {
+                Reference = new ContentArtifactReference
+                {
+                    ArtifactId = citation.ArtifactRevision.ArtifactId,
+                    RevisionId = citation.ArtifactRevision.RevisionId,
+                    ContentHash = citation.ArtifactRevision.ContentHash,
+                    MediaType = citation.ArtifactRevision.MediaType,
+                },
+            };
+        }
+        if (citation.ExternalSource != null)
+        {
+            var externalSource = new ContentArtifactExternalCitationSource
+            {
+                SourceUri = citation.ExternalSource.SourceUri ?? string.Empty,
+                StableExternalId = citation.ExternalSource.StableExternalId ?? string.Empty,
+                DocumentRevision = citation.ExternalSource.DocumentRevision ?? string.Empty,
+                ContentHash = citation.ExternalSource.ContentHash ?? string.Empty,
+            };
+            if (ToTimestamp(citation.ExternalSource.PublishedAtUtc) is { } publishedAtUtc)
+                externalSource.PublishedAtUtc = publishedAtUtc;
+            if (ToTimestamp(citation.ExternalSource.FetchedAtUtc) is { } fetchedAtUtc)
+                externalSource.FetchedAtUtc = fetchedAtUtc;
+            result.ExternalSource = externalSource;
+        }
+        return result;
+    }
+
+    private static ContentArtifactAccessPolicy ToAccessPolicy(
+        ContentArtifactAccessPolicyContract? policy,
+        ContentArtifactPrincipalContract owner)
+    {
+        var result = new ContentArtifactAccessPolicy { Owner = ToPrincipal(owner) };
+        result.ReaderPrincipalIds.Add(policy?.ReaderPrincipalIds ?? []);
+        result.WriterPrincipalIds.Add(policy?.WriterPrincipalIds ?? []);
+        return result;
+    }
+
+    private static ContentArtifactRetentionPolicy? ToRetentionPolicy(ContentArtifactRetentionPolicyContract? policy) =>
+        policy == null
+            ? null
+            : new ContentArtifactRetentionPolicy
+            {
+                PolicyId = policy.PolicyId,
+                ExpiresAtUtc = ToTimestamp(policy.ExpiresAtUtc),
+            };
+
+    private static ContentArtifactPrincipal ToPrincipal(ContentArtifactPrincipalContract principal) =>
+        new()
+        {
+            PrincipalId = principal.PrincipalId,
+            PrincipalKind = principal.PrincipalKind,
+        };
+
+    private static ContentArtifactKind ToKind(string value) => value.Trim().ToLowerInvariant() switch
+    {
+        "text" => ContentArtifactKind.Text,
+        "markdown" => ContentArtifactKind.Markdown,
+        "structured_document" => ContentArtifactKind.StructuredDocument,
+        "other_content" => ContentArtifactKind.OtherContent,
+        _ => throw new InvalidOperationException($"Unsupported ContentArtifact kind '{value}'."),
+    };
+
+    private static Timestamp? ToTimestamp(DateTimeOffset? value) =>
+        value.HasValue ? Timestamp.FromDateTimeOffset(value.Value) : null;
+
+    private static string BuildCommandId(
+        string operation,
+        string artifactId,
+        long expectedConcurrencyVersion,
+        IMessage payload)
+    {
+        var digest = Convert.ToHexStringLower(SHA256.HashData(BuildCanonicalCommandBytes(payload)));
+        return $"content-artifact-{operation}-{artifactId}-v{expectedConcurrencyVersion}-{digest}";
+    }
+
+    private static byte[] BuildCanonicalCommandBytes(IMessage payload)
+    {
+        switch (payload)
+        {
+            case CreateContentArtifact command:
+            {
+                var canonical = command.Clone();
+                canonical.RequestedAtUtc = null;
+                canonical.FirstRevision.CreatedAtUtc = null;
+                return canonical.ToByteArray();
+            }
+            case AppendContentArtifactRevision command:
+            {
+                var canonical = command.Clone();
+                canonical.RequestedAtUtc = null;
+                canonical.Revision.CreatedAtUtc = null;
+                return canonical.ToByteArray();
+            }
+            case AdvanceContentArtifactCurrentRevision command:
+            {
+                var canonical = command.Clone();
+                canonical.RequestedAtUtc = null;
+                return canonical.ToByteArray();
+            }
+            case RedactContentArtifactRevision command:
+            {
+                var canonical = command.Clone();
+                canonical.RequestedAtUtc = null;
+                return canonical.ToByteArray();
+            }
+            case ExpireContentArtifactRevision command:
+            {
+                var canonical = command.Clone();
+                canonical.RequestedAtUtc = null;
+                return canonical.ToByteArray();
+            }
+            case TombstoneContentArtifact command:
+            {
+                var canonical = command.Clone();
+                canonical.RequestedAtUtc = null;
+                return canonical.ToByteArray();
+            }
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported ContentArtifact command payload '{payload.Descriptor.FullName}'.");
+        }
+    }
+}

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs
@@ -58,7 +58,6 @@ internal sealed class ActorDispatchContentArtifactCommandService : IContentArtif
     public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(
         string scopeId,
         string artifactId,
-        long revisionNumber,
         AppendContentArtifactRevisionRequest request,
         ContentArtifactPrincipalContract requester,
         CancellationToken ct = default)
@@ -70,13 +69,12 @@ internal sealed class ActorDispatchContentArtifactCommandService : IContentArtif
             new AppendContentArtifactRevision
             {
                 ArtifactId = artifactId,
-                ExpectedConcurrencyVersion = request.ExpectedConcurrencyVersion,
                 RequestedBy = ToPrincipal(requester),
-                Revision = ToRevision(artifactId, revisionNumber, request.Revision, now),
+                Revision = ToRevision(artifactId, revisionNumber: 0, request.Revision, now),
                 RequestedAtUtc = now,
             },
             "append",
-            request.ExpectedConcurrencyVersion,
+            0,
             ct);
     }
 
@@ -204,7 +202,9 @@ internal sealed class ActorDispatchContentArtifactCommandService : IContentArtif
     {
         var revision = new ContentArtifactRevision
         {
-            RevisionId = ContentArtifactConventions.BuildRevisionId(artifactId, revisionNumber),
+            RevisionId = revisionNumber > 0
+                ? ContentArtifactConventions.BuildRevisionId(artifactId, revisionNumber)
+                : string.Empty,
             RevisionNumber = revisionNumber,
             DedupKey = request.DedupKey,
             ParentRevisionId = request.ParentRevisionId ?? string.Empty,

--- a/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ using Aevatar.Studio.Projection.Projectors;
 using Aevatar.Studio.Projection.QueryPorts;
 using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.GAgents.StudioMember;
+using Aevatar.GAgents.ContentArtifacts;
 using Aevatar.GAgents.WorkOrder;
 using Aevatar.Studio.Workspace;
 using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
@@ -50,6 +51,7 @@ public static class ServiceCollectionExtensions
             typeof(Aevatar.GAgents.UserConfig.UserConfigGAgent).Assembly,
             typeof(Aevatar.GAgents.StudioMember.StudioMemberGAgent).Assembly,
             typeof(Aevatar.GAgents.StudioTeam.StudioTeamGAgent).Assembly,
+            typeof(ContentArtifactGAgent).Assembly,
             typeof(Aevatar.GAgents.WorkOrder.WorkOrderGAgent).Assembly,
             typeof(Aevatar.Studio.Workspace.StudioWorkspaceGAgent).Assembly));
         services.AddStudioProjectionActorCommandDispatch();
@@ -119,6 +121,10 @@ public static class ServiceCollectionExtensions
         services.AddCurrentStateProjectionMaterializer<
             StudioMaterializationContext,
             StudioMemberCurrentStateProjector>();
+
+        services.AddCurrentStateProjectionMaterializer<
+            StudioMaterializationContext,
+            ContentArtifactCurrentStateProjector>();
 
         services.AddCurrentStateProjectionMaterializer<
             StudioMaterializationContext,
@@ -212,6 +218,10 @@ public static class ServiceCollectionExtensions
             StudioMemberCurrentStateDocumentMetadataProvider>();
 
         services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<ContentArtifactCurrentStateDocument>,
+            ContentArtifactCurrentStateDocumentMetadataProvider>();
+
+        services.TryAddSingleton<
             IProjectionDocumentMetadataProvider<WorkOrderCurrentStateDocument>,
             WorkOrderCurrentStateDocumentMetadataProvider>();
 
@@ -245,6 +255,7 @@ public static class ServiceCollectionExtensions
         // Query ports (read side)
         services.TryAddSingleton<IUserConfigQueryPort, ProjectionUserConfigQueryPort>();
         services.TryAddSingleton<IStudioMemberQueryPort, ProjectionStudioMemberQueryPort>();
+        services.TryAddSingleton<IContentArtifactQueryPort, ProjectionContentArtifactQueryPort>();
         services.TryAddSingleton<IWorkOrderQueryPort, ProjectionWorkOrderQueryPort>();
         services.TryAddSingleton<IStudioMemberBindingRunQueryPort, ProjectionStudioMemberBindingRunQueryPort>();
         services.TryAddSingleton<IStudioTeamQueryPort, ProjectionStudioTeamQueryPort>();
@@ -257,6 +268,7 @@ public static class ServiceCollectionExtensions
         // Command services (write side)
         services.TryAddSingleton<IUserConfigCommandService, ActorDispatchUserConfigCommandService>();
         services.TryAddSingleton<IStudioMemberCommandPort, ActorDispatchStudioMemberCommandService>();
+        services.TryAddSingleton<IContentArtifactCommandPort, ActorDispatchContentArtifactCommandService>();
         services.TryAddSingleton<IWorkOrderCommandPort, ActorDispatchWorkOrderCommandService>();
         services.TryAddSingleton<IStudioMemberPlatformBindingCommandPort, ScopeBindingStudioMemberPlatformBindingCommandService>();
         services.TryAddSingleton<IStudioTeamCommandPort, ActorDispatchStudioTeamCommandService>();

--- a/src/Aevatar.Studio.Projection/Metadata/ContentArtifactCurrentStateDocumentMetadataProvider.cs
+++ b/src/Aevatar.Studio.Projection/Metadata/ContentArtifactCurrentStateDocumentMetadataProvider.cs
@@ -1,0 +1,17 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Studio.Projection.ReadModels;
+
+namespace Aevatar.Studio.Projection.Metadata;
+
+public sealed class ContentArtifactCurrentStateDocumentMetadataProvider
+    : IProjectionDocumentMetadataProvider<ContentArtifactCurrentStateDocument>
+{
+    public DocumentIndexMetadata Metadata { get; } = new(
+        IndexName: "studio-content-artifacts",
+        Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["dynamic"] = true,
+        },
+        Settings: new Dictionary<string, object?>(StringComparer.Ordinal),
+        Aliases: new Dictionary<string, object?>(StringComparer.Ordinal));
+}

--- a/src/Aevatar.Studio.Projection/Orchestration/StudioCommittedStateProjectionActivationPlanProvider.cs
+++ b/src/Aevatar.Studio.Projection/Orchestration/StudioCommittedStateProjectionActivationPlanProvider.cs
@@ -1,6 +1,7 @@
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions.EventSourcing;
 using Aevatar.GAgents.ChatHistory;
+using Aevatar.GAgents.ContentArtifacts;
 using Aevatar.GAgents.ConnectorCatalog;
 using Aevatar.GAgents.Registry;
 using Aevatar.GAgents.RoleCatalog;
@@ -33,6 +34,7 @@ public sealed class StudioCommittedStateProjectionActivationPlanProvider : IProj
             [typeof(StudioMemberGAgent)] = StudioMemberGAgent.ProjectionKind,
             [typeof(StudioMemberBindingRunGAgent)] = StudioMemberBindingRunGAgent.ProjectionKind,
             [typeof(StudioTeamGAgent)] = StudioTeamGAgent.ProjectionKind,
+            [typeof(ContentArtifactGAgent)] = ContentArtifactGAgent.ProjectionKind,
             [typeof(WorkOrderGAgent)] = WorkOrderGAgent.ProjectionKind,
             [typeof(StudioWorkspaceGAgent)] = StudioWorkspaceGAgent.ProjectionKind,
         };

--- a/src/Aevatar.Studio.Projection/Projectors/ContentArtifactCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/ContentArtifactCurrentStateProjector.cs
@@ -1,0 +1,225 @@
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Abstractions.Orchestration;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Studio.Projection.Orchestration;
+using Aevatar.Studio.Projection.ReadModels;
+
+namespace Aevatar.Studio.Projection.Projectors;
+
+public sealed class ContentArtifactCurrentStateProjector
+    : ICurrentStateProjectionMaterializer<StudioMaterializationContext>
+{
+    private readonly IProjectionWriteDispatcher<ContentArtifactCurrentStateDocument> _writeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    public ContentArtifactCurrentStateProjector(
+        IProjectionWriteDispatcher<ContentArtifactCurrentStateDocument> writeDispatcher,
+        IProjectionClock clock)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async ValueTask ProjectAsync(
+        StudioMaterializationContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+        if (!CommittedStateEventEnvelope.TryUnpackState<ContentArtifactState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out var state) ||
+            stateEvent == null ||
+            state == null ||
+            string.IsNullOrWhiteSpace(state.ArtifactId))
+        {
+            return;
+        }
+
+        await _writeDispatcher.UpsertAsync(
+            ToDocument(
+                context.RootActorId,
+                stateEvent,
+                state,
+                CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow)),
+            ct);
+    }
+
+    public static ContentArtifactCurrentStateDocument ToDocument(
+        string actorId,
+        StateEvent stateEvent,
+        ContentArtifactState state,
+        DateTimeOffset observedAt)
+    {
+        ArgumentNullException.ThrowIfNull(stateEvent);
+        ArgumentNullException.ThrowIfNull(state);
+        var document = new ContentArtifactCurrentStateDocument
+        {
+            Id = actorId,
+            ActorId = actorId,
+            StateVersion = stateEvent.Version,
+            LastEventId = stateEvent.EventId ?? string.Empty,
+            UpdatedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(observedAt),
+            ArtifactId = state.ArtifactId,
+            DedupKey = state.DedupKey,
+            ScopeId = state.ScopeId,
+            TeamId = state.TeamId,
+            Kind = ToWireName(state.Kind),
+            Title = state.Title,
+            Classification = state.Classification,
+            LifecycleStatus = ToWireName(state.LifecycleStatus),
+            CurrentRevisionId = state.CurrentRevisionId,
+            ConcurrencyVersion = state.ConcurrencyVersion,
+            OwnerPrincipalId = state.AccessPolicy?.Owner?.PrincipalId ?? string.Empty,
+            OwnerPrincipalKind = state.AccessPolicy?.Owner?.PrincipalKind ?? string.Empty,
+            RetentionPolicyId = state.RetentionPolicy?.PolicyId ?? string.Empty,
+            RetentionExpiresAtUtc = state.RetentionPolicy?.ExpiresAtUtc?.Clone(),
+            WorkOrderId = state.WorkOrderId,
+            CreatedAtUtc = state.CreatedAtUtc?.Clone(),
+            ArtifactUpdatedAtUtc = state.UpdatedAtUtc?.Clone(),
+            TombstoneReason = state.TombstoneReason,
+            TombstonedAtUtc = state.TombstonedAtUtc?.Clone(),
+        };
+        if (state.AccessPolicy != null)
+        {
+            document.ReaderPrincipalIds.Add(state.AccessPolicy.ReaderPrincipalIds);
+            document.WriterPrincipalIds.Add(state.AccessPolicy.WriterPrincipalIds);
+        }
+
+        foreach (var revision in state.Revisions.Values.OrderBy(static item => item.RevisionNumber))
+        {
+            document.Revisions.Add(ToRevision(revision));
+            if (!string.IsNullOrWhiteSpace(revision.Provenance?.RunId) &&
+                !document.ProvenanceRunIds.Contains(revision.Provenance.RunId))
+            {
+                document.ProvenanceRunIds.Add(revision.Provenance.RunId);
+            }
+        }
+        return document;
+    }
+
+    private static ContentArtifactRevisionDocument ToRevision(ContentArtifactRevision revision)
+    {
+        var document = new ContentArtifactRevisionDocument
+        {
+            RevisionId = revision.RevisionId,
+            RevisionNumber = revision.RevisionNumber,
+            ParentRevisionId = revision.ParentRevisionId,
+            MediaType = revision.MediaType,
+            ByteLength = revision.ByteLength,
+            ContentHash = revision.ContentHash,
+            Availability = ToWireName(revision.Availability),
+            CreatedAtUtc = revision.CreatedAtUtc?.Clone(),
+            RedactionReason = revision.RedactionReason,
+            RedactedAtUtc = revision.RedactedAtUtc?.Clone(),
+            RetentionExpiredAtUtc = revision.RetentionExpiredAtUtc?.Clone(),
+            SupersessionReason = revision.SupersessionReason,
+        };
+        CopyRevisionContent(document, revision.Content);
+        CopyRevisionProvenance(document, revision.Provenance);
+        document.Citations.Add(revision.Citations.Select(ToCitation));
+        return document;
+    }
+
+    private static void CopyRevisionContent(
+        ContentArtifactRevisionDocument document,
+        ContentArtifactRevisionContent? content)
+    {
+        document.ContentLocationKind = content?.LocationCase switch
+        {
+            ContentArtifactRevisionContent.LocationOneofCase.InlineContent => "inline",
+            ContentArtifactRevisionContent.LocationOneofCase.BackingObject => "backing_object",
+            _ => string.Empty,
+        };
+        document.InlineContent = content?.InlineContent ?? Google.Protobuf.ByteString.Empty;
+        document.BackingProvider = content?.BackingObject?.Provider ?? string.Empty;
+        document.BackingObjectKey = content?.BackingObject?.ObjectKey ?? string.Empty;
+    }
+
+    private static void CopyRevisionProvenance(
+        ContentArtifactRevisionDocument document,
+        ContentArtifactExecutionProvenance? provenance)
+    {
+        document.ProvenanceScopeId = provenance?.ScopeId ?? string.Empty;
+        document.ProvenanceTeamId = provenance?.TeamId ?? string.Empty;
+        document.ProvenanceMemberId = provenance?.MemberId ?? string.Empty;
+        document.ProvenanceWorkflowId = provenance?.WorkflowId ?? string.Empty;
+        document.ProvenancePublishedServiceId = provenance?.PublishedServiceId ?? string.Empty;
+        document.ProvenanceRunId = provenance?.RunId ?? string.Empty;
+        document.ProvenanceWorkOrderId = provenance?.WorkOrderId ?? string.Empty;
+    }
+
+    private static ContentArtifactCitationDocument ToCitation(ContentArtifactCitation citation)
+    {
+        var document = new ContentArtifactCitationDocument
+        {
+            CitationId = citation.CitationId,
+            Label = citation.Label,
+        };
+        CopyCitationLocator(document, citation.Locator);
+        CopyArtifactCitationSource(document, citation.ArtifactRevision?.Reference);
+        CopyExternalCitationSource(document, citation.ExternalSource);
+        return document;
+    }
+
+    private static void CopyCitationLocator(
+        ContentArtifactCitationDocument document,
+        ContentArtifactCitationLocator? locator)
+    {
+        document.LocatorSection = locator?.Section ?? string.Empty;
+        document.LocatorStartOffset = locator?.StartOffset ?? 0;
+        document.LocatorEndOffset = locator?.EndOffset ?? 0;
+        document.LocatorSelector = locator?.Selector ?? string.Empty;
+    }
+
+    private static void CopyArtifactCitationSource(
+        ContentArtifactCitationDocument document,
+        ContentArtifactReference? reference)
+    {
+        document.SourceArtifactId = reference?.ArtifactId ?? string.Empty;
+        document.SourceArtifactRevisionId = reference?.RevisionId ?? string.Empty;
+        document.SourceArtifactContentHash = reference?.ContentHash ?? string.Empty;
+        document.SourceArtifactMediaType = reference?.MediaType ?? string.Empty;
+    }
+
+    private static void CopyExternalCitationSource(
+        ContentArtifactCitationDocument document,
+        ContentArtifactExternalCitationSource? source)
+    {
+        document.ExternalSourceUri = source?.SourceUri ?? string.Empty;
+        document.ExternalStableId = source?.StableExternalId ?? string.Empty;
+        document.ExternalDocumentRevision = source?.DocumentRevision ?? string.Empty;
+        document.ExternalContentHash = source?.ContentHash ?? string.Empty;
+        document.ExternalPublishedAtUtc = source?.PublishedAtUtc?.Clone();
+        document.ExternalFetchedAtUtc = source?.FetchedAtUtc?.Clone();
+    }
+
+    private static string ToWireName(ContentArtifactKind kind) => kind switch
+    {
+        ContentArtifactKind.Text => "text",
+        ContentArtifactKind.Markdown => "markdown",
+        ContentArtifactKind.StructuredDocument => "structured_document",
+        ContentArtifactKind.OtherContent => "other_content",
+        _ => string.Empty,
+    };
+
+    private static string ToWireName(ContentArtifactLifecycleStatus status) => status switch
+    {
+        ContentArtifactLifecycleStatus.Active => "active",
+        ContentArtifactLifecycleStatus.Tombstoned => "tombstoned",
+        _ => string.Empty,
+    };
+
+    private static string ToWireName(ContentArtifactRevisionAvailability availability) => availability switch
+    {
+        ContentArtifactRevisionAvailability.Available => "available",
+        ContentArtifactRevisionAvailability.Redacted => "redacted",
+        ContentArtifactRevisionAvailability.RetentionExpired => "retention_expired",
+        _ => string.Empty,
+    };
+}

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
@@ -25,19 +25,18 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
 
     public async Task<ContentArtifactListResponse> ListAsync(
         string scopeId,
-        string ownerPrincipalId,
+        string requesterPrincipalId,
         ContentArtifactQueryRequest query,
         CancellationToken ct = default)
     {
         var normalizedScopeId = ContentArtifactConventions.NormalizeScopeId(scopeId);
-        var normalizedOwnerPrincipalId = ContentArtifactConventions.NormalizeRequired(
-            ownerPrincipalId,
-            nameof(ownerPrincipalId));
+        var normalizedRequesterPrincipalId = ContentArtifactConventions.NormalizeRequired(
+            requesterPrincipalId,
+            nameof(requesterPrincipalId));
         query ??= new ContentArtifactQueryRequest();
         var filters = new List<ProjectionDocumentFilter>
         {
             Equal("scope_id", normalizedScopeId),
-            Equal("owner_principal_id", normalizedOwnerPrincipalId),
         };
         AddOptionalEqual(filters, "team_id", query.TeamId);
         AddOptionalEqual(filters, "kind", query.Kind);
@@ -51,23 +50,19 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
             new ProjectionDocumentQuery
             {
                 Filters = filters,
+                AnyOfFilters =
+                [
+                    Equal("owner_principal_id", normalizedRequesterPrincipalId),
+                    Equal("reader_principal_ids", normalizedRequesterPrincipalId),
+                ],
                 Take = pageSize,
                 Cursor = NormalizeOptional(query.PageToken),
             },
             ct);
 
-        var artifacts = result.Items
-            .Where(document => MatchesQuery(
-                document,
-                normalizedScopeId,
-                normalizedOwnerPrincipalId,
-                query))
-            .Take(pageSize)
-            .Select(ToResponse)
-            .ToArray();
         return new ContentArtifactListResponse(
             normalizedScopeId,
-            artifacts,
+            result.Items.Select(ToResponse).ToArray(),
             NormalizeOptional(result.NextCursor));
     }
 
@@ -251,11 +246,10 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
         var principalId = ContentArtifactConventions.NormalizeRequired(
             requester.PrincipalId,
             "requester.principalId");
-        var principalKind = ContentArtifactConventions.NormalizeRequired(
+        _ = ContentArtifactConventions.NormalizeRequired(
             requester.PrincipalKind,
             "requester.principalKind");
-        var isOwner = string.Equals(document.OwnerPrincipalId, principalId, StringComparison.Ordinal) &&
-                      string.Equals(document.OwnerPrincipalKind, principalKind, StringComparison.Ordinal);
+        var isOwner = string.Equals(document.OwnerPrincipalId, principalId, StringComparison.Ordinal);
         if (!isOwner && !document.ReaderPrincipalIds.Contains(principalId))
             throw new InvalidOperationException("ContentArtifact principal is not authorized to read.");
     }
@@ -315,28 +309,11 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
                     citation.ExternalPublishedAtUtc?.ToDateTimeOffset(),
                     citation.ExternalFetchedAtUtc?.ToDateTimeOffset()));
 
-    private static bool MatchesQuery(
-        ContentArtifactCurrentStateDocument document,
-        string scopeId,
-        string ownerPrincipalId,
-        ContentArtifactQueryRequest query) =>
-        string.Equals(document.ScopeId, scopeId, StringComparison.Ordinal) &&
-        string.Equals(document.OwnerPrincipalId, ownerPrincipalId, StringComparison.Ordinal) &&
-        Matches(document.TeamId, query.TeamId) &&
-        Matches(document.Kind, query.Kind) &&
-        Matches(document.LifecycleStatus, query.LifecycleStatus) &&
-        Matches(document.WorkOrderId, query.WorkOrderId) &&
-        (string.IsNullOrWhiteSpace(query.RunId) || document.ProvenanceRunIds.Contains(query.RunId.Trim()));
-
     private static bool HasLocator(ContentArtifactCitationDocument citation) =>
         !string.IsNullOrWhiteSpace(citation.LocatorSection) ||
         !string.IsNullOrWhiteSpace(citation.LocatorSelector) ||
         citation.LocatorStartOffset != 0 ||
         citation.LocatorEndOffset != 0;
-
-    private static bool Matches(string actual, string? expected) =>
-        string.IsNullOrWhiteSpace(expected) ||
-        string.Equals(actual, expected.Trim(), StringComparison.Ordinal);
 
     private static ProjectionDocumentFilter Equal(string fieldPath, string value) =>
         new()

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
@@ -85,6 +85,15 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
         return ToResponse(document);
     }
 
+    public Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(
+        string scopeId,
+        string dedupKey,
+        CancellationToken ct = default) =>
+        GetAsync(
+            scopeId,
+            ContentArtifactConventions.BuildArtifactId(scopeId, dedupKey),
+            ct);
+
     public async Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
         string scopeId,
         string artifactId,
@@ -104,30 +113,27 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
             throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
         }
         EnsureReadAuthorized(document, requester);
-        if (!string.Equals(document.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
+        var revision = document.Revisions.FirstOrDefault(item =>
+            string.Equals(item.RevisionId, normalizedRevisionId, StringComparison.Ordinal));
+        if (revision == null)
+            throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
+        if (string.Equals(document.LifecycleStatus, ContentArtifactLifecycleStatusNames.Tombstoned, StringComparison.Ordinal))
         {
             throw new ContentArtifactContentUnavailableException(
                 normalizedArtifactId,
                 normalizedRevisionId,
                 "artifact is tombstoned");
         }
-
-        var revision = document.Revisions.FirstOrDefault(item =>
-            string.Equals(item.RevisionId, normalizedRevisionId, StringComparison.Ordinal));
-        if (revision == null)
-        {
-            throw new ContentArtifactContentUnavailableException(
-                normalizedArtifactId,
-                normalizedRevisionId,
-                "revision was not found");
-        }
-        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+        if (revision.Availability is ContentArtifactRevisionAvailabilityNames.Redacted or
+            ContentArtifactRevisionAvailabilityNames.RetentionExpired)
         {
             throw new ContentArtifactContentUnavailableException(
                 normalizedArtifactId,
                 normalizedRevisionId,
                 revision.Availability);
         }
+        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+            throw new InvalidDataException("ContentArtifact revision availability is invalid.");
 
         var content = await ReadContentAsync(normalizedArtifactId, revision, ct);
         VerifyContent(normalizedArtifactId, revision, content);
@@ -148,19 +154,9 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
         if (string.Equals(revision.ContentLocationKind, "inline", StringComparison.Ordinal))
             return revision.InlineContent.ToByteArray();
         if (!string.Equals(revision.ContentLocationKind, "backing_object", StringComparison.Ordinal))
-        {
-            throw new ContentArtifactContentUnavailableException(
-                artifactId,
-                revision.RevisionId,
-                "content location is unavailable");
-        }
+            throw new InvalidDataException("ContentArtifact content location is unavailable.");
         if (_backingContentPort == null)
-        {
-            throw new ContentArtifactContentUnavailableException(
-                artifactId,
-                revision.RevisionId,
-                "backing content provider is unavailable");
-        }
+            throw new IOException("ContentArtifact backing content provider is unavailable.");
 
         try
         {
@@ -180,17 +176,11 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
         }
         catch (FileNotFoundException ex)
         {
-            throw new ContentArtifactContentUnavailableException(
-                artifactId,
-                revision.RevisionId,
-                $"missing backing content ({ex.Message})");
+            throw new IOException("ContentArtifact backing content is missing.", ex);
         }
         catch (DirectoryNotFoundException ex)
         {
-            throw new ContentArtifactContentUnavailableException(
-                artifactId,
-                revision.RevisionId,
-                $"missing backing content ({ex.Message})");
+            throw new IOException("ContentArtifact backing content is missing.", ex);
         }
     }
 
@@ -251,7 +241,7 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
             "requester.principalKind");
         var isOwner = string.Equals(document.OwnerPrincipalId, principalId, StringComparison.Ordinal);
         if (!isOwner && !document.ReaderPrincipalIds.Contains(principalId))
-            throw new InvalidOperationException("ContentArtifact principal is not authorized to read.");
+            throw new ContentArtifactNotFoundException(document.ScopeId, document.ArtifactId);
     }
 
     private static ContentArtifactRevisionResponse ToRevisionResponse(ContentArtifactRevisionDocument revision) =>

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
@@ -1,0 +1,361 @@
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.ContentArtifacts;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Projection.ReadModels;
+
+namespace Aevatar.Studio.Projection.QueryPorts;
+
+public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPort
+{
+    public const int MaxPageSize = 200;
+
+    private readonly IProjectionDocumentReader<ContentArtifactCurrentStateDocument, string> _documentReader;
+    private readonly IContentArtifactBackingContentPort? _backingContentPort;
+
+    public ProjectionContentArtifactQueryPort(
+        IProjectionDocumentReader<ContentArtifactCurrentStateDocument, string> documentReader,
+        IContentArtifactBackingContentPort? backingContentPort = null)
+    {
+        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
+        _backingContentPort = backingContentPort;
+    }
+
+    public async Task<ContentArtifactListResponse> ListAsync(
+        string scopeId,
+        string ownerPrincipalId,
+        ContentArtifactQueryRequest query,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = ContentArtifactConventions.NormalizeScopeId(scopeId);
+        var normalizedOwnerPrincipalId = ContentArtifactConventions.NormalizeRequired(
+            ownerPrincipalId,
+            nameof(ownerPrincipalId));
+        query ??= new ContentArtifactQueryRequest();
+        var filters = new List<ProjectionDocumentFilter>
+        {
+            Equal("scope_id", normalizedScopeId),
+            Equal("owner_principal_id", normalizedOwnerPrincipalId),
+        };
+        AddOptionalEqual(filters, "team_id", query.TeamId);
+        AddOptionalEqual(filters, "kind", query.Kind);
+        AddOptionalEqual(filters, "lifecycle_status", query.LifecycleStatus);
+        AddOptionalEqual(filters, "work_order_id", query.WorkOrderId);
+        AddOptionalEqual(filters, "provenance_run_ids", query.RunId);
+        var pageSize = query.PageSize is > 0 and <= MaxPageSize
+            ? query.PageSize.Value
+            : MaxPageSize;
+        var result = await _documentReader.QueryAsync(
+            new ProjectionDocumentQuery
+            {
+                Filters = filters,
+                Take = pageSize,
+                Cursor = NormalizeOptional(query.PageToken),
+            },
+            ct);
+
+        var artifacts = result.Items
+            .Where(document => MatchesQuery(
+                document,
+                normalizedScopeId,
+                normalizedOwnerPrincipalId,
+                query))
+            .Take(pageSize)
+            .Select(ToResponse)
+            .ToArray();
+        return new ContentArtifactListResponse(
+            normalizedScopeId,
+            artifacts,
+            NormalizeOptional(result.NextCursor));
+    }
+
+    public async Task<ContentArtifactCurrentStateResponse?> GetAsync(
+        string scopeId,
+        string artifactId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = ContentArtifactConventions.NormalizeScopeId(scopeId);
+        var normalizedArtifactId = ContentArtifactConventions.NormalizeArtifactId(artifactId);
+        var document = await _documentReader.GetAsync(
+            ContentArtifactConventions.BuildActorId(normalizedScopeId, normalizedArtifactId),
+            ct);
+        if (document == null ||
+            !string.Equals(document.ScopeId, normalizedScopeId, StringComparison.Ordinal) ||
+            !string.Equals(document.ArtifactId, normalizedArtifactId, StringComparison.Ordinal))
+        {
+            return null;
+        }
+        return ToResponse(document);
+    }
+
+    public async Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
+        string scopeId,
+        string artifactId,
+        string revisionId,
+        ContentArtifactPrincipalContract requester,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = ContentArtifactConventions.NormalizeScopeId(scopeId);
+        var normalizedArtifactId = ContentArtifactConventions.NormalizeArtifactId(artifactId);
+        var normalizedRevisionId = ContentArtifactConventions.NormalizeRequired(revisionId, nameof(revisionId));
+        var document = await _documentReader.GetAsync(
+            ContentArtifactConventions.BuildActorId(normalizedScopeId, normalizedArtifactId),
+            ct) ?? throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
+        if (!string.Equals(document.ScopeId, normalizedScopeId, StringComparison.Ordinal) ||
+            !string.Equals(document.ArtifactId, normalizedArtifactId, StringComparison.Ordinal))
+        {
+            throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
+        }
+        EnsureReadAuthorized(document, requester);
+        if (!string.Equals(document.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
+        {
+            throw new ContentArtifactContentUnavailableException(
+                normalizedArtifactId,
+                normalizedRevisionId,
+                "artifact is tombstoned");
+        }
+
+        var revision = document.Revisions.FirstOrDefault(item =>
+            string.Equals(item.RevisionId, normalizedRevisionId, StringComparison.Ordinal));
+        if (revision == null)
+        {
+            throw new ContentArtifactContentUnavailableException(
+                normalizedArtifactId,
+                normalizedRevisionId,
+                "revision was not found");
+        }
+        if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+        {
+            throw new ContentArtifactContentUnavailableException(
+                normalizedArtifactId,
+                normalizedRevisionId,
+                revision.Availability);
+        }
+
+        var content = await ReadContentAsync(normalizedArtifactId, revision, ct);
+        VerifyContent(normalizedArtifactId, revision, content);
+        return new ContentArtifactRevisionContentResponse(
+            new ContentArtifactReferenceContract(
+                normalizedArtifactId,
+                normalizedRevisionId,
+                revision.ContentHash,
+                revision.MediaType),
+            content);
+    }
+
+    private async Task<byte[]> ReadContentAsync(
+        string artifactId,
+        ContentArtifactRevisionDocument revision,
+        CancellationToken ct)
+    {
+        if (string.Equals(revision.ContentLocationKind, "inline", StringComparison.Ordinal))
+            return revision.InlineContent.ToByteArray();
+        if (!string.Equals(revision.ContentLocationKind, "backing_object", StringComparison.Ordinal))
+        {
+            throw new ContentArtifactContentUnavailableException(
+                artifactId,
+                revision.RevisionId,
+                "content location is unavailable");
+        }
+        if (_backingContentPort == null)
+        {
+            throw new ContentArtifactContentUnavailableException(
+                artifactId,
+                revision.RevisionId,
+                "backing content provider is unavailable");
+        }
+
+        try
+        {
+            await using var stream = await _backingContentPort.OpenReadAsync(
+                new ContentArtifactBackingContentRequest(
+                    new ContentArtifactBackingObjectReference
+                    {
+                        Provider = revision.BackingProvider,
+                        ObjectKey = revision.BackingObjectKey,
+                    },
+                    revision.ProvenanceScopeId,
+                    NormalizeOptional(revision.ProvenanceRunId)),
+                ct);
+            using var buffer = new MemoryStream();
+            await stream.CopyToAsync(buffer, ct);
+            return buffer.ToArray();
+        }
+        catch (FileNotFoundException ex)
+        {
+            throw new ContentArtifactContentUnavailableException(
+                artifactId,
+                revision.RevisionId,
+                $"missing backing content ({ex.Message})");
+        }
+        catch (DirectoryNotFoundException ex)
+        {
+            throw new ContentArtifactContentUnavailableException(
+                artifactId,
+                revision.RevisionId,
+                $"missing backing content ({ex.Message})");
+        }
+    }
+
+    private static void VerifyContent(
+        string artifactId,
+        ContentArtifactRevisionDocument revision,
+        byte[] content)
+    {
+        var hash = Convert.ToHexStringLower(SHA256.HashData(content));
+        if (content.LongLength != revision.ByteLength ||
+            !string.Equals(hash, revision.ContentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"ContentArtifact '{artifactId}' revision '{revision.RevisionId}' content hash verification failed.");
+        }
+    }
+
+    private static ContentArtifactCurrentStateResponse ToResponse(ContentArtifactCurrentStateDocument document) =>
+        new(
+            document.ArtifactId,
+            document.ScopeId,
+            NormalizeOptional(document.TeamId),
+            document.Kind,
+            document.Title,
+            document.Classification,
+            document.LifecycleStatus,
+            NormalizeOptional(document.CurrentRevisionId),
+            document.ConcurrencyVersion,
+            document.StateVersion,
+            new ContentArtifactPrincipalContract(document.OwnerPrincipalId, document.OwnerPrincipalKind),
+            document.ReaderPrincipalIds.ToArray(),
+            document.WriterPrincipalIds.ToArray(),
+            string.IsNullOrWhiteSpace(document.RetentionPolicyId)
+                ? null
+                : new ContentArtifactRetentionPolicyContract(
+                    document.RetentionPolicyId,
+                    document.RetentionExpiresAtUtc?.ToDateTimeOffset()),
+            NormalizeOptional(document.WorkOrderId),
+            document.Revisions
+                .OrderBy(static revision => revision.RevisionNumber)
+                .Select(ToRevisionResponse)
+                .ToArray(),
+            document.CreatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
+            document.ArtifactUpdatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
+            NormalizeOptional(document.TombstoneReason),
+            document.TombstonedAtUtc?.ToDateTimeOffset());
+
+    private static void EnsureReadAuthorized(
+        ContentArtifactCurrentStateDocument document,
+        ContentArtifactPrincipalContract requester)
+    {
+        ArgumentNullException.ThrowIfNull(requester);
+        var principalId = ContentArtifactConventions.NormalizeRequired(
+            requester.PrincipalId,
+            "requester.principalId");
+        var principalKind = ContentArtifactConventions.NormalizeRequired(
+            requester.PrincipalKind,
+            "requester.principalKind");
+        var isOwner = string.Equals(document.OwnerPrincipalId, principalId, StringComparison.Ordinal) &&
+                      string.Equals(document.OwnerPrincipalKind, principalKind, StringComparison.Ordinal);
+        if (!isOwner && !document.ReaderPrincipalIds.Contains(principalId))
+            throw new InvalidOperationException("ContentArtifact principal is not authorized to read.");
+    }
+
+    private static ContentArtifactRevisionResponse ToRevisionResponse(ContentArtifactRevisionDocument revision) =>
+        new(
+            revision.RevisionId,
+            revision.RevisionNumber,
+            NormalizeOptional(revision.ParentRevisionId),
+            revision.MediaType,
+            revision.ByteLength,
+            revision.ContentHash,
+            revision.Availability,
+            string.Equals(revision.ContentLocationKind, "inline", StringComparison.Ordinal),
+            string.Equals(revision.ContentLocationKind, "backing_object", StringComparison.Ordinal),
+            new ContentArtifactExecutionProvenanceContract(
+                revision.ProvenanceScopeId,
+                NormalizeOptional(revision.ProvenanceTeamId),
+                NormalizeOptional(revision.ProvenanceMemberId),
+                NormalizeOptional(revision.ProvenanceWorkflowId),
+                NormalizeOptional(revision.ProvenancePublishedServiceId),
+                NormalizeOptional(revision.ProvenanceRunId),
+                NormalizeOptional(revision.ProvenanceWorkOrderId)),
+            revision.Citations.Select(ToCitationResponse).ToArray(),
+            revision.CreatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
+            NormalizeOptional(revision.RedactionReason),
+            revision.RedactedAtUtc?.ToDateTimeOffset(),
+            revision.RetentionExpiredAtUtc?.ToDateTimeOffset(),
+            NormalizeOptional(revision.SupersessionReason));
+
+    private static ContentArtifactCitationContract ToCitationResponse(ContentArtifactCitationDocument citation) =>
+        new(
+            citation.CitationId,
+            NormalizeOptional(citation.Label),
+            HasLocator(citation)
+                ? new ContentArtifactCitationLocatorContract(
+                    NormalizeOptional(citation.LocatorSection),
+                    citation.LocatorStartOffset,
+                    citation.LocatorEndOffset,
+                    NormalizeOptional(citation.LocatorSelector))
+                : null,
+            string.IsNullOrWhiteSpace(citation.SourceArtifactId)
+                ? null
+                : new ContentArtifactReferenceContract(
+                    citation.SourceArtifactId,
+                    citation.SourceArtifactRevisionId,
+                    citation.SourceArtifactContentHash,
+                    citation.SourceArtifactMediaType),
+            string.IsNullOrWhiteSpace(citation.ExternalSourceUri) &&
+            string.IsNullOrWhiteSpace(citation.ExternalStableId)
+                ? null
+                : new ContentArtifactExternalCitationSourceContract(
+                    NormalizeOptional(citation.ExternalSourceUri),
+                    NormalizeOptional(citation.ExternalStableId),
+                    NormalizeOptional(citation.ExternalDocumentRevision),
+                    NormalizeOptional(citation.ExternalContentHash),
+                    citation.ExternalPublishedAtUtc?.ToDateTimeOffset(),
+                    citation.ExternalFetchedAtUtc?.ToDateTimeOffset()));
+
+    private static bool MatchesQuery(
+        ContentArtifactCurrentStateDocument document,
+        string scopeId,
+        string ownerPrincipalId,
+        ContentArtifactQueryRequest query) =>
+        string.Equals(document.ScopeId, scopeId, StringComparison.Ordinal) &&
+        string.Equals(document.OwnerPrincipalId, ownerPrincipalId, StringComparison.Ordinal) &&
+        Matches(document.TeamId, query.TeamId) &&
+        Matches(document.Kind, query.Kind) &&
+        Matches(document.LifecycleStatus, query.LifecycleStatus) &&
+        Matches(document.WorkOrderId, query.WorkOrderId) &&
+        (string.IsNullOrWhiteSpace(query.RunId) || document.ProvenanceRunIds.Contains(query.RunId.Trim()));
+
+    private static bool HasLocator(ContentArtifactCitationDocument citation) =>
+        !string.IsNullOrWhiteSpace(citation.LocatorSection) ||
+        !string.IsNullOrWhiteSpace(citation.LocatorSelector) ||
+        citation.LocatorStartOffset != 0 ||
+        citation.LocatorEndOffset != 0;
+
+    private static bool Matches(string actual, string? expected) =>
+        string.IsNullOrWhiteSpace(expected) ||
+        string.Equals(actual, expected.Trim(), StringComparison.Ordinal);
+
+    private static ProjectionDocumentFilter Equal(string fieldPath, string value) =>
+        new()
+        {
+            FieldPath = fieldPath,
+            Operator = ProjectionDocumentFilterOperator.Eq,
+            Value = ProjectionDocumentValue.FromString(value),
+        };
+
+    private static void AddOptionalEqual(
+        ICollection<ProjectionDocumentFilter> filters,
+        string fieldPath,
+        string? value)
+    {
+        var normalized = NormalizeOptional(value);
+        if (normalized != null)
+            filters.Add(Equal(fieldPath, normalized));
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Aevatar.Studio.Projection/ReadModels/ContentArtifactCurrentStateDocument.Partial.cs
+++ b/src/Aevatar.Studio.Projection/ReadModels/ContentArtifactCurrentStateDocument.Partial.cs
@@ -1,0 +1,16 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+
+namespace Aevatar.Studio.Projection.ReadModels;
+
+public sealed partial class ContentArtifactCurrentStateDocument
+    : IProjectionReadModel<ContentArtifactCurrentStateDocument>
+{
+    string IProjectionReadModel.ActorId => ActorId;
+
+    long IProjectionReadModel.StateVersion => StateVersion;
+
+    string IProjectionReadModel.LastEventId => LastEventId;
+
+    DateTimeOffset IProjectionReadModel.UpdatedAt =>
+        UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue;
+}

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -6,6 +6,86 @@ import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "user_config_messages.proto";
 
+message ContentArtifactCitationDocument {
+  string citation_id = 1;
+  string label = 2;
+  string locator_section = 3;
+  int64 locator_start_offset = 4;
+  int64 locator_end_offset = 5;
+  string locator_selector = 6;
+  string source_artifact_id = 7;
+  string source_artifact_revision_id = 8;
+  string source_artifact_content_hash = 9;
+  string source_artifact_media_type = 10;
+  string external_source_uri = 11;
+  string external_stable_id = 12;
+  string external_document_revision = 13;
+  string external_content_hash = 14;
+  google.protobuf.Timestamp external_published_at_utc = 15;
+  google.protobuf.Timestamp external_fetched_at_utc = 16;
+}
+
+message ContentArtifactRevisionDocument {
+  string revision_id = 1;
+  int64 revision_number = 2;
+  string parent_revision_id = 3;
+  string media_type = 4;
+  int64 byte_length = 5;
+  string content_hash = 6;
+  string availability = 7;
+  string content_location_kind = 8;
+  bytes inline_content = 9;
+  string backing_provider = 10;
+  string backing_object_key = 11;
+  string provenance_scope_id = 12;
+  string provenance_team_id = 13;
+  string provenance_member_id = 14;
+  string provenance_workflow_id = 15;
+  string provenance_published_service_id = 16;
+  string provenance_run_id = 17;
+  string provenance_work_order_id = 18;
+  repeated ContentArtifactCitationDocument citations = 19;
+  google.protobuf.Timestamp created_at_utc = 20;
+  string redaction_reason = 21;
+  google.protobuf.Timestamp redacted_at_utc = 22;
+  google.protobuf.Timestamp retention_expired_at_utc = 23;
+  string supersession_reason = 24;
+}
+
+// Actor-scoped current-state replica for ContentArtifactGAgent. Immutable
+// revision facts are copied from the authoritative actor state; projection
+// never reconstructs or advances artifact lifecycle state.
+message ContentArtifactCurrentStateDocument {
+  string id = 1;
+  string actor_id = 2;
+  int64 state_version = 3;
+  string last_event_id = 4;
+  google.protobuf.Timestamp updated_at = 5;
+  string artifact_id = 20;
+  string dedup_key = 21;
+  string scope_id = 22;
+  string team_id = 23;
+  string kind = 24;
+  string title = 25;
+  string classification = 26;
+  string lifecycle_status = 27;
+  string current_revision_id = 28;
+  int64 concurrency_version = 29;
+  string owner_principal_id = 30;
+  string owner_principal_kind = 31;
+  repeated string reader_principal_ids = 32;
+  repeated string writer_principal_ids = 33;
+  string retention_policy_id = 34;
+  google.protobuf.Timestamp retention_expires_at_utc = 35;
+  string work_order_id = 36;
+  repeated ContentArtifactRevisionDocument revisions = 37;
+  repeated string provenance_run_ids = 38;
+  google.protobuf.Timestamp created_at_utc = 39;
+  google.protobuf.Timestamp artifact_updated_at_utc = 40;
+  string tombstone_reason = 41;
+  google.protobuf.Timestamp tombstoned_at_utc = 42;
+}
+
 message WorkOrderArtifactReferenceDocument {
   string artifact_id = 1;
   string artifact_kind = 2;

--- a/src/platform/Aevatar.GAgentService.Abstractions/Aevatar.GAgentService.Abstractions.csproj
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Aevatar.GAgentService.Abstractions.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Aevatar.ContentArtifacts.Abstractions\Aevatar.ContentArtifacts.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.AGUI.Contracts\Aevatar.AGUI.Contracts.csproj" />
@@ -35,7 +36,7 @@
     <Protobuf Include="Protos/service_deployment.proto" GrpcServices="None" ProtoRoot="Protos" />
     <Protobuf Include="Protos/service_serving.proto" GrpcServices="None" ProtoRoot="Protos" />
     <Protobuf Include="Protos/service_invocation_catalog.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="$(MSBuildProjectDirectory)/../../workflow/Aevatar.Workflow.Abstractions" />
-    <Protobuf Include="Protos/service_runs.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="$(MSBuildProjectDirectory)/../../workflow/Aevatar.Workflow.Abstractions" />
+    <Protobuf Include="Protos/service_runs.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="$(MSBuildProjectDirectory)/../../workflow/Aevatar.Workflow.Abstractions;$(MSBuildProjectDirectory)/../../Aevatar.ContentArtifacts.Abstractions" />
     <Protobuf Include="Protos/llm_sessions.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="..\..\Aevatar.AI.Abstractions;..\..\Aevatar.Foundation.VoicePresence.Abstractions;..\..\Aevatar.Foundation.Abstractions" />
     <Protobuf Include="Protos/scheduled_invocation_authorization_evidence.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="$(MSBuildProjectDirectory)/../../workflow/Aevatar.Workflow.Abstractions" />
     <Protobuf Include="Protos/scheduled_invocation_authorization_plan.proto" GrpcServices="None" ProtoRoot="Protos" AdditionalImportDirs="$(MSBuildProjectDirectory)/../../workflow/Aevatar.Workflow.Abstractions" />

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceRunResultArtifactAttachmentPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IServiceRunResultArtifactAttachmentPort.cs
@@ -1,0 +1,19 @@
+using Aevatar.ContentArtifacts.Abstractions;
+
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public interface IServiceRunResultArtifactAttachmentPort
+{
+    Task<ServiceRunArtifactAttachmentResult> AttachResultArtifactsAsync(
+        string runActorId,
+        string runId,
+        long expectedStateVersion,
+        IReadOnlyList<ContentArtifactReference> resultArtifacts,
+        CancellationToken ct = default);
+}
+
+public sealed record ServiceRunArtifactAttachmentResult(
+    string RunId,
+    string CommandId,
+    string CorrelationId,
+    DateTimeOffset? AcceptedAtUtc = null);

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_runs.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_runs.proto
@@ -8,6 +8,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "service_endpoint.proto";
 import "service_revision.proto";
+import "content_artifact_messages.proto";
 
 enum ServiceRunStatus {
   SERVICE_RUN_STATUS_UNSPECIFIED = 0;
@@ -45,6 +46,7 @@ message ServiceRunRecord {
   string last_error = 17;
   string schedule_id = 18;
   ServiceRunCompletionNotificationTarget completion_notification_target = 19;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 20;
 }
 
 message ServiceRunState {
@@ -68,6 +70,7 @@ message ServiceRunTerminalNotification {
   string output = 7;
   string error = 8;
   google.protobuf.Timestamp terminal_at = 9;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 10;
 }
 
 message RegisterServiceRunRequested {
@@ -79,6 +82,13 @@ message UpdateServiceRunStatusRequested {
   ServiceRunStatus status = 2;
   google.protobuf.StringValue last_output = 3;
   google.protobuf.StringValue last_error = 4;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 5;
+}
+
+message AttachServiceRunResultArtifactsRequested {
+  string run_id = 1;
+  int64 expected_state_version = 2;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 3;
 }
 
 message ServiceRunRegisteredEvent {
@@ -91,6 +101,13 @@ message ServiceRunStatusUpdatedEvent {
   google.protobuf.Timestamp updated_at = 3;
   google.protobuf.StringValue last_output = 4;
   google.protobuf.StringValue last_error = 5;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 6;
+}
+
+message ServiceRunResultArtifactsAttachedEvent {
+  string run_id = 1;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 2;
+  google.protobuf.Timestamp attached_at = 3;
 }
 
 message ServiceRunTerminalNotificationPreparedEvent {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceRunSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceRunSnapshot.cs
@@ -1,3 +1,5 @@
+using Aevatar.ContentArtifacts.Abstractions;
+
 namespace Aevatar.GAgentService.Abstractions.Queries;
 
 public sealed record ServiceRunSnapshot(
@@ -23,7 +25,10 @@ public sealed record ServiceRunSnapshot(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt,
     string LastOutput,
-    string LastError);
+    string LastError)
+{
+    public IReadOnlyList<ContentArtifactReference> ResultArtifacts { get; init; } = [];
+}
 
 public sealed record ServiceRunQuery(
     string ScopeId,

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceRunGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/ServiceRunGAgent.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Aevatar.AI.Abstractions;
+using Aevatar.ContentArtifacts.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
@@ -65,6 +66,29 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
             command,
             sourceTerminalAt: null,
             implementationTerminalEvidence: false);
+
+    [EventHandler]
+    public async Task HandleAttachResultArtifactsAsync(AttachServiceRunResultArtifactsRequested command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var record = GetRegisteredRun(command.RunId, "result artifact attachment");
+        var additions = SelectNewResultArtifacts(record.ResultArtifacts, command.ResultArtifacts);
+        if (additions.Count == 0)
+            return;
+        if (State.LastAppliedEventVersion != command.ExpectedStateVersion)
+        {
+            throw new InvalidOperationException(
+                $"Service run state version is {State.LastAppliedEventVersion}, not {command.ExpectedStateVersion}.");
+        }
+
+        var attached = new ServiceRunResultArtifactsAttachedEvent
+        {
+            RunId = record.RunId,
+            AttachedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+        attached.ResultArtifacts.Add(additions);
+        await PersistDomainEventAsync(attached);
+    }
 
     [EventHandler]
     public Task HandleRoleChatCompletedAsync(RoleChatSessionCompletedEvent terminal)
@@ -192,6 +216,7 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
     {
         ArgumentNullException.ThrowIfNull(command);
         var existing = GetRegisteredRunForStatusUpdate(command);
+        var resultArtifactAdditions = SelectNewResultArtifacts(existing.ResultArtifacts, command.ResultArtifacts);
 
         if (command.Status == ServiceRunStatus.Unspecified)
             return;
@@ -206,13 +231,14 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
                             !string.Equals(existing.LastOutput ?? string.Empty, command.LastOutput ?? string.Empty, StringComparison.Ordinal);
         var errorChanged = command.LastError != null &&
                            !string.Equals(existing.LastError ?? string.Empty, command.LastError ?? string.Empty, StringComparison.Ordinal);
+        var resultArtifactsChanged = resultArtifactAdditions.Count > 0;
         var shouldPrepareTerminalNotification =
             implementationTerminalEvidence &&
             IsTerminal(command.Status) &&
             HasCompletionNotificationTarget(existing.CompletionNotificationTarget) &&
             State.PendingTerminalNotification == null &&
             State.TerminalNotificationDeliveryStatus == ServiceRunTerminalNotificationDeliveryStatus.Unspecified;
-        if (existing.Status == command.Status && !outputChanged && !errorChanged)
+        if (existing.Status == command.Status && !outputChanged && !errorChanged && !resultArtifactsChanged)
         {
             if (shouldPrepareTerminalNotification)
             {
@@ -236,6 +262,7 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
             LastOutput = command.LastOutput,
             LastError = command.LastError,
         };
+        statusEvent.ResultArtifacts.Add(resultArtifactAdditions);
         if (shouldPrepareTerminalNotification)
         {
             await PersistDomainEventsAsync(
@@ -255,20 +282,23 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
         await DeliverPendingTerminalNotificationAsync();
     }
 
-    private ServiceRunRecord GetRegisteredRunForStatusUpdate(UpdateServiceRunStatusRequested command)
+    private ServiceRunRecord GetRegisteredRunForStatusUpdate(UpdateServiceRunStatusRequested command) =>
+        GetRegisteredRun(command.RunId, "status update");
+
+    private ServiceRunRecord GetRegisteredRun(string? runId, string operation)
     {
         var existing = State.Record;
         if (existing == null || string.IsNullOrWhiteSpace(existing.RunId))
         {
             throw new InvalidOperationException(
-                $"Service run actor '{Id}' has no registered run; status update rejected.");
+                $"Service run actor '{Id}' has no registered run; {operation} rejected.");
         }
 
-        if (!string.IsNullOrWhiteSpace(command.RunId) &&
-            !string.Equals(existing.RunId, command.RunId, StringComparison.Ordinal))
+        if (!string.IsNullOrWhiteSpace(runId) &&
+            !string.Equals(existing.RunId, runId, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
-                $"Service run actor '{Id}' is bound to run '{existing.RunId}' and cannot update run '{command.RunId}'.");
+                $"Service run actor '{Id}' is bound to run '{existing.RunId}' and cannot apply {operation} for run '{runId}'.");
         }
 
         return existing;
@@ -279,6 +309,7 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
             .Match(current, evt)
             .On<ServiceRunRegisteredEvent>(ApplyRegistered)
             .On<ServiceRunStatusUpdatedEvent>(ApplyStatusUpdated)
+            .On<ServiceRunResultArtifactsAttachedEvent>(ApplyResultArtifactsAttached)
             .On<ServiceRunTerminalNotificationPreparedEvent>(ApplyTerminalNotificationPrepared)
             .On<ServiceRunTerminalNotificationRetryScheduledEvent>(ApplyTerminalNotificationRetryScheduled)
             .On<ServiceRunTerminalNotificationDispatchedEvent>(ApplyTerminalNotificationDispatched)
@@ -305,8 +336,22 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
             next.Record.LastOutput = evt.LastOutput ?? string.Empty;
         if (evt.LastError != null)
             next.Record.LastError = evt.LastError ?? string.Empty;
+        MergeResultArtifacts(next.Record.ResultArtifacts, evt.ResultArtifacts);
         next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
         next.LastEventId = $"{next.Record.RunId}:status:{(int)evt.Status}";
+        return next;
+    }
+
+    private static ServiceRunState ApplyResultArtifactsAttached(
+        ServiceRunState state,
+        ServiceRunResultArtifactsAttachedEvent evt)
+    {
+        var next = state.Clone();
+        next.Record ??= new ServiceRunRecord();
+        MergeResultArtifacts(next.Record.ResultArtifacts, evt.ResultArtifacts);
+        next.Record.UpdatedAt = evt.AttachedAt?.Clone() ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
+        next.LastEventId = $"{next.Record.RunId}:result-artifacts:attached";
         return next;
     }
 
@@ -562,8 +607,9 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
     private static ServiceRunTerminalNotification CreateTerminalNotification(
         ServiceRunRecord existing,
         UpdateServiceRunStatusRequested command,
-        Timestamp terminalAt) =>
-        new()
+        Timestamp terminalAt)
+    {
+        var notification = new ServiceRunTerminalNotification
         {
             DeliveryId = existing.CompletionNotificationTarget.DeliveryId.Trim(),
             RunId = existing.RunId,
@@ -575,6 +621,73 @@ public sealed class ServiceRunGAgent : GAgentBase<ServiceRunState>
             Error = command.LastError ?? existing.LastError ?? string.Empty,
             TerminalAt = terminalAt.Clone(),
         };
+        notification.ResultArtifacts.Add(existing.ResultArtifacts.Select(static artifact => artifact.Clone()));
+        MergeResultArtifacts(notification.ResultArtifacts, command.ResultArtifacts);
+        return notification;
+    }
+
+    private static IReadOnlyList<ContentArtifactReference> SelectNewResultArtifacts(
+        IEnumerable<ContentArtifactReference> existing,
+        IEnumerable<ContentArtifactReference> incoming)
+    {
+        var known = existing.ToDictionary(ResultArtifactKey, static artifact => artifact, StringComparer.Ordinal);
+        var additions = new List<ContentArtifactReference>();
+        foreach (var artifact in incoming)
+        {
+            ValidateResultArtifact(artifact);
+            var key = ResultArtifactKey(artifact);
+            if (known.TryGetValue(key, out var current))
+            {
+                if (!string.Equals(current.ContentHash, artifact.ContentHash, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"ContentArtifact '{artifact.ArtifactId}' revision '{artifact.RevisionId}' has a conflicting content hash.");
+                }
+                if (!string.Equals(current.MediaType, artifact.MediaType, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"ContentArtifact '{artifact.ArtifactId}' revision '{artifact.RevisionId}' has a conflicting media type.");
+                }
+                continue;
+            }
+
+            var clone = artifact.Clone();
+            known.Add(key, clone);
+            additions.Add(clone);
+        }
+        return additions;
+    }
+
+    private static void MergeResultArtifacts(
+        Google.Protobuf.Collections.RepeatedField<ContentArtifactReference> destination,
+        IEnumerable<ContentArtifactReference> incoming)
+    {
+        destination.Add(SelectNewResultArtifacts(destination, incoming));
+    }
+
+    private static void ValidateResultArtifact(ContentArtifactReference artifact)
+    {
+        if (artifact == null || string.IsNullOrWhiteSpace(artifact.ArtifactId))
+            throw new InvalidOperationException("ContentArtifact result reference artifact_id is required.");
+        if (string.IsNullOrWhiteSpace(artifact.RevisionId))
+            throw new InvalidOperationException("ContentArtifact result reference revision_id is required.");
+        if (string.IsNullOrWhiteSpace(artifact.MediaType))
+            throw new InvalidOperationException("ContentArtifact result reference media_type is required.");
+        if (artifact.ContentHash?.Length != 64)
+            throw new InvalidOperationException("ContentArtifact result reference content_hash must be a SHA-256 hex digest.");
+        try
+        {
+            _ = Convert.FromHexString(artifact.ContentHash);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException(
+                "ContentArtifact result reference content_hash must be a SHA-256 hex digest.", ex);
+        }
+    }
+
+    private static string ResultArtifactKey(ContentArtifactReference artifact) =>
+        $"{artifact.ArtifactId}\n{artifact.RevisionId}";
 
     private async Task DeliverPendingTerminalNotificationAsync(
         CancellationToken ct = default,

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -120,7 +120,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NyxIdToolOptions>();
         services.TryAddSingleton<INyxIdServiceRegistrationPort, NyxIdServiceRegistrationAdapter>();
         services.TryAddSingleton<INyxIdRegistrationTokenAccessor, ConfiguredNyxIdRegistrationTokenAccessor>();
-        services.TryAddSingleton<IServiceRunRegistrationPort, ServiceRunRegistrationAdapter>();
+        AddServiceRunWritePorts(services);
         services.TryAddSingleton<ILlmSessionRegistrationPort, LlmSessionRegistrationAdapter>();
         services.TryAddSingleton<IResponsesAgentToolStateCommandPort, ResponsesAgentToolStateCommandAdapter>();
         services.TryAddSingleton<ILlmSessionRunObservationService, LlmSessionRunObservationService>();
@@ -232,7 +232,7 @@ public static class ServiceCollectionExtensions
         services.AddNyxIdAuthorizationCatalogHosting(configuration);
         services.TryAddSingleton<PreparedServiceRevisionArtifactAssembler>();
         services.TryAddSingleton<IServiceServingTargetResolver, DefaultServiceServingTargetResolver>();
-        services.TryAddSingleton<IServiceRunRegistrationPort, ServiceRunRegistrationAdapter>();
+        AddServiceRunWritePorts(services);
         services.TryAddSingleton<ServiceInvocationResolutionService>();
         services.TryAddSingleton<IServiceInvocationResolutionPort>(sp =>
             sp.GetRequiredService<ServiceInvocationResolutionService>());
@@ -422,6 +422,15 @@ public static class ServiceCollectionExtensions
             keySelector: keySelector,
             keyFormatter: static key => key,
             defaultSortSelector: static readModel => readModel.UpdatedAt);
+    }
+
+    private static void AddServiceRunWritePorts(IServiceCollection services)
+    {
+        services.TryAddSingleton<ServiceRunRegistrationAdapter>();
+        services.TryAddSingleton<IServiceRunRegistrationPort>(sp =>
+            sp.GetRequiredService<ServiceRunRegistrationAdapter>());
+        services.TryAddSingleton<IServiceRunResultArtifactAttachmentPort>(sp =>
+            sp.GetRequiredService<ServiceRunRegistrationAdapter>());
     }
 
 }

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ServiceRunRegistrationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/ServiceRunRegistrationAdapter.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+using Aevatar.ContentArtifacts.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
@@ -11,7 +14,9 @@ namespace Aevatar.GAgentService.Infrastructure.Adapters;
 /// commands to <see cref="ServiceRunGAgent"/> actors. The actor commits the events
 /// and the current-state projection materializes them into the durable readmodel.
 /// </summary>
-public sealed class ServiceRunRegistrationAdapter : IServiceRunRegistrationPort
+public sealed class ServiceRunRegistrationAdapter :
+    IServiceRunRegistrationPort,
+    IServiceRunResultArtifactAttachmentPort
 {
     private const string PublisherId = "gagent-service.runs";
 
@@ -97,6 +102,52 @@ public sealed class ServiceRunRegistrationAdapter : IServiceRunRegistrationPort
             commandId,
             commandId);
         await _dispatchPort.DispatchAsync(runActorId, envelope, ct);
+    }
+
+    public async Task<ServiceRunArtifactAttachmentResult> AttachResultArtifactsAsync(
+        string runActorId,
+        string runId,
+        long expectedStateVersion,
+        IReadOnlyList<ContentArtifactReference> resultArtifacts,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(runActorId))
+            throw new ArgumentException("runActorId is required.", nameof(runActorId));
+        if (string.IsNullOrWhiteSpace(runId))
+            throw new ArgumentException("runId is required.", nameof(runId));
+        ArgumentNullException.ThrowIfNull(resultArtifacts);
+        if (resultArtifacts.Count == 0)
+            throw new InvalidOperationException("At least one result artifact reference is required.");
+
+        var command = new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = runId.Trim(),
+            ExpectedStateVersion = expectedStateVersion,
+        };
+        command.ResultArtifacts.Add(resultArtifacts.Select(static artifact => artifact.Clone()));
+        var commandId = BuildResultArtifactCommandId(command);
+        await _dispatchPort.DispatchAsync(
+            runActorId,
+            CreateEnvelope(runActorId, Any.Pack(command), commandId, commandId),
+            ct);
+        return new ServiceRunArtifactAttachmentResult(
+            command.RunId,
+            commandId,
+            commandId,
+            DateTimeOffset.UtcNow);
+    }
+
+    private static string BuildResultArtifactCommandId(AttachServiceRunResultArtifactsRequested command)
+    {
+        var identity = string.Join(
+            "\n",
+            command.ResultArtifacts
+                .OrderBy(static artifact => artifact.ArtifactId, StringComparer.Ordinal)
+                .ThenBy(static artifact => artifact.RevisionId, StringComparer.Ordinal)
+                .Select(static artifact =>
+                    $"{artifact.ArtifactId}\t{artifact.RevisionId}\t{artifact.ContentHash}\t{artifact.MediaType}"));
+        var digest = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(identity)));
+        return $"service-run-artifacts-{command.RunId}-v{command.ExpectedStateVersion}-{digest}";
     }
 
     private static EventEnvelope CreateEnvelope(

--- a/src/platform/Aevatar.GAgentService.Projection/Aevatar.GAgentService.Projection.csproj
+++ b/src/platform/Aevatar.GAgentService.Projection/Aevatar.GAgentService.Projection.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
   <ItemGroup>
-    <Protobuf Include="service_projection_read_models.proto" GrpcServices="None" AdditionalImportDirs="..\Aevatar.GAgentService.Abstractions\Protos;..\..\Aevatar.AI.Abstractions;..\..\Aevatar.Foundation.VoicePresence.Abstractions;..\..\Aevatar.Foundation.Abstractions;..\..\workflow\Aevatar.Workflow.Abstractions" />
+    <Protobuf Include="service_projection_read_models.proto" GrpcServices="None" AdditionalImportDirs="..\Aevatar.GAgentService.Abstractions\Protos;..\..\Aevatar.AI.Abstractions;..\..\Aevatar.Foundation.VoicePresence.Abstractions;..\..\Aevatar.Foundation.Abstractions;..\..\workflow\Aevatar.Workflow.Abstractions;..\..\Aevatar.ContentArtifacts.Abstractions" />
     <Protobuf Include="Authorization/nyxid_authorization_catalog_read_model.proto"
               GrpcServices="None"
               AdditionalImportDirs="..\Aevatar.GAgentService.Abstractions\Protos;..\..\workflow\Aevatar.Workflow.Abstractions" />

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRunCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRunCurrentStateProjector.cs
@@ -74,6 +74,7 @@ public sealed class ServiceRunCurrentStateProjector
             LastOutput = record.LastOutput ?? string.Empty,
             LastError = record.LastError ?? string.Empty,
         };
+        document.ResultArtifacts.Add(record.ResultArtifacts.Select(static artifact => artifact.Clone()));
 
         await _writeDispatcher.UpsertAsync(document, ct);
     }

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceRunQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceRunQueryReader.cs
@@ -195,7 +195,7 @@ public sealed class ServiceRunQueryReader : IServiceRunQueryPort
     }
 
     private static ServiceRunSnapshot Map(ServiceRunCurrentStateReadModel readModel) =>
-        new(
+        new ServiceRunSnapshot(
             readModel.ScopeId,
             readModel.ServiceId,
             readModel.ServiceKey,
@@ -218,5 +218,8 @@ public sealed class ServiceRunQueryReader : IServiceRunQueryPort
             readModel.CreatedAt,
             readModel.UpdatedAt,
             readModel.LastOutput,
-            readModel.LastError);
+            readModel.LastError)
+        {
+            ResultArtifacts = readModel.ResultArtifacts.Select(static artifact => artifact.Clone()).ToArray(),
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -10,6 +10,7 @@ import "llm_sessions.proto";
 import "service_definition.proto";
 import "service_invocation_catalog.proto";
 import "service_revision.proto";
+import "content_artifact_messages.proto";
 
 // --- ServiceCatalogReadModel ---
 
@@ -253,6 +254,7 @@ message ServiceRunCurrentStateReadModel {
   string last_output = 22;
   string last_error = 23;
   string schedule_id = 24;
+  repeated aevatar.content_artifacts.ContentArtifactReference result_artifacts = 25;
 }
 // --- GAgentRunTerminalReadModel ---
 

--- a/test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
@@ -7,6 +7,67 @@ namespace Aevatar.CQRS.Projection.Core.Tests;
 public sealed class InMemoryProjectionDocumentStoreBehaviorTests
 {
     [Fact]
+    public async Task QueryAsync_ShouldResolveProtoFieldNames()
+    {
+        var store = new InMemoryProjectionDocumentStore<TestStoreReadModel, string>(
+            keySelector: model => model.Id);
+        await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "item-1",
+            ActorId = "actor-1",
+            StateVersion = 1,
+            LastEventId = "event-1",
+            UpdatedAt = DateTimeOffset.UnixEpoch,
+        });
+
+        var result = await store.QueryAsync(new ProjectionDocumentQuery
+        {
+            Filters =
+            [
+                new ProjectionDocumentFilter
+                {
+                    FieldPath = "actor_id",
+                    Operator = ProjectionDocumentFilterOperator.Eq,
+                    Value = ProjectionDocumentValue.FromString("actor-1"),
+                },
+            ],
+        });
+
+        result.Items.Should().ContainSingle().Which.Id.Should().Be("item-1");
+    }
+
+    [Fact]
+    public async Task QueryAsync_ShouldMatchScalarEqualityAgainstRepeatedFieldElement()
+    {
+        var store = new InMemoryProjectionDocumentStore<TestRecursiveWellKnownReadModel, string>(
+            keySelector: model => model.Id);
+        await store.UpsertAsync(new TestRecursiveWellKnownReadModel
+        {
+            Id = "item-1",
+            ActorId = "actor-1",
+            StateVersion = 1,
+            LastEventId = "event-1",
+            UpdatedAt = DateTimeOffset.UnixEpoch,
+            Tags = { "reader-1", "reader-2" },
+        });
+
+        var result = await store.QueryAsync(new ProjectionDocumentQuery
+        {
+            Filters =
+            [
+                new ProjectionDocumentFilter
+                {
+                    FieldPath = "tags",
+                    Operator = ProjectionDocumentFilterOperator.Eq,
+                    Value = ProjectionDocumentValue.FromString("reader-1"),
+                },
+            ],
+        });
+
+        result.Items.Should().ContainSingle().Which.Id.Should().Be("item-1");
+    }
+
+    [Fact]
     public async Task QueryAsync_ShouldApplyAnyOfFiltersBeforeCountAndPaging()
     {
         var store = new InMemoryProjectionDocumentStore<TestStoreReadModel, string>(

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceRunContentArtifactTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceRunContentArtifactTests.cs
@@ -74,6 +74,94 @@ public sealed class ServiceRunContentArtifactTests
     }
 
     [Fact]
+    public async Task AttachResultArtifacts_ShouldRejectConflictingRevisionMediaType()
+    {
+        var actor = CreateAgent(new InMemoryEventStore());
+        await actor.ActivateAsync();
+        await actor.HandleRegisterAsync(new RegisterServiceRunRequested { Record = BuildRecord() });
+        var reference = BuildReference("artifact-1", "revision-1", 'a');
+        await actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 1,
+            ResultArtifacts = { reference },
+        });
+        var conflicting = reference.Clone();
+        conflicting.MediaType = "application/json";
+
+        var act = () => actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 2,
+            ResultArtifacts = { conflicting },
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*artifact-1*revision-1*conflicting media type*");
+    }
+
+    [Fact]
+    public async Task AttachResultArtifacts_ShouldValidateReferenceFieldsBeforePersisting()
+    {
+        var actor = CreateAgent(new InMemoryEventStore());
+        await actor.ActivateAsync();
+        await actor.HandleRegisterAsync(new RegisterServiceRunRequested { Record = BuildRecord() });
+
+        async Task AssertRejectedAsync(ContentArtifactReference reference, string expectedMessage)
+        {
+            var act = () => actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+            {
+                RunId = "run-1",
+                ExpectedStateVersion = 1,
+                ResultArtifacts = { reference },
+            });
+            await act.Should().ThrowAsync<InvalidOperationException>().WithMessage(expectedMessage);
+        }
+
+        var missingArtifact = BuildReference(string.Empty, "revision-1", 'a');
+        await AssertRejectedAsync(missingArtifact, "*artifact_id is required*");
+        var missingRevision = BuildReference("artifact-1", string.Empty, 'a');
+        await AssertRejectedAsync(missingRevision, "*revision_id is required*");
+        var missingMediaType = BuildReference("artifact-1", "revision-1", 'a');
+        missingMediaType.MediaType = string.Empty;
+        await AssertRejectedAsync(missingMediaType, "*media_type is required*");
+        var shortHash = BuildReference("artifact-1", "revision-1", 'a');
+        shortHash.ContentHash = "abc";
+        await AssertRejectedAsync(shortHash, "*content_hash must be a SHA-256 hex digest*");
+        var invalidHex = BuildReference("artifact-1", "revision-1", 'z');
+        await AssertRejectedAsync(invalidHex, "*content_hash must be a SHA-256 hex digest*");
+
+        actor.State.LastAppliedEventVersion.Should().Be(1);
+        actor.State.Record!.ResultArtifacts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AttachResultArtifacts_ShouldRejectUnregisteredOrMismatchedRunIdentity()
+    {
+        var actor = CreateAgent(new InMemoryEventStore());
+        await actor.ActivateAsync();
+        var reference = BuildReference("artifact-1", "revision-1", 'a');
+        var unregistered = () => actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 0,
+            ResultArtifacts = { reference },
+        });
+        await unregistered.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no registered run; result artifact attachment rejected*");
+
+        await actor.HandleRegisterAsync(new RegisterServiceRunRequested { Record = BuildRecord() });
+        var mismatched = () => actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-other",
+            ExpectedStateVersion = 1,
+            ResultArtifacts = { reference },
+        });
+        await mismatched.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot apply result artifact attachment for run 'run-other'*");
+    }
+
+    [Fact]
     public async Task TerminalStatus_ShouldPreserveTypedResultReferencesWithoutEmbeddingContent()
     {
         var actor = CreateAgent(new InMemoryEventStore());

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceRunContentArtifactTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceRunContentArtifactTests.cs
@@ -1,0 +1,132 @@
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Core.GAgents;
+using Aevatar.GAgentService.Tests.TestSupport;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Core;
+
+public sealed class ServiceRunContentArtifactTests
+{
+    [Fact]
+    public async Task AttachResultArtifacts_ShouldBeActorOwnedCasAndRecoverAfterRestart()
+    {
+        var store = new InMemoryEventStore();
+        var original = CreateAgent(store);
+        await original.ActivateAsync();
+        await original.HandleRegisterAsync(new RegisterServiceRunRequested { Record = BuildRecord() });
+        var reference = BuildReference("artifact-1", "artifact-1-revision-1", 'a');
+
+        var command = new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 1,
+            ResultArtifacts = { reference },
+        };
+        await original.HandleAttachResultArtifactsAsync(command);
+        await original.HandleAttachResultArtifactsAsync(command.Clone());
+
+        original.State.Record!.ResultArtifacts.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(reference);
+        original.State.LastAppliedEventVersion.Should().Be(2);
+
+        var recovered = CreateAgent(store);
+        await recovered.ActivateAsync();
+        recovered.State.Record!.ResultArtifacts.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(reference);
+
+        var stale = () => recovered.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 1,
+            ResultArtifacts = { BuildReference("artifact-2", "artifact-2-revision-1", 'b') },
+        });
+        await stale.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*state version is 2, not 1*");
+    }
+
+    [Fact]
+    public async Task AttachResultArtifacts_ShouldRejectConflictingRevisionIdentity()
+    {
+        var actor = CreateAgent(new InMemoryEventStore());
+        await actor.ActivateAsync();
+        await actor.HandleRegisterAsync(new RegisterServiceRunRequested { Record = BuildRecord() });
+        await actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 1,
+            ResultArtifacts = { BuildReference("artifact-1", "revision-1", 'a') },
+        });
+
+        var act = () => actor.HandleAttachResultArtifactsAsync(new AttachServiceRunResultArtifactsRequested
+        {
+            RunId = "run-1",
+            ExpectedStateVersion = 2,
+            ResultArtifacts = { BuildReference("artifact-1", "revision-1", 'b') },
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*artifact-1*revision-1*conflicting content hash*");
+        actor.State.Record!.ResultArtifacts.Should().ContainSingle()
+            .Which.ContentHash.Should().Be(new string('a', 64));
+    }
+
+    [Fact]
+    public async Task TerminalStatus_ShouldPreserveTypedResultReferencesWithoutEmbeddingContent()
+    {
+        var actor = CreateAgent(new InMemoryEventStore());
+        await actor.ActivateAsync();
+        await actor.HandleRegisterAsync(new RegisterServiceRunRequested { Record = BuildRecord() });
+        var reference = BuildReference("artifact-1", "revision-1", 'a');
+
+        await actor.HandleUpdateStatusAsync(new UpdateServiceRunStatusRequested
+        {
+            RunId = "run-1",
+            Status = ServiceRunStatus.Completed,
+            LastOutput = "done",
+            ResultArtifacts = { reference },
+        });
+
+        actor.State.Record!.ResultArtifacts.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(reference);
+        actor.State.Record.ToString().Should().NotContain("inline_content");
+    }
+
+    private static ServiceRunGAgent CreateAgent(InMemoryEventStore store) =>
+        GAgentServiceTestKit.CreateStatefulAgent<ServiceRunGAgent, ServiceRunState>(
+            store,
+            "service-run:tenant-1:svc-1:run-1",
+            static () => new ServiceRunGAgent());
+
+    private static ServiceRunRecord BuildRecord() =>
+        new()
+        {
+            ScopeId = "tenant-1",
+            ServiceId = "svc-1",
+            ServiceKey = "tenant-1:svc-1",
+            RunId = "run-1",
+            CommandId = "cmd-run-1",
+            CorrelationId = "corr-run-1",
+            EndpointId = "run",
+            ImplementationKind = ServiceImplementationKind.Static,
+            TargetActorId = "target-run-1",
+            RevisionId = "r1",
+            DeploymentId = "dep-1",
+            Status = ServiceRunStatus.Unspecified,
+            CreatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-20T00:00:00Z")),
+        };
+
+    private static ContentArtifactReference BuildReference(
+        string artifactId,
+        string revisionId,
+        char hashCharacter) =>
+        new()
+        {
+            ArtifactId = artifactId,
+            RevisionId = revisionId,
+            ContentHash = new string(hashCharacter, 64),
+            MediaType = "text/markdown",
+        };
+}

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceRunRegistrationAdapterTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceRunRegistrationAdapterTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.ContentArtifacts.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
@@ -101,6 +102,84 @@ public sealed class ServiceRunRegistrationAdapterTests
         dispatchPort.Calls.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task AttachResultArtifactsAsync_ShouldDispatchStableOrderIndependentCommandIdentity()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var adapter = new ServiceRunRegistrationAdapter(
+            new RecordingRunRegistryRuntime(),
+            dispatchPort);
+        var actorId = "service-run:tenant:svc:run-1";
+        var first = BuildArtifactReference("artifact-b", "revision-2", 'b');
+        var second = BuildArtifactReference("artifact-a", "revision-1", 'a');
+
+        var firstReceipt = await adapter.AttachResultArtifactsAsync(
+            actorId,
+            " run-1 ",
+            expectedStateVersion: 7,
+            [first, second]);
+        var secondReceipt = await adapter.AttachResultArtifactsAsync(
+            actorId,
+            "run-1",
+            expectedStateVersion: 7,
+            [second, first]);
+
+        firstReceipt.RunId.Should().Be("run-1");
+        firstReceipt.CommandId.Should().StartWith("service-run-artifacts-run-1-v7-");
+        firstReceipt.CorrelationId.Should().Be(firstReceipt.CommandId);
+        secondReceipt.CommandId.Should().Be(firstReceipt.CommandId);
+        dispatchPort.Calls.Should().HaveCount(2);
+        var envelope = dispatchPort.Calls[0].envelope;
+        envelope.Id.Should().Be(firstReceipt.CommandId);
+        envelope.Route.GetTargetActorId().Should().Be(actorId);
+        envelope.Propagation.CorrelationId.Should().Be(firstReceipt.CommandId);
+        var command = envelope.Payload.Unpack<AttachServiceRunResultArtifactsRequested>();
+        command.RunId.Should().Be("run-1");
+        command.ExpectedStateVersion.Should().Be(7);
+        command.ResultArtifacts.Should().Equal(first, second);
+    }
+
+    [Fact]
+    public async Task AttachResultArtifactsAsync_ShouldRejectInvalidAttachmentRequests()
+    {
+        var adapter = new ServiceRunRegistrationAdapter(
+            new RecordingRunRegistryRuntime(),
+            new RecordingDispatchPort());
+        var reference = BuildArtifactReference("artifact-1", "revision-1", 'a');
+
+        var missingActor = () => adapter.AttachResultArtifactsAsync(
+            " ",
+            "run-1",
+            1,
+            [reference]);
+        await missingActor.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("runActorId");
+
+        var missingRun = () => adapter.AttachResultArtifactsAsync(
+            "service-run:tenant:svc:run-1",
+            " ",
+            1,
+            [reference]);
+        await missingRun.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("runId");
+
+        var nullArtifacts = () => adapter.AttachResultArtifactsAsync(
+            "service-run:tenant:svc:run-1",
+            "run-1",
+            1,
+            null!);
+        await nullArtifacts.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("resultArtifacts");
+
+        var emptyArtifacts = () => adapter.AttachResultArtifactsAsync(
+            "service-run:tenant:svc:run-1",
+            "run-1",
+            1,
+            []);
+        await emptyArtifacts.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("At least one result artifact reference is required.");
+    }
+
     private static ServiceRunRecord BuildRecord(string scopeId, string serviceId, string runId) =>
         new()
         {
@@ -117,6 +196,18 @@ public sealed class ServiceRunRegistrationAdapterTests
             DeploymentId = "dep-1",
             Status = ServiceRunStatus.Unspecified,
             CreatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+        };
+
+    private static ContentArtifactReference BuildArtifactReference(
+        string artifactId,
+        string revisionId,
+        char hashCharacter) =>
+        new()
+        {
+            ArtifactId = artifactId,
+            RevisionId = revisionId,
+            ContentHash = new string(hashCharacter, 64),
+            MediaType = "text/markdown",
         };
 
     private sealed class RecordingRunRegistryRuntime : IActorRuntime

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceRunCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceRunCurrentStateProjectorTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.ContentArtifacts.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Projection.Contexts;
@@ -32,6 +33,13 @@ public sealed class ServiceRunCurrentStateProjectorTests
             createdAt: observedAt);
         record.LastOutput = "final output";
         record.LastError = "final error";
+        record.ResultArtifacts.Add(new ContentArtifactReference
+        {
+            ArtifactId = "artifact-1",
+            RevisionId = "artifact-1-revision-1",
+            ContentHash = new string('a', 64),
+            MediaType = "text/markdown",
+        });
         var envelope = WrapCommittedRunState(
             record,
             stateVersion: 3,
@@ -58,6 +66,8 @@ public sealed class ServiceRunCurrentStateProjectorTests
         doc.Status.Should().Be((int)ServiceRunStatus.Accepted);
         doc.LastOutput.Should().Be("final output");
         doc.LastError.Should().Be("final error");
+        doc.ResultArtifacts.Should().ContainSingle()
+            .Which.RevisionId.Should().Be("artifact-1-revision-1");
         doc.StateVersion.Should().Be(3);
         doc.LastEventId.Should().Be("evt-registered");
     }
@@ -92,10 +102,24 @@ public sealed class ServiceRunCurrentStateProjectorTests
             store,
             new FixedProjectionClock(DateTimeOffset.Parse("2026-04-27T00:00:00+00:00")));
         var reader = new ServiceRunQueryReader(store);
+        var runA = BuildRecord(
+            "tenant-1",
+            "svc-1",
+            "run-a",
+            "cmd-a",
+            ServiceImplementationKind.Static,
+            "actor-a");
+        runA.ResultArtifacts.Add(new ContentArtifactReference
+        {
+            ArtifactId = "artifact-a",
+            RevisionId = "artifact-a-revision-1",
+            ContentHash = new string('a', 64),
+            MediaType = "text/markdown",
+        });
         await projector.ProjectAsync(
             CreateContext("service-run:run-a"),
             WrapCommittedRunState(
-                BuildRecord("tenant-1", "svc-1", "run-a", "cmd-a", ServiceImplementationKind.Static, "actor-a"),
+                runA,
                 stateVersion: 1,
                 eventId: "evt-a",
                 observedAt: DateTimeOffset.Parse("2026-04-27T01:00:00+00:00")));
@@ -126,6 +150,8 @@ public sealed class ServiceRunCurrentStateProjectorTests
         byRun!.CommandId.Should().Be("cmd-a");
         byRun.LastOutput.Should().BeEmpty();
         byRun.LastError.Should().BeEmpty();
+        byRun.ResultArtifacts.Should().ContainSingle()
+            .Which.RevisionId.Should().Be("artifact-a-revision-1");
 
         var byCommand = await reader.GetByCommandIdAsync("tenant-1", "svc-1", "cmd-b");
         byCommand.Should().NotBeNull();

--- a/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj
+++ b/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Aevatar.Studio.Domain/Aevatar.Studio.Domain.csproj" />
+    <ProjectReference Include="../../src/Aevatar.ContentArtifacts.Abstractions/Aevatar.ContentArtifacts.Abstractions.csproj" />
     <ProjectReference Include="../../src/Aevatar.Studio.Application.Abstractions/Aevatar.Studio.Application.Abstractions.csproj" />
     <ProjectReference Include="../../src/Aevatar.Studio.Application/Aevatar.Studio.Application.csproj" />
     <ProjectReference Include="../../src/Aevatar.AI.ToolProviders.NyxId/Aevatar.AI.ToolProviders.NyxId.csproj" />
@@ -36,6 +37,7 @@
     <ProjectReference Include="../../agents/Aevatar.GAgents.StudioTeam/Aevatar.GAgents.StudioTeam.csproj" />
     <ProjectReference Include="../../agents/Aevatar.GAgents.WorkOrder/Aevatar.GAgents.WorkOrder.csproj" />
     <ProjectReference Include="../../agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj" />
+    <ProjectReference Include="../../agents/Aevatar.GAgents.ContentArtifacts/Aevatar.GAgents.ContentArtifacts.csproj" />
     <ProjectReference Include="../../src/workflow/Aevatar.Workflow.Studio/Aevatar.Workflow.Studio.csproj" />
   </ItemGroup>
 

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
@@ -43,7 +43,7 @@ public sealed class ContentArtifactCommandServiceTests
     }
 
     [Fact]
-    public async Task AppendRevisionAsync_ShouldUseServerDerivedRevisionNumberIndependentlyFromExpectedVersion()
+    public async Task AppendRevisionAsync_ShouldLeaveRevisionIdentityForActor()
     {
         var dispatchPort = new RecordingDispatchPort();
         var service = new ActorDispatchContentArtifactCommandService(
@@ -51,21 +51,19 @@ public sealed class ContentArtifactCommandServiceTests
             CreateCommandDispatch(dispatchPort));
         var artifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, "report-dedup");
         var request = new AppendContentArtifactRevisionRequest(
-            ExpectedConcurrencyVersion: 7,
-            Revision: RevisionWrite("revision four", "revision-4-dedup", "revision-3"));
+            RevisionWrite("revision four", "revision-4-dedup", "revision-3"));
 
         var receipt = await service.AppendRevisionAsync(
             ScopeId,
             artifactId,
-            revisionNumber: 4,
             request,
             new ContentArtifactPrincipalContract("owner-1", "user"));
 
-        receipt.CommandId.Should().StartWith($"content-artifact-append-{artifactId}-v7-");
+        receipt.CommandId.Should().StartWith($"content-artifact-append-{artifactId}-v0-");
         var command = dispatchPort.Envelopes.Should().ContainSingle().Subject.Payload!
             .Unpack<Aevatar.ContentArtifacts.Abstractions.AppendContentArtifactRevision>();
-        command.Revision.RevisionNumber.Should().Be(4);
-        command.Revision.RevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(artifactId, 4));
+        command.Revision.RevisionNumber.Should().Be(0);
+        command.Revision.RevisionId.Should().BeEmpty();
         command.Revision.ParentRevisionId.Should().Be("revision-3");
     }
 

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
@@ -1,0 +1,144 @@
+using System.Security.Cryptography;
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.ContentArtifacts;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Projection.CommandServices;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests.ContentArtifacts;
+
+public sealed class ContentArtifactCommandServiceTests
+{
+    private const string ScopeId = "scope-1";
+
+    [Fact]
+    public async Task CreateAsync_ShouldUseStableArtifactRevisionAndRuntimeDedupIdentities()
+    {
+        var bootstrap = new RecordingBootstrap();
+        var dispatchPort = new RecordingDispatchPort();
+        var service = new ActorDispatchContentArtifactCommandService(
+            bootstrap,
+            CreateCommandDispatch(dispatchPort));
+        var request = CreateRequest();
+        var owner = new ContentArtifactPrincipalContract("owner-1", "user");
+        var artifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, request.DedupKey);
+
+        var first = await service.CreateAsync(ScopeId, request, owner);
+        var second = await service.CreateAsync(ScopeId, request, owner);
+
+        first.ArtifactId.Should().Be(artifactId);
+        first.CommandId.Should().StartWith($"content-artifact-create-{artifactId}-v0-");
+        first.CorrelationId.Should().Be(first.CommandId);
+        first.Stage.Should().Be(ContentArtifactCommandStageNames.DispatchAccepted);
+        second.Should().BeEquivalentTo(first, options => options.Excluding(receipt => receipt.AcceptedAtUtc));
+        bootstrap.ActorIds.Should().OnlyContain(id => id == ContentArtifactConventions.BuildActorId(ScopeId, artifactId));
+        var command = dispatchPort.Envelopes[0].Payload!.Unpack<Aevatar.ContentArtifacts.Abstractions.CreateContentArtifact>();
+        command.FirstRevision.RevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(artifactId, 1));
+        command.FirstRevision.RevisionNumber.Should().Be(1);
+        command.FirstRevision.Provenance.ScopeId.Should().Be(ScopeId);
+        dispatchPort.Envelopes.Select(static envelope => envelope.EnsureRuntime().EnsureDeduplication().OperationId)
+            .Should().OnlyContain(id => id == first.CommandId);
+    }
+
+    [Fact]
+    public async Task AppendRevisionAsync_ShouldUseServerDerivedRevisionNumberIndependentlyFromExpectedVersion()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var service = new ActorDispatchContentArtifactCommandService(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatchPort));
+        var artifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, "report-dedup");
+        var request = new AppendContentArtifactRevisionRequest(
+            ExpectedConcurrencyVersion: 7,
+            Revision: RevisionWrite("revision four", "revision-4-dedup", "revision-3"));
+
+        var receipt = await service.AppendRevisionAsync(
+            ScopeId,
+            artifactId,
+            revisionNumber: 4,
+            request,
+            new ContentArtifactPrincipalContract("owner-1", "user"));
+
+        receipt.CommandId.Should().StartWith($"content-artifact-append-{artifactId}-v7-");
+        var command = dispatchPort.Envelopes.Should().ContainSingle().Subject.Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.AppendContentArtifactRevision>();
+        command.Revision.RevisionNumber.Should().Be(4);
+        command.Revision.RevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(artifactId, 4));
+        command.Revision.ParentRevisionId.Should().Be("revision-3");
+    }
+
+    private static CreateContentArtifactRequest CreateRequest() =>
+        new(
+            TeamId: "team-1",
+            Kind: "markdown",
+            Title: "Quarterly report",
+            Classification: "internal",
+            DedupKey: "report-dedup",
+            FirstRevision: RevisionWrite("report", "revision-1-dedup"));
+
+    private static ContentArtifactRevisionWriteRequest RevisionWrite(
+        string content,
+        string dedupKey,
+        string? parentRevisionId = null) =>
+        new(
+            DedupKey: dedupKey,
+            MediaType: "text/markdown",
+            ContentHash: Convert.ToHexStringLower(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content))),
+            ByteLength: System.Text.Encoding.UTF8.GetByteCount(content),
+            Provenance: new(ScopeId, TeamId: "team-1", PublishedServiceId: "service-1", RunId: "run-1"),
+            InlineContent: System.Text.Encoding.UTF8.GetBytes(content),
+            ParentRevisionId: parentRevisionId);
+
+    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort) =>
+        new(new DefaultCommandDispatchService<
+            StudioProjectionActorCommand,
+            StudioProjectionActorCommandTarget,
+            StudioProjectionActorCommandReceipt,
+            StudioProjectionActorCommandStartError>(
+            new DefaultCommandDispatchPipeline<
+                StudioProjectionActorCommand,
+                StudioProjectionActorCommandTarget,
+                StudioProjectionActorCommandReceipt,
+                StudioProjectionActorCommandStartError>(
+                new StudioProjectionActorCommandTargetResolver(),
+                new DefaultCommandContextPolicy(),
+                new StudioProjectionActorCommandEnvelopeFactory(),
+                new ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
+                new StudioProjectionActorCommandReceiptFactory())));
+
+    private sealed class RecordingBootstrap : IStudioActorBootstrap
+    {
+        public List<string> ActorIds { get; } = [];
+
+        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
+            where TAgent : IAgent, IProjectedActor
+        {
+            ActorIds.Add(actorId);
+            return Task.FromResult<IActor>(new StubActor(actorId));
+        }
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public List<EventEnvelope> Envelopes { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Envelopes.Add(envelope);
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+}

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
@@ -69,6 +69,220 @@ public sealed class ContentArtifactCommandServiceTests
         command.Revision.ParentRevisionId.Should().Be("revision-3");
     }
 
+    [Fact]
+    public async Task CreateAsync_ShouldMapBackingContentPoliciesProvenanceAndCitations()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var service = new ActorDispatchContentArtifactCommandService(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatchPort));
+        var publishedAt = DateTimeOffset.Parse("2026-07-19T10:00:00Z");
+        var fetchedAt = publishedAt.AddMinutes(5);
+        var expiresAt = publishedAt.AddYears(1);
+        var request = new CreateContentArtifactRequest(
+            TeamId: null,
+            Kind: " structured_document ",
+            Title: "Research brief",
+            Classification: "confidential",
+            DedupKey: "research-brief-dedup",
+            FirstRevision: new ContentArtifactRevisionWriteRequest(
+                DedupKey: "research-brief-revision-1",
+                MediaType: "application/vnd.aevatar.document+json",
+                ContentHash: new string('A', 64),
+                ByteLength: 512,
+                Provenance: new ContentArtifactExecutionProvenanceContract(
+                    ScopeId,
+                    TeamId: "team-1",
+                    MemberId: "member-1",
+                    WorkflowId: "workflow-1",
+                    PublishedServiceId: "service-1",
+                    RunId: "run-1",
+                    WorkOrderId: "work-order-1"),
+                BackingObject: new ContentArtifactBackingObjectContract("workflow-file", "drafts/report.json"),
+                Citations:
+                [
+                    new ContentArtifactCitationContract(
+                        "citation-artifact",
+                        "Prior revision",
+                        new ContentArtifactCitationLocatorContract("summary", 10, 20, "$.summary"),
+                        new ContentArtifactReferenceContract(
+                            "source-artifact",
+                            "source-revision",
+                            new string('b', 64),
+                            "text/markdown")),
+                    new ContentArtifactCitationContract(
+                        "citation-external",
+                        ExternalSource: new ContentArtifactExternalCitationSourceContract(
+                            "https://example.test/source",
+                            "source-42",
+                            "2026-07-19",
+                            new string('c', 64),
+                            publishedAt,
+                            fetchedAt)),
+                ],
+                SupersessionReason: "normalized source material"),
+            AccessPolicy: new ContentArtifactAccessPolicyContract(["reader-1"], ["writer-1"]),
+            RetentionPolicy: new ContentArtifactRetentionPolicyContract("retain-one-year", expiresAt),
+            WorkOrderId: "work-order-1");
+
+        await service.CreateAsync(
+            ScopeId,
+            request,
+            new ContentArtifactPrincipalContract("owner-1", "user"));
+
+        var command = dispatchPort.Envelopes.Should().ContainSingle().Subject.Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.CreateContentArtifact>();
+        command.TeamId.Should().BeEmpty();
+        command.Kind.Should().Be(Aevatar.ContentArtifacts.Abstractions.ContentArtifactKind.StructuredDocument);
+        command.AccessPolicy.Owner.PrincipalId.Should().Be("owner-1");
+        command.AccessPolicy.ReaderPrincipalIds.Should().Equal("reader-1");
+        command.AccessPolicy.WriterPrincipalIds.Should().Equal("writer-1");
+        command.RetentionPolicy.PolicyId.Should().Be("retain-one-year");
+        command.RetentionPolicy.ExpiresAtUtc.ToDateTimeOffset().Should().Be(expiresAt);
+        command.WorkOrderId.Should().Be("work-order-1");
+        command.FirstRevision.Content.BackingObject.Provider.Should().Be("workflow-file");
+        command.FirstRevision.Content.BackingObject.ObjectKey.Should().Be("drafts/report.json");
+        command.FirstRevision.ContentHash.Should().Be(new string('a', 64));
+        command.FirstRevision.SupersessionReason.Should().Be("normalized source material");
+        command.FirstRevision.Provenance.Should().BeEquivalentTo(new
+        {
+            ScopeId,
+            TeamId = "team-1",
+            MemberId = "member-1",
+            WorkflowId = "workflow-1",
+            PublishedServiceId = "service-1",
+            RunId = "run-1",
+            WorkOrderId = "work-order-1",
+        });
+        command.FirstRevision.Citations.Should().HaveCount(2);
+        command.FirstRevision.Citations[0].Locator.Section.Should().Be("summary");
+        command.FirstRevision.Citations[0].Locator.StartOffset.Should().Be(10);
+        command.FirstRevision.Citations[0].Locator.EndOffset.Should().Be(20);
+        command.FirstRevision.Citations[0].Locator.Selector.Should().Be("$.summary");
+        command.FirstRevision.Citations[0].ArtifactRevision.Reference.ArtifactId.Should().Be("source-artifact");
+        command.FirstRevision.Citations[1].ExternalSource.SourceUri.Should().Be("https://example.test/source");
+        command.FirstRevision.Citations[1].ExternalSource.PublishedAtUtc.ToDateTimeOffset().Should().Be(publishedAt);
+        command.FirstRevision.Citations[1].ExternalSource.FetchedAtUtc.ToDateTimeOffset().Should().Be(fetchedAt);
+    }
+
+    [Fact]
+    public async Task LifecycleCommands_ShouldMapRequesterConcurrencyAndOperationSpecificFields()
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var service = new ActorDispatchContentArtifactCommandService(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatchPort));
+        var artifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, "report-dedup");
+        var requester = new ContentArtifactPrincipalContract("writer-1", "service");
+
+        var advanceReceipt = await service.AdvanceCurrentRevisionAsync(
+            ScopeId,
+            artifactId,
+            new AdvanceContentArtifactCurrentRevisionRequest(8, "revision-4"),
+            requester);
+        var redactReceipt = await service.RedactRevisionAsync(
+            ScopeId,
+            artifactId,
+            "revision-3",
+            new RedactContentArtifactRevisionRequest(9, "policy violation"),
+            requester);
+        var expireReceipt = await service.ExpireRevisionAsync(
+            ScopeId,
+            artifactId,
+            "revision-2",
+            new ExpireContentArtifactRevisionRequest(10),
+            requester);
+        var tombstoneReceipt = await service.TombstoneAsync(
+            ScopeId,
+            artifactId,
+            new TombstoneContentArtifactRequest(11, "retention complete"),
+            requester);
+
+        advanceReceipt.CommandId.Should().StartWith($"content-artifact-advance-{artifactId}-v8-");
+        redactReceipt.CommandId.Should().StartWith($"content-artifact-redact-{artifactId}-v9-");
+        expireReceipt.CommandId.Should().StartWith($"content-artifact-expire-{artifactId}-v10-");
+        tombstoneReceipt.CommandId.Should().StartWith($"content-artifact-tombstone-{artifactId}-v11-");
+        var advance = dispatchPort.Envelopes[0].Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.AdvanceContentArtifactCurrentRevision>();
+        advance.RevisionId.Should().Be("revision-4");
+        advance.ExpectedConcurrencyVersion.Should().Be(8);
+        advance.RequestedBy.PrincipalId.Should().Be("writer-1");
+        advance.RequestedBy.PrincipalKind.Should().Be("service");
+        var redact = dispatchPort.Envelopes[1].Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.RedactContentArtifactRevision>();
+        redact.RevisionId.Should().Be("revision-3");
+        redact.Reason.Should().Be("policy violation");
+        var expire = dispatchPort.Envelopes[2].Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.ExpireContentArtifactRevision>();
+        expire.RevisionId.Should().Be("revision-2");
+        expire.ExpectedConcurrencyVersion.Should().Be(10);
+        var tombstone = dispatchPort.Envelopes[3].Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.TombstoneContentArtifact>();
+        tombstone.Reason.Should().Be("retention complete");
+        tombstone.ExpectedConcurrencyVersion.Should().Be(11);
+    }
+
+    [Theory]
+    [InlineData("text", Aevatar.ContentArtifacts.Abstractions.ContentArtifactKind.Text)]
+    [InlineData("other_content", Aevatar.ContentArtifacts.Abstractions.ContentArtifactKind.OtherContent)]
+    public async Task CreateAsync_ShouldMapSupportedKinds(
+        string kind,
+        Aevatar.ContentArtifacts.Abstractions.ContentArtifactKind expectedKind)
+    {
+        var dispatchPort = new RecordingDispatchPort();
+        var service = new ActorDispatchContentArtifactCommandService(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatchPort));
+
+        await service.CreateAsync(
+            ScopeId,
+            CreateRequest() with { Kind = kind, DedupKey = $"{kind}-dedup" },
+            new ContentArtifactPrincipalContract("owner-1", "user"));
+
+        dispatchPort.Envelopes.Should().ContainSingle().Subject.Payload!
+            .Unpack<Aevatar.ContentArtifacts.Abstractions.CreateContentArtifact>()
+            .Kind.Should().Be(expectedKind);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldRejectAmbiguousMissingOrUnsupportedRevisionInputs()
+    {
+        var service = new ActorDispatchContentArtifactCommandService(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(new RecordingDispatchPort()));
+        var inlineRevision = RevisionWrite("report", "revision-1-dedup");
+
+        var ambiguous = () => service.CreateAsync(
+            ScopeId,
+            CreateRequest() with
+            {
+                FirstRevision = inlineRevision with
+                {
+                    BackingObject = new ContentArtifactBackingObjectContract("workflow-file", "report.md"),
+                },
+            },
+            new ContentArtifactPrincipalContract("owner-1", "user"));
+        await ambiguous.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot contain both inline and backing content*");
+
+        var missing = () => service.CreateAsync(
+            ScopeId,
+            CreateRequest() with
+            {
+                FirstRevision = inlineRevision with { InlineContent = null },
+            },
+            new ContentArtifactPrincipalContract("owner-1", "user"));
+        await missing.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*content location is required*");
+
+        var unsupported = () => service.CreateAsync(
+            ScopeId,
+            CreateRequest() with { Kind = "binary" },
+            new ContentArtifactPrincipalContract("owner-1", "user"));
+        await unsupported.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Unsupported ContentArtifact kind 'binary'.");
+    }
+
     private static CreateContentArtifactRequest CreateRequest() =>
         new(
             TeamId: "team-1",

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs
@@ -1,0 +1,153 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Hosting.Endpoints;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Aevatar.Studio.Tests.ContentArtifacts;
+
+public sealed class ContentArtifactEndpointsTests
+{
+    private const string ScopeId = "scope-1";
+
+    [Fact]
+    public async Task HandleCreateAsync_ShouldReturnAcceptedReceiptForAuthenticatedOwner()
+    {
+        var service = new RecordingService();
+        var request = CreateRequest();
+
+        var result = await ContentArtifactEndpoints.HandleCreateAsync(
+            CreateContext("owner-1"),
+            ScopeId,
+            request,
+            service,
+            CancellationToken.None);
+
+        var accepted = result.Should().BeOfType<Accepted<ContentArtifactAcceptedReceipt>>().Subject;
+        accepted.Location.Should().Be($"/api/scopes/{ScopeId}/content-artifacts/artifact-1");
+        accepted.Value!.Stage.Should().Be(ContentArtifactCommandStageNames.DispatchAccepted);
+        service.Requester.Should().Be(new ContentArtifactPrincipalContract("owner-1", "user"));
+    }
+
+    [Fact]
+    public async Task HandleGetRevisionContentAsync_ShouldRequireAuthenticatedPrincipal()
+    {
+        var service = new RecordingService();
+
+        var result = await ContentArtifactEndpoints.HandleGetRevisionContentAsync(
+            CreateContext(requesterId: null),
+            ScopeId,
+            "artifact-1",
+            "revision-1",
+            service,
+            CancellationToken.None);
+
+        result.Should().BeOfType<UnauthorizedHttpResult>();
+        service.ContentRead.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleGetRevisionContentAsync_ShouldReturnVerifiedContentWithMediaType()
+    {
+        var service = new RecordingService();
+
+        var result = await ContentArtifactEndpoints.HandleGetRevisionContentAsync(
+            CreateContext("reader-1"),
+            ScopeId,
+            "artifact-1",
+            "revision-1",
+            service,
+            CancellationToken.None);
+
+        var file = result.Should().BeOfType<FileContentHttpResult>().Subject;
+        file.ContentType.Should().Be("text/markdown");
+        file.FileContents.Should().BeOfType<ReadOnlyMemory<byte>>().Which.ToArray()
+            .Should().Equal(System.Text.Encoding.UTF8.GetBytes("report"));
+    }
+
+    private static CreateContentArtifactRequest CreateRequest()
+    {
+        var content = System.Text.Encoding.UTF8.GetBytes("report");
+        return new CreateContentArtifactRequest(
+            "team-1",
+            "markdown",
+            "Quarterly report",
+            "internal",
+            "report-dedup",
+            new ContentArtifactRevisionWriteRequest(
+                "revision-1-dedup",
+                "text/markdown",
+                Convert.ToHexStringLower(SHA256.HashData(content)),
+                content.Length,
+                new ContentArtifactExecutionProvenanceContract(ScopeId, TeamId: "team-1"),
+                InlineContent: content));
+    }
+
+    private static HttpContext CreateContext(string? requesterId)
+    {
+        var claims = new List<Claim> { new("scope_id", ScopeId) };
+        if (requesterId != null)
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, requesterId));
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Aevatar:Authentication:Enabled"] = "true",
+                })
+                .Build())
+            .AddSingleton<IHostEnvironment>(new TestHostEnvironment())
+            .BuildServiceProvider();
+        return new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "test")),
+            RequestServices = services,
+        };
+    }
+
+    private sealed class RecordingService : IContentArtifactService
+    {
+        public ContentArtifactPrincipalContract? Requester { get; private set; }
+        public bool ContentRead { get; private set; }
+
+        public Task<ContentArtifactAcceptedReceipt> CreateAsync(string scopeId, CreateContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
+        {
+            Requester = requester;
+            return Task.FromResult(new ContentArtifactAcceptedReceipt("artifact-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted));
+        }
+
+        public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
+        {
+            ContentRead = true;
+            var content = System.Text.Encoding.UTF8.GetBytes("report");
+            return Task.FromResult(new ContentArtifactRevisionContentResponse(
+                new ContentArtifactReferenceContract(artifactId, revisionId, Convert.ToHexStringLower(SHA256.HashData(content)), "text/markdown"),
+                content));
+        }
+
+        public Task<ContentArtifactListResponse> ListAsync(string scopeId, ContentArtifactQueryRequest query, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactCurrentStateResponse> GetAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactRevisionResponse> GetRevisionAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactRevisionResponse> GetCurrentRevisionAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactRunAttachmentReceipt> AttachToRunAsync(string scopeId, AttachContentArtifactsToRunRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Aevatar.Studio.Tests";
+        public string ContentRootPath { get; set; } = Directory.GetCurrentDirectory();
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Hosting.Endpoints;
@@ -72,6 +73,129 @@ public sealed class ContentArtifactEndpointsTests
             .Should().Equal(System.Text.Encoding.UTF8.GetBytes("report"));
     }
 
+    [Theory]
+    [InlineData("get")]
+    [InlineData("get-revision")]
+    [InlineData("get-current-revision")]
+    [InlineData("get-content")]
+    [InlineData("append")]
+    [InlineData("advance")]
+    [InlineData("redact")]
+    [InlineData("expire")]
+    [InlineData("tombstone")]
+    [InlineData("attach")]
+    public async Task ArtifactNotFound_ShouldMapToNonLeaking404(string operation)
+    {
+        var service = new RecordingService(new ContentArtifactNotFoundException(ScopeId, "artifact-1"));
+
+        var result = await InvokeAsync(operation, service);
+
+        StatusCode(result).Should().Be(StatusCodes.Status404NotFound);
+        var body = JsonSerializer.Serialize(((IValueHttpResult)result).Value);
+        body.Should().NotContain("authorized")
+            .And.NotContain("tombstoned")
+            .And.NotContain("concurrency");
+    }
+
+    [Fact]
+    public async Task HandleCreateAsync_ShouldMapDedupKeyOccupancyTo409Only()
+    {
+        var service = new RecordingService(
+            new ContentArtifactIdentityConflictException("report-dedup"));
+
+        var result = await ContentArtifactEndpoints.HandleCreateAsync(
+            CreateContext("owner-2"),
+            ScopeId,
+            CreateRequest(),
+            service,
+            CancellationToken.None);
+
+        StatusCode(result).Should().Be(StatusCodes.Status409Conflict);
+        var body = JsonSerializer.Serialize(((IValueHttpResult)result).Value);
+        body.Should().Contain("CONTENT_ARTIFACT_DEDUP_KEY_OCCUPIED")
+            .And.Contain("report-dedup")
+            .And.NotContain("artifact-1")
+            .And.NotContain("owner-1");
+    }
+
+    [Theory]
+    [InlineData("get-current-revision")]
+    [InlineData("get-content")]
+    [InlineData("append")]
+    [InlineData("attach")]
+    public async Task PersistedUnavailableContent_ShouldMapUniformlyTo410(string operation)
+    {
+        var service = new RecordingService(new ContentArtifactContentUnavailableException(
+            "artifact-1",
+            "revision-1",
+            "redacted"));
+
+        var result = await InvokeAsync(operation, service);
+
+        StatusCode(result).Should().Be(StatusCodes.Status410Gone);
+    }
+
+    [Fact]
+    public async Task HandleAdvanceCurrentRevisionAsync_ShouldKeepReadableCasConflictAs400()
+    {
+        var service = new RecordingService(
+            new InvalidOperationException("ContentArtifact concurrency version is 4, not 3."));
+
+        var result = await InvokeAsync("advance", service);
+
+        StatusCode(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task HandleGetAsync_ShouldRejectRouteScopeMismatchAs403()
+    {
+        var service = new RecordingService();
+
+        var result = await ContentArtifactEndpoints.HandleGetAsync(
+            CreateContext("reader-1"),
+            "scope-other",
+            "artifact-1",
+            service,
+            CancellationToken.None);
+
+        StatusCode(result).Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    private static Task<IResult> InvokeAsync(string operation, IContentArtifactService service) =>
+        operation switch
+        {
+            "get" => ContentArtifactEndpoints.HandleGetAsync(
+                CreateContext("reader-1"), ScopeId, "artifact-1", service, CancellationToken.None),
+            "get-revision" => ContentArtifactEndpoints.HandleGetRevisionAsync(
+                CreateContext("reader-1"), ScopeId, "artifact-1", "revision-1", service, CancellationToken.None),
+            "get-current-revision" => ContentArtifactEndpoints.HandleGetCurrentRevisionAsync(
+                CreateContext("reader-1"), ScopeId, "artifact-1", service, CancellationToken.None),
+            "get-content" => ContentArtifactEndpoints.HandleGetRevisionContentAsync(
+                CreateContext("reader-1"), ScopeId, "artifact-1", "revision-1", service, CancellationToken.None),
+            "append" => ContentArtifactEndpoints.HandleAppendRevisionAsync(
+                CreateContext("writer-1"), ScopeId, "artifact-1",
+                new AppendContentArtifactRevisionRequest(CreateRequest().FirstRevision), service, CancellationToken.None),
+            "advance" => ContentArtifactEndpoints.HandleAdvanceCurrentRevisionAsync(
+                CreateContext("owner-1"), ScopeId, "artifact-1",
+                new AdvanceContentArtifactCurrentRevisionRequest(1, "revision-1"), service, CancellationToken.None),
+            "redact" => ContentArtifactEndpoints.HandleRedactRevisionAsync(
+                CreateContext("owner-1"), ScopeId, "artifact-1", "revision-1",
+                new RedactContentArtifactRevisionRequest(1, "privacy request"), service, CancellationToken.None),
+            "expire" => ContentArtifactEndpoints.HandleExpireRevisionAsync(
+                CreateContext("owner-1"), ScopeId, "artifact-1", "revision-1",
+                new ExpireContentArtifactRevisionRequest(1), service, CancellationToken.None),
+            "tombstone" => ContentArtifactEndpoints.HandleTombstoneAsync(
+                CreateContext("owner-1"), ScopeId, "artifact-1",
+                new TombstoneContentArtifactRequest(1, "retention complete"), service, CancellationToken.None),
+            "attach" => ContentArtifactEndpoints.HandleAttachToRunAsync(
+                CreateContext("reader-1"), ScopeId,
+                new AttachContentArtifactsToRunRequest("service-1", "run-1", 1, []), service, CancellationToken.None),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null),
+        };
+
+    private static int? StatusCode(IResult result) =>
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Subject.StatusCode;
+
     private static CreateContentArtifactRequest CreateRequest()
     {
         var content = System.Text.Encoding.UTF8.GetBytes("report");
@@ -111,7 +235,7 @@ public sealed class ContentArtifactEndpointsTests
         };
     }
 
-    private sealed class RecordingService : IContentArtifactService
+    private sealed class RecordingService(Exception? exception = null) : IContentArtifactService
     {
         public ContentArtifactPrincipalContract? Requester { get; private set; }
         public bool ContentRead { get; private set; }
@@ -119,28 +243,56 @@ public sealed class ContentArtifactEndpointsTests
         public Task<ContentArtifactAcceptedReceipt> CreateAsync(string scopeId, CreateContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
         {
             Requester = requester;
+            ThrowIfConfigured();
             return Task.FromResult(new ContentArtifactAcceptedReceipt("artifact-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted));
         }
 
         public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
         {
             ContentRead = true;
+            ThrowIfConfigured();
             var content = System.Text.Encoding.UTF8.GetBytes("report");
             return Task.FromResult(new ContentArtifactRevisionContentResponse(
                 new ContentArtifactReferenceContract(artifactId, revisionId, Convert.ToHexStringLower(SHA256.HashData(content)), "text/markdown"),
                 content));
         }
 
-        public Task<ContentArtifactListResponse> ListAsync(string scopeId, ContentArtifactQueryRequest query, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactCurrentStateResponse> GetAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactRevisionResponse> GetRevisionAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactRevisionResponse> GetCurrentRevisionAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task<ContentArtifactRunAttachmentReceipt> AttachToRunAsync(string scopeId, AttachContentArtifactsToRunRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<ContentArtifactListResponse> ListAsync(string scopeId, ContentArtifactQueryRequest query, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(new ContentArtifactListResponse(scopeId, [])));
+        public Task<ContentArtifactCurrentStateResponse> GetAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Current()));
+        public Task<ContentArtifactRevisionResponse> GetRevisionAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Revision()));
+        public Task<ContentArtifactRevisionResponse> GetCurrentRevisionAsync(string scopeId, string artifactId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Revision()));
+        public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Receipt()));
+        public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Receipt()));
+        public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Receipt()));
+        public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Receipt()));
+        public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(Receipt()));
+        public Task<ContentArtifactRunAttachmentReceipt> AttachToRunAsync(string scopeId, AttachContentArtifactsToRunRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Task.FromResult(Result(new ContentArtifactRunAttachmentReceipt("run-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted)));
+
+        private T Result<T>(T value)
+        {
+            ThrowIfConfigured();
+            return value;
+        }
+
+        private void ThrowIfConfigured()
+        {
+            if (exception != null)
+                throw exception;
+        }
+
+        private static ContentArtifactAcceptedReceipt Receipt() =>
+            new("artifact-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted);
+
+        private static ContentArtifactRevisionResponse Revision() =>
+            new("revision-1", 1, null, "text/markdown", 6, new string('a', 64),
+                ContentArtifactRevisionAvailabilityNames.Available, true, false,
+                new ContentArtifactExecutionProvenanceContract(ScopeId), [], DateTimeOffset.UtcNow);
+
+        private static ContentArtifactCurrentStateResponse Current() =>
+            new("artifact-1", ScopeId, null, "markdown", "Report", "internal",
+                ContentArtifactLifecycleStatusNames.Active, "revision-1", 1, 1,
+                new ContentArtifactPrincipalContract("owner-1", "user"), [], [], null, null,
+                [Revision()], DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
     }
 
     private sealed class TestHostEnvironment : IHostEnvironment

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
@@ -92,7 +92,105 @@ public sealed class ContentArtifactGAgentTests
     }
 
     [Fact]
-    public async Task AppendAndAdvance_ShouldKeepPriorRevisionImmutableAndUseCas()
+    public async Task DuplicateCreate_ShouldUseCommittedHashWithoutReopeningBackingContent()
+    {
+        var content = "backed report";
+        var command = BuildCreate(content);
+        command.FirstRevision.Content = new ContentArtifactRevisionContent
+        {
+            BackingObject = new ContentArtifactBackingObjectReference
+            {
+                Provider = "object-store",
+                ObjectKey = "scope-1/reports/1",
+            },
+        };
+        var port = new RecordingBackingContentPort(content);
+        var agent = await CreateAgentAsync(backingContentPort: port);
+        await agent.HandleCreateAsync(command);
+        port.Available = false;
+        var retry = command.Clone();
+        retry.RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-21T00:00:00Z"));
+        retry.FirstRevision.CreatedAtUtc = retry.RequestedAtUtc.Clone();
+        retry.FirstRevision.Availability = ContentArtifactRevisionAvailability.Unspecified;
+
+        await agent.HandleCreateAsync(retry);
+
+        port.OpenReadCount.Should().Be(1);
+        agent.State.ConcurrencyVersion.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Append_ShouldBeWriterBlindRetrySafeAndAssignRevisionIdentity()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var revision = BuildRevision(2, "revision two", "revision-2-dedup", agent.State.CurrentRevisionId);
+        revision.RevisionId = string.Empty;
+        revision.RevisionNumber = 0;
+        var append = new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            RequestedBy = Principal("writer-1"),
+            Revision = revision,
+        };
+
+        await agent.HandleAppendRevisionAsync(append);
+        await agent.HandleAppendRevisionAsync(append.Clone());
+
+        agent.State.ConcurrencyVersion.Should().Be(2);
+        var appended = agent.State.Revisions.Values.Should()
+            .ContainSingle(item => item.DedupKey == "revision-2-dedup").Subject;
+        appended.RevisionNumber.Should().Be(2);
+        appended.RevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(ArtifactId, 2));
+    }
+
+    [Fact]
+    public async Task AppendDuplicate_ShouldAuthorizeBeforeReturningSuccess()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var append = new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            RequestedBy = Principal("writer-1"),
+            Revision = BuildRevision(2, "revision two", "revision-2-dedup", agent.State.CurrentRevisionId),
+        };
+        await agent.HandleAppendRevisionAsync(append);
+        append.RequestedBy = Principal("unrelated-1");
+
+        var act = () => agent.HandleAppendRevisionAsync(append);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not authorized*");
+        agent.State.ConcurrencyVersion.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task AppendDuplicate_ShouldRejectDifferentFactsForSameDedupKey()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var first = new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            RequestedBy = Principal("writer-1"),
+            Revision = BuildRevision(2, "revision two", "revision-2-dedup", agent.State.CurrentRevisionId),
+        };
+        await agent.HandleAppendRevisionAsync(first);
+        var conflicting = first.Clone();
+        conflicting.Revision.Content.InlineContent = ByteString.CopyFromUtf8("different revision");
+        conflicting.Revision.ByteLength = conflicting.Revision.Content.InlineContent.Length;
+        conflicting.Revision.ContentHash = ContentHash("different revision");
+
+        var act = () => agent.HandleAppendRevisionAsync(conflicting);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*dedup_key already exists with different facts*");
+        agent.State.ConcurrencyVersion.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task AppendAndAdvance_ShouldKeepPriorRevisionImmutableAndUseAdvanceCas()
     {
         var agent = await CreateAgentAsync();
         await agent.HandleCreateAsync(BuildCreate("revision one"));
@@ -102,7 +200,6 @@ public sealed class ContentArtifactGAgentTests
         await agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
         {
             ArtifactId = ArtifactId,
-            ExpectedConcurrencyVersion = 1,
             RequestedBy = Principal("owner-1"),
             Revision = second,
         });
@@ -123,19 +220,19 @@ public sealed class ContentArtifactGAgentTests
         agent.State.CurrentRevisionId.Should().Be(second.RevisionId);
         agent.State.ConcurrencyVersion.Should().Be(3);
 
-        var stale = () => agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        var stale = () => agent.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
         {
             ArtifactId = ArtifactId,
             ExpectedConcurrencyVersion = 2,
             RequestedBy = Principal("owner-1"),
-            Revision = BuildRevision(3, "stale", "revision-3-dedup", second.RevisionId),
+            RevisionId = first.RevisionId,
         });
         await stale.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*concurrency version is 3, not 2*");
     }
 
     [Fact]
-    public async Task DuplicateAppendAndAdvance_ShouldBeIdempotentAfterVersionMoves()
+    public async Task DuplicateAppend_ShouldBeIdempotentAfterVersionMoves()
     {
         var agent = await CreateAgentAsync();
         await agent.HandleCreateAsync(BuildCreate("revision one"));
@@ -143,7 +240,6 @@ public sealed class ContentArtifactGAgentTests
         var append = new AppendContentArtifactRevision
         {
             ArtifactId = ArtifactId,
-            ExpectedConcurrencyVersion = 1,
             RequestedBy = Principal("owner-1"),
             Revision = second,
         };
@@ -157,13 +253,6 @@ public sealed class ContentArtifactGAgentTests
         });
 
         await agent.HandleAppendRevisionAsync(append.Clone());
-        await agent.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
-        {
-            ArtifactId = ArtifactId,
-            ExpectedConcurrencyVersion = 2,
-            RequestedBy = Principal("owner-1"),
-            RevisionId = second.RevisionId,
-        });
 
         agent.State.ConcurrencyVersion.Should().Be(3);
         agent.State.Revisions.Should().HaveCount(2);
@@ -179,7 +268,6 @@ public sealed class ContentArtifactGAgentTests
         await original.HandleAppendRevisionAsync(new AppendContentArtifactRevision
         {
             ArtifactId = ArtifactId,
-            ExpectedConcurrencyVersion = 1,
             RequestedBy = Principal("owner-1"),
             Revision = second,
         });
@@ -238,7 +326,6 @@ public sealed class ContentArtifactGAgentTests
         var act = () => agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
         {
             ArtifactId = ArtifactId,
-            ExpectedConcurrencyVersion = 1,
             RequestedBy = Principal("owner-1"),
             Revision = invalid,
         });
@@ -272,7 +359,6 @@ public sealed class ContentArtifactGAgentTests
         await agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
         {
             ArtifactId = ArtifactId,
-            ExpectedConcurrencyVersion = 2,
             RequestedBy = Principal("owner-1"),
             Revision = second,
         });
@@ -423,11 +509,15 @@ public sealed class ContentArtifactGAgentTests
     private sealed class RecordingBackingContentPort(string content) : IContentArtifactBackingContentPort
     {
         public List<ContentArtifactBackingContentRequest> Described { get; } = [];
+        public bool Available { get; set; } = true;
+        public int OpenReadCount { get; private set; }
 
         public Task<ContentArtifactBackingContentDescriptor> DescribeAsync(
             ContentArtifactBackingContentRequest request,
             CancellationToken ct = default)
         {
+            if (!Available)
+                throw new FileNotFoundException("backing content is unavailable");
             Described.Add(request with { Reference = request.Reference.Clone() });
             return Task.FromResult(new ContentArtifactBackingContentDescriptor(
                 ByteString.CopyFromUtf8(content).Length,
@@ -436,7 +526,12 @@ public sealed class ContentArtifactGAgentTests
 
         public Task<Stream> OpenReadAsync(
             ContentArtifactBackingContentRequest request,
-            CancellationToken ct = default) =>
-            Task.FromResult<Stream>(new MemoryStream(ByteString.CopyFromUtf8(content).ToByteArray()));
+            CancellationToken ct = default)
+        {
+            if (!Available)
+                throw new FileNotFoundException("backing content is unavailable");
+            OpenReadCount++;
+            return Task.FromResult<Stream>(new MemoryStream(ByteString.CopyFromUtf8(content).ToByteArray()));
+        }
     }
 }

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
@@ -1,0 +1,442 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.Foundation.Abstractions.Hooks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.GAgents.ContentArtifacts;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Studio.Tests.ContentArtifacts;
+
+public sealed class ContentArtifactGAgentTests
+{
+    private const string ScopeId = "scope-1";
+    private const string DedupKey = "quarterly-report";
+    private static readonly string ArtifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, DedupKey);
+    private static readonly string ActorId = ContentArtifactConventions.BuildActorId(ScopeId, ArtifactId);
+
+    private static readonly MethodInfo SetIdMethod = typeof(GAgentBase)
+        .GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("GAgentBase.SetId was not found.");
+
+    [Fact]
+    public async Task Create_ShouldCommitFirstRevisionAndKeepIdentitiesSeparate()
+    {
+        var agent = await CreateAgentAsync();
+        var command = BuildCreate("initial report");
+
+        await agent.HandleCreateAsync(command);
+
+        agent.State.ArtifactId.Should().Be(ArtifactId);
+        agent.State.ScopeId.Should().Be(ScopeId);
+        agent.State.TeamId.Should().Be("team-1");
+        agent.State.WorkOrderId.Should().Be("work-order-1");
+        agent.State.AccessPolicy.Owner.PrincipalId.Should().Be("owner-1");
+        agent.State.ConcurrencyVersion.Should().Be(1);
+        agent.State.LifecycleStatus.Should().Be(ContentArtifactLifecycleStatus.Active);
+        agent.State.CurrentRevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(ArtifactId, 1));
+
+        var revision = agent.State.Revisions[agent.State.CurrentRevisionId];
+        revision.RevisionNumber.Should().Be(1);
+        revision.ContentHash.Should().Be(ContentHash("initial report"));
+        revision.Content.InlineContent.ToStringUtf8().Should().Be("initial report");
+        revision.Provenance.RunId.Should().Be("run-1");
+        revision.Provenance.PublishedServiceId.Should().Be("service-1");
+    }
+
+    [Fact]
+    public async Task Create_ShouldRejectNonCanonicalIdentityAndHashMismatch()
+    {
+        var command = BuildCreate("initial report");
+        command.ArtifactId = "artifact-noncanonical";
+        var wrongIdentity = await CreateAgentAsync(actorId: "content-artifact:scope-1:artifact-noncanonical");
+
+        var identityAct = () => wrongIdentity.HandleCreateAsync(command);
+
+        await identityAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*canonical*scope*dedup*");
+
+        command = BuildCreate("initial report");
+        command.FirstRevision.ContentHash = new string('0', 64);
+        var hashAgent = await CreateAgentAsync();
+
+        var hashAct = () => hashAgent.HandleCreateAsync(command);
+
+        await hashAct.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*content_hash*does not match*");
+    }
+
+    [Fact]
+    public async Task DuplicateCreate_ShouldBeIdempotentAndConflictingCreateShouldFailClosed()
+    {
+        var agent = await CreateAgentAsync();
+        var command = BuildCreate("initial report");
+        await agent.HandleCreateAsync(command);
+
+        await agent.HandleCreateAsync(command.Clone());
+
+        agent.State.ConcurrencyVersion.Should().Be(1);
+
+        var conflicting = command.Clone();
+        conflicting.Title = "Different title";
+        var act = () => agent.HandleCreateAsync(conflicting);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*logical identity already exists with a different request*");
+        agent.State.Title.Should().Be("Quarterly report");
+    }
+
+    [Fact]
+    public async Task AppendAndAdvance_ShouldKeepPriorRevisionImmutableAndUseCas()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var first = agent.State.Revisions[agent.State.CurrentRevisionId].Clone();
+        var second = BuildRevision(2, "revision two", "revision-2-dedup", first.RevisionId);
+
+        await agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 1,
+            RequestedBy = Principal("owner-1"),
+            Revision = second,
+        });
+
+        agent.State.ConcurrencyVersion.Should().Be(2);
+        agent.State.CurrentRevisionId.Should().Be(first.RevisionId);
+        agent.State.Revisions[first.RevisionId].Should().BeEquivalentTo(first);
+        agent.State.Revisions[second.RevisionId].Content.InlineContent.ToStringUtf8().Should().Be("revision two");
+
+        await agent.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 2,
+            RequestedBy = Principal("owner-1"),
+            RevisionId = second.RevisionId,
+        });
+
+        agent.State.CurrentRevisionId.Should().Be(second.RevisionId);
+        agent.State.ConcurrencyVersion.Should().Be(3);
+
+        var stale = () => agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 2,
+            RequestedBy = Principal("owner-1"),
+            Revision = BuildRevision(3, "stale", "revision-3-dedup", second.RevisionId),
+        });
+        await stale.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*concurrency version is 3, not 2*");
+    }
+
+    [Fact]
+    public async Task DuplicateAppendAndAdvance_ShouldBeIdempotentAfterVersionMoves()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var second = BuildRevision(2, "revision two", "revision-2-dedup", agent.State.CurrentRevisionId);
+        var append = new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 1,
+            RequestedBy = Principal("owner-1"),
+            Revision = second,
+        };
+        await agent.HandleAppendRevisionAsync(append);
+        await agent.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 2,
+            RequestedBy = Principal("owner-1"),
+            RevisionId = second.RevisionId,
+        });
+
+        await agent.HandleAppendRevisionAsync(append.Clone());
+        await agent.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 2,
+            RequestedBy = Principal("owner-1"),
+            RevisionId = second.RevisionId,
+        });
+
+        agent.State.ConcurrencyVersion.Should().Be(3);
+        agent.State.Revisions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Restart_ShouldRecoverRevisionHistoryAndContinueFromAuthoritativeVersion()
+    {
+        var store = new InMemoryEventStore();
+        var original = await CreateAgentAsync(eventStore: store);
+        await original.HandleCreateAsync(BuildCreate("revision one"));
+        var second = BuildRevision(2, "revision two", "revision-2-dedup", original.State.CurrentRevisionId);
+        await original.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 1,
+            RequestedBy = Principal("owner-1"),
+            Revision = second,
+        });
+
+        var recovered = await CreateAgentAsync(eventStore: store);
+
+        recovered.State.Revisions.Should().HaveCount(2);
+        recovered.State.ConcurrencyVersion.Should().Be(2);
+        await recovered.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 2,
+            RequestedBy = Principal("owner-1"),
+            RevisionId = second.RevisionId,
+        });
+        recovered.State.CurrentRevisionId.Should().Be(second.RevisionId);
+    }
+
+    [Fact]
+    public async Task Citation_ShouldRequireExactRevisionOrStableExternalIdentity()
+    {
+        var agent = await CreateAgentAsync();
+        var command = BuildCreate("cited report");
+        command.FirstRevision.Citations.Add(new ContentArtifactCitation
+        {
+            CitationId = "citation-1",
+            Label = "source report",
+            ArtifactRevision = new ContentArtifactRevisionCitationSource
+            {
+                Reference = new ContentArtifactReference
+                {
+                    ArtifactId = "source-artifact",
+                    RevisionId = "source-revision-3",
+                    ContentHash = new string('a', 64),
+                    MediaType = "text/markdown",
+                },
+            },
+            Locator = new ContentArtifactCitationLocator { Section = "results" },
+        });
+
+        await agent.HandleCreateAsync(command);
+
+        var citation = agent.State.Revisions[agent.State.CurrentRevisionId].Citations.Should().ContainSingle().Subject;
+        citation.ArtifactRevision.Reference.RevisionId.Should().Be("source-revision-3");
+        citation.Locator.Section.Should().Be("results");
+
+        var invalid = BuildRevision(2, "bad citation", "revision-2-dedup", agent.State.CurrentRevisionId);
+        invalid.Citations.Add(new ContentArtifactCitation
+        {
+            CitationId = "citation-invalid",
+            ArtifactRevision = new ContentArtifactRevisionCitationSource
+            {
+                Reference = new ContentArtifactReference { ArtifactId = "source-artifact" },
+            },
+        });
+        var act = () => agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 1,
+            RequestedBy = Principal("owner-1"),
+            Revision = invalid,
+        });
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*citation*revision_id*required*");
+    }
+
+    [Fact]
+    public async Task RedactionExpiryAndTombstone_ShouldPreserveProvenanceWithoutServingContent()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("sensitive report"));
+        var firstRevisionId = agent.State.CurrentRevisionId;
+
+        await agent.HandleRedactRevisionAsync(new RedactContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 1,
+            RequestedBy = Principal("owner-1"),
+            RevisionId = firstRevisionId,
+            Reason = "privacy request",
+        });
+
+        var redacted = agent.State.Revisions[firstRevisionId];
+        redacted.Availability.Should().Be(ContentArtifactRevisionAvailability.Redacted);
+        redacted.Content.LocationCase.Should().Be(ContentArtifactRevisionContent.LocationOneofCase.None);
+        redacted.ContentHash.Should().Be(ContentHash("sensitive report"));
+        redacted.Provenance.RunId.Should().Be("run-1");
+
+        var second = BuildRevision(2, "temporary report", "revision-2-dedup", firstRevisionId);
+        await agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 2,
+            RequestedBy = Principal("owner-1"),
+            Revision = second,
+        });
+        await agent.HandleExpireRevisionAsync(new ExpireContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 3,
+            RequestedBy = Principal("owner-1"),
+            RevisionId = second.RevisionId,
+        });
+        agent.State.Revisions[second.RevisionId].Availability.Should()
+            .Be(ContentArtifactRevisionAvailability.RetentionExpired);
+
+        await agent.HandleTombstoneAsync(new TombstoneContentArtifact
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = 4,
+            RequestedBy = Principal("owner-1"),
+            Reason = "retention complete",
+        });
+
+        agent.State.LifecycleStatus.Should().Be(ContentArtifactLifecycleStatus.Tombstoned);
+        agent.State.CurrentRevisionId.Should().BeEmpty();
+        agent.State.Revisions.Should().HaveCount(2);
+        agent.State.Revisions.Values.Should().OnlyContain(revision => revision.Provenance.RunId == "run-1");
+    }
+
+    [Fact]
+    public async Task BackingObject_ShouldBeVerifiedAndUnavailableProviderShouldFailClosed()
+    {
+        var content = "backed report";
+        var backing = new ContentArtifactBackingObjectReference
+        {
+            Provider = "object-store",
+            ObjectKey = "scope-1/reports/1",
+        };
+        var command = BuildCreate(content);
+        command.FirstRevision.Content = new ContentArtifactRevisionContent
+        {
+            BackingObject = backing,
+        };
+        var port = new RecordingBackingContentPort(content);
+        var agent = await CreateAgentAsync(backingContentPort: port);
+
+        await agent.HandleCreateAsync(command);
+
+        var described = port.Described.Should().ContainSingle().Subject;
+        described.Reference.Should().BeEquivalentTo(backing);
+        described.ScopeId.Should().Be(ScopeId);
+        described.RunId.Should().Be("run-1");
+        agent.State.Revisions[agent.State.CurrentRevisionId].Content.BackingObject.ObjectKey.Should()
+            .Be("scope-1/reports/1");
+
+        var unavailable = await CreateAgentAsync();
+        var act = () => unavailable.HandleCreateAsync(command.Clone());
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*backing content port*not registered*");
+    }
+
+    private static async Task<ContentArtifactGAgent> CreateAgentAsync(
+        string? actorId = null,
+        InMemoryEventStore? eventStore = null,
+        IContentArtifactBackingContentPort? backingContentPort = null)
+    {
+        var agent = new ContentArtifactGAgent(backingContentPort)
+        {
+            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<ContentArtifactState>(
+                eventStore ?? new InMemoryEventStore()),
+            Services = new ServiceCollection()
+                .AddSingleton<IEnumerable<IGAgentExecutionHook>>([])
+                .BuildServiceProvider(),
+        };
+        SetIdMethod.Invoke(agent, [actorId ?? ActorId]);
+        await agent.ActivateAsync();
+        return agent;
+    }
+
+    private static CreateContentArtifact BuildCreate(string content)
+    {
+        var command = new CreateContentArtifact
+        {
+            ArtifactId = ArtifactId,
+            DedupKey = DedupKey,
+            ScopeId = ScopeId,
+            TeamId = "team-1",
+            Kind = ContentArtifactKind.Markdown,
+            Title = "Quarterly report",
+            Classification = "internal",
+            AccessPolicy = new ContentArtifactAccessPolicy
+            {
+                Owner = Principal("owner-1"),
+                ReaderPrincipalIds = { "reader-1" },
+                WriterPrincipalIds = { "writer-1" },
+            },
+            RetentionPolicy = new ContentArtifactRetentionPolicy
+            {
+                PolicyId = "retain-365-days",
+                ExpiresAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2027-07-20T00:00:00Z")),
+            },
+            WorkOrderId = "work-order-1",
+            ExpectedConcurrencyVersion = 0,
+        };
+        command.FirstRevision = BuildRevision(1, content, "revision-1-dedup");
+        return command;
+    }
+
+    private static ContentArtifactRevision BuildRevision(
+        long number,
+        string content,
+        string dedupKey,
+        string? parentRevisionId = null) =>
+        new()
+        {
+            RevisionId = ContentArtifactConventions.BuildRevisionId(ArtifactId, number),
+            RevisionNumber = number,
+            DedupKey = dedupKey,
+            ParentRevisionId = parentRevisionId ?? string.Empty,
+            MediaType = "text/markdown",
+            ByteLength = ByteString.CopyFromUtf8(content).Length,
+            ContentHash = ContentHash(content),
+            Content = new ContentArtifactRevisionContent
+            {
+                InlineContent = ByteString.CopyFromUtf8(content),
+            },
+            Provenance = new ContentArtifactExecutionProvenance
+            {
+                ScopeId = ScopeId,
+                TeamId = "team-1",
+                MemberId = "member-1",
+                WorkflowId = "workflow-1",
+                PublishedServiceId = "service-1",
+                RunId = "run-1",
+                WorkOrderId = "work-order-1",
+            },
+            Availability = ContentArtifactRevisionAvailability.Available,
+        };
+
+    private static ContentArtifactPrincipal Principal(string principalId) =>
+        new()
+        {
+            PrincipalId = principalId,
+            PrincipalKind = "user",
+        };
+
+    private static string ContentHash(string content) =>
+        Convert.ToHexStringLower(SHA256.HashData(ByteString.CopyFromUtf8(content).Span));
+
+    private sealed class RecordingBackingContentPort(string content) : IContentArtifactBackingContentPort
+    {
+        public List<ContentArtifactBackingContentRequest> Described { get; } = [];
+
+        public Task<ContentArtifactBackingContentDescriptor> DescribeAsync(
+            ContentArtifactBackingContentRequest request,
+            CancellationToken ct = default)
+        {
+            Described.Add(request with { Reference = request.Reference.Clone() });
+            return Task.FromResult(new ContentArtifactBackingContentDescriptor(
+                ByteString.CopyFromUtf8(content).Length,
+                ContentHash(content)));
+        }
+
+        public Task<Stream> OpenReadAsync(
+            ContentArtifactBackingContentRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult<Stream>(new MemoryStream(ByteString.CopyFromUtf8(content).ToByteArray()));
+    }
+}

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
@@ -189,6 +189,91 @@ public sealed class ContentArtifactGAgentTests
         agent.State.ConcurrencyVersion.Should().Be(2);
     }
 
+    [Theory]
+    [InlineData("advance")]
+    [InlineData("redact")]
+    [InlineData("expire")]
+    public async Task ReadRequiringMutation_ShouldRejectWriterOnlyAndAllowReaderWriter(string operation)
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        if (operation == "advance")
+            await AppendSecondRevisionAsync(agent);
+
+        var expectedVersion = agent.State.ConcurrencyVersion;
+        var writerOnly = () => InvokeMutationAsync(agent, operation, "writer-1", expectedVersion);
+
+        await writerOnly.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not authorized*");
+        await InvokeMutationAsync(agent, operation, "editor-1", expectedVersion);
+        agent.State.ConcurrencyVersion.Should().Be(expectedVersion + 1);
+    }
+
+    [Fact]
+    public async Task OwnerAuthorization_ShouldUsePrincipalIdOnly()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var ownerWithDifferentKind = Principal("owner-1");
+        ownerWithDifferentKind.PrincipalKind = "service";
+
+        await agent.HandleTombstoneAsync(new TombstoneContentArtifact
+        {
+            ArtifactId = ArtifactId,
+            ExpectedConcurrencyVersion = agent.State.ConcurrencyVersion,
+            RequestedBy = ownerWithDifferentKind,
+            Reason = "retention complete",
+        });
+
+        agent.State.LifecycleStatus.Should().Be(ContentArtifactLifecycleStatus.Tombstoned);
+    }
+
+    [Theory]
+    [InlineData("advance")]
+    [InlineData("redact")]
+    [InlineData("expire")]
+    [InlineData("tombstone")]
+    public async Task ExactMutationRetry_ShouldFailWhenCasIsStale(string operation)
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        if (operation == "advance")
+            await AppendSecondRevisionAsync(agent);
+
+        var expectedVersion = agent.State.ConcurrencyVersion;
+        await InvokeMutationAsync(agent, operation, "owner-1", expectedVersion);
+        var retry = () => InvokeMutationAsync(agent, operation, "owner-1", expectedVersion);
+
+        await retry.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*concurrency version is {expectedVersion + 1}, not {expectedVersion}*");
+    }
+
+    [Theory]
+    [InlineData("advance")]
+    [InlineData("redact")]
+    [InlineData("expire")]
+    [InlineData("tombstone")]
+    public async Task ExactMutationRetry_ShouldAuthorizeBeforeNoOpDecision(string operation)
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        if (operation == "advance")
+            await AppendSecondRevisionAsync(agent);
+
+        await InvokeMutationAsync(agent, operation, "owner-1", agent.State.ConcurrencyVersion);
+        var retry = () => InvokeMutationAsync(
+            agent,
+            operation,
+            "unrelated-1",
+            agent.State.ConcurrencyVersion);
+
+        var assertion = await retry.Should().ThrowAsync<InvalidOperationException>();
+        if (operation == "tombstone")
+            assertion.WithMessage("*owner*");
+        else
+            assertion.WithMessage("*not authorized*");
+    }
+
     [Fact]
     public async Task AppendAndAdvance_ShouldKeepPriorRevisionImmutableAndUseAdvanceCas()
     {
@@ -450,8 +535,8 @@ public sealed class ContentArtifactGAgentTests
             AccessPolicy = new ContentArtifactAccessPolicy
             {
                 Owner = Principal("owner-1"),
-                ReaderPrincipalIds = { "reader-1" },
-                WriterPrincipalIds = { "writer-1" },
+                ReaderPrincipalIds = { "reader-1", "editor-1" },
+                WriterPrincipalIds = { "writer-1", "editor-1" },
             },
             RetentionPolicy = new ContentArtifactRetentionPolicy
             {
@@ -501,6 +586,57 @@ public sealed class ContentArtifactGAgentTests
         {
             PrincipalId = principalId,
             PrincipalKind = "user",
+        };
+
+    private static Task AppendSecondRevisionAsync(ContentArtifactGAgent agent) =>
+        agent.HandleAppendRevisionAsync(new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            RequestedBy = Principal("owner-1"),
+            Revision = BuildRevision(
+                2,
+                "revision two",
+                "revision-2-dedup",
+                agent.State.CurrentRevisionId),
+        });
+
+    private static Task InvokeMutationAsync(
+        ContentArtifactGAgent agent,
+        string operation,
+        string principalId,
+        long expectedVersion) =>
+        operation switch
+        {
+            "advance" => agent.HandleAdvanceCurrentRevisionAsync(new AdvanceContentArtifactCurrentRevision
+            {
+                ArtifactId = ArtifactId,
+                ExpectedConcurrencyVersion = expectedVersion,
+                RequestedBy = Principal(principalId),
+                RevisionId = ContentArtifactConventions.BuildRevisionId(ArtifactId, 2),
+            }),
+            "redact" => agent.HandleRedactRevisionAsync(new RedactContentArtifactRevision
+            {
+                ArtifactId = ArtifactId,
+                ExpectedConcurrencyVersion = expectedVersion,
+                RequestedBy = Principal(principalId),
+                RevisionId = ContentArtifactConventions.BuildRevisionId(ArtifactId, 1),
+                Reason = "privacy request",
+            }),
+            "expire" => agent.HandleExpireRevisionAsync(new ExpireContentArtifactRevision
+            {
+                ArtifactId = ArtifactId,
+                ExpectedConcurrencyVersion = expectedVersion,
+                RequestedBy = Principal(principalId),
+                RevisionId = ContentArtifactConventions.BuildRevisionId(ArtifactId, 1),
+            }),
+            "tombstone" => agent.HandleTombstoneAsync(new TombstoneContentArtifact
+            {
+                ArtifactId = ArtifactId,
+                ExpectedConcurrencyVersion = expectedVersion,
+                RequestedBy = Principal(principalId),
+                Reason = "retention complete",
+            }),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null),
         };
 
     private static string ContentHash(string content) =>

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
@@ -1,0 +1,358 @@
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.ContentArtifacts;
+using Aevatar.Studio.Hosting;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Projection.DependencyInjection;
+using Aevatar.Studio.Projection.Orchestration;
+using Aevatar.Studio.Projection.Projectors;
+using Aevatar.Studio.Projection.QueryPorts;
+using Aevatar.Studio.Projection.ReadModels;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Studio.Tests.ContentArtifacts;
+
+public sealed class ContentArtifactProjectionTests
+{
+    private const string ScopeId = "scope-1";
+    private const string ArtifactId = "artifact-1";
+    private static readonly string ActorId = ContentArtifactConventions.BuildActorId(ScopeId, ArtifactId);
+
+    [Fact]
+    public void ReadModelProviders_ShouldRegisterContentArtifactStore()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddStudioProjectionComponents();
+        services.AddStudioProjectionReadModelProviders(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IProjectionDocumentReader<ContentArtifactCurrentStateDocument, string>>()
+            .Should().BeOfType<InMemoryProjectionDocumentStore<ContentArtifactCurrentStateDocument, string>>();
+        provider.GetRequiredService<IProjectionDocumentWriter<ContentArtifactCurrentStateDocument>>()
+            .Should().BeOfType<InMemoryProjectionDocumentStore<ContentArtifactCurrentStateDocument, string>>();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldCopyAuthoritativeCurrentStateAndImmutableRevisionFacts()
+    {
+        var observedAt = DateTimeOffset.Parse("2026-07-20T10:00:00Z");
+        var updatedAt = observedAt.AddMinutes(-5);
+        var dispatcher = new RecordingWriteDispatcher();
+        var projector = new ContentArtifactCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(observedAt));
+        var state = BuildState(updatedAt);
+
+        await projector.ProjectAsync(
+            new StudioMaterializationContext
+            {
+                RootActorId = ActorId,
+                ProjectionKind = ContentArtifactGAgent.ProjectionKind,
+            },
+            WrapCommitted(state, observedAt));
+
+        var document = dispatcher.Upserts.Should().ContainSingle().Subject;
+        document.Id.Should().Be(ActorId);
+        document.StateVersion.Should().Be(7);
+        document.ArtifactId.Should().Be(ArtifactId);
+        document.ScopeId.Should().Be(ScopeId);
+        document.TeamId.Should().Be("team-1");
+        document.OwnerPrincipalId.Should().Be("owner-1");
+        document.CurrentRevisionId.Should().Be("revision-2");
+        document.ConcurrencyVersion.Should().Be(3);
+        document.ArtifactUpdatedAtUtc.ToDateTimeOffset().Should().Be(updatedAt);
+        document.Revisions.Select(static revision => revision.RevisionNumber).Should().Equal(1, 2);
+        document.Revisions[0].InlineContent.ToStringUtf8().Should().Be("revision one");
+        document.Revisions[1].ProvenanceRunId.Should().Be("run-1");
+        document.Revisions[1].Citations.Should().ContainSingle()
+            .Which.SourceArtifactRevisionId.Should().Be("source-revision-1");
+    }
+
+    [Fact]
+    public async Task QueryPort_ShouldFilterByScopeOwnerAndResolveExactRevision()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var reader = new RecordingDocumentReader(document);
+        var queryPort = new ProjectionContentArtifactQueryPort(reader, backingContentPort: null);
+
+        var list = await queryPort.ListAsync(
+            ScopeId,
+            "owner-1",
+            new ContentArtifactQueryRequest(
+                TeamId: "team-1",
+                Kind: "markdown",
+                RunId: "run-1"));
+        var current = await queryPort.GetAsync(ScopeId, ArtifactId);
+
+        list.Artifacts.Should().ContainSingle();
+        current.Should().NotBeNull();
+        current!.Revisions.Select(static revision => revision.RevisionId).Should()
+            .Equal("revision-1", "revision-2");
+        reader.LastQuery!.Filters.Should().Contain(filter => filter.FieldPath == "scope_id");
+        reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "owner_principal_id");
+        reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "team_id");
+        reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "kind");
+        reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "provenance_run_ids");
+    }
+
+    [Fact]
+    public async Task GetRevisionContentAsync_ShouldVerifyInlineHashAndRejectTamperedProjection()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var queryPort = new ProjectionContentArtifactQueryPort(
+            new RecordingDocumentReader(document),
+            backingContentPort: null);
+
+        var content = await queryPort.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-1",
+            Principal("owner-1"));
+
+        content.Content.Should().Equal(ByteString.CopyFromUtf8("revision one").ToByteArray());
+        content.Reference.ContentHash.Should().Be(ContentHash("revision one"));
+
+        document.Revisions[0].ContentHash = new string('0', 64);
+        var tampered = new ProjectionContentArtifactQueryPort(
+            new RecordingDocumentReader(document),
+            backingContentPort: null);
+        var act = () => tampered.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-1",
+            Principal("owner-1"));
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*content hash verification failed*");
+    }
+
+    [Fact]
+    public async Task GetRevisionContentAsync_ShouldFailClosedForMissingBackingContent()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var backed = document.Revisions[1];
+        backed.InlineContent = ByteString.Empty;
+        backed.ContentLocationKind = "backing_object";
+        backed.BackingProvider = "object-store";
+        backed.BackingObjectKey = "missing-object";
+        var queryPort = new ProjectionContentArtifactQueryPort(
+            new RecordingDocumentReader(document),
+            new MissingBackingContentPort());
+
+        var act = () => queryPort.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-2",
+            Principal("owner-1"));
+
+        await act.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*missing backing content*");
+    }
+
+    [Fact]
+    public async Task GetRevisionContentAsync_ShouldAuthorizeAgainstTheContentReadSnapshot()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var queryPort = new ProjectionContentArtifactQueryPort(
+            new RecordingDocumentReader(document),
+            backingContentPort: null);
+
+        var act = () => queryPort.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-1",
+            Principal("revoked-reader"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not authorized to read*");
+    }
+
+    private static ContentArtifactState BuildState(DateTimeOffset updatedAt)
+    {
+        var firstContent = ByteString.CopyFromUtf8("revision one");
+        var secondContent = ByteString.CopyFromUtf8("revision two");
+        var state = new ContentArtifactState
+        {
+            ArtifactId = ArtifactId,
+            DedupKey = "report-dedup",
+            ScopeId = ScopeId,
+            TeamId = "team-1",
+            Kind = ContentArtifactKind.Markdown,
+            Title = "Quarterly report",
+            Classification = "internal",
+            AccessPolicy = new ContentArtifactAccessPolicy
+            {
+                Owner = new ContentArtifactPrincipal { PrincipalId = "owner-1", PrincipalKind = "user" },
+                ReaderPrincipalIds = { "reader-1" },
+                WriterPrincipalIds = { "writer-1" },
+            },
+            RetentionPolicy = new ContentArtifactRetentionPolicy { PolicyId = "retain-365-days" },
+            WorkOrderId = "work-order-1",
+            CurrentRevisionId = "revision-2",
+            ConcurrencyVersion = 3,
+            LifecycleStatus = ContentArtifactLifecycleStatus.Active,
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(updatedAt.AddHours(-1)),
+            UpdatedAtUtc = Timestamp.FromDateTimeOffset(updatedAt),
+        };
+        state.Revisions["revision-1"] = new ContentArtifactRevision
+        {
+            RevisionId = "revision-1",
+            RevisionNumber = 1,
+            DedupKey = "revision-1-dedup",
+            MediaType = "text/markdown",
+            ByteLength = firstContent.Length,
+            ContentHash = ContentHash("revision one"),
+            Content = new ContentArtifactRevisionContent { InlineContent = firstContent },
+            Provenance = BuildProvenance(),
+            Availability = ContentArtifactRevisionAvailability.Available,
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(updatedAt.AddMinutes(-30)),
+        };
+        state.Revisions["revision-2"] = new ContentArtifactRevision
+        {
+            RevisionId = "revision-2",
+            RevisionNumber = 2,
+            DedupKey = "revision-2-dedup",
+            ParentRevisionId = "revision-1",
+            MediaType = "text/markdown",
+            ByteLength = secondContent.Length,
+            ContentHash = ContentHash("revision two"),
+            Content = new ContentArtifactRevisionContent { InlineContent = secondContent },
+            Provenance = BuildProvenance(),
+            Availability = ContentArtifactRevisionAvailability.Available,
+            CreatedAtUtc = Timestamp.FromDateTimeOffset(updatedAt),
+        };
+        state.Revisions["revision-2"].Citations.Add(new ContentArtifactCitation
+        {
+            CitationId = "citation-1",
+            ArtifactRevision = new ContentArtifactRevisionCitationSource
+            {
+                Reference = new ContentArtifactReference
+                {
+                    ArtifactId = "source-artifact",
+                    RevisionId = "source-revision-1",
+                    ContentHash = new string('a', 64),
+                    MediaType = "text/plain",
+                },
+            },
+        });
+        return state;
+    }
+
+    private static ContentArtifactExecutionProvenance BuildProvenance() =>
+        new()
+        {
+            ScopeId = ScopeId,
+            TeamId = "team-1",
+            MemberId = "member-1",
+            WorkflowId = "workflow-1",
+            PublishedServiceId = "service-1",
+            RunId = "run-1",
+            WorkOrderId = "work-order-1",
+        };
+
+    private static EventEnvelope WrapCommitted(ContentArtifactState state, DateTimeOffset observedAt) =>
+        new()
+        {
+            Id = "envelope-7",
+            Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication(ActorId),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = "event-7",
+                    Version = 7,
+                    EventData = Any.Pack(new ContentArtifactCurrentRevisionAdvancedEvent()),
+                    Timestamp = Timestamp.FromDateTimeOffset(observedAt),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+
+    private static string ContentHash(string content) =>
+        Convert.ToHexStringLower(SHA256.HashData(ByteString.CopyFromUtf8(content).Span));
+
+    private static ContentArtifactPrincipalContract Principal(string principalId) =>
+        new(principalId, "user");
+
+    private sealed class RecordingWriteDispatcher
+        : IProjectionWriteDispatcher<ContentArtifactCurrentStateDocument>
+    {
+        public List<ContentArtifactCurrentStateDocument> Upserts { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(
+            ContentArtifactCurrentStateDocument readModel,
+            CancellationToken ct = default)
+        {
+            Upserts.Add(readModel);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
+            Task.FromResult(ProjectionWriteResult.Applied());
+    }
+
+    private sealed class RecordingDocumentReader(ContentArtifactCurrentStateDocument document)
+        : IProjectionDocumentReader<ContentArtifactCurrentStateDocument, string>
+    {
+        public ProjectionDocumentQuery? LastQuery { get; private set; }
+
+        public Task<ContentArtifactCurrentStateDocument?> GetAsync(string key, CancellationToken ct = default) =>
+            Task.FromResult<ContentArtifactCurrentStateDocument?>(key == document.Id ? document : null);
+
+        public Task<ProjectionDocumentQueryResult<ContentArtifactCurrentStateDocument>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default)
+        {
+            LastQuery = query;
+            return Task.FromResult(new ProjectionDocumentQueryResult<ContentArtifactCurrentStateDocument>
+            {
+                Items = [document],
+            });
+        }
+    }
+
+    private sealed class FixedProjectionClock(DateTimeOffset utcNow) : IProjectionClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+    }
+
+    private sealed class MissingBackingContentPort : IContentArtifactBackingContentPort
+    {
+        public Task<ContentArtifactBackingContentDescriptor> DescribeAsync(
+            ContentArtifactBackingContentRequest request,
+            CancellationToken ct = default) =>
+            throw new FileNotFoundException("missing backing content");
+
+        public Task<Stream> OpenReadAsync(
+            ContentArtifactBackingContentRequest request,
+            CancellationToken ct = default) =>
+            throw new FileNotFoundException("missing backing content");
+    }
+}

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
@@ -113,6 +113,23 @@ public sealed class ContentArtifactProjectionTests
     }
 
     [Fact]
+    public async Task GetByDedupKeyAsync_ShouldUseCanonicalArtifactAddress()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var reader = new RecordingDocumentReader(document);
+        var queryPort = new ProjectionContentArtifactQueryPort(reader);
+
+        await queryPort.GetByDedupKeyAsync(ScopeId, "report-dedup");
+
+        var artifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, "report-dedup");
+        reader.LastKey.Should().Be(ContentArtifactConventions.BuildActorId(ScopeId, artifactId));
+    }
+
+    [Fact]
     public async Task ListAsync_ShouldApplyReadableAclBeforeCursorPaging()
     {
         var store = new InMemoryProjectionDocumentStore<ContentArtifactCurrentStateDocument, string>(
@@ -180,7 +197,7 @@ public sealed class ContentArtifactProjectionTests
     }
 
     [Fact]
-    public async Task GetRevisionContentAsync_ShouldFailClosedForMissingBackingContent()
+    public async Task GetRevisionContentAsync_ShouldTreatMissingBackingContentAsAReadFailureNotGone()
     {
         var document = ContentArtifactCurrentStateProjector.ToDocument(
             ActorId,
@@ -202,8 +219,8 @@ public sealed class ContentArtifactProjectionTests
             "revision-2",
             Principal("owner-1"));
 
-        await act.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
-            .WithMessage("*missing backing content*");
+        var exception = (await act.Should().ThrowAsync<IOException>()).Which;
+        exception.Message.Should().Contain("backing content is missing");
     }
 
     [Fact]
@@ -224,8 +241,7 @@ public sealed class ContentArtifactProjectionTests
             "revision-1",
             Principal("revoked-reader"));
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*not authorized to read*");
+        await act.Should().ThrowAsync<ContentArtifactNotFoundException>();
     }
 
     [Fact]
@@ -313,8 +329,13 @@ public sealed class ContentArtifactProjectionTests
 
         var missingRevisionRead = () => new ProjectionContentArtifactQueryPort(new RecordingDocumentReader(document))
             .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-missing", Principal("owner-1"));
-        await missingRevisionRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
-            .WithMessage("*revision was not found*");
+        await missingRevisionRead.Should().ThrowAsync<ContentArtifactNotFoundException>();
+
+        var tombstonedMissingRevision = tombstoned.Clone();
+        var tombstonedMissingRevisionRead = () => new ProjectionContentArtifactQueryPort(
+                new RecordingDocumentReader(tombstonedMissingRevision))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-missing", Principal("owner-1"));
+        await tombstonedMissingRevisionRead.Should().ThrowAsync<ContentArtifactNotFoundException>();
 
         var redacted = document.Clone();
         redacted.Revisions[0].Availability = ContentArtifactRevisionAvailabilityNames.Redacted;
@@ -323,21 +344,30 @@ public sealed class ContentArtifactProjectionTests
         await redactedRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
             .WithMessage("*redacted*");
 
+        var expired = document.Clone();
+        expired.Revisions[0].Availability = ContentArtifactRevisionAvailabilityNames.RetentionExpired;
+        var expiredRead = () => new ProjectionContentArtifactQueryPort(new RecordingDocumentReader(expired))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
+        await expiredRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*retention_expired*");
+
         var missingLocation = document.Clone();
         missingLocation.Revisions[0].ContentLocationKind = string.Empty;
         var missingLocationRead = () => new ProjectionContentArtifactQueryPort(
                 new RecordingDocumentReader(missingLocation))
             .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
-        await missingLocationRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
-            .WithMessage("*content location is unavailable*");
+        var missingLocationException = (await missingLocationRead.Should()
+            .ThrowAsync<InvalidDataException>()).Which;
+        missingLocationException.Message.Should().Contain("content location is unavailable");
 
         var missingProvider = document.Clone();
         missingProvider.Revisions[0].ContentLocationKind = "backing_object";
         var missingProviderRead = () => new ProjectionContentArtifactQueryPort(
                 new RecordingDocumentReader(missingProvider))
             .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
-        await missingProviderRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
-            .WithMessage("*backing content provider is unavailable*");
+        var missingProviderException = (await missingProviderRead.Should()
+            .ThrowAsync<IOException>()).Which;
+        missingProviderException.Message.Should().Contain("backing content provider is unavailable");
     }
 
     [Fact]
@@ -595,10 +625,14 @@ public sealed class ContentArtifactProjectionTests
     private sealed class RecordingDocumentReader(ContentArtifactCurrentStateDocument document)
         : IProjectionDocumentReader<ContentArtifactCurrentStateDocument, string>
     {
+        public string? LastKey { get; private set; }
         public ProjectionDocumentQuery? LastQuery { get; private set; }
 
-        public Task<ContentArtifactCurrentStateDocument?> GetAsync(string key, CancellationToken ct = default) =>
-            Task.FromResult<ContentArtifactCurrentStateDocument?>(key == document.Id ? document : null);
+        public Task<ContentArtifactCurrentStateDocument?> GetAsync(string key, CancellationToken ct = default)
+        {
+            LastKey = key;
+            return Task.FromResult<ContentArtifactCurrentStateDocument?>(key == document.Id ? document : null);
+        }
 
         public Task<ProjectionDocumentQueryResult<ContentArtifactCurrentStateDocument>> QueryAsync(
             ProjectionDocumentQuery query,

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
@@ -80,7 +80,7 @@ public sealed class ContentArtifactProjectionTests
     }
 
     [Fact]
-    public async Task QueryPort_ShouldFilterByScopeOwnerAndResolveExactRevision()
+    public async Task QueryPort_ShouldFilterByScopeReadablePrincipalAndResolveExactRevision()
     {
         var document = ContentArtifactCurrentStateProjector.ToDocument(
             ActorId,
@@ -104,10 +104,45 @@ public sealed class ContentArtifactProjectionTests
         current!.Revisions.Select(static revision => revision.RevisionId).Should()
             .Equal("revision-1", "revision-2");
         reader.LastQuery!.Filters.Should().Contain(filter => filter.FieldPath == "scope_id");
-        reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "owner_principal_id");
+        reader.LastQuery.Filters.Should().NotContain(filter => filter.FieldPath == "owner_principal_id");
+        reader.LastQuery.AnyOfFilters.Should().Contain(filter => filter.FieldPath == "owner_principal_id");
+        reader.LastQuery.AnyOfFilters.Should().Contain(filter => filter.FieldPath == "reader_principal_ids");
         reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "team_id");
         reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "kind");
         reader.LastQuery.Filters.Should().Contain(filter => filter.FieldPath == "provenance_run_ids");
+    }
+
+    [Fact]
+    public async Task ListAsync_ShouldApplyReadableAclBeforeCursorPaging()
+    {
+        var store = new InMemoryProjectionDocumentStore<ContentArtifactCurrentStateDocument, string>(
+            keySelector: document => document.Id);
+        await store.UpsertAsync(BuildListDocument("owner-artifact", "caller-1"));
+        await store.UpsertAsync(BuildListDocument(
+            "reader-artifact",
+            "other-owner",
+            readers: ["caller-1"],
+            lifecycleStatus: ContentArtifactLifecycleStatusNames.Tombstoned));
+        await store.UpsertAsync(BuildListDocument(
+            "writer-artifact",
+            "other-owner",
+            writers: ["caller-1"]));
+        await store.UpsertAsync(BuildListDocument("unrelated-artifact", "other-owner"));
+        var queryPort = new ProjectionContentArtifactQueryPort(store);
+
+        var first = await queryPort.ListAsync(
+            ScopeId,
+            "caller-1",
+            new ContentArtifactQueryRequest(PageSize: 1));
+        var second = await queryPort.ListAsync(
+            ScopeId,
+            "caller-1",
+            new ContentArtifactQueryRequest(PageSize: 1, PageToken: first.NextPageToken));
+
+        first.NextPageToken.Should().NotBeNullOrWhiteSpace();
+        second.NextPageToken.Should().BeNull();
+        first.Artifacts.Concat(second.Artifacts).Select(artifact => artifact.ArtifactId).Should()
+            .BeEquivalentTo(["owner-artifact", "reader-artifact"]);
     }
 
     [Fact]
@@ -191,6 +226,28 @@ public sealed class ContentArtifactProjectionTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*not authorized to read*");
+    }
+
+    [Fact]
+    public async Task GetRevisionContentAsync_ShouldIdentifyOwnerByPrincipalIdOnly()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var queryPort = new ProjectionContentArtifactQueryPort(
+            new RecordingDocumentReader(document),
+            backingContentPort: null);
+        var ownerWithDifferentKind = new ContentArtifactPrincipalContract("owner-1", "service");
+
+        var result = await queryPort.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-1",
+            ownerWithDifferentKind);
+
+        result.Reference.RevisionId.Should().Be("revision-1");
     }
 
     [Fact]
@@ -460,6 +517,38 @@ public sealed class ContentArtifactProjectionTests
             RunId = "run-1",
             WorkOrderId = "work-order-1",
         };
+
+    private static ContentArtifactCurrentStateDocument BuildListDocument(
+        string artifactId,
+        string ownerPrincipalId,
+        IReadOnlyList<string>? readers = null,
+        IReadOnlyList<string>? writers = null,
+        string lifecycleStatus = ContentArtifactLifecycleStatusNames.Active)
+    {
+        var actorId = ContentArtifactConventions.BuildActorId(ScopeId, artifactId);
+        var timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-20T00:00:00Z"));
+        var document = new ContentArtifactCurrentStateDocument
+        {
+            Id = actorId,
+            ActorId = actorId,
+            StateVersion = 1,
+            LastEventId = $"event-{artifactId}",
+            UpdatedAt = timestamp.Clone(),
+            ArtifactId = artifactId,
+            ScopeId = ScopeId,
+            Kind = "markdown",
+            Title = artifactId,
+            Classification = "internal",
+            LifecycleStatus = lifecycleStatus,
+            OwnerPrincipalId = ownerPrincipalId,
+            OwnerPrincipalKind = "user",
+            CreatedAtUtc = timestamp.Clone(),
+            ArtifactUpdatedAtUtc = timestamp.Clone(),
+        };
+        document.ReaderPrincipalIds.Add(readers ?? []);
+        document.WriterPrincipalIds.Add(writers ?? []);
+        return document;
+    }
 
     private static EventEnvelope WrapCommitted(ContentArtifactState state, DateTimeOffset observedAt) =>
         new()

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactProjectionTests.cs
@@ -6,8 +6,8 @@ using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.ContentArtifacts;
-using Aevatar.Studio.Hosting;
 using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Hosting;
 using Aevatar.Studio.Projection.DependencyInjection;
 using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.Projectors;
@@ -193,6 +193,191 @@ public sealed class ContentArtifactProjectionTests
             .WithMessage("*not authorized to read*");
     }
 
+    [Fact]
+    public async Task GetRevisionContentAsync_ShouldReadAndVerifyBackingContent()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var backed = document.Revisions[1];
+        backed.InlineContent = ByteString.Empty;
+        backed.ContentLocationKind = "backing_object";
+        backed.BackingProvider = "workflow-file";
+        backed.BackingObjectKey = "runs/run-1/revision-2.md";
+        var backingContentPort = new RecordingBackingContentPort("revision two");
+        var queryPort = new ProjectionContentArtifactQueryPort(
+            new RecordingDocumentReader(document),
+            backingContentPort);
+
+        var result = await queryPort.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-2",
+            Principal("reader-1"));
+
+        result.Content.Should().Equal(ByteString.CopyFromUtf8("revision two").ToByteArray());
+        backingContentPort.Requests.Should().ContainSingle().Which.Should().BeEquivalentTo(new
+        {
+            ScopeId,
+            RunId = "run-1",
+        });
+        backingContentPort.Requests[0].Reference.Provider.Should().Be("workflow-file");
+        backingContentPort.Requests[0].Reference.ObjectKey.Should().Be("runs/run-1/revision-2.md");
+    }
+
+    [Fact]
+    public async Task GetAndContentRead_ShouldFailClosedForMismatchedOrUnavailableSnapshots()
+    {
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 7, EventId = "event-7" },
+            BuildState(DateTimeOffset.Parse("2026-07-20T09:00:00Z")),
+            DateTimeOffset.Parse("2026-07-20T10:00:00Z"));
+        var mismatched = document.Clone();
+        mismatched.ScopeId = "scope-other";
+        var mismatchedPort = new ProjectionContentArtifactQueryPort(new RecordingDocumentReader(mismatched));
+
+        (await mismatchedPort.GetAsync(ScopeId, ArtifactId)).Should().BeNull();
+        var mismatchedRead = () => mismatchedPort.GetRevisionContentAsync(
+            ScopeId,
+            ArtifactId,
+            "revision-1",
+            Principal("owner-1"));
+        await mismatchedRead.Should().ThrowAsync<ContentArtifactNotFoundException>();
+
+        var tombstoned = document.Clone();
+        tombstoned.LifecycleStatus = ContentArtifactLifecycleStatusNames.Tombstoned;
+        var tombstonedRead = () => new ProjectionContentArtifactQueryPort(new RecordingDocumentReader(tombstoned))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
+        await tombstonedRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*artifact is tombstoned*");
+
+        var missingRevisionRead = () => new ProjectionContentArtifactQueryPort(new RecordingDocumentReader(document))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-missing", Principal("owner-1"));
+        await missingRevisionRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*revision was not found*");
+
+        var redacted = document.Clone();
+        redacted.Revisions[0].Availability = ContentArtifactRevisionAvailabilityNames.Redacted;
+        var redactedRead = () => new ProjectionContentArtifactQueryPort(new RecordingDocumentReader(redacted))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
+        await redactedRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*redacted*");
+
+        var missingLocation = document.Clone();
+        missingLocation.Revisions[0].ContentLocationKind = string.Empty;
+        var missingLocationRead = () => new ProjectionContentArtifactQueryPort(
+                new RecordingDocumentReader(missingLocation))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
+        await missingLocationRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*content location is unavailable*");
+
+        var missingProvider = document.Clone();
+        missingProvider.Revisions[0].ContentLocationKind = "backing_object";
+        var missingProviderRead = () => new ProjectionContentArtifactQueryPort(
+                new RecordingDocumentReader(missingProvider))
+            .GetRevisionContentAsync(ScopeId, ArtifactId, "revision-1", Principal("owner-1"));
+        await missingProviderRead.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*backing content provider is unavailable*");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldIgnoreEnvelopesWithoutCommittedContentArtifactState()
+    {
+        var dispatcher = new RecordingWriteDispatcher();
+        var projector = new ContentArtifactCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-07-20T10:00:00Z")));
+
+        await projector.ProjectAsync(
+            new StudioMaterializationContext
+            {
+                RootActorId = ActorId,
+                ProjectionKind = ContentArtifactGAgent.ProjectionKind,
+            },
+            new EventEnvelope { Payload = Any.Pack(new StringValue { Value = "not committed state" }) });
+
+        dispatcher.Upserts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToDocument_ShouldMapAllContentArtifactWireVariants()
+    {
+        var observedAt = DateTimeOffset.Parse("2026-07-20T10:00:00Z");
+        var state = BuildState(observedAt.AddMinutes(-5));
+        state.AccessPolicy = null;
+        state.RetentionPolicy = null;
+        state.Kind = ContentArtifactKind.Text;
+        state.LifecycleStatus = ContentArtifactLifecycleStatus.Tombstoned;
+        state.Revisions["revision-1"].Availability = ContentArtifactRevisionAvailability.Redacted;
+        state.Revisions["revision-1"].Content = null;
+        state.Revisions["revision-1"].Provenance = null;
+        state.Revisions["revision-2"].Availability = ContentArtifactRevisionAvailability.RetentionExpired;
+        state.Revisions["revision-2"].Content = new ContentArtifactRevisionContent
+        {
+            BackingObject = new ContentArtifactBackingObjectReference
+            {
+                Provider = "workflow-file",
+                ObjectKey = "runs/run-1/revision-2.md",
+            },
+        };
+
+        var document = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent { Version = 8, EventId = "event-8" },
+            state,
+            observedAt);
+
+        document.Kind.Should().Be("text");
+        document.LifecycleStatus.Should().Be(ContentArtifactLifecycleStatusNames.Tombstoned);
+        document.OwnerPrincipalId.Should().BeEmpty();
+        document.RetentionPolicyId.Should().BeEmpty();
+        document.Revisions[0].Availability.Should().Be(ContentArtifactRevisionAvailabilityNames.Redacted);
+        document.Revisions[0].ContentLocationKind.Should().BeEmpty();
+        document.Revisions[0].ProvenanceScopeId.Should().BeEmpty();
+        document.Revisions[1].Availability.Should().Be(ContentArtifactRevisionAvailabilityNames.RetentionExpired);
+        document.Revisions[1].ContentLocationKind.Should().Be("backing_object");
+
+        state.Kind = ContentArtifactKind.StructuredDocument;
+        ContentArtifactCurrentStateProjector.ToDocument(ActorId, new StateEvent(), state, observedAt)
+            .Kind.Should().Be("structured_document");
+        state.Kind = ContentArtifactKind.OtherContent;
+        ContentArtifactCurrentStateProjector.ToDocument(ActorId, new StateEvent(), state, observedAt)
+            .Kind.Should().Be("other_content");
+        state.Kind = ContentArtifactKind.Unspecified;
+        state.LifecycleStatus = ContentArtifactLifecycleStatus.Unspecified;
+        state.Revisions["revision-1"].Availability = ContentArtifactRevisionAvailability.Unspecified;
+        var unspecified = ContentArtifactCurrentStateProjector.ToDocument(
+            ActorId,
+            new StateEvent(),
+            state,
+            observedAt);
+        unspecified.Kind.Should().BeEmpty();
+        unspecified.LifecycleStatus.Should().BeEmpty();
+        unspecified.Revisions[0].Availability.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CurrentStateDocument_ShouldExposeProjectionIdentityAndAuthoritativeVersion()
+    {
+        var updatedAt = DateTimeOffset.Parse("2026-07-20T10:00:00Z");
+        IProjectionReadModel readModel = new ContentArtifactCurrentStateDocument
+        {
+            Id = ActorId,
+            ActorId = ActorId,
+            StateVersion = 9,
+            LastEventId = "event-9",
+            UpdatedAt = Timestamp.FromDateTimeOffset(updatedAt),
+        };
+
+        readModel.ActorId.Should().Be(ActorId);
+        readModel.StateVersion.Should().Be(9);
+        readModel.LastEventId.Should().Be("event-9");
+        readModel.UpdatedAt.Should().Be(updatedAt);
+    }
+
     private static ContentArtifactState BuildState(DateTimeOffset updatedAt)
     {
         var firstContent = ByteString.CopyFromUtf8("revision one");
@@ -354,5 +539,23 @@ public sealed class ContentArtifactProjectionTests
             ContentArtifactBackingContentRequest request,
             CancellationToken ct = default) =>
             throw new FileNotFoundException("missing backing content");
+    }
+
+    private sealed class RecordingBackingContentPort(string content) : IContentArtifactBackingContentPort
+    {
+        public List<ContentArtifactBackingContentRequest> Requests { get; } = [];
+
+        public Task<ContentArtifactBackingContentDescriptor> DescribeAsync(
+            ContentArtifactBackingContentRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<Stream> OpenReadAsync(
+            ContentArtifactBackingContentRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult<Stream>(new MemoryStream(ByteString.CopyFromUtf8(content).ToByteArray()));
+        }
     }
 }

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
@@ -89,14 +89,13 @@ public sealed class ContentArtifactServiceTests
     }
 
     [Fact]
-    public async Task AppendRevisionAsync_ShouldAuthorizeWriterAndRequireCurrentCasVersion()
+    public async Task AppendRevisionAsync_ShouldAuthorizeWriterWithoutDerivingWriteFacts()
     {
         var queryPort = new RecordingQueryPort(BuildCurrentState());
         var commandPort = new RecordingCommandPort();
         var service = CreateService(commandPort: commandPort, queryPort: queryPort);
         var request = new AppendContentArtifactRevisionRequest(
-            ExpectedConcurrencyVersion: 1,
-            Revision: RevisionWrite("revision two", "revision-2-dedup", parentRevisionId: "revision-1"));
+            RevisionWrite("revision two", "revision-2-dedup", parentRevisionId: "revision-1"));
 
         await service.AppendRevisionAsync(
             "scope-1",
@@ -105,36 +104,28 @@ public sealed class ContentArtifactServiceTests
             Principal("writer-1"));
 
         commandPort.AppendRequest.Should().NotBeNull();
-        commandPort.AppendRevisionNumber.Should().Be(2);
         commandPort.AppendRequest!.Revision.ParentRevisionId.Should().Be("revision-1");
-
-        var stale = () => service.AppendRevisionAsync(
-            "scope-1",
-            "artifact-1",
-            request with { ExpectedConcurrencyVersion = 0 },
-            Principal("owner-1"));
-        await stale.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*concurrency version is 1, not 0*");
     }
 
     [Fact]
-    public async Task AppendRevisionAsync_ShouldDeriveRevisionNumberFromHistoryNotCasVersion()
+    public async Task AppendRevisionAsync_ShouldDispatchWhenAdvisoryReadModelIsMissing()
     {
-        var current = BuildCurrentState() with { ConcurrencyVersion = 7 };
         var commandPort = new RecordingCommandPort();
         var service = CreateService(
             commandPort: commandPort,
-            queryPort: new RecordingQueryPort(current));
+            queryPort: new RecordingQueryPort(current: null));
 
         await service.AppendRevisionAsync(
-            "scope-1",
-            "artifact-1",
+            " scope-1 ",
+            " artifact-1 ",
             new AppendContentArtifactRevisionRequest(
-                ExpectedConcurrencyVersion: 7,
-                Revision: RevisionWrite("revision two", "revision-2-dedup", "revision-1")),
-            Principal("owner-1"));
+                RevisionWrite("revision two", "revision-2-dedup", "revision-1")),
+            Principal("writer-1"));
 
-        commandPort.AppendRevisionNumber.Should().Be(2);
+        commandPort.ScopeId.Should().Be("scope-1");
+        commandPort.AppendArtifactId.Should().Be("artifact-1");
+        commandPort.AppendRequest!.Revision.Provenance.ScopeId.Should().Be("scope-1");
+        commandPort.AppendRequest.Revision.Provenance.TeamId.Should().Be("caller-supplied-team");
     }
 
     [Fact]
@@ -336,7 +327,7 @@ public sealed class ContentArtifactServiceTests
         public string? ScopeId { get; private set; }
         public CreateContentArtifactRequest? CreateRequest { get; private set; }
         public AppendContentArtifactRevisionRequest? AppendRequest { get; private set; }
-        public long AppendRevisionNumber { get; private set; }
+        public string? AppendArtifactId { get; private set; }
 
         public Task<ContentArtifactAcceptedReceipt> CreateAsync(string scopeId, CreateContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
         {
@@ -345,9 +336,10 @@ public sealed class ContentArtifactServiceTests
             return Receipt();
         }
 
-        public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, long revisionNumber, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
+        public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
         {
-            AppendRevisionNumber = revisionNumber;
+            ScopeId = scopeId;
+            AppendArtifactId = artifactId;
             AppendRequest = request;
             return Receipt();
         }
@@ -361,12 +353,14 @@ public sealed class ContentArtifactServiceTests
             Task.FromResult(new ContentArtifactAcceptedReceipt("artifact-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted));
     }
 
-    private sealed class RecordingQueryPort(ContentArtifactCurrentStateResponse current) : IContentArtifactQueryPort
+    private sealed class RecordingQueryPort(ContentArtifactCurrentStateResponse? current) : IContentArtifactQueryPort
     {
         public int ContentReadCount { get; private set; }
 
         public Task<ContentArtifactListResponse> ListAsync(string scopeId, string ownerPrincipalId, ContentArtifactQueryRequest query, CancellationToken ct = default) =>
-            Task.FromResult(new ContentArtifactListResponse(scopeId, [current]));
+            Task.FromResult(new ContentArtifactListResponse(
+                scopeId,
+                current == null ? [] : [current]));
 
         public Task<ContentArtifactCurrentStateResponse?> GetAsync(string scopeId, string artifactId, CancellationToken ct = default) =>
             Task.FromResult<ContentArtifactCurrentStateResponse?>(current);
@@ -374,7 +368,7 @@ public sealed class ContentArtifactServiceTests
         public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
         {
             ContentReadCount++;
-            var revision = current.Revisions.Single(item => item.RevisionId == revisionId);
+            var revision = current!.Revisions.Single(item => item.RevisionId == revisionId);
             return Task.FromResult(new ContentArtifactRevisionContentResponse(
                 new ContentArtifactReferenceContract(artifactId, revisionId, revision.ContentHash, revision.MediaType),
                 System.Text.Encoding.UTF8.GetBytes("report")));

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
@@ -89,6 +89,19 @@ public sealed class ContentArtifactServiceTests
     }
 
     [Fact]
+    public async Task GetAsync_ShouldIdentifyOwnerByPrincipalIdOnly()
+    {
+        var service = CreateService(queryPort: new RecordingQueryPort(BuildCurrentState()));
+
+        var result = await service.GetAsync(
+            "scope-1",
+            "artifact-1",
+            Principal("owner-1", "service"));
+
+        result.ArtifactId.Should().Be("artifact-1");
+    }
+
+    [Fact]
     public async Task AppendRevisionAsync_ShouldAuthorizeWriterWithoutDerivingWriteFacts()
     {
         var queryPort = new RecordingQueryPort(BuildCurrentState());
@@ -126,6 +139,56 @@ public sealed class ContentArtifactServiceTests
         commandPort.AppendArtifactId.Should().Be("artifact-1");
         commandPort.AppendRequest!.Revision.Provenance.ScopeId.Should().Be("scope-1");
         commandPort.AppendRequest.Revision.Provenance.TeamId.Should().Be("caller-supplied-team");
+    }
+
+    [Theory]
+    [InlineData("advance")]
+    [InlineData("redact")]
+    [InlineData("expire")]
+    public async Task ReadRequiringMutation_ShouldRejectWriterOnlyAndAllowReaderWriterAndOwner(string operation)
+    {
+        var current = BuildCurrentState() with
+        {
+            ReaderPrincipalIds = ["reader-1", "editor-1"],
+            WriterPrincipalIds = ["writer-1", "editor-1"],
+        };
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(commandPort: commandPort, queryPort: new RecordingQueryPort(current));
+
+        var writerOnly = () => InvokeMutationAsync(service, operation, Principal("writer-1"));
+
+        await writerOnly.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not authorized to read*");
+        await InvokeMutationAsync(service, operation, Principal("editor-1"));
+        await InvokeMutationAsync(service, operation, Principal("owner-1"));
+        commandPort.MutationCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task TombstoneAsync_ShouldRemainOwnerOnly()
+    {
+        var current = BuildCurrentState() with
+        {
+            ReaderPrincipalIds = ["editor-1"],
+            WriterPrincipalIds = ["editor-1"],
+        };
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(commandPort: commandPort, queryPort: new RecordingQueryPort(current));
+
+        var editor = () => service.TombstoneAsync(
+            "scope-1",
+            "artifact-1",
+            new TombstoneContentArtifactRequest(1, "retention complete"),
+            Principal("editor-1"));
+
+        await editor.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*owner*");
+        await service.TombstoneAsync(
+            "scope-1",
+            "artifact-1",
+            new TombstoneContentArtifactRequest(1, "retention complete"),
+            Principal("owner-1"));
+        commandPort.MutationCallCount.Should().Be(1);
     }
 
     [Fact]
@@ -293,7 +356,33 @@ public sealed class ContentArtifactServiceTests
             LastOutput: "done",
             LastError: string.Empty);
 
-    private static ContentArtifactPrincipalContract Principal(string id) => new(id, "user");
+    private static ContentArtifactPrincipalContract Principal(string id, string kind = "user") => new(id, kind);
+
+    private static Task<ContentArtifactAcceptedReceipt> InvokeMutationAsync(
+        ContentArtifactService service,
+        string operation,
+        ContentArtifactPrincipalContract principal) =>
+        operation switch
+        {
+            "advance" => service.AdvanceCurrentRevisionAsync(
+                "scope-1",
+                "artifact-1",
+                new AdvanceContentArtifactCurrentRevisionRequest(1, "revision-1"),
+                principal),
+            "redact" => service.RedactRevisionAsync(
+                "scope-1",
+                "artifact-1",
+                "revision-1",
+                new RedactContentArtifactRevisionRequest(1, "privacy request"),
+                principal),
+            "expire" => service.ExpireRevisionAsync(
+                "scope-1",
+                "artifact-1",
+                "revision-1",
+                new ExpireContentArtifactRevisionRequest(1),
+                principal),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null),
+        };
 
     private static string ContentHash(string content) =>
         Convert.ToHexStringLower(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content)));
@@ -328,6 +417,7 @@ public sealed class ContentArtifactServiceTests
         public CreateContentArtifactRequest? CreateRequest { get; private set; }
         public AppendContentArtifactRevisionRequest? AppendRequest { get; private set; }
         public string? AppendArtifactId { get; private set; }
+        public int MutationCallCount { get; private set; }
 
         public Task<ContentArtifactAcceptedReceipt> CreateAsync(string scopeId, CreateContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
         {
@@ -344,10 +434,16 @@ public sealed class ContentArtifactServiceTests
             return Receipt();
         }
 
-        public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
-        public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
-        public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
-        public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
+        public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => MutationReceipt();
+        public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => MutationReceipt();
+        public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => MutationReceipt();
+        public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => MutationReceipt();
+
+        private Task<ContentArtifactAcceptedReceipt> MutationReceipt()
+        {
+            MutationCallCount++;
+            return Receipt();
+        }
 
         private static Task<ContentArtifactAcceptedReceipt> Receipt() =>
             Task.FromResult(new ContentArtifactAcceptedReceipt("artifact-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted));

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
@@ -73,6 +73,30 @@ public sealed class ContentArtifactServiceTests
     }
 
     [Fact]
+    public async Task CreateAsync_ShouldExposeOnlyDedupKeyOccupancyForAnotherOwner()
+    {
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(
+            commandPort: commandPort,
+            queryPort: new RecordingQueryPort(BuildCurrentState()));
+
+        var occupied = () => service.CreateAsync(
+            "scope-1",
+            CreateRequest(),
+            Principal("other-owner"));
+
+        var conflict = (await occupied.Should().ThrowAsync<ContentArtifactIdentityConflictException>())
+            .Which;
+        conflict.Message.Should().Contain("report-dedup")
+            .And.NotContain("artifact-1")
+            .And.NotContain("owner-1");
+        commandPort.CreateRequest.Should().BeNull();
+
+        await service.CreateAsync("scope-1", CreateRequest(), Principal("owner-1", "service"));
+        commandPort.CreateRequest.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task GetAsync_ShouldAuthorizeOwnerAndExplicitReaderOnly()
     {
         var queryPort = new RecordingQueryPort(BuildCurrentState());
@@ -84,8 +108,7 @@ public sealed class ContentArtifactServiceTests
 
         owner.ArtifactId.Should().Be("artifact-1");
         reader.ArtifactId.Should().Be("artifact-1");
-        await denied.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*not authorized to read*");
+        await denied.Should().ThrowAsync<ContentArtifactNotFoundException>();
     }
 
     [Fact]
@@ -157,8 +180,7 @@ public sealed class ContentArtifactServiceTests
 
         var writerOnly = () => InvokeMutationAsync(service, operation, Principal("writer-1"));
 
-        await writerOnly.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*not authorized to read*");
+        await writerOnly.Should().ThrowAsync<ContentArtifactNotFoundException>();
         await InvokeMutationAsync(service, operation, Principal("editor-1"));
         await InvokeMutationAsync(service, operation, Principal("owner-1"));
         commandPort.MutationCallCount.Should().Be(2);
@@ -181,14 +203,65 @@ public sealed class ContentArtifactServiceTests
             new TombstoneContentArtifactRequest(1, "retention complete"),
             Principal("editor-1"));
 
-        await editor.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*owner*");
+        await editor.Should().ThrowAsync<ContentArtifactNotFoundException>();
         await service.TombstoneAsync(
             "scope-1",
             "artifact-1",
             new TombstoneContentArtifactRequest(1, "retention complete"),
             Principal("owner-1"));
         commandPort.MutationCallCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("get")]
+    [InlineData("get-revision")]
+    [InlineData("get-current-revision")]
+    [InlineData("get-content")]
+    [InlineData("append")]
+    [InlineData("advance")]
+    [InlineData("redact")]
+    [InlineData("expire")]
+    [InlineData("tombstone")]
+    [InlineData("attach")]
+    public async Task ArtifactAclDenial_ShouldBeIndistinguishableFromAbsence(string operation)
+    {
+        var service = CreateService(queryPort: new RecordingQueryPort(BuildCurrentState()));
+        var principal = Principal(operation == "append" ? "unrelated-1" : "writer-1");
+
+        var denied = () => InvokeOperationAsync(service, operation, principal);
+
+        var notFound = (await denied.Should().ThrowAsync<ContentArtifactNotFoundException>()).Which;
+        notFound.Message.Should().NotContain("authorized")
+            .And.NotContain("tombstoned")
+            .And.NotContain("concurrency");
+    }
+
+    [Fact]
+    public async Task GetRevisionAsync_ShouldReturnNotFoundForMissingRevision()
+    {
+        var service = CreateService(queryPort: new RecordingQueryPort(BuildCurrentState()));
+
+        var missing = () => service.GetRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            "revision-missing",
+            Principal("owner-1"));
+
+        await missing.Should().ThrowAsync<ContentArtifactNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetCurrentRevisionAsync_ShouldReturnNotFoundWhenActiveArtifactHasNoRevision()
+    {
+        var current = BuildCurrentState() with { CurrentRevisionId = null, Revisions = [] };
+        var service = CreateService(queryPort: new RecordingQueryPort(current));
+
+        var missing = () => service.GetCurrentRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            Principal("owner-1"));
+
+        await missing.Should().ThrowAsync<ContentArtifactNotFoundException>();
     }
 
     [Fact]
@@ -384,6 +457,65 @@ public sealed class ContentArtifactServiceTests
             _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null),
         };
 
+    private static async Task InvokeOperationAsync(
+        ContentArtifactService service,
+        string operation,
+        ContentArtifactPrincipalContract principal)
+    {
+        switch (operation)
+        {
+            case "get":
+                await service.GetAsync("scope-1", "artifact-1", principal);
+                break;
+            case "get-revision":
+                await service.GetRevisionAsync("scope-1", "artifact-1", "revision-1", principal);
+                break;
+            case "get-current-revision":
+                await service.GetCurrentRevisionAsync("scope-1", "artifact-1", principal);
+                break;
+            case "get-content":
+                await service.GetRevisionContentAsync("scope-1", "artifact-1", "revision-1", principal);
+                break;
+            case "append":
+                await service.AppendRevisionAsync(
+                    "scope-1",
+                    "artifact-1",
+                    new AppendContentArtifactRevisionRequest(
+                        RevisionWrite("revision two", "revision-2-dedup", "revision-1")),
+                    principal);
+                break;
+            case "advance":
+            case "redact":
+            case "expire":
+                await InvokeMutationAsync(service, operation, principal);
+                break;
+            case "tombstone":
+                await service.TombstoneAsync(
+                    "scope-1",
+                    "artifact-1",
+                    new TombstoneContentArtifactRequest(1, "retention complete"),
+                    principal);
+                break;
+            case "attach":
+                var revision = BuildCurrentState().Revisions[0];
+                await service.AttachToRunAsync(
+                    "scope-1",
+                    new AttachContentArtifactsToRunRequest(
+                        "service-1",
+                        "run-1",
+                        4,
+                        [new ContentArtifactReferenceContract(
+                            "artifact-1",
+                            revision.RevisionId,
+                            revision.ContentHash,
+                            revision.MediaType)]),
+                    principal);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(operation), operation, null);
+        }
+    }
+
     private static string ContentHash(string content) =>
         Convert.ToHexStringLower(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content)));
 
@@ -459,6 +591,9 @@ public sealed class ContentArtifactServiceTests
                 current == null ? [] : [current]));
 
         public Task<ContentArtifactCurrentStateResponse?> GetAsync(string scopeId, string artifactId, CancellationToken ct = default) =>
+            Task.FromResult<ContentArtifactCurrentStateResponse?>(current);
+
+        public Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(string scopeId, string dedupKey, CancellationToken ct = default) =>
             Task.FromResult<ContentArtifactCurrentStateResponse?>(current);
 
         public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default)

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
@@ -1,0 +1,415 @@
+using System.Security.Cryptography;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests.ContentArtifacts;
+
+public sealed class ContentArtifactServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_ShouldValidateActiveTeamAndNormalizeExecutionProvenance()
+    {
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(commandPort: commandPort);
+        var request = CreateRequest();
+
+        var receipt = await service.CreateAsync(
+            " scope-1 ",
+            request,
+            Principal("owner-1"));
+
+        receipt.ArtifactId.Should().Be("artifact-1");
+        commandPort.ScopeId.Should().Be("scope-1");
+        commandPort.CreateRequest!.TeamId.Should().Be("team-1");
+        commandPort.CreateRequest.FirstRevision.Provenance.ScopeId.Should().Be("scope-1");
+        commandPort.CreateRequest.FirstRevision.Provenance.TeamId.Should().Be("team-1");
+        commandPort.CreateRequest.FirstRevision.ContentHash.Should().Be(ContentHash("report"));
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldFailClosedWhenTeamIsOutsideScope()
+    {
+        var teams = new RecordingTeamQueryPort(team: new StudioTeamSummaryResponse(
+            "team-1",
+            "other-scope",
+            "Team",
+            string.Empty,
+            TeamLifecycleStageNames.Active,
+            1,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow));
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(teams, commandPort);
+
+        var act = () => service.CreateAsync("scope-1", CreateRequest(), Principal("owner-1"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Team was not found in the requested Scope*");
+        commandPort.CreateRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldAllowScopeOwnedArtifactWithoutTeam()
+    {
+        var teams = new RecordingTeamQueryPort();
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(teams, commandPort);
+
+        await service.CreateAsync(
+            "scope-1",
+            CreateRequest(teamId: null),
+            Principal("owner-1"));
+
+        teams.GetCallCount.Should().Be(0);
+        commandPort.CreateRequest.Should().NotBeNull();
+        commandPort.CreateRequest!.TeamId.Should().BeNull();
+        commandPort.CreateRequest.FirstRevision.Provenance.TeamId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_ShouldAuthorizeOwnerAndExplicitReaderOnly()
+    {
+        var queryPort = new RecordingQueryPort(BuildCurrentState());
+        var service = CreateService(queryPort: queryPort);
+
+        var owner = await service.GetAsync("scope-1", "artifact-1", Principal("owner-1"));
+        var reader = await service.GetAsync("scope-1", "artifact-1", Principal("reader-1"));
+        var denied = () => service.GetAsync("scope-1", "artifact-1", Principal("other-user"));
+
+        owner.ArtifactId.Should().Be("artifact-1");
+        reader.ArtifactId.Should().Be("artifact-1");
+        await denied.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not authorized to read*");
+    }
+
+    [Fact]
+    public async Task AppendRevisionAsync_ShouldAuthorizeWriterAndRequireCurrentCasVersion()
+    {
+        var queryPort = new RecordingQueryPort(BuildCurrentState());
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(commandPort: commandPort, queryPort: queryPort);
+        var request = new AppendContentArtifactRevisionRequest(
+            ExpectedConcurrencyVersion: 1,
+            Revision: RevisionWrite("revision two", "revision-2-dedup", parentRevisionId: "revision-1"));
+
+        await service.AppendRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            request,
+            Principal("writer-1"));
+
+        commandPort.AppendRequest.Should().NotBeNull();
+        commandPort.AppendRevisionNumber.Should().Be(2);
+        commandPort.AppendRequest!.Revision.ParentRevisionId.Should().Be("revision-1");
+
+        var stale = () => service.AppendRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            request with { ExpectedConcurrencyVersion = 0 },
+            Principal("owner-1"));
+        await stale.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*concurrency version is 1, not 0*");
+    }
+
+    [Fact]
+    public async Task AppendRevisionAsync_ShouldDeriveRevisionNumberFromHistoryNotCasVersion()
+    {
+        var current = BuildCurrentState() with { ConcurrencyVersion = 7 };
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(
+            commandPort: commandPort,
+            queryPort: new RecordingQueryPort(current));
+
+        await service.AppendRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            new AppendContentArtifactRevisionRequest(
+                ExpectedConcurrencyVersion: 7,
+                Revision: RevisionWrite("revision two", "revision-2-dedup", "revision-1")),
+            Principal("owner-1"));
+
+        commandPort.AppendRevisionNumber.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetRevisionContentAsync_ShouldRejectRedactedRevisionBeforeReadingBackingStore()
+    {
+        var current = BuildCurrentState() with
+        {
+            Revisions =
+            [
+                BuildRevisionResponse() with
+                {
+                    Availability = ContentArtifactRevisionAvailabilityNames.Redacted,
+                    RedactionReason = "privacy",
+                },
+            ],
+        };
+        var queryPort = new RecordingQueryPort(current);
+        var service = CreateService(queryPort: queryPort);
+
+        var act = () => service.GetRevisionContentAsync(
+            "scope-1",
+            "artifact-1",
+            "revision-1",
+            Principal("owner-1"));
+
+        await act.Should().ThrowAsync<ContentArtifactContentUnavailableException>()
+            .WithMessage("*redacted*");
+        queryPort.ContentReadCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AttachToRunAsync_ShouldValidateRunAndExactArtifactRevisions()
+    {
+        var current = BuildCurrentState();
+        var queryPort = new RecordingQueryPort(current);
+        var runQuery = new RecordingServiceRunQueryPort(BuildRun());
+        var runCommands = new RecordingServiceRunResultArtifactAttachmentPort();
+        var service = CreateService(
+            queryPort: queryPort,
+            serviceRunQueryPort: runQuery,
+            serviceRunResultArtifactAttachmentPort: runCommands);
+        var revision = current.Revisions[0];
+        var request = new AttachContentArtifactsToRunRequest(
+            "service-1",
+            "run-1",
+            ExpectedRunStateVersion: 4,
+            Artifacts:
+            [
+                new ContentArtifactReferenceContract(
+                    current.ArtifactId,
+                    revision.RevisionId,
+                    revision.ContentHash,
+                    revision.MediaType),
+            ]);
+
+        var receipt = await service.AttachToRunAsync(
+            "scope-1",
+            request,
+            Principal("owner-1"));
+
+        receipt.Stage.Should().Be(ContentArtifactCommandStageNames.DispatchAccepted);
+        runCommands.Attached.Should().ContainSingle();
+        runCommands.Attached[0].ArtifactId.Should().Be("artifact-1");
+        runCommands.RunActorId.Should().Be("service-run-actor-1");
+        runCommands.ExpectedStateVersion.Should().Be(4);
+    }
+
+    private static ContentArtifactService CreateService(
+        IStudioTeamQueryPort? teamQueryPort = null,
+        RecordingCommandPort? commandPort = null,
+        RecordingQueryPort? queryPort = null,
+        IServiceRunQueryPort? serviceRunQueryPort = null,
+        IServiceRunResultArtifactAttachmentPort? serviceRunResultArtifactAttachmentPort = null) =>
+        new(
+            teamQueryPort ?? new RecordingTeamQueryPort(),
+            commandPort ?? new RecordingCommandPort(),
+            queryPort ?? new RecordingQueryPort(BuildCurrentState()),
+            serviceRunQueryPort ?? new RecordingServiceRunQueryPort(BuildRun()),
+            serviceRunResultArtifactAttachmentPort ?? new RecordingServiceRunResultArtifactAttachmentPort());
+
+    private static CreateContentArtifactRequest CreateRequest(string? teamId = " team-1 ") =>
+        new(
+            TeamId: teamId,
+            Kind: "markdown",
+            Title: " Quarterly report ",
+            Classification: "internal",
+            DedupKey: "report-dedup",
+            FirstRevision: RevisionWrite("report", "revision-1-dedup"),
+            AccessPolicy: new([" reader-1 "], [" writer-1 "]),
+            RetentionPolicy: new("retain-365-days"),
+            WorkOrderId: "work-order-1");
+
+    private static ContentArtifactRevisionWriteRequest RevisionWrite(
+        string content,
+        string dedupKey,
+        string? parentRevisionId = null) =>
+        new(
+            DedupKey: dedupKey,
+            MediaType: "text/markdown",
+            ContentHash: ContentHash(content),
+            ByteLength: System.Text.Encoding.UTF8.GetByteCount(content),
+            Provenance: new("caller-supplied-scope", TeamId: "caller-supplied-team", PublishedServiceId: "service-1", RunId: "run-1"),
+            InlineContent: System.Text.Encoding.UTF8.GetBytes(content),
+            ParentRevisionId: parentRevisionId);
+
+    private static ContentArtifactCurrentStateResponse BuildCurrentState() =>
+        new(
+            ArtifactId: "artifact-1",
+            ScopeId: "scope-1",
+            TeamId: "team-1",
+            Kind: "markdown",
+            Title: "Quarterly report",
+            Classification: "internal",
+            LifecycleStatus: ContentArtifactLifecycleStatusNames.Active,
+            CurrentRevisionId: "revision-1",
+            ConcurrencyVersion: 1,
+            StateVersion: 1,
+            Owner: Principal("owner-1"),
+            ReaderPrincipalIds: ["reader-1"],
+            WriterPrincipalIds: ["writer-1"],
+            RetentionPolicy: new("retain-365-days"),
+            WorkOrderId: "work-order-1",
+            Revisions: [BuildRevisionResponse()],
+            CreatedAtUtc: DateTimeOffset.Parse("2026-07-20T00:00:00Z"),
+            UpdatedAtUtc: DateTimeOffset.Parse("2026-07-20T00:00:00Z"));
+
+    private static ContentArtifactRevisionResponse BuildRevisionResponse() =>
+        new(
+            RevisionId: "revision-1",
+            RevisionNumber: 1,
+            ParentRevisionId: null,
+            MediaType: "text/markdown",
+            ByteLength: 6,
+            ContentHash: ContentHash("report"),
+            Availability: ContentArtifactRevisionAvailabilityNames.Available,
+            HasInlineContent: true,
+            HasBackingContent: false,
+            Provenance: new("scope-1", TeamId: "team-1", PublishedServiceId: "service-1", RunId: "run-1"),
+            Citations: [],
+            CreatedAtUtc: DateTimeOffset.Parse("2026-07-20T00:00:00Z"));
+
+    private static ServiceRunSnapshot BuildRun() =>
+        new(
+            ScopeId: "scope-1",
+            ServiceId: "service-1",
+            ServiceKey: "scope-1:service-1",
+            RunId: "run-1",
+            CommandId: "command-1",
+            CorrelationId: "correlation-1",
+            EndpointId: "run",
+            ScheduleId: string.Empty,
+            ImplementationKind: ServiceImplementationKind.Workflow,
+            TargetActorId: "workflow-run-1",
+            RevisionId: "service-revision-1",
+            DeploymentId: "deployment-1",
+            Status: ServiceRunStatus.Completed,
+            ActorId: "service-run-actor-1",
+            TenantId: "scope-1",
+            AppId: "app-1",
+            Namespace: "default",
+            StateVersion: 4,
+            LastEventId: "event-4",
+            CreatedAt: DateTimeOffset.Parse("2026-07-20T00:00:00Z"),
+            UpdatedAt: DateTimeOffset.Parse("2026-07-20T00:01:00Z"),
+            LastOutput: "done",
+            LastError: string.Empty);
+
+    private static ContentArtifactPrincipalContract Principal(string id) => new(id, "user");
+
+    private static string ContentHash(string content) =>
+        Convert.ToHexStringLower(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(content)));
+
+    private sealed class RecordingTeamQueryPort(StudioTeamSummaryResponse? team = null) : IStudioTeamQueryPort
+    {
+        private readonly StudioTeamSummaryResponse _team = team ?? new(
+            "team-1",
+            "scope-1",
+            "Team",
+            string.Empty,
+            TeamLifecycleStageNames.Active,
+            1,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        public int GetCallCount { get; private set; }
+
+        public Task<StudioTeamRosterResponse> ListAsync(string scopeId, StudioTeamRosterPageRequest? page = null, CancellationToken ct = default) =>
+            Task.FromResult(new StudioTeamRosterResponse(scopeId, [_team]));
+
+        public Task<StudioTeamSummaryResponse?> GetAsync(string scopeId, string teamId, CancellationToken ct = default)
+        {
+            GetCallCount++;
+            return Task.FromResult<StudioTeamSummaryResponse?>(_team);
+        }
+    }
+
+    private sealed class RecordingCommandPort : IContentArtifactCommandPort
+    {
+        public string? ScopeId { get; private set; }
+        public CreateContentArtifactRequest? CreateRequest { get; private set; }
+        public AppendContentArtifactRevisionRequest? AppendRequest { get; private set; }
+        public long AppendRevisionNumber { get; private set; }
+
+        public Task<ContentArtifactAcceptedReceipt> CreateAsync(string scopeId, CreateContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
+        {
+            ScopeId = scopeId;
+            CreateRequest = request;
+            return Receipt();
+        }
+
+        public Task<ContentArtifactAcceptedReceipt> AppendRevisionAsync(string scopeId, string artifactId, long revisionNumber, AppendContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
+        {
+            AppendRevisionNumber = revisionNumber;
+            AppendRequest = request;
+            return Receipt();
+        }
+
+        public Task<ContentArtifactAcceptedReceipt> AdvanceCurrentRevisionAsync(string scopeId, string artifactId, AdvanceContentArtifactCurrentRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
+        public Task<ContentArtifactAcceptedReceipt> RedactRevisionAsync(string scopeId, string artifactId, string revisionId, RedactContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
+        public Task<ContentArtifactAcceptedReceipt> ExpireRevisionAsync(string scopeId, string artifactId, string revisionId, ExpireContentArtifactRevisionRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
+        public Task<ContentArtifactAcceptedReceipt> TombstoneAsync(string scopeId, string artifactId, TombstoneContentArtifactRequest request, ContentArtifactPrincipalContract requester, CancellationToken ct = default) => Receipt();
+
+        private static Task<ContentArtifactAcceptedReceipt> Receipt() =>
+            Task.FromResult(new ContentArtifactAcceptedReceipt("artifact-1", "command-1", "correlation-1", ContentArtifactCommandStageNames.DispatchAccepted));
+    }
+
+    private sealed class RecordingQueryPort(ContentArtifactCurrentStateResponse current) : IContentArtifactQueryPort
+    {
+        public int ContentReadCount { get; private set; }
+
+        public Task<ContentArtifactListResponse> ListAsync(string scopeId, string ownerPrincipalId, ContentArtifactQueryRequest query, CancellationToken ct = default) =>
+            Task.FromResult(new ContentArtifactListResponse(scopeId, [current]));
+
+        public Task<ContentArtifactCurrentStateResponse?> GetAsync(string scopeId, string artifactId, CancellationToken ct = default) =>
+            Task.FromResult<ContentArtifactCurrentStateResponse?>(current);
+
+        public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default)
+        {
+            ContentReadCount++;
+            var revision = current.Revisions.Single(item => item.RevisionId == revisionId);
+            return Task.FromResult(new ContentArtifactRevisionContentResponse(
+                new ContentArtifactReferenceContract(artifactId, revisionId, revision.ContentHash, revision.MediaType),
+                System.Text.Encoding.UTF8.GetBytes("report")));
+        }
+    }
+
+    private sealed class RecordingServiceRunQueryPort(ServiceRunSnapshot run) : IServiceRunQueryPort
+    {
+        public Task<IReadOnlyList<ServiceRunSnapshot>> ListAsync(ServiceRunQuery query, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceRunSnapshot>>([run]);
+
+        public Task<ServiceRunSnapshot?> GetByRunIdAsync(string scopeId, string serviceId, string runId, CancellationToken ct = default) =>
+            Task.FromResult<ServiceRunSnapshot?>(run);
+
+        public Task<ServiceRunSnapshot?> GetByCommandIdAsync(string scopeId, string serviceId, string commandId, CancellationToken ct = default) =>
+            Task.FromResult<ServiceRunSnapshot?>(run);
+    }
+
+    private sealed class RecordingServiceRunResultArtifactAttachmentPort : IServiceRunResultArtifactAttachmentPort
+    {
+        public string? RunActorId { get; private set; }
+        public long ExpectedStateVersion { get; private set; }
+        public List<ContentArtifactReference> Attached { get; } = [];
+
+        public Task<ServiceRunArtifactAttachmentResult> AttachResultArtifactsAsync(
+            string runActorId,
+            string runId,
+            long expectedStateVersion,
+            IReadOnlyList<ContentArtifactReference> resultArtifacts,
+            CancellationToken ct = default)
+        {
+            RunActorId = runActorId;
+            ExpectedStateVersion = expectedStateVersion;
+            Attached.AddRange(resultArtifacts.Select(static artifact => artifact.Clone()));
+            return Task.FromResult(new ServiceRunArtifactAttachmentResult(runId, "attach-command-1", "attach-correlation-1"));
+        }
+    }
+}

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/WorkflowFileContentArtifactBackingContentPortTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/WorkflowFileContentArtifactBackingContentPortTests.cs
@@ -1,0 +1,141 @@
+using System.Security.Cryptography;
+using System.Text;
+using Aevatar.ContentArtifacts.Abstractions;
+using Aevatar.Studio.Hosting.ContentArtifacts;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Studio.Tests.ContentArtifacts;
+
+public sealed class WorkflowFileContentArtifactBackingContentPortTests
+{
+    [Fact]
+    public async Task Read_ShouldMapStableWorkflowArtifactIdentityAndOwnership()
+    {
+        var content = Encoding.UTF8.GetBytes("durable report");
+        var hash = Convert.ToHexStringLower(SHA256.HashData(content));
+        var workflowFiles = new RecordingFileArtifactReadPort(new FileArtifactRef
+        {
+            FileId = "wf-file-1",
+            ArtifactId = "workflow-file://wf-file-1",
+            OwnerScopeId = "scope-1",
+            OwnerRunId = "run-1",
+            SizeBytes = content.LongLength,
+            Sha256 = hash,
+        }, content);
+        var port = new WorkflowFileContentArtifactBackingContentPort(workflowFiles);
+        var request = new ContentArtifactBackingContentRequest(
+            new ContentArtifactBackingObjectReference
+            {
+                Provider = WorkflowFileContentArtifactBackingContentPort.Provider,
+                ObjectKey = "workflow-file://wf-file-1",
+            },
+            "scope-1",
+            "run-1");
+
+        var descriptor = await port.DescribeAsync(request);
+        await using var stream = await port.OpenReadAsync(request);
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+
+        descriptor.Should().Be(new ContentArtifactBackingContentDescriptor(content.LongLength, hash));
+        buffer.ToArray().Should().Equal(content);
+        workflowFiles.Requests.Should().OnlyContain(fileRef =>
+            fileRef.ArtifactId == "workflow-file://wf-file-1" &&
+            fileRef.OwnerScopeId == "scope-1" &&
+            fileRef.OwnerRunId == "run-1");
+    }
+
+    [Fact]
+    public async Task Describe_ShouldFailClosedWhenWorkflowOwnershipDoesNotMatch()
+    {
+        var content = Encoding.UTF8.GetBytes("other scope");
+        var workflowFiles = new RecordingFileArtifactReadPort(new FileArtifactRef
+        {
+            ArtifactId = "workflow-file://wf-file-1",
+            OwnerScopeId = "scope-2",
+            OwnerRunId = "run-1",
+            SizeBytes = content.LongLength,
+            Sha256 = Convert.ToHexStringLower(SHA256.HashData(content)),
+        }, content);
+        var port = new WorkflowFileContentArtifactBackingContentPort(workflowFiles);
+
+        var act = () => port.DescribeAsync(new ContentArtifactBackingContentRequest(
+            new ContentArtifactBackingObjectReference
+            {
+                Provider = WorkflowFileContentArtifactBackingContentPort.Provider,
+                ObjectKey = "workflow-file://wf-file-1",
+            },
+            "scope-1",
+            "run-1"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not belong to the ContentArtifact Scope*");
+    }
+
+    [Fact]
+    public async Task Describe_ShouldFailClosedWhenWorkflowProviderIsUnavailable()
+    {
+        var port = new WorkflowFileContentArtifactBackingContentPort();
+
+        var act = () => port.DescribeAsync(new ContentArtifactBackingContentRequest(
+            new ContentArtifactBackingObjectReference
+            {
+                Provider = WorkflowFileContentArtifactBackingContentPort.Provider,
+                ObjectKey = "workflow-file://wf-file-1",
+            },
+            "scope-1",
+            "run-1"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*provider is unavailable*");
+    }
+
+    [Fact]
+    public async Task DependencyInjection_ShouldKeepInlineArtifactsAvailableWithoutWorkflowFilePort()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<
+            IContentArtifactBackingContentPort,
+            WorkflowFileContentArtifactBackingContentPort>();
+        await using var provider = services.BuildServiceProvider();
+
+        var port = provider.GetRequiredService<IContentArtifactBackingContentPort>();
+        var act = () => port.DescribeAsync(new ContentArtifactBackingContentRequest(
+            new ContentArtifactBackingObjectReference
+            {
+                Provider = WorkflowFileContentArtifactBackingContentPort.Provider,
+                ObjectKey = "workflow-file://wf-file-1",
+            },
+            "scope-1"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*provider is unavailable*");
+    }
+
+    private sealed class RecordingFileArtifactReadPort(
+        FileArtifactRef descriptor,
+        byte[] content) : IFileArtifactReadPort
+    {
+        public List<FileArtifactRef> Requests { get; } = [];
+
+        public ValueTask<FileArtifactRef> DescribeAsync(
+            FileArtifactRef fileRef,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(fileRef);
+            return ValueTask.FromResult(descriptor);
+        }
+
+        public ValueTask<FileArtifactContent> OpenReadAsync(
+            FileArtifactRef fileRef,
+            CancellationToken cancellationToken = default)
+        {
+            Requests.Add(fileRef);
+            return ValueTask.FromResult(new FileArtifactContent(
+                descriptor,
+                new MemoryStream(content, writable: false)));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Revisioned ContentArtifacts existed, but issue #3011 identified authority and access gaps: append identity depended on projection state, duplicate/no-op paths could leak artifact facts before authorization, writer-only ACL entries were unusable, list ACL filtering happened after paging, create retries could depend on mutable backing content, and HTTP failures did not consistently hide artifact existence.

Closes #2790.
Closes #3011.

## Solution

- Keep `ContentArtifactGAgent` as the sole write authority. The Actor assigns revision ids/numbers, deduplicates append by `revision.dedup_key`, and compares committed create retries before touching mutable backing content.
- Authorize before lifecycle, revision, duplicate, or no-op probes. A writer-only principal can append; advance/redact/expire require owner or explicit reader+writer; tombstone remains owner-only.
- Preserve identity boundaries: `principal_id` is the ACL identity, Team ownership grants no implicit access, and cross-owner create occupancy returns typed `CONTENT_ARTIFACT_DEDUP_KEY_OCCUPIED` without exposing artifact facts.
- Push owner/reader ACL filtering into the projection provider before cursor paging. Align InMemory protobuf snake_case field paths and repeated-field scalar membership with Elasticsearch behavior.
- Keep queries read-model-only and accepted command receipts unchanged. Normalize HTTP outcomes to 401 authentication, 403 Scope denial, 404 artifact ACL denial/absence/missing revision, 409 dedup occupancy, and 410 only committed tombstone/redaction/retention expiry.
- Document the ContentArtifact authority, workflow-file backing boundary, and WorkOrder/ServiceRun interoperability semantics.

## Impact

This adds and tightens ContentArtifact and ServiceRun attachment Protobuf/contracts, Actor behavior, Studio application/projection/query/HTTP surfaces, and projection-provider filtering. Per repository policy, interface changes require at least two reviewer approvals before merge.

## Verification

Fresh verification on final local head `7deac95ba`, rebased on `origin/feature/integrate@de3887669`:

- `dotnet restore aevatar.slnx --nologo` — exit 0
- `dotnet build aevatar.slnx --nologo --no-restore` — exit 0, 0 errors
- `dotnet test aevatar.slnx --nologo --no-restore` — exit 0, 0 failures; repository-configured external/distributed tests skipped
- ContentArtifact-focused Studio tests — 96/96 passed
- ContentArtifact service/projection/endpoint tests — 60/60 passed
- projection provider tests — 79/79 passed
- GAgentService ContentArtifact tests — 6/6 passed
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`
- `bash tools/ci/projection_state_version_guard.sh`
- `bash tools/ci/projection_state_mirror_current_state_guard.sh`
- `bash tools/ci/projection_route_mapping_guard.sh`
- `bash tools/ci/workflow_binding_boundary_guard.sh`
- `bash tools/docs/lint.sh` — 83 files, 0 errors
- `bash tools/ci/architecture_guards.sh`
- `git diff --check`

All listed guards and checks passed locally. PR CI must pass on the pushed head before merge.

⟦AI:FKST⟧
