### PR TITLE
Fence runtime callback cleanup by generation

### DIFF
--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs
@@ -168,6 +168,26 @@ public sealed class RuntimeCallbackSchedulerGrain : Grain, IRuntimeCallbackSched
         }
     }
 
+    internal static bool TryClearCompletedOneShotCallback(
+        RuntimeCallbackSchedulerState state,
+        string callbackId,
+        RuntimeScheduledCallback firedCallback)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(callbackId);
+        ArgumentNullException.ThrowIfNull(firedCallback);
+
+        if (!state.ReminderCallbacks.TryGetValue(callbackId, out var current) ||
+            current.Generation != firedCallback.Generation ||
+            current.SlotEpoch != firedCallback.SlotEpoch)
+        {
+            return false;
+        }
+
+        state.ReminderCallbacks.Remove(callbackId);
+        return true;
+    }
+
     private async Task FireCallbackAsync(
         string callbackId,
         DateTimeOffset observedAtUtc,
@@ -191,9 +211,11 @@ public sealed class RuntimeCallbackSchedulerGrain : Grain, IRuntimeCallbackSched
 
         if (!scheduled.Periodic)
         {
-            _state.State.ReminderCallbacks.Remove(callbackId);
-            await _state.WriteStateAsync();
-            await TryUnregisterReminderAsync(callbackId);
+            if (TryClearCompletedOneShotCallback(_state.State, callbackId, scheduled))
+            {
+                await _state.WriteStateAsync();
+                await TryUnregisterReminderAsync(callbackId);
+            }
             return;
         }
 

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerGrainRecoveryTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerGrainRecoveryTests.cs
@@ -23,6 +23,51 @@ namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 public sealed class RuntimeCallbackSchedulerGrainRecoveryTests
 {
     [Fact]
+    public void TryClearCompletedOneShotCallback_WhenCallbackWasRescheduled_ShouldKeepNewGeneration()
+    {
+        const string callbackId = "scheduled-dispatch-next-fire";
+        var firedCallback = CreateScheduledCallback(callbackId, generation: 7);
+        var state = new RuntimeCallbackSchedulerState
+        {
+            ReminderCallbacks =
+            {
+                [callbackId] = CreateScheduledCallback(callbackId, generation: 8),
+            },
+        };
+
+        var cleared = RuntimeCallbackSchedulerGrain.TryClearCompletedOneShotCallback(
+            state,
+            callbackId,
+            firedCallback);
+
+        cleared.Should().BeFalse();
+        state.ReminderCallbacks.Should().ContainKey(callbackId);
+        state.ReminderCallbacks[callbackId].Generation.Should().Be(8);
+    }
+
+    [Fact]
+    public void TryClearCompletedOneShotCallback_WhenCallbackStillCurrent_ShouldClearCallback()
+    {
+        const string callbackId = "scheduled-dispatch-next-fire";
+        var firedCallback = CreateScheduledCallback(callbackId, generation: 7);
+        var state = new RuntimeCallbackSchedulerState
+        {
+            ReminderCallbacks =
+            {
+                [callbackId] = firedCallback.Clone(),
+            },
+        };
+
+        var cleared = RuntimeCallbackSchedulerGrain.TryClearCompletedOneShotCallback(
+            state,
+            callbackId,
+            firedCallback);
+
+        cleared.Should().BeTrue();
+        state.ReminderCallbacks.Should().NotContainKey(callbackId);
+    }
+
+    [Fact]
     public async Task OnActivateAsync_WhenDurableTimeoutIsOverdue_ShouldPublishAndClearOneShotCallback()
     {
         const string actorId = "scheduled-recovery-actor";
@@ -100,6 +145,22 @@ public sealed class RuntimeCallbackSchedulerGrainRecoveryTests
                 });
             })
             .Build());
+
+    private static RuntimeScheduledCallback CreateScheduledCallback(string callbackId, long generation) => new()
+    {
+        ActorId = "scheduled-recovery-actor",
+        CallbackId = callbackId,
+        Generation = generation,
+        SlotEpoch = RuntimeCallbackSlotEpoch.OrleansSchedulerV2,
+        Periodic = false,
+        DueTimeMillis = 1000,
+        PeriodMillis = 0,
+        FireIndex = 0,
+        DeliveryMode = RuntimeCallbackScheduleDeliveryMode.FiredSelfEvent,
+        TriggerEnvelope = CreateEnvelope($"evt-{generation}"),
+        NextDueAtUnixTimeMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+        OverduePolicy = RuntimeCallbackOverduePolicy.Deliver,
+    };
 
     private static EventEnvelope CreateEnvelope(string id) => new()
     {


### PR DESCRIPTION
## Summary
- Fence completed one-shot runtime callback cleanup by generation and slot epoch.
- Preserve newer callback generations registered during recurring schedule rescheduling.
- Add regression coverage for stale-generation preservation and current-generation cleanup.

## Test plan
- [x] `dotnet test test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj --nologo --filter \"RuntimeCallbackSchedulerGrainRecoveryTests|OrleansActorRuntimeCallbackSchedulerTests|InMemoryActorRuntimeCallbackSchedulerTests\"`
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter ScheduledDispatchGAgentTests`
- [x] `PATH=\"/usr/bin:/bin:/usr/sbin:/sbin:$PATH\" bash tools/ci/test_stability_guards.sh`

## Review
- sshx architecture reviewer: approve
- sshx quality reviewer: approve
- sshx tests reviewer: approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)