### PR TITLE
fix: prevent IME Enter from submitting chat

### DIFF
--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+import { ChatInput } from './chatPresentation';
+
+function ChatInputHarness({ onSend }: { onSend: (value: string) => void }) {
+  const [value, setValue] = useState('');
+
+  return (
+    <ChatInput
+      disabled={false}
+      isStreaming={false}
+      onChange={setValue}
+      onSend={() => onSend(value)}
+      onStop={() => undefined}
+      placeholder="Chat prompt"
+      value={value}
+    />
+  );
+}
+
+describe('ChatInput', () => {
+  it('keeps composed text in the input when Enter confirms an IME candidate', () => {
+    const onSend = jest.fn();
+    render(<ChatInputHarness onSend={onSend} />);
+
+    const composer = screen.getByPlaceholderText('Chat prompt');
+
+    fireEvent.compositionStart(composer);
+    fireEvent.change(composer, { target: { value: 'workflow' } });
+    fireEvent.keyDown(composer, { code: 'Enter', key: 'Enter' });
+    fireEvent.compositionEnd(composer);
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composer).toHaveValue('workflow');
+
+    fireEvent.keyDown(composer, { code: 'Enter', key: 'Enter' });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenLastCalledWith('workflow');
+  });
+
+  it('ignores a legacy IME Enter reported after composition ends', () => {
+    const onSend = jest.fn();
+    render(<ChatInputHarness onSend={onSend} />);
+
+    const composer = screen.getByPlaceholderText('Chat prompt');
+    fireEvent.compositionStart(composer);
+    fireEvent.change(composer, { target: { value: 'workflow' } });
+    fireEvent.compositionEnd(composer);
+    fireEvent.keyDown(composer, {
+      code: 'Enter',
+      key: 'Enter',
+      keyCode: 229,
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composer).toHaveValue('workflow');
+  });
+
+  it('ignores Enter while the native keyboard event is composing', () => {
+    const onSend = jest.fn();
+    render(<ChatInputHarness onSend={onSend} />);
+
+    const composer = screen.getByPlaceholderText('Chat prompt');
+    fireEvent.change(composer, { target: { value: 'workflow' } });
+    fireEvent.keyDown(composer, {
+      code: 'Enter',
+      isComposing: true,
+      key: 'Enter',
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(composer).toHaveValue('workflow');
+
+    fireEvent.keyDown(composer, { code: 'Enter', key: 'Enter' });
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenLastCalledWith('workflow');
+  });
+
+  it('keeps Shift+Enter available for multiline input', () => {
+    const onSend = jest.fn();
+    render(<ChatInputHarness onSend={onSend} />);
+
+    const composer = screen.getByPlaceholderText('Chat prompt');
+    fireEvent.change(composer, { target: { value: 'workflow' } });
+
+    expect(
+      fireEvent.keyDown(composer, {
+        code: 'Enter',
+        key: 'Enter',
+        shiftKey: true,
+      }),
+    ).toBe(true);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
@@ -2069,6 +2069,8 @@ export function ConversationLlmConfigBar({
   );
 }
 
+const IME_PROCESSING_KEY_CODE = 229;
+
 export function ChatInput({
   disabled,
   footer,
@@ -2088,6 +2090,7 @@ export function ChatInput({
   onStop: () => void;
   value: string;
 }): React.ReactElement {
+  const isComposingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const resizeTextarea = useCallback(() => {
@@ -2136,8 +2139,22 @@ export function ChatInput({
               onChange(event.target.value);
               resizeTextarea();
             }}
+            onCompositionEnd={() => {
+              isComposingRef.current = false;
+            }}
+            onCompositionStart={() => {
+              isComposingRef.current = true;
+            }}
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.shiftKey) {
+                if (
+                  isComposingRef.current ||
+                  event.nativeEvent.isComposing ||
+                  event.nativeEvent.keyCode === IME_PROCESSING_KEY_CODE
+                ) {
+                  return;
+                }
+
                 event.preventDefault();
                 handleSend();
               }


### PR DESCRIPTION
## Problem

When a user types with a Chinese, Japanese, or Korean IME, pressing Enter to confirm the current candidate also triggered the Chat composer submit handler. The candidate text was sent immediately instead of remaining in the input.

## Solution

- Track the textarea composition lifecycle and ignore Enter while composition is active.
- Honor the native `KeyboardEvent.isComposing` flag.
- Handle the legacy/Safari IME processing key code `229`, including the event order where `compositionend` arrives before the terminating keydown.
- Preserve normal Enter-to-send and Shift+Enter multiline behavior.

## Impacted Paths

- `apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx`
- `apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx`

No backend, root configuration, dependency, or documentation files changed.

## Test Coverage

The regression suite covers:

- Enter during a `compositionStart -> keydown -> compositionEnd` sequence does not send.
- `compositionEnd -> keydown(keyCode=229)` does not send.
- `nativeEvent.isComposing=true` does not send.
- The next normal Enter sends exactly once with the committed `workflow` text.
- Shift+Enter remains available for multiline input.

## Verification

- [x] `CI=1 pnpm --dir apps/aevatar-console-web test:ui --runInBand --watch=false --runTestsByPath src/pages/chat/chatPresentation.test.tsx` (4/4 passed)
- [x] `pnpm --dir apps/aevatar-console-web tsc`
- [x] `pnpm --dir apps/aevatar-console-web build`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `git diff --check`
- [x] Biome check for the new test file

A prior full serial frontend run completed 128/130 suites and 1114/1116 tests. The two unrelated timeouts were `src/pages/gagents/index.test.tsx` and `src/pages/settings/index.test.tsx`; rerunning those suites independently passed 16/16 tests. The focused Chat regression suite, type check, and production build all pass in the dedicated worktree.

## Review

Testing, maintainability, performance, design-lite, and independent adversarial reviews were run. The only concrete coverage gap found, the native `isComposing` branch, was added before commit. No unresolved production finding remains.

## Documentation

No documentation update is required. The behavior change is captured by regression tests next to the Chat composer.