### PR TITLE
Fix chat history command contract

### DIFF
--- a/apps/aevatar-console-web/src/pages/chat/chatApi.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatApi.test.ts
@@ -88,10 +88,8 @@ describe("chatApi", () => {
 
     await startChatStream(
       {
-        conversation: {
-          conversationId: null,
-          createIdempotencyKey: " create-key-a ",
-        },
+        commandId: " create-command-a ",
+        conversation: { conversationId: null },
         prompt: "New conversation",
         sessionId: "runtime-session-a",
       },
@@ -109,7 +107,8 @@ describe("chatApi", () => {
     const firstBody = JSON.parse((authFetch as jest.Mock).mock.calls[0][1].body);
     const secondBody = JSON.parse((authFetch as jest.Mock).mock.calls[1][1].body);
     expect(firstBody).toEqual({
-      conversation: { createIdempotencyKey: "create-key-a" },
+      commandId: "create-command-a",
+      conversation: {},
       prompt: "New conversation",
       sessionId: "runtime-session-a",
       workflow: "studio",
@@ -122,14 +121,14 @@ describe("chatApi", () => {
     });
   });
 
-  it("rejects a create key on a continuation request", async () => {
+  it("rejects the stale nested create identity contract", async () => {
     await expect(
       startChatStream(
         {
           conversation: {
             conversationId: "conversation-a",
             createIdempotencyKey: "create-key-a",
-          },
+          } as never,
           prompt: "Continue",
           sessionId: "session-a",
         },

--- a/apps/aevatar-console-web/src/pages/chat/chatApi.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatApi.ts
@@ -16,10 +16,10 @@ const CHAT_HISTORY_CONTEXT_TYPE_URL =
 
 export type ChatConversationIntent = {
   conversationId?: string | null;
-  createIdempotencyKey?: string;
 };
 
 export type ChatStreamRequest = {
+  commandId?: string;
   prompt: string;
   conversation?: ChatConversationIntent;
   sessionId: string;
@@ -290,13 +290,9 @@ function normalizeConversationIntent(
   const record = asRecord(conversation);
   if (
     !record ||
-    Object.keys(record).some(
-      (key) => key !== "conversationId" && key !== "createIdempotencyKey"
-    ) ||
+    Object.keys(record).some((key) => key !== "conversationId") ||
     (record.conversationId != null &&
-      typeof record.conversationId !== "string") ||
-    (record.createIdempotencyKey != null &&
-      typeof record.createIdempotencyKey !== "string")
+      typeof record.conversationId !== "string")
   ) {
     throw new ChatApiError(
       "Conversation input is invalid.",
@@ -317,26 +313,7 @@ function normalizeConversationIntent(
     );
   }
 
-  const createIdempotencyKey =
-    typeof record.createIdempotencyKey === "string"
-      ? record.createIdempotencyKey.trim()
-      : undefined;
-  if (record.createIdempotencyKey != null && !createIdempotencyKey) {
-    throw new ChatApiError(
-      "Create idempotency key is invalid.",
-      400,
-      "INVALID_CONVERSATION_INPUT"
-    );
-  }
-  if (conversationId && createIdempotencyKey) {
-    throw new ChatApiError(
-      "Conversation input is invalid.",
-      400,
-      "INVALID_CONVERSATION_INPUT"
-    );
-  }
-
-  return compactObject({ conversationId, createIdempotencyKey });
+  return compactObject({ conversationId });
 }
 
 export async function startChatStream(
@@ -346,6 +323,7 @@ export async function startChatStream(
   const response = await authFetch("/api/chat", {
     body: JSON.stringify(
       compactObject({
+        commandId: request.commandId?.trim() || undefined,
         conversation: normalizeConversationIntent(request.conversation),
         prompt: request.prompt.trim(),
         sessionId: request.sessionId.trim(),

--- a/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts
@@ -116,7 +116,7 @@ describe("chatHistoryApi", () => {
     (authFetch as jest.Mock).mockResolvedValue(
       jsonResponse({
         conversationId: "conversation-a",
-        sourceVersion: 3,
+        stateVersion: 3,
         status: "append_committed",
         turnId: "turn-a",
       })
@@ -126,12 +126,12 @@ describe("chatHistoryApi", () => {
       chatHistoryApi.recoverCreate("scope/a", "create/key")
     ).resolves.toEqual({
       conversationId: "conversation-a",
-      sourceVersion: 3,
+      stateVersion: 3,
       status: "append_committed",
       turnId: "turn-a",
     });
     expect(authFetch).toHaveBeenCalledWith(
-      "/api/scopes/scope%2Fa/chat-history/create-recoveries/create%2Fkey",
+      "/api/scopes/scope%2Fa/chat-history/create-recovery/create%2Fkey",
       {
         headers: { Accept: "application/json" },
         method: "GET",
@@ -140,7 +140,7 @@ describe("chatHistoryApi", () => {
     expect(() =>
       decodeChatCreateRecovery({
         conversationId: "conversation-a",
-        sourceVersion: -1,
+        stateVersion: -1,
         status: "reserved",
         turnId: "turn-a",
       })

--- a/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts
@@ -191,14 +191,14 @@ export function decodeChatHistoryIndex(value: unknown): ChatHistoryIndex {
 
 export function decodeChatCreateRecovery(value: unknown): ChatCreateRecovery {
   const record = asRecord(value, "$recovery");
-  const sourceVersion = readNumber(record, "sourceVersion", "$recovery");
-  if (!Number.isInteger(sourceVersion) || sourceVersion < 0) {
-    return failContract("$recovery.sourceVersion", "a non-negative integer");
+  const stateVersion = readNumber(record, "stateVersion", "$recovery");
+  if (!Number.isInteger(stateVersion) || stateVersion < 0) {
+    return failContract("$recovery.stateVersion", "a non-negative integer");
   }
 
   return {
     conversationId: readString(record, "conversationId", "$recovery"),
-    sourceVersion,
+    stateVersion,
     status: readString(record, "status", "$recovery"),
     turnId: readString(record, "turnId", "$recovery"),
   };
@@ -230,10 +230,10 @@ function buildConversationPath(scopeId: string, conversationId: string): string 
 
 function buildCreateRecoveryPath(
   scopeId: string,
-  createIdempotencyKey: string
+  commandId: string
 ): string {
-  return `${buildHistoryPath(scopeId)}/create-recoveries/${encodeSegment(
-    createIdempotencyKey
+  return `${buildHistoryPath(scopeId)}/create-recovery/${encodeSegment(
+    commandId
   )}`;
 }
 
@@ -297,10 +297,10 @@ export const chatHistoryApi = {
 
   async recoverCreate(
     scopeId: string,
-    createIdempotencyKey: string
+    commandId: string
   ): Promise<ChatCreateRecovery> {
     return requestJson(
-      buildCreateRecoveryPath(scopeId, createIdempotencyKey),
+      buildCreateRecoveryPath(scopeId, commandId),
       decodeChatCreateRecovery
     );
   },

--- a/apps/aevatar-console-web/src/pages/chat/chatTypes.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatTypes.ts
@@ -149,7 +149,7 @@ export type ChatHistoryIndex = {
 
 export type ChatCreateRecovery = {
   conversationId: string;
-  sourceVersion: number;
+  stateVersion: number;
   status: string;
   turnId: string;
 };

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -258,7 +258,7 @@ describe("ChatPage server-backed history", () => {
     );
     (chatHistoryApi.recoverCreate as jest.Mock).mockResolvedValue({
       conversationId: "recovered-conversation",
-      sourceVersion: 2,
+      stateVersion: 2,
       status: "append_committed",
       turnId: "recovered-turn",
     });
@@ -268,17 +268,13 @@ describe("ChatPage server-backed history", () => {
 
     expect(await screen.findByText("Recovered response")).toBeTruthy();
     const [body] = chatRequestBodies();
-    expect(body.conversation).toEqual({
-      createIdempotencyKey: expect.any(String),
-    });
-    const createIdempotencyKey = String(
-      (body.conversation as { createIdempotencyKey: unknown })
-        .createIdempotencyKey
-    );
+    expect(body.conversation).toEqual({});
+    expect(body.commandId).toEqual(expect.any(String));
+    const createCommandId = String(body.commandId);
     await waitFor(() =>
       expect(chatHistoryApi.recoverCreate).toHaveBeenCalledWith(
         "scope-a",
-        createIdempotencyKey
+        createCommandId
       )
     );
     expect(
@@ -486,7 +482,8 @@ describe("ChatPage server-backed history", () => {
     ).toBeTruthy();
     const [body] = chatRequestBodies();
     expect(body).toEqual({
-      conversation: { createIdempotencyKey: expect.any(String) },
+      commandId: expect.any(String),
+      conversation: {},
       prompt: "Create a support team",
       sessionId: expect.any(String),
       workflow: "studio",
@@ -516,6 +513,38 @@ describe("ChatPage server-backed history", () => {
     ).toBeTruthy();
   });
 
+  it("keeps a create command id for the same prompt and replaces it for new input", async () => {
+    (authFetch as jest.Mock).mockResolvedValue(
+      createSseResponse([
+        { runFinished: { result: { output: "Unbound response" } } },
+      ])
+    );
+    (chatHistoryApi.recoverCreate as jest.Mock).mockRejectedValue(
+      new Error("Recovery failed.")
+    );
+
+    renderWithQueryClient(<ChatPage />);
+    await sendPrompt("Original create request");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument()
+    );
+
+    await sendPrompt("Original create request");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2));
+    const [firstBody, retryBody] = chatRequestBodies();
+    expect(retryBody.commandId).toBe(firstBody.commandId);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument(),
+      { timeout: 5_000 }
+    );
+    await sendPrompt("Changed create request");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(3));
+    const changedBody = chatRequestBodies()[2];
+    expect(changedBody.commandId).toEqual(expect.any(String));
+    expect(changedBody.commandId).not.toBe(firstBody.commandId);
+  });
+
   it("binds the server conversation id and reuses the independent session id", async () => {
     (authFetch as jest.Mock)
       .mockResolvedValueOnce(
@@ -538,15 +567,39 @@ describe("ChatPage server-backed history", () => {
     await screen.findByText("Second answer");
 
     const [firstBody, secondBody] = chatRequestBodies();
-    expect(firstBody.conversation).toEqual({
-      createIdempotencyKey: expect.any(String),
-    });
+    expect(firstBody.commandId).toEqual(expect.any(String));
+    expect(firstBody.conversation).toEqual({});
     expect(secondBody.conversation).toEqual({
       conversationId: "server-conversation",
     });
+    expect(secondBody).not.toHaveProperty("commandId");
     expect(secondBody.sessionId).toBe(firstBody.sessionId);
     expect(secondBody.prompt).toBe("Second prompt");
     expect(String(secondBody.prompt)).not.toContain("<conversation_history>");
+  });
+
+  it("does not use create recovery for a continuation without context", async () => {
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      serverConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(serverMessages);
+    (authFetch as jest.Mock).mockResolvedValue(
+      createSseResponse([
+        { runFinished: { result: { output: "Unbound follow-up" } } },
+      ])
+    );
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Continue without context");
+
+    expect(
+      await screen.findByText("Chat completed without a conversation context.")
+    ).toBeTruthy();
+    expect(chatHistoryApi.recoverCreate).not.toHaveBeenCalled();
   });
 
   it("rejects a later Chat History context from a different scope", async () => {
@@ -950,6 +1003,7 @@ describe("ChatPage server-backed history", () => {
       conversation: { conversationId: "conversation-a" },
       prompt: "Add retry handling",
     });
+    expect(body).not.toHaveProperty("commandId");
     expect(String(body.prompt)).not.toContain("Create a support workflow");
   });
 

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -66,7 +66,8 @@ import { t } from "@/shared/i18n/messages";
 type ConversationState = {
   clientId: string;
   conversationId?: string;
-  createIdempotencyKey?: string;
+  createCommandId?: string;
+  createRequestPrompt?: string;
   expectedTurnCount: number;
   latestTurnId?: string;
   messages: ChatMessage[];
@@ -122,7 +123,7 @@ function createClientId(): string {
 function createDraftConversation(): ConversationState {
   return {
     clientId: createClientId(),
-    createIdempotencyKey: createClientId(),
+    createCommandId: createClientId(),
     expectedTurnCount: 0,
     messages: [],
     sessionId: createClientId(),
@@ -1104,8 +1105,18 @@ const ChatPage: React.FC = () => {
           : conversation.title;
       const nextStatus: LocalChatStatus =
         conversation.status === "needs_confirmation" ? "creating" : "streaming";
+      const createCommandId = conversation.conversationId
+        ? undefined
+        : !conversation.createRequestPrompt ||
+            conversation.createRequestPrompt === trimmedInput
+          ? conversation.createCommandId ?? conversation.clientId
+          : createClientId();
       const startedConversation: ConversationState = {
         ...conversation,
+        createCommandId,
+        createRequestPrompt: conversation.conversationId
+          ? undefined
+          : trimmedInput,
         messages: [...conversation.messages, userMessage, assistantMessage],
         status: nextStatus,
         title,
@@ -1117,8 +1128,6 @@ const ChatPage: React.FC = () => {
         typeof extractChatHistoryContext
       > = null;
       let streamingConversation = startedConversation;
-      const createIdempotencyKey =
-        conversation.createIdempotencyKey ?? conversation.clientId;
 
       abortControllerRef.current?.abort();
       if (conversation.conversationId) {
@@ -1141,9 +1150,10 @@ const ChatPage: React.FC = () => {
       try {
         const response = await startChatStreamWithProjectionRetry(
           {
+            commandId: createCommandId,
             conversation: conversation.conversationId
               ? { conversationId: conversation.conversationId }
-              : { createIdempotencyKey },
+              : {},
             prompt: trimmedInput,
             sessionId: conversation.sessionId,
           },
@@ -1241,7 +1251,7 @@ const ChatPage: React.FC = () => {
         if (scopeEpochRef.current !== runScopeEpoch) {
           return;
         }
-        if (!receivedChatHistoryContext) {
+        if (!receivedChatHistoryContext && createCommandId) {
           let recovery: Awaited<ReturnType<typeof chatHistoryApi.recoverCreate>> | null =
             null;
           for (const delayMs of [0, 300, 900, 1_800]) {
@@ -1249,7 +1259,7 @@ const ChatPage: React.FC = () => {
             try {
               recovery = await chatHistoryApi.recoverCreate(
                 scopeId,
-                createIdempotencyKey
+                createCommandId
               );
               break;
             } catch (error) {
@@ -1261,31 +1271,28 @@ const ChatPage: React.FC = () => {
               }
             }
           }
-          if (!recovery) {
-            throw new Error(
-              t(
-                "pages.chat.index.missingChatHistoryContext",
-                "Chat completed without a conversation context."
-              )
+          if (recovery) {
+            receivedChatHistoryContext = true;
+            streamingConversation = {
+              ...streamingConversation,
+              conversationId: recovery.conversationId,
+              expectedTurnCount: conversation.expectedTurnCount + 1,
+              latestTurnId: recovery.turnId,
+            };
+            activeConversationRef.current = streamingConversation;
+            setActiveConversation((current) =>
+              current?.clientId === conversation.clientId
+                ? streamingConversation
+                : current
             );
           }
-          acceptedChatHistoryContext = {
-            conversationId: recovery.conversationId,
-            scopeId,
-            turnId: recovery.turnId,
-          };
-          receivedChatHistoryContext = true;
-          streamingConversation = {
-            ...streamingConversation,
-            conversationId: recovery.conversationId,
-            expectedTurnCount: conversation.expectedTurnCount + 1,
-            latestTurnId: recovery.turnId,
-          };
-          activeConversationRef.current = streamingConversation;
-          setActiveConversation((current) =>
-            current?.clientId === conversation.clientId
-              ? streamingConversation
-              : current
+        }
+        if (!receivedChatHistoryContext) {
+          throw new Error(
+            t(
+              "pages.chat.index.missingChatHistoryContext",
+              "Chat completed without a conversation context."
+            )
           );
         }
 


### PR DESCRIPTION
## Problem

The console Chat History client was still using the obsolete frontend contract: create identity was nested as `conversation.createIdempotencyKey`, create recovery used the plural route, and recovery parsed `sourceVersion`. The backend contract on `origin/feature/integrate` expects a top-level `commandId`, `conversation: {}` for creation, the singular recovery route, and `stateVersion`.

A failed create could also retain its command ID when the user changed the prompt. Because the backend fingerprints the full create request, that reuse could produce `409 IDEMPOTENCY_CONFLICT`.

## Solution

- Send new chats with a top-level `commandId` and `conversation: {}`.
- Send continuations with only `conversation.conversationId` and no create command ID.
- Use `/api/chat-history/scopes/{scopeId}/create-recovery/{commandId}` and parse `stateVersion`.
- Reuse a create command ID only when retrying the same normalized prompt; generate a new ID when the create input changes.
- Add exact request, recovery, continuation, missing-context, and retry identity regression coverage.

## Impact

Only the following frontend Chat files changed:

- `apps/aevatar-console-web/src/pages/chat/chatApi.ts`
- `apps/aevatar-console-web/src/pages/chat/chatApi.test.ts`
- `apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts`
- `apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts`
- `apps/aevatar-console-web/src/pages/chat/chatTypes.ts`
- `apps/aevatar-console-web/src/pages/chat/index.tsx`
- `apps/aevatar-console-web/src/pages/chat/index.test.tsx`

No backend, root configuration, version, changelog, or documentation files changed.

## Verification

- `CI=1 pnpm --dir apps/aevatar-console-web test src/pages/chat --runInBand --watchman=false --forceExit`: 6 suites passed, 61 tests passed.
- `pnpm --dir apps/aevatar-console-web tsc`: passed.
- `pnpm --dir apps/aevatar-console-web build`: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `git diff --check`: passed.

A full frontend Jest run was also attempted. It did not complete cleanly because unrelated existing Workflow Studio tests timed out or failed to initialize `graph-canvas`; none of those files are touched by this PR. The complete affected Chat test scope passes as reported above.
