### PR TITLE
fix(console): render Chat Markdown tables

### DIFF
--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
@@ -221,16 +221,17 @@ Run the command from Step 2.
 
 Expected: PASS with 5 tests in `chatContent.test.ts`.
 
-- [ ] **Step 5: Commit the parser behavior**
+- [ ] **Step 5: Inspect the parser diff and keep it uncommitted**
 
 ```bash
-git add \
+git diff --check -- \
   apps/aevatar-console-web/src/pages/chat/chatContent.ts \
   apps/aevatar-console-web/src/pages/chat/chatContent.test.ts
-git -c user.name=AbigailDeng \
-  -c user.email=108705114+AbigailDeng@users.noreply.github.com \
-  commit -m "Parse Chat Markdown tables"
 ```
+
+Expected: no whitespace errors. Keep this change uncommitted because the new
+union member requires the Chat, Studio, and Explorer consumers to be updated
+before the source commit can pass `tsc`.
 
 ### Task 2: Render Responsive Semantic Tables In Chat
 
@@ -391,16 +392,16 @@ Run the command from Step 2.
 
 Expected: PASS with 5 tests in `chatPresentation.test.tsx`.
 
-- [ ] **Step 5: Commit the Chat renderer**
+- [ ] **Step 5: Inspect the Chat renderer diff and keep it uncommitted**
 
 ```bash
-git add \
+git diff --check -- \
   apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx \
   apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx
-git -c user.name=AbigailDeng \
-  -c user.email=108705114+AbigailDeng@users.noreply.github.com \
-  commit -m "Render responsive Chat Markdown tables"
 ```
+
+Expected: no whitespace errors. Keep this change with Task 1 until all shared
+parser consumers compile.
 
 ### Task 3: Keep Shared Parser Consumers Exhaustive
 
@@ -560,15 +561,19 @@ pnpm --dir apps/aevatar-console-web exec jest \
 
 Expected: TypeScript passes; 2 test suites and 10 tests pass.
 
-- [ ] **Step 5: Commit shared-consumer alignment**
+- [ ] **Step 5: Commit the complete buildable implementation**
 
 ```bash
 git add \
+  apps/aevatar-console-web/src/pages/chat/chatContent.ts \
+  apps/aevatar-console-web/src/pages/chat/chatContent.test.ts \
+  apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx \
+  apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx \
   apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx \
   apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx
 git -c user.name=AbigailDeng \
   -c user.email=108705114+AbigailDeng@users.noreply.github.com \
-  commit -m "Align Markdown table consumers"
+  commit -m "Render Chat Markdown tables"
 ```
 
 ### Task 4: Verify The Complete Frontend Change

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
@@ -16,7 +16,7 @@
 - Modify: `apps/aevatar-console-web/src/pages/chat/chatContent.test.ts`
 - Modify: `apps/aevatar-console-web/src/pages/chat/chatContent.ts`
 
-- [ ] **Step 1: Write the failing parser test**
+- [x] **Step 1: Write the failing parser test**
 
 Append this test inside `describe("chatContent", ...)`:
 
@@ -60,7 +60,7 @@ it("keeps malformed table syntax as paragraph content", () => {
 });
 ```
 
-- [ ] **Step 2: Run the parser test and verify RED**
+- [x] **Step 2: Run the parser test and verify RED**
 
 Run:
 
@@ -73,7 +73,7 @@ pnpm --dir apps/aevatar-console-web exec jest \
 
 Expected: FAIL because the actual value is a `paragraph` block containing raw table lines.
 
-- [ ] **Step 3: Add the typed table contract and scanner**
+- [x] **Step 3: Add the typed table contract and scanner**
 
 Add these exported types and the union member near `MarkdownBlock`:
 
@@ -172,13 +172,12 @@ function parseMarkdownTableAlignments(
 
   const alignments: MarkdownTableAlignment[] = [];
   for (const cell of cells) {
-    const delimiter = cell.replace(/\s+/g, "");
-    if (!MARKDOWN_TABLE_DELIMITER_CELL_PATTERN.test(delimiter)) {
+    if (!MARKDOWN_TABLE_DELIMITER_CELL_PATTERN.test(cell)) {
       return null;
     }
 
-    const left = delimiter.startsWith(":");
-    const right = delimiter.endsWith(":");
+    const left = cell.startsWith(":");
+    const right = cell.endsWith(":");
     alignments.push(left && right ? "center" : right ? "right" : left ? "left" : null);
   }
 
@@ -215,13 +214,14 @@ if (headers && alignments && headers.length === alignments.length) {
 }
 ```
 
-- [ ] **Step 4: Run the parser test and verify GREEN**
+- [x] **Step 4: Run the parser test and verify GREEN**
 
 Run the command from Step 2.
 
-Expected: PASS with 5 tests in `chatContent.test.ts`.
+Actual: PASS with 6 tests in `chatContent.test.ts`, including the review-driven
+internal-whitespace delimiter regression.
 
-- [ ] **Step 5: Inspect the parser diff and keep it uncommitted**
+- [x] **Step 5: Inspect the parser diff and keep it uncommitted**
 
 ```bash
 git diff --check -- \
@@ -239,7 +239,7 @@ before the source commit can pass `tsc`.
 - Modify: `apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx`
 - Modify: `apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx`
 
-- [ ] **Step 1: Write the failing Chat presentation test**
+- [x] **Step 1: Write the failing Chat presentation test**
 
 Change imports to include `within`, `ChatMessageBubble`, and `ChatMessage`, then append:
 
@@ -276,7 +276,7 @@ it('renders GFM tables with accessible headers and responsive containment', () =
 });
 ```
 
-- [ ] **Step 2: Run the presentation test and verify RED**
+- [x] **Step 2: Run the presentation test and verify RED**
 
 Run:
 
@@ -289,7 +289,7 @@ pnpm --dir apps/aevatar-console-web exec jest \
 
 Expected: FAIL because no accessible `region` or `table` exists.
 
-- [ ] **Step 3: Add stable table styles and render the typed block**
+- [x] **Step 3: Add stable table styles and render the typed block**
 
 Add module-level `React.CSSProperties` constants near the Markdown renderer:
 
@@ -386,13 +386,13 @@ case "table":
   );
 ```
 
-- [ ] **Step 4: Run the presentation test and verify GREEN**
+- [x] **Step 4: Run the presentation test and verify GREEN**
 
 Run the command from Step 2.
 
 Expected: PASS with 5 tests in `chatPresentation.test.tsx`.
 
-- [ ] **Step 5: Inspect the Chat renderer diff and keep it uncommitted**
+- [x] **Step 5: Inspect the Chat renderer diff and keep it uncommitted**
 
 ```bash
 git diff --check -- \
@@ -409,7 +409,7 @@ parser consumers compile.
 - Modify: `apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx`
 - Modify: `apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx`
 
-- [ ] **Step 1: Run TypeScript and verify the typed-contract failures**
+- [x] **Step 1: Run TypeScript and verify the typed-contract failures**
 
 Run:
 
@@ -419,7 +419,7 @@ pnpm --dir apps/aevatar-console-web tsc
 
 Expected: FAIL where Studio and Explorer default branches read `block.lines` from the new table member.
 
-- [ ] **Step 2: Convert Studio's workaround to the typed table block**
+- [x] **Step 2: Convert Studio's workaround to the typed table block**
 
 Add `case 'table': return renderMarkdownTable(block, index);` before the code case. Delete `splitMarkdownTableRow` and `isMarkdownTableSeparator`. Change the existing table renderer to:
 
@@ -483,7 +483,7 @@ return (
 );
 ```
 
-- [ ] **Step 3: Add an explicit Explorer table case**
+- [x] **Step 3: Add an explicit Explorer table case**
 
 Before Explorer's code case, render the typed block directly:
 
@@ -545,7 +545,7 @@ case "table":
   );
 ```
 
-- [ ] **Step 4: Run TypeScript and focused Chat tests**
+- [x] **Step 4: Run TypeScript and focused Chat tests**
 
 Run:
 
@@ -559,9 +559,9 @@ pnpm --dir apps/aevatar-console-web exec jest \
   --runInBand
 ```
 
-Expected: TypeScript passes; 2 test suites and 10 tests pass.
+Actual: TypeScript passes; 2 test suites and 11 tests pass.
 
-- [ ] **Step 5: Commit the complete buildable implementation**
+- [x] **Step 5: Commit the complete buildable implementation**
 
 ```bash
 git add \
@@ -581,13 +581,13 @@ git -c user.name=AbigailDeng \
 **Files:**
 - Inspect: all files changed from `origin/dev`
 
-- [ ] **Step 1: Run focused regression tests**
+- [x] **Step 1: Run focused regression tests**
 
 Run the exact Jest command from Task 3 Step 4.
 
-Expected: 2 suites and 10 tests pass with no warnings caused by this change.
+Actual: 2 suites and 11 tests pass with no warnings caused by this change.
 
-- [ ] **Step 2: Run mandatory frontend validation**
+- [x] **Step 2: Run mandatory frontend validation**
 
 Run each command independently:
 
@@ -598,9 +598,11 @@ pnpm --dir apps/aevatar-console-web build
 bash tools/ci/test_stability_guards.sh
 ```
 
-Expected: all commands exit 0. Record any unrelated baseline failure before deciding whether it blocks delivery.
+Actual: TypeScript, test stability, production build, and the second full UI
+run all exited 0. The first UI run exposed the missing catalog entry; after the
+catalog fix, 114 suites and 1028 tests passed.
 
-- [ ] **Step 3: Run diff and architecture checks**
+- [x] **Step 3: Run diff and architecture checks**
 
 ```bash
 git diff --check origin/dev...HEAD
@@ -610,7 +612,7 @@ git status --short
 
 Expected: no whitespace errors, no changes outside `apps/aevatar-console-web/**`, and a clean worktree.
 
-- [ ] **Step 4: Validate desktop and mobile containment locally**
+- [x] **Step 4: Validate desktop and mobile containment locally**
 
 Start the frontend on an allowed port:
 
@@ -620,7 +622,11 @@ pnpm --dir apps/aevatar-console-web start:dev --port 5173
 
 Open the local Chat route in the in-app browser at desktop and mobile widths. Verify the table is nonblank, headers and cells align, the message width does not expand, horizontal scrolling is available when required, inline code remains legible, and no adjacent content overlaps. If authentication or backend state prevents a table-bearing Chat message, document that limitation and use the DOM-focused Jest evidence as the authoritative rendering verification.
 
-- [ ] **Step 5: Commit any verification-only corrections**
+Actual: the local route was blocked by the NyxID configuration gate before Chat
+rendered. The DOM-focused Jest test is the authoritative responsive/semantic
+evidence for this environment.
+
+- [x] **Step 5: Commit any verification-only corrections**
 
 If verification required a source correction, repeat its focused red-green test and commit only the verified correction with an imperative message. If no correction was needed, do not create an empty commit.
 
@@ -669,6 +675,8 @@ Chat treated valid GFM table source as paragraph text because the custom typed M
 ## Impacted paths
 
 - `apps/aevatar-console-web/src/pages/chat/**`
+- `apps/aevatar-console-web/src/locales/projectMessages.en-US.ts`
+- `apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts`
 - `apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx`
 - `apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx`
 - `apps/aevatar-console-web/docs/superpowers/**`

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
@@ -635,7 +635,7 @@ If verification required a source correction, repeat its focused red-green test 
 **Files:**
 - No additional repository files.
 
-- [ ] **Step 1: Confirm AbigailDeng authentication and branch state**
+- [x] **Step 1: Confirm AbigailDeng authentication and branch state**
 
 ```bash
 gh auth status
@@ -645,7 +645,9 @@ git status --short
 
 Expected: `AbigailDeng` is active, branch is `fix/2026-07-22_chat-markdown-tables`, and status is clean.
 
-- [ ] **Step 2: Apply FKST issue labels**
+Actual: all three conditions were confirmed before the GitHub writes.
+
+- [x] **Step 2: Apply FKST issue labels**
 
 ```bash
 gh issue edit 2885 --repo aevatarAI/aevatar \
@@ -655,7 +657,9 @@ gh issue edit 2885 --repo aevatarAI/aevatar \
 
 Expected: issue #2885 has both FKST labels.
 
-- [ ] **Step 3: Push the issue branch**
+Actual: issue #2885 has `fkst-dev:enabled` and `fkst-class:standard`.
+
+- [x] **Step 3: Push the issue branch**
 
 ```bash
 git push --set-upstream origin fix/2026-07-22_chat-markdown-tables
@@ -663,7 +667,10 @@ git push --set-upstream origin fix/2026-07-22_chat-markdown-tables
 
 Expected: the branch is published under the AbigailDeng GitHub credentials.
 
-- [ ] **Step 4: Open a ready PR against dev**
+Actual: `origin/fix/2026-07-22_chat-markdown-tables` was created by the active
+AbigailDeng credentials.
+
+- [x] **Step 4: Open a ready PR against dev**
 
 Create `/tmp/aevatar-pr-2885.md` with `apply_patch` using this exact body:
 
@@ -709,7 +716,10 @@ gh pr create \
 
 Expected: a non-draft PR URL.
 
-- [ ] **Step 5: Enable squash auto-merge as explicitly authorized**
+Actual: https://github.com/aevatarAI/aevatar/pull/2919 is open and ready against
+`dev`.
+
+- [x] **Step 5: Enable squash auto-merge as explicitly authorized**
 
 ```bash
 PR_NUMBER=$(gh pr view --repo aevatarAI/aevatar --json number --jq .number)
@@ -718,6 +728,9 @@ gh pr merge "$PR_NUMBER" --repo aevatarAI/aevatar --auto --squash
 
 Expected: GitHub reports auto-merge enabled, or reports that branch protection already permits an immediate merge. Do not bypass required checks or administrator protections.
 
-- [ ] **Step 6: Report final state**
+Actual: GitHub records an enabled squash auto-merge request by AbigailDeng;
+required CI checks continue normally.
+
+- [x] **Step 6: Report final state**
 
 Record the issue URL, PR URL and number, commit list, all verification results, and auto-merge status. Keep the local development server running and provide its URL when the route remains usable for the user.

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md
@@ -1,0 +1,710 @@
+# Chat Markdown Tables Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render valid GFM tables in Chat as accessible, responsive HTML tables while keeping the repository's existing typed Markdown pipeline authoritative.
+
+**Architecture:** Extend `parseMarkdownBlocks` with a typed table block and a row scanner that distinguishes structural pipes from escaped and code-span pipes. Render that block explicitly in Chat, Studio run output, and Explorer so every existing consumer honors the shared parser contract without a second Markdown implementation or a new dependency.
+
+**Tech Stack:** React 19, TypeScript, Jest 29, Testing Library, pnpm, Ant Design/Umi frontend.
+
+---
+
+### Task 1: Parse GFM Tables Into A Typed Block
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/chat/chatContent.test.ts`
+- Modify: `apps/aevatar-console-web/src/pages/chat/chatContent.ts`
+
+- [ ] **Step 1: Write the failing parser test**
+
+Append this test inside `describe("chatContent", ...)`:
+
+```typescript
+it("parses GFM tables without splitting escaped or code-span pipes", () => {
+  expect(
+    parseMarkdownBlocks(`| Name | \`member|id\` | Workflow |
+| :--- | :---: | ---: |
+| Observatory \\| beta | \`m-alpha\` | \`wf-alpha-with-a-long-identifier\` |`),
+  ).toEqual([
+    {
+      kind: "table",
+      headers: ["Name", "`member|id`", "Workflow"],
+      alignments: ["left", "center", "right"],
+      rows: [
+        [
+          "Observatory | beta",
+          "`m-alpha`",
+          "`wf-alpha-with-a-long-identifier`",
+        ],
+      ],
+    },
+  ]);
+});
+
+it("keeps malformed table syntax as paragraph content", () => {
+  expect(
+    parseMarkdownBlocks(`| Name | Member | Workflow |
+| --- | --- |
+| Observatory | m-alpha | wf-alpha |`),
+  ).toEqual([
+    {
+      kind: "paragraph",
+      lines: [
+        "| Name | Member | Workflow |",
+        "| --- | --- |",
+        "| Observatory | m-alpha | wf-alpha |",
+      ],
+    },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the parser test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest \
+  --selectProjects jsdom \
+  --runTestsByPath src/pages/chat/chatContent.test.ts \
+  --runInBand
+```
+
+Expected: FAIL because the actual value is a `paragraph` block containing raw table lines.
+
+- [ ] **Step 3: Add the typed table contract and scanner**
+
+Add these exported types and the union member near `MarkdownBlock`:
+
+```typescript
+export type MarkdownTableAlignment = "left" | "center" | "right" | null;
+
+export type MarkdownTableBlock = {
+  kind: "table";
+  headers: string[];
+  alignments: MarkdownTableAlignment[];
+  rows: string[][];
+};
+
+export type MarkdownBlock =
+  | { kind: "paragraph"; lines: string[] }
+  | { kind: "heading"; level: number; text: string }
+  | { kind: "blockquote"; lines: string[] }
+  | { kind: "unordered-list"; items: string[] }
+  | { kind: "ordered-list"; items: string[] }
+  | { kind: "code"; lang: string; code: string }
+  | { kind: "thematic-break" }
+  | MarkdownTableBlock;
+```
+
+Add these parser helpers above `parseMarkdownBlocks`:
+
+```typescript
+const MARKDOWN_TABLE_DELIMITER_CELL_PATTERN = /^:?-{3,}:?$/;
+
+function splitMarkdownTableRow(line: string): string[] | null {
+  const source = line.trim();
+  const cells: string[] = [];
+  let cell = "";
+  let codeFenceLength = 0;
+  let structuralPipeCount = 0;
+  let lastStructuralPipeIndex = -1;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+
+    if (character === "\\" && source[index + 1] === "|") {
+      cell += "|";
+      index += 1;
+      continue;
+    }
+
+    if (character === "`") {
+      let runLength = 1;
+      while (source[index + runLength] === "`") {
+        runLength += 1;
+      }
+
+      cell += "`".repeat(runLength);
+      if (codeFenceLength === 0) {
+        codeFenceLength = runLength;
+      } else if (codeFenceLength === runLength) {
+        codeFenceLength = 0;
+      }
+      index += runLength - 1;
+      continue;
+    }
+
+    if (character === "|" && codeFenceLength === 0) {
+      structuralPipeCount += 1;
+      lastStructuralPipeIndex = index;
+      cells.push(cell.trim());
+      cell = "";
+      continue;
+    }
+
+    cell += character;
+  }
+
+  if (structuralPipeCount === 0) {
+    return null;
+  }
+
+  cells.push(cell.trim());
+  if (source.startsWith("|")) {
+    cells.shift();
+  }
+  if (lastStructuralPipeIndex === source.length - 1) {
+    cells.pop();
+  }
+
+  return cells;
+}
+
+function parseMarkdownTableAlignments(
+  line: string,
+): MarkdownTableAlignment[] | null {
+  const cells = splitMarkdownTableRow(line);
+  if (!cells || cells.length === 0) {
+    return null;
+  }
+
+  const alignments: MarkdownTableAlignment[] = [];
+  for (const cell of cells) {
+    const delimiter = cell.replace(/\s+/g, "");
+    if (!MARKDOWN_TABLE_DELIMITER_CELL_PATTERN.test(delimiter)) {
+      return null;
+    }
+
+    const left = delimiter.startsWith(":");
+    const right = delimiter.endsWith(":");
+    alignments.push(left && right ? "center" : right ? "right" : left ? "left" : null);
+  }
+
+  return alignments;
+}
+```
+
+After code-fence parsing and before heading parsing in `parseMarkdownBlocks`, add:
+
+```typescript
+const alignments =
+  index + 1 < lines.length
+    ? parseMarkdownTableAlignments(lines[index + 1])
+    : null;
+const headers = alignments ? splitMarkdownTableRow(line) : null;
+if (headers && alignments && headers.length === alignments.length) {
+  flushParagraph();
+  const rows: string[][] = [];
+  let cursor = index + 2;
+
+  while (cursor < lines.length) {
+    const cells = splitMarkdownTableRow(lines[cursor]);
+    if (!cells) {
+      break;
+    }
+
+    rows.push(headers.map((_, cellIndex) => cells[cellIndex] ?? ""));
+    cursor += 1;
+  }
+
+  blocks.push({ kind: "table", headers, alignments, rows });
+  index = cursor - 1;
+  continue;
+}
+```
+
+- [ ] **Step 4: Run the parser test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS with 5 tests in `chatContent.test.ts`.
+
+- [ ] **Step 5: Commit the parser behavior**
+
+```bash
+git add \
+  apps/aevatar-console-web/src/pages/chat/chatContent.ts \
+  apps/aevatar-console-web/src/pages/chat/chatContent.test.ts
+git -c user.name=AbigailDeng \
+  -c user.email=108705114+AbigailDeng@users.noreply.github.com \
+  commit -m "Parse Chat Markdown tables"
+```
+
+### Task 2: Render Responsive Semantic Tables In Chat
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx`
+
+- [ ] **Step 1: Write the failing Chat presentation test**
+
+Change imports to include `within`, `ChatMessageBubble`, and `ChatMessage`, then append:
+
+```typescript
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { ChatInput, ChatMessageBubble } from './chatPresentation';
+import type { ChatMessage } from './chatTypes';
+
+it('renders GFM tables with accessible headers and responsive containment', () => {
+  const message: ChatMessage = {
+    id: 'message-table',
+    role: 'assistant',
+    content: `| 名称 | member_id | workflow_id |
+| --- | :---: | ---: |
+| Observatory | \`m-alpha\` | \`wf-alpha-with-a-long-identifier\` |`,
+    timestamp: 1,
+    status: 'complete',
+  };
+
+  render(<ChatMessageBubble message={message} />);
+
+  const region = screen.getByRole('region', { name: 'Message table' });
+  expect(region).toHaveStyle({ maxWidth: '100%', overflowX: 'auto' });
+
+  const table = within(region).getByRole('table');
+  const headers = within(table).getAllByRole('columnheader');
+  expect(headers).toHaveLength(3);
+  expect(headers[0]).toHaveAttribute('scope', 'col');
+  expect(headers[2]).toHaveStyle({ textAlign: 'right' });
+
+  const workflowId = within(table).getByText('wf-alpha-with-a-long-identifier');
+  expect(workflowId.tagName).toBe('CODE');
+  expect(workflowId.closest('td')).toHaveStyle({ overflowWrap: 'anywhere' });
+});
+```
+
+- [ ] **Step 2: Run the presentation test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest \
+  --selectProjects jsdom \
+  --runTestsByPath src/pages/chat/chatPresentation.test.tsx \
+  --runInBand
+```
+
+Expected: FAIL because no accessible `region` or `table` exists.
+
+- [ ] **Step 3: Add stable table styles and render the typed block**
+
+Add module-level `React.CSSProperties` constants near the Markdown renderer:
+
+```typescript
+const markdownTableRegionStyle: React.CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  margin: "8px 0 12px",
+  maxWidth: "100%",
+  overflowX: "auto",
+};
+
+const markdownTableStyle: React.CSSProperties = {
+  borderCollapse: "collapse",
+  fontSize: 13,
+  minWidth: "100%",
+  width: "max-content",
+};
+
+const markdownTableHeaderCellStyle: React.CSSProperties = {
+  background: "#f8fafc",
+  borderBottom: "1px solid #d1d5db",
+  color: "#475569",
+  fontWeight: 700,
+  padding: "9px 11px",
+  textAlign: "left",
+  whiteSpace: "nowrap",
+};
+
+const markdownTableCellStyle: React.CSSProperties = {
+  borderTop: "1px solid #eef2f7",
+  maxWidth: 320,
+  overflowWrap: "anywhere",
+  padding: "9px 11px",
+  verticalAlign: "top",
+  wordBreak: "normal",
+};
+```
+
+Add this `case` to `renderMarkdownBlock` before `case "code"`:
+
+```tsx
+case "table":
+  return (
+    <div
+      aria-label={t("pages.chat.chatpresentation.message.table", "Message table")}
+      key={`block-${blockIndex}`}
+      role="region"
+      style={markdownTableRegionStyle}
+      tabIndex={0}
+    >
+      <table style={markdownTableStyle}>
+        <thead>
+          <tr>
+            {block.headers.map((header, cellIndex) => (
+              <th
+                key={`table-${blockIndex}-header-${cellIndex}`}
+                scope="col"
+                style={{
+                  ...markdownTableHeaderCellStyle,
+                  textAlign: block.alignments[cellIndex] ?? "left",
+                }}
+              >
+                {renderInlineTokens(
+                  tokenizeInlineContent(header),
+                  `table-${blockIndex}-header-${cellIndex}`,
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {block.rows.map((row, rowIndex) => (
+            <tr key={`table-${blockIndex}-row-${rowIndex}`}>
+              {block.headers.map((_, cellIndex) => (
+                <td
+                  key={`table-${blockIndex}-row-${rowIndex}-${cellIndex}`}
+                  style={{
+                    ...markdownTableCellStyle,
+                    textAlign: block.alignments[cellIndex] ?? "left",
+                  }}
+                >
+                  {renderInlineTokens(
+                    tokenizeInlineContent(row[cellIndex] ?? ""),
+                    `table-${blockIndex}-row-${rowIndex}-${cellIndex}`,
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+```
+
+- [ ] **Step 4: Run the presentation test and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: PASS with 5 tests in `chatPresentation.test.tsx`.
+
+- [ ] **Step 5: Commit the Chat renderer**
+
+```bash
+git add \
+  apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx \
+  apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx
+git -c user.name=AbigailDeng \
+  -c user.email=108705114+AbigailDeng@users.noreply.github.com \
+  commit -m "Render responsive Chat Markdown tables"
+```
+
+### Task 3: Keep Shared Parser Consumers Exhaustive
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx`
+
+- [ ] **Step 1: Run TypeScript and verify the typed-contract failures**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web tsc
+```
+
+Expected: FAIL where Studio and Explorer default branches read `block.lines` from the new table member.
+
+- [ ] **Step 2: Convert Studio's workaround to the typed table block**
+
+Add `case 'table': return renderMarkdownTable(block, index);` before the code case. Delete `splitMarkdownTableRow` and `isMarkdownTableSeparator`. Change the existing table renderer to:
+
+```tsx
+function renderMarkdownTable(
+  block: Extract<MarkdownBlock, { kind: 'table' }>,
+  index: number,
+) {
+  return (
+    <div key={`table-${index}`} style={markdownTableWrapperStyle}>
+      <table style={markdownTableStyle}>
+        <thead>
+          <tr>
+            {block.headers.map((cell, cellIndex) => (
+              <th
+                key={cellIndex}
+                scope="col"
+                style={{
+                  ...markdownTableHeaderCellStyle,
+                  textAlign: block.alignments[cellIndex] ?? 'left',
+                }}
+              >
+                {renderInlineContent(cell, `table-${index}-head-${cellIndex}`)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {block.rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {block.headers.map((_, cellIndex) => (
+                <td
+                  key={cellIndex}
+                  style={{
+                    ...markdownTableCellStyle,
+                    textAlign: block.alignments[cellIndex] ?? 'left',
+                  }}
+                >
+                  {renderInlineContent(
+                    row[cellIndex] ?? '',
+                    `table-${index}-${rowIndex}-${cellIndex}`,
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+Replace `renderRunOutputContent`'s paragraph sniff with:
+
+```tsx
+return (
+  <div style={renderedOutputStyle}>
+    {blocks.map((block, index) => renderMarkdownBlock(block, index))}
+  </div>
+);
+```
+
+- [ ] **Step 3: Add an explicit Explorer table case**
+
+Before Explorer's code case, render the typed block directly:
+
+```tsx
+case "table":
+  return (
+    <div
+      key={key}
+      style={{
+        border: "1px solid var(--ant-color-border-secondary)",
+        borderRadius: 8,
+        marginBottom: 12,
+        maxWidth: "100%",
+        overflowX: "auto",
+      }}
+    >
+      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "max-content" }}>
+        <thead>
+          <tr>
+            {block.headers.map((header, cellIndex) => (
+              <th
+                key={`${key}-header-${cellIndex}`}
+                scope="col"
+                style={{
+                  background: "var(--ant-color-fill-quaternary)",
+                  borderBottom: "1px solid var(--ant-color-border-secondary)",
+                  padding: "8px 10px",
+                  textAlign: block.alignments[cellIndex] ?? "left",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {renderInlineContent(header)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {block.rows.map((row, rowIndex) => (
+            <tr key={`${key}-row-${rowIndex}`}>
+              {block.headers.map((_, cellIndex) => (
+                <td
+                  key={`${key}-row-${rowIndex}-${cellIndex}`}
+                  style={{
+                    borderTop: "1px solid var(--ant-color-border-secondary)",
+                    overflowWrap: "anywhere",
+                    padding: "8px 10px",
+                    textAlign: block.alignments[cellIndex] ?? "left",
+                    verticalAlign: "top",
+                  }}
+                >
+                  {renderInlineContent(row[cellIndex] ?? "")}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+```
+
+- [ ] **Step 4: Run TypeScript and focused Chat tests**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web tsc
+pnpm --dir apps/aevatar-console-web exec jest \
+  --selectProjects jsdom \
+  --runTestsByPath \
+  src/pages/chat/chatContent.test.ts \
+  src/pages/chat/chatPresentation.test.tsx \
+  --runInBand
+```
+
+Expected: TypeScript passes; 2 test suites and 10 tests pass.
+
+- [ ] **Step 5: Commit shared-consumer alignment**
+
+```bash
+git add \
+  apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx \
+  apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx
+git -c user.name=AbigailDeng \
+  -c user.email=108705114+AbigailDeng@users.noreply.github.com \
+  commit -m "Align Markdown table consumers"
+```
+
+### Task 4: Verify The Complete Frontend Change
+
+**Files:**
+- Inspect: all files changed from `origin/dev`
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run the exact Jest command from Task 3 Step 4.
+
+Expected: 2 suites and 10 tests pass with no warnings caused by this change.
+
+- [ ] **Step 2: Run mandatory frontend validation**
+
+Run each command independently:
+
+```bash
+pnpm --dir apps/aevatar-console-web tsc
+pnpm --dir apps/aevatar-console-web test:ui -- --runInBand
+pnpm --dir apps/aevatar-console-web build
+bash tools/ci/test_stability_guards.sh
+```
+
+Expected: all commands exit 0. Record any unrelated baseline failure before deciding whether it blocks delivery.
+
+- [ ] **Step 3: Run diff and architecture checks**
+
+```bash
+git diff --check origin/dev...HEAD
+git diff --stat origin/dev...HEAD
+git status --short
+```
+
+Expected: no whitespace errors, no changes outside `apps/aevatar-console-web/**`, and a clean worktree.
+
+- [ ] **Step 4: Validate desktop and mobile containment locally**
+
+Start the frontend on an allowed port:
+
+```bash
+pnpm --dir apps/aevatar-console-web start:dev --port 5173
+```
+
+Open the local Chat route in the in-app browser at desktop and mobile widths. Verify the table is nonblank, headers and cells align, the message width does not expand, horizontal scrolling is available when required, inline code remains legible, and no adjacent content overlaps. If authentication or backend state prevents a table-bearing Chat message, document that limitation and use the DOM-focused Jest evidence as the authoritative rendering verification.
+
+- [ ] **Step 5: Commit any verification-only corrections**
+
+If verification required a source correction, repeat its focused red-green test and commit only the verified correction with an imperative message. If no correction was needed, do not create an empty commit.
+
+### Task 5: Create The PR And Enable Auto-Merge
+
+**Files:**
+- No additional repository files.
+
+- [ ] **Step 1: Confirm AbigailDeng authentication and branch state**
+
+```bash
+gh auth status
+git branch --show-current
+git status --short
+```
+
+Expected: `AbigailDeng` is active, branch is `fix/2026-07-22_chat-markdown-tables`, and status is clean.
+
+- [ ] **Step 2: Apply FKST issue labels**
+
+```bash
+gh issue edit 2885 --repo aevatarAI/aevatar \
+  --add-label "fkst-dev:enabled" \
+  --add-label "fkst-class:standard"
+```
+
+Expected: issue #2885 has both FKST labels.
+
+- [ ] **Step 3: Push the issue branch**
+
+```bash
+git push --set-upstream origin fix/2026-07-22_chat-markdown-tables
+```
+
+Expected: the branch is published under the AbigailDeng GitHub credentials.
+
+- [ ] **Step 4: Open a ready PR against dev**
+
+Create `/tmp/aevatar-pr-2885.md` with `apply_patch` using this exact body:
+
+```markdown
+## Problem and solution
+
+Chat treated valid GFM table source as paragraph text because the custom typed Markdown parser had no table block. This change adds a typed table contract, parses delimiters/alignment/escaped pipes, and renders semantic responsive tables with scoped headers.
+
+## Impacted paths
+
+- `apps/aevatar-console-web/src/pages/chat/**`
+- `apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx`
+- `apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx`
+- `apps/aevatar-console-web/docs/superpowers/**`
+
+## Verification
+
+- `pnpm --dir apps/aevatar-console-web tsc`
+- `pnpm --dir apps/aevatar-console-web test:ui -- --runInBand`
+- `pnpm --dir apps/aevatar-console-web build`
+- `bash tools/ci/test_stability_guards.sh`
+
+## Documentation
+
+- `apps/aevatar-console-web/docs/superpowers/specs/2026-07-22-chat-markdown-tables-design.md`
+- `apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md`
+
+Closes #2885
+```
+
+Then create the PR:
+
+```bash
+gh pr create \
+  --repo aevatarAI/aevatar \
+  --base dev \
+  --head fix/2026-07-22_chat-markdown-tables \
+  --title "fix(console): render Chat Markdown tables" \
+  --body-file /tmp/aevatar-pr-2885.md
+```
+
+Expected: a non-draft PR URL.
+
+- [ ] **Step 5: Enable squash auto-merge as explicitly authorized**
+
+```bash
+PR_NUMBER=$(gh pr view --repo aevatarAI/aevatar --json number --jq .number)
+gh pr merge "$PR_NUMBER" --repo aevatarAI/aevatar --auto --squash
+```
+
+Expected: GitHub reports auto-merge enabled, or reports that branch protection already permits an immediate merge. Do not bypass required checks or administrator protections.
+
+- [ ] **Step 6: Report final state**
+
+Record the issue URL, PR URL and number, commit list, all verification results, and auto-merge status. Keep the local development server running and provide its URL when the route remains usable for the user.

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-07-22-chat-markdown-tables-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-07-22-chat-markdown-tables-design.md
@@ -1,0 +1,136 @@
+# Chat Markdown Table Rendering Design
+
+## Status
+
+Approved for implementation on 2026-07-22.
+
+## Problem
+
+Chat assistant messages render GFM table source as paragraph text. The custom
+Markdown parser has no table block, so the presentation layer receives only
+lines and emits line breaks. Long identifiers and inline code then wrap without
+any row or column structure.
+
+GitHub issue: `aevatarAI/aevatar#2885`.
+
+## Goals
+
+- Parse valid GFM table headers, delimiter rows, optional column alignment, and
+  body rows into one typed Markdown block.
+- Render semantic Chat tables with identifiable column headers.
+- Keep tables contained on desktop and narrow screens without overlapping
+  adjacent message content.
+- Preserve inline code, bold text, and links inside cells.
+- Keep malformed or incomplete table syntax as ordinary paragraph content.
+- Reuse the existing parser and inline tokenization path without adding a
+  Markdown runtime dependency.
+
+## Non-Goals
+
+- Implement every GFM extension.
+- Replace the existing Markdown renderer.
+- Change Chat navigation, message layout, or backend contracts.
+- Introduce repository-wide Markdown styling.
+
+## Root Cause
+
+`parseMarkdownBlocks` returns headings, paragraphs, blockquotes, lists, code,
+and thematic breaks, but no table variant. A table is therefore accumulated as
+one paragraph. `ChatMessageBubble` calls the paragraph renderer, which preserves
+the source pipes and inserts `<br>` elements between lines.
+
+Studio currently compensates in its renderer by inspecting paragraph lines and
+calling `split('|')`. That workaround is not an authoritative parser and cannot
+distinguish delimiters from escaped pipes or pipes inside inline code.
+
+## Design
+
+### Typed Parser Contract
+
+Add a table member to `MarkdownBlock` containing:
+
+- `headers`: header cell source strings;
+- `alignments`: `left`, `center`, `right`, or `null` per column;
+- `rows`: body cell source strings.
+
+The parser recognizes a table only when a candidate header is immediately
+followed by a valid GFM delimiter row and both rows have the same non-zero
+column count. Each delimiter cell must contain at least three hyphens, with
+optional leading and trailing colons.
+
+The row splitter scans a line once. It ignores escaped pipes and pipes inside
+inline code spans, removes only optional outer pipes, and unescapes escaped
+pipes in returned cell text. Body rows are normalized to the header width:
+missing cells become empty strings and additional cells are ignored, matching
+the table's declared column contract.
+
+Code fences remain higher priority than table recognition. An incomplete table
+during streaming stays a paragraph until the delimiter row arrives, after
+which the normal React rerender produces the table.
+
+### Presentation
+
+Chat renders the block as:
+
+```text
+scroll region
+  table
+    thead > tr > th scope="col"
+    tbody > tr > td
+```
+
+Every cell reuses the existing inline tokenizer and renderer, so inline code,
+links, and bold text retain current behavior. Column alignment is applied to
+both header and body cells.
+
+The scroll region is capped at the message width, uses horizontal overflow,
+and is keyboard focusable with an accessible label. The table fills available
+width but may grow wider when content requires it. Cells allow safe wrapping
+for long identifiers; inline code can wrap without enlarging the message
+container. Styling follows the existing quiet Chat palette and compact type
+scale.
+
+### Existing Parser Consumers
+
+The parser is also used by Studio run output and Explorer content. Both must
+handle the typed table block so the shared contract remains exhaustive:
+
+- Studio removes its paragraph-sniffing table workaround and renders the typed
+  table with its current table visual treatment.
+- Explorer renders the typed table using its existing theme variables.
+
+These updates preserve Studio behavior and prevent a new table block from
+falling through to paragraph-only code.
+
+## Error Handling And Safety
+
+- Invalid delimiter rows do not create tables.
+- Header/delimiter width mismatches do not create tables.
+- Missing body cells render as empty cells.
+- Raw HTML remains plain text because this change does not introduce an HTML
+  parser or `dangerouslySetInnerHTML`.
+- Link behavior remains governed by the existing inline token renderer.
+
+## Testing
+
+Follow red-green-refactor:
+
+1. Add parser tests that expect a typed table with alignment, inline code, and
+   escaped pipe handling; confirm they fail because the parser returns a
+   paragraph.
+2. Add a Chat presentation test that expects table, columnheader, cell, inline
+   code, and responsive scroll-region semantics; confirm it fails because no
+   table is rendered.
+3. Implement the smallest parser and renderer changes to make those tests pass.
+4. Run the focused tests, `tsc`, the full `test:ui` suite, production build, and
+   the repository test-stability guard.
+5. Inspect desktop and mobile Chat rendering in a local browser when a runnable
+   authenticated or mocked Chat route is available.
+
+## Alternatives Rejected
+
+- Chat-only paragraph sniffing: smaller diff, but duplicates Studio's weak
+  workaround and leaves table semantics outside the parser.
+- `react-markdown` plus `remark-gfm`: standards-based, but adds bundle and lock
+  file scope, creates a second rendering path, and is unnecessary for the
+  requested table extension.

--- a/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.en-US.ts
@@ -680,6 +680,7 @@ const projectMessages = {
   "pages.chat.chatpresentation.manual": "Manual",
   "pages.chat.chatpresentation.message.count.many": "{count} msgs",
   "pages.chat.chatpresentation.message.count.one": "{count} msg",
+  "pages.chat.chatpresentation.message.table": "Message table",
   "pages.chat.chatpresentation.model": "Model",
   "pages.chat.chatpresentation.msg": "msg",
   "pages.chat.chatpresentation.new.chat": "New chat",

--- a/apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts
@@ -680,6 +680,7 @@ const projectMessages = {
   "pages.chat.chatpresentation.manual": "手动的",
   "pages.chat.chatpresentation.message.count.many": "{count} 条消息",
   "pages.chat.chatpresentation.message.count.one": "{count} 条消息",
+  "pages.chat.chatpresentation.message.table": "消息表格",
   "pages.chat.chatpresentation.model": "模型",
   "pages.chat.chatpresentation.msg": "msg",
   "pages.chat.chatpresentation.new.chat": "新聊天",

--- a/apps/aevatar-console-web/src/pages/chat/chatContent.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatContent.test.ts
@@ -39,6 +39,61 @@ const value = 1;
     ]);
   });
 
+  it("parses GFM tables without splitting escaped or code-span pipes", () => {
+    expect(
+      parseMarkdownBlocks(`| Name | \`member|id\` | Workflow |
+| :--- | :---: | ---: |
+| Observatory \\| beta | \`m-alpha\` | \`wf-alpha-with-a-long-identifier\` |`),
+    ).toEqual([
+      {
+        kind: "table",
+        headers: ["Name", "`member|id`", "Workflow"],
+        alignments: ["left", "center", "right"],
+        rows: [
+          [
+            "Observatory | beta",
+            "`m-alpha`",
+            "`wf-alpha-with-a-long-identifier`",
+          ],
+        ],
+      },
+    ]);
+  });
+
+  it("keeps malformed table syntax as paragraph content", () => {
+    expect(
+      parseMarkdownBlocks(`| Name | Member | Workflow |
+| --- | --- |
+| Observatory | m-alpha | wf-alpha |`),
+    ).toEqual([
+      {
+        kind: "paragraph",
+        lines: [
+          "| Name | Member | Workflow |",
+          "| --- | --- |",
+          "| Observatory | m-alpha | wf-alpha |",
+        ],
+      },
+    ]);
+  });
+
+  it("rejects table delimiters with internal whitespace", () => {
+    expect(
+      parseMarkdownBlocks(`| Name | Member |
+| - - - | --- |
+| Observatory | m-alpha |`),
+    ).toEqual([
+      {
+        kind: "paragraph",
+        lines: [
+          "| Name | Member |",
+          "| - - - | --- |",
+          "| Observatory | m-alpha |",
+        ],
+      },
+    ]);
+  });
+
   it("tokenizes bold text, code spans, and links", () => {
     expect(
       tokenizeInlineContent("Visit **[Docs](https://example.com)** and use `cmd`."),

--- a/apps/aevatar-console-web/src/pages/chat/chatContent.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatContent.ts
@@ -35,6 +35,15 @@ export type InlineContentToken =
   | { kind: "code"; text: string }
   | { kind: "link"; text: string; href: string; bold: boolean };
 
+export type MarkdownTableAlignment = "left" | "center" | "right" | null;
+
+export type MarkdownTableBlock = {
+  kind: "table";
+  headers: string[];
+  alignments: MarkdownTableAlignment[];
+  rows: string[][];
+};
+
 export type MarkdownBlock =
   | { kind: "paragraph"; lines: string[] }
   | { kind: "heading"; level: number; text: string }
@@ -42,7 +51,8 @@ export type MarkdownBlock =
   | { kind: "unordered-list"; items: string[] }
   | { kind: "ordered-list"; items: string[] }
   | { kind: "code"; lang: string; code: string }
-  | { kind: "thematic-break" };
+  | { kind: "thematic-break" }
+  | MarkdownTableBlock;
 
 const FUNCTION_CALL_PATTERNS: [string, string, string][] = [
   [
@@ -198,6 +208,91 @@ function appendLinkifiedTokens(
   }
 }
 
+const MARKDOWN_TABLE_DELIMITER_CELL_PATTERN = /^:?-{3,}:?$/;
+
+function splitMarkdownTableRow(line: string): string[] | null {
+  const source = line.trim();
+  const cells: string[] = [];
+  let cell = "";
+  let codeSpanDelimiterLength = 0;
+  let structuralPipeCount = 0;
+  let lastStructuralPipeIndex = -1;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+
+    if (character === "\\" && source[index + 1] === "|") {
+      cell += "|";
+      index += 1;
+      continue;
+    }
+
+    if (character === "`") {
+      let runLength = 1;
+      while (source[index + runLength] === "`") {
+        runLength += 1;
+      }
+
+      cell += "`".repeat(runLength);
+      if (codeSpanDelimiterLength === 0) {
+        codeSpanDelimiterLength = runLength;
+      } else if (codeSpanDelimiterLength === runLength) {
+        codeSpanDelimiterLength = 0;
+      }
+      index += runLength - 1;
+      continue;
+    }
+
+    if (character === "|" && codeSpanDelimiterLength === 0) {
+      structuralPipeCount += 1;
+      lastStructuralPipeIndex = index;
+      cells.push(cell.trim());
+      cell = "";
+      continue;
+    }
+
+    cell += character;
+  }
+
+  if (structuralPipeCount === 0) {
+    return null;
+  }
+
+  cells.push(cell.trim());
+  if (source.startsWith("|")) {
+    cells.shift();
+  }
+  if (lastStructuralPipeIndex === source.length - 1) {
+    cells.pop();
+  }
+
+  return cells;
+}
+
+function parseMarkdownTableAlignments(
+  line: string,
+): MarkdownTableAlignment[] | null {
+  const cells = splitMarkdownTableRow(line);
+  if (!cells || cells.length === 0) {
+    return null;
+  }
+
+  const alignments: MarkdownTableAlignment[] = [];
+  for (const cell of cells) {
+    if (!MARKDOWN_TABLE_DELIMITER_CELL_PATTERN.test(cell)) {
+      return null;
+    }
+
+    const left = cell.startsWith(":");
+    const right = cell.endsWith(":");
+    alignments.push(
+      left && right ? "center" : right ? "right" : left ? "left" : null,
+    );
+  }
+
+  return alignments;
+}
+
 export function parseMarkdownBlocks(text: string): MarkdownBlock[] {
   if (!text) {
     return [];
@@ -242,6 +337,31 @@ export function parseMarkdownBlocks(text: string): MarkdownBlock[] {
         code: codeLines.join("\n"),
       });
       index = cursor < lines.length ? cursor : lines.length;
+      continue;
+    }
+
+    const alignments =
+      index + 1 < lines.length
+        ? parseMarkdownTableAlignments(lines[index + 1])
+        : null;
+    const headers = alignments ? splitMarkdownTableRow(line) : null;
+    if (headers && alignments && headers.length === alignments.length) {
+      flushParagraph();
+      const rows: string[][] = [];
+      let cursor = index + 2;
+
+      while (cursor < lines.length) {
+        const cells = splitMarkdownTableRow(lines[cursor]);
+        if (!cells) {
+          break;
+        }
+
+        rows.push(headers.map((_, cellIndex) => cells[cellIndex] ?? ""));
+        cursor += 1;
+      }
+
+      blocks.push({ kind: "table", headers, alignments, rows });
+      index = cursor - 1;
       continue;
     }
 

--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import React, { useState } from 'react';
-import { ChatInput } from './chatPresentation';
+import { ChatInput, ChatMessageBubble } from './chatPresentation';
+import type { ChatMessage } from './chatTypes';
 
 function ChatInputHarness({ onSend }: { onSend: (value: string) => void }) {
   const [value, setValue] = useState('');
@@ -93,5 +94,36 @@ describe('ChatInput', () => {
       }),
     ).toBe(true);
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChatMessageBubble', () => {
+  it('renders GFM tables with accessible headers and responsive containment', () => {
+    const message: ChatMessage = {
+      id: 'message-table',
+      role: 'assistant',
+      content: `| 名称 | member_id | workflow_id |
+| --- | :---: | ---: |
+| Observatory | \`m-alpha\` | \`wf-alpha-with-a-long-identifier\` |`,
+      timestamp: 1,
+      status: 'complete',
+    };
+
+    render(<ChatMessageBubble message={message} />);
+
+    const region = screen.getByRole('region', { name: 'Message table' });
+    expect(region).toHaveStyle({ maxWidth: '100%', overflowX: 'auto' });
+
+    const table = within(region).getByRole('table');
+    const headers = within(table).getAllByRole('columnheader');
+    expect(headers).toHaveLength(3);
+    expect(headers[0]).toHaveAttribute('scope', 'col');
+    expect(headers[2]).toHaveStyle({ textAlign: 'right' });
+
+    const workflowId = within(table).getByText(
+      'wf-alpha-with-a-long-identifier',
+    );
+    expect(workflowId.tagName).toBe('CODE');
+    expect(workflowId.closest('td')).toHaveStyle({ overflowWrap: 'anywhere' });
   });
 });

--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
@@ -120,6 +120,40 @@ function renderLineCollection(
   ));
 }
 
+const markdownTableRegionStyle: React.CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: 8,
+  margin: "8px 0 12px",
+  maxWidth: "100%",
+  overflowX: "auto",
+};
+
+const markdownTableStyle: React.CSSProperties = {
+  borderCollapse: "collapse",
+  fontSize: 13,
+  minWidth: "100%",
+  width: "max-content",
+};
+
+const markdownTableHeaderCellStyle: React.CSSProperties = {
+  background: "#f8fafc",
+  borderBottom: "1px solid #d1d5db",
+  color: "#475569",
+  fontWeight: 700,
+  padding: "9px 11px",
+  textAlign: "left",
+  whiteSpace: "nowrap",
+};
+
+const markdownTableCellStyle: React.CSSProperties = {
+  borderTop: "1px solid #eef2f7",
+  maxWidth: 320,
+  overflowWrap: "anywhere",
+  padding: "9px 11px",
+  verticalAlign: "top",
+  wordBreak: "normal",
+};
+
 function renderMarkdownBlock(
   block: MarkdownBlock,
   blockIndex: number
@@ -200,6 +234,61 @@ function renderMarkdownBlock(
           ))}
         </div>
       );
+    case "table":
+      return (
+        <div
+          aria-label={t(
+            "pages.chat.chatpresentation.message.table",
+            "Message table"
+          )}
+          key={`block-${blockIndex}`}
+          role="region"
+          style={markdownTableRegionStyle}
+          tabIndex={0}
+        >
+          <table style={markdownTableStyle}>
+            <thead>
+              <tr>
+                {block.headers.map((header, cellIndex) => (
+                  <th
+                    key={`table-${blockIndex}-header-${cellIndex}`}
+                    scope="col"
+                    style={{
+                      ...markdownTableHeaderCellStyle,
+                      textAlign: block.alignments[cellIndex] ?? "left",
+                    }}
+                  >
+                    {renderInlineTokens(
+                      tokenizeInlineContent(header),
+                      `table-${blockIndex}-header-${cellIndex}`
+                    )}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {block.rows.map((row, rowIndex) => (
+                <tr key={`table-${blockIndex}-row-${rowIndex}`}>
+                  {block.headers.map((_, cellIndex) => (
+                    <td
+                      key={`table-${blockIndex}-row-${rowIndex}-${cellIndex}`}
+                      style={{
+                        ...markdownTableCellStyle,
+                        textAlign: block.alignments[cellIndex] ?? "left",
+                      }}
+                    >
+                      {renderInlineTokens(
+                        tokenizeInlineContent(row[cellIndex] ?? ""),
+                        `table-${blockIndex}-row-${rowIndex}-${cellIndex}`
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
     case "code":
       return (
         <div
@@ -252,8 +341,6 @@ function renderMarkdownBlock(
           }}
         />
       );
-    default:
-      return null;
   }
 }
 

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx
@@ -512,6 +512,8 @@ function renderMarkdownBlock(
           {renderMarkdownLines(block.lines, `quote-${index}`)}
         </blockquote>
       );
+    case 'table':
+      return renderMarkdownTable(block, index);
     case 'code':
       return (
         <pre key={index} style={markdownCodeStyle}>
@@ -526,7 +528,6 @@ function renderMarkdownBlock(
         />
       );
     case 'paragraph':
-    default:
       return (
         <div key={index} style={markdownParagraphStyle}>
           {renderMarkdownLines(block.lines, `paragraph-${index}`)}
@@ -535,42 +536,42 @@ function renderMarkdownBlock(
   }
 }
 
-function splitMarkdownTableRow(line: string): string[] {
-  return line
-    .trim()
-    .replace(/^\|/, '')
-    .replace(/\|$/, '')
-    .split('|')
-    .map((cell) => cell.trim());
-}
-
-function isMarkdownTableSeparator(line: string): boolean {
-  return /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(line);
-}
-
-function renderMarkdownTable(lines: readonly string[], index: number) {
-  const header = splitMarkdownTableRow(lines[0]);
-  const rows = lines.slice(2).map(splitMarkdownTableRow);
-
+function renderMarkdownTable(
+  block: Extract<MarkdownBlock, { kind: 'table' }>,
+  index: number,
+) {
   return (
     <div key={`table-${index}`} style={markdownTableWrapperStyle}>
       <table style={markdownTableStyle}>
         <thead>
           <tr>
-            {header.map((cell, cellIndex) => (
-              <th key={cellIndex} style={markdownTableHeaderCellStyle}>
+            {block.headers.map((cell, cellIndex) => (
+              <th
+                key={cellIndex}
+                scope="col"
+                style={{
+                  ...markdownTableHeaderCellStyle,
+                  textAlign: block.alignments[cellIndex] ?? 'left',
+                }}
+              >
                 {renderInlineContent(cell, `table-${index}-head-${cellIndex}`)}
               </th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {rows.map((row, rowIndex) => (
+          {block.rows.map((row, rowIndex) => (
             <tr key={rowIndex}>
-              {header.map((_, cellIndex) => (
-                <td key={cellIndex} style={markdownTableCellStyle}>
+              {block.headers.map((_, cellIndex) => (
+                <td
+                  key={cellIndex}
+                  style={{
+                    ...markdownTableCellStyle,
+                    textAlign: block.alignments[cellIndex] ?? 'left',
+                  }}
+                >
                   {renderInlineContent(
-                    row[cellIndex] || '',
+                    row[cellIndex] ?? '',
                     `table-${index}-${rowIndex}-${cellIndex}`,
                   )}
                 </td>
@@ -591,18 +592,7 @@ function renderRunOutputContent(text: string): React.ReactNode {
 
   return (
     <div style={renderedOutputStyle}>
-      {blocks.map((block, index) => {
-        if (
-          block.kind === 'paragraph' &&
-          block.lines.length >= 3 &&
-          block.lines[0].includes('|') &&
-          isMarkdownTableSeparator(block.lines[1])
-        ) {
-          return renderMarkdownTable(block.lines, index);
-        }
-
-        return renderMarkdownBlock(block, index);
-      })}
+      {blocks.map((block, index) => renderMarkdownBlock(block, index))}
     </div>
   );
 }

--- a/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx
@@ -346,6 +346,69 @@ function renderMarkdownContent(text: string): React.ReactNode {
 
 function renderBlock(block: MarkdownBlock, key: number): React.ReactElement {
   switch (block.kind) {
+    case "table":
+      return (
+        <div
+          key={key}
+          style={{
+            border: "1px solid var(--ant-color-border-secondary)",
+            borderRadius: 8,
+            marginBottom: 12,
+            maxWidth: "100%",
+            overflowX: "auto",
+          }}
+        >
+          <table
+            style={{
+              borderCollapse: "collapse",
+              minWidth: "100%",
+              width: "max-content",
+            }}
+          >
+            <thead>
+              <tr>
+                {block.headers.map((header, cellIndex) => (
+                  <th
+                    key={`${key}-header-${cellIndex}`}
+                    scope="col"
+                    style={{
+                      background: "var(--ant-color-fill-quaternary)",
+                      borderBottom:
+                        "1px solid var(--ant-color-border-secondary)",
+                      padding: "8px 10px",
+                      textAlign: block.alignments[cellIndex] ?? "left",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {renderInlineContent(header)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {block.rows.map((row, rowIndex) => (
+                <tr key={`${key}-row-${rowIndex}`}>
+                  {block.headers.map((_, cellIndex) => (
+                    <td
+                      key={`${key}-row-${rowIndex}-${cellIndex}`}
+                      style={{
+                        borderTop:
+                          "1px solid var(--ant-color-border-secondary)",
+                        overflowWrap: "anywhere",
+                        padding: "8px 10px",
+                        textAlign: block.alignments[cellIndex] ?? "left",
+                        verticalAlign: "top",
+                      }}
+                    >
+                      {renderInlineContent(row[cellIndex] ?? "")}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
     case "code":
       return (
         <pre
@@ -416,7 +479,6 @@ function renderBlock(block: MarkdownBlock, key: number): React.ReactElement {
         />
       );
     case "paragraph":
-    default:
       return (
         <div key={key} style={{ lineHeight: 1.7, marginBottom: 12 }}>
           {block.lines.map((line, index) => (


### PR DESCRIPTION
## Problem and solution

Chat treated valid GFM table source as paragraph text because the custom typed Markdown parser had no table block. This change:

- adds a typed table contract with delimiter alignment plus escaped/code-span pipe handling;
- renders semantic `table` / `thead` / scoped `th` / `tbody` / `td` markup inside a keyboard-focusable responsive scroll region;
- keeps Studio and Explorer on the same parser contract and removes Studio's paragraph-sniffing `split('|')` workaround;
- catalogs the table accessibility label in English and Chinese.

Malformed delimiters remain paragraph content, long identifiers wrap safely, and inline code/links continue through the existing inline token renderer.

## Impacted paths

- `apps/aevatar-console-web/src/pages/chat/**`
- `apps/aevatar-console-web/src/pages/studio/components/StudioMemberCurrentRunPanel.tsx`
- `apps/aevatar-console-web/src/pages/studio/explorer/ExplorerContentView.tsx`
- `apps/aevatar-console-web/src/locales/projectMessages.en-US.ts`
- `apps/aevatar-console-web/src/locales/projectMessages.zh-CN.ts`
- `apps/aevatar-console-web/docs/superpowers/**`

## Verification

- `pnpm --dir apps/aevatar-console-web tsc` - passed
- focused parser, Chat DOM, i18n audit, and catalog tests - 4 suites / 24 tests passed
- `pnpm --dir apps/aevatar-console-web test:ui --runInBand` - 114 suites / 1028 tests passed
- `pnpm --dir apps/aevatar-console-web build` - compiled successfully
- `bash tools/ci/test_stability_guards.sh` - passed
- `git diff --check origin/dev...HEAD` and frontend-only path guard - passed

Local `/chat` browser inspection reached the NyxID configuration gate before authenticated Chat content could render. Responsive containment and semantic markup are therefore verified by the real `ChatMessageBubble` jsdom regression test rather than injected browser state.

## Documentation

- `apps/aevatar-console-web/docs/superpowers/specs/2026-07-22-chat-markdown-tables-design.md`
- `apps/aevatar-console-web/docs/superpowers/plans/2026-07-22-chat-markdown-tables.md`

Closes #2885
