### PR TITLE
Resolve chat workflow caller binding

### DIFF
--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -84,34 +84,15 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool, IAgentToolC
                 "scope_id is required in AgentToolRequestContext. The local Studio member workflow schedule tool uses the caller scope from the tool execution context.");
         }
 
-        var typedAuthority = AgentToolRequestContext.NyxIdAuthority;
-        var authorityOwnerSubject = typedAuthority.IsComplete
-            ? Normalize(typedAuthority.ExternalUserId)
-            : Normalize(AgentToolRequestContext.OwnerSubject);
-        if (authorityOwnerSubject is null)
+        var authorizationContext = StudioMemberWorkflowScheduleAuthorizationResolver.Resolve();
+        if (authorizationContext.Error is { } authorizationError)
         {
             return ErrorJson(
-                "caller_subject_unavailable",
-                "owner subject is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+                authorizationError.Code,
+                authorizationError.Message);
         }
-        var bindingId = Normalize(AgentToolRequestContext.SenderBindingId);
-        var nyxUserId = typedAuthority.IsComplete
-            ? authorityOwnerSubject
-            : Normalize(AgentToolRequestContext.SenderNyxUserId) ?? authorityOwnerSubject;
-        var subjectPlatform = typedAuthority.IsComplete
-            ? Normalize(typedAuthority.Platform) ?? "nyxid"
-            : Normalize(AgentToolRequestContext.ChannelPlatform) ?? "nyxid";
-        var subjectTenant = typedAuthority.IsComplete
-            ? Normalize(typedAuthority.Tenant) ?? string.Empty
-            : Normalize(AgentToolRequestContext.ChannelRegistrationScopeId) ?? string.Empty;
-        var subjectExternalUserId = typedAuthority.IsComplete
-            ? authorityOwnerSubject
-            : Normalize(AgentToolRequestContext.ChannelSenderId) ?? authorityOwnerSubject;
-        if (bindingId is null)
-            return ErrorJson("authenticated_owner_context_unavailable", "A verified NyxID binding is required to authorize a Team schedule.");
-        var provisioningBearerToken = Normalize(AgentToolRequestContext.NyxIdAccessToken);
-        if (provisioningBearerToken is null && !typedAuthority.IsComplete)
-            return ErrorJson("caller_credential_unavailable", "A current NyxID credential is required to create the schedule credential.");
+
+        var resolvedAuthorization = authorizationContext.Resolved!;
 
         ScheduleStudioMemberWorkflowArguments? args;
         try
@@ -147,7 +128,7 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool, IAgentToolC
         var operationIdentity = TryBuildOperationIdentity(
             scopeId,
             memberId,
-            nyxUserId);
+            resolvedAuthorization.OwnerSubject);
         if (operationIdentity is null)
         {
             return ErrorJson(
@@ -160,24 +141,14 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool, IAgentToolC
             MemberId: memberId,
             ScheduleCron: scheduleCron,
             ScheduleTimezone: scheduleTimezone,
-            AuthenticatedOwner: new AuthenticatedAuthorizationOwnerContext(
-                new AuthorizationOwnerIdentity
-                {
-                    Authority = NyxIdAuthorizationAuthorities.NyxId,
-                    OwnerKind = AuthorizationOwnerKind.Personal,
-                    OwnerSubject = nyxUserId,
-                },
-                subjectPlatform,
-                subjectTenant,
-                subjectExternalUserId,
-                bindingId))
+            AuthenticatedOwner: resolvedAuthorization.AuthenticatedOwner)
         {
             OperationId = operationIdentity.OperationId,
             IdempotencyKey = operationIdentity.IdempotencyKey,
             CredentialProvisioningKind = CredentialProvisioningKind,
             Prompt = prompt,
             DisplayName = displayName,
-            ProvisioningBearerToken = provisioningBearerToken,
+            ProvisioningBearerToken = resolvedAuthorization.ProvisioningBearerToken,
         };
 
         try
@@ -308,3 +279,89 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool, IAgentToolC
 
     private sealed record ScheduleStudioMemberWorkflowErrorBody(string Code, string Message);
 }
+
+internal static class StudioMemberWorkflowScheduleAuthorizationResolver
+{
+    public static StudioMemberWorkflowScheduleAuthorizationResolution Resolve()
+    {
+        var typedAuthority = AgentToolRequestContext.NyxIdAuthority;
+        var ownerSubject = typedAuthority.IsComplete
+            ? Normalize(typedAuthority.ExternalUserId)
+            : Normalize(AgentToolRequestContext.OwnerSubject);
+        if (ownerSubject is null)
+        {
+            return StudioMemberWorkflowScheduleAuthorizationResolution.Failure(
+                "caller_subject_unavailable",
+                "owner subject is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        var bindingId = Normalize(AgentToolRequestContext.SenderBindingId);
+        if (bindingId is null)
+        {
+            return StudioMemberWorkflowScheduleAuthorizationResolution.Failure(
+                "authenticated_owner_context_unavailable",
+                "A verified NyxID binding is required to authorize a Team schedule.");
+        }
+
+        var provisioningBearerToken = Normalize(AgentToolRequestContext.NyxIdAccessToken);
+        if (provisioningBearerToken is null && !typedAuthority.IsComplete)
+        {
+            return StudioMemberWorkflowScheduleAuthorizationResolution.Failure(
+                "caller_credential_unavailable",
+                "A current NyxID credential is required to create the schedule credential.");
+        }
+
+        var nyxUserId = typedAuthority.IsComplete
+            ? ownerSubject
+            : Normalize(AgentToolRequestContext.SenderNyxUserId) ?? ownerSubject;
+        var subjectPlatform = typedAuthority.IsComplete
+            ? Normalize(typedAuthority.Platform) ?? NyxIdAuthorizationAuthorities.NyxId
+            : Normalize(AgentToolRequestContext.ChannelPlatform) ?? NyxIdAuthorizationAuthorities.NyxId;
+        var subjectTenant = typedAuthority.IsComplete
+            ? Normalize(typedAuthority.Tenant) ?? string.Empty
+            : Normalize(AgentToolRequestContext.Current?.SenderBinding.SenderTenant) ??
+              Normalize(AgentToolRequestContext.ChannelRegistrationScopeId) ??
+              string.Empty;
+        var subjectExternalUserId = typedAuthority.IsComplete
+            ? ownerSubject
+            : Normalize(AgentToolRequestContext.ChannelSenderId) ?? ownerSubject;
+
+        return StudioMemberWorkflowScheduleAuthorizationResolution.Success(
+            new StudioMemberWorkflowScheduleAuthorizationContext(
+                OwnerSubject: nyxUserId,
+                AuthenticatedOwner: new AuthenticatedAuthorizationOwnerContext(
+                    new AuthorizationOwnerIdentity
+                    {
+                        Authority = NyxIdAuthorizationAuthorities.NyxId,
+                        OwnerKind = AuthorizationOwnerKind.Personal,
+                        OwnerSubject = nyxUserId,
+                    },
+                    subjectPlatform,
+                    subjectTenant,
+                    subjectExternalUserId,
+                    bindingId),
+                ProvisioningBearerToken: provisioningBearerToken));
+    }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}
+
+internal sealed record StudioMemberWorkflowScheduleAuthorizationResolution(
+    StudioMemberWorkflowScheduleAuthorizationContext? Resolved,
+    StudioMemberWorkflowScheduleAuthorizationError? Error)
+{
+    public static StudioMemberWorkflowScheduleAuthorizationResolution Success(
+        StudioMemberWorkflowScheduleAuthorizationContext context) =>
+        new(context, null);
+
+    public static StudioMemberWorkflowScheduleAuthorizationResolution Failure(string code, string message) =>
+        new(null, new StudioMemberWorkflowScheduleAuthorizationError(code, message));
+}
+
+internal sealed record StudioMemberWorkflowScheduleAuthorizationContext(
+    string OwnerSubject,
+    AuthenticatedAuthorizationOwnerContext AuthenticatedOwner,
+    string? ProvisioningBearerToken);
+
+internal sealed record StudioMemberWorkflowScheduleAuthorizationError(string Code, string Message);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\Aevatar.Audit.Abstractions\Aevatar.Audit.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Audit.Hosting\Aevatar.Audit.Hosting.csproj" />
     <ProjectReference Include="..\..\Aevatar.BackendConsole.Hosting\Aevatar.BackendConsole.Hosting.csproj" />
+    <ProjectReference Include="..\..\..\agents\Aevatar.GAgents.Channel.Identity.Abstractions\Aevatar.GAgents.Channel.Identity.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -183,6 +183,7 @@ public static class WorkflowCapabilityEndpoints
             var callerCredential = await WorkflowCallerCredentialExtractor.ExtractAsync(
                 http,
                 serviceProvider?.GetService<IExternalIdentityBindingQueryPort>(),
+                logger,
                 ct);
             if (!callerCredential.Succeeded)
             {
@@ -287,6 +288,7 @@ public static class WorkflowCapabilityEndpoints
             var callerCredential = await WorkflowCallerCredentialExtractor.ExtractAsync(
                 http,
                 serviceProvider?.GetService<IExternalIdentityBindingQueryPort>(),
+                logger,
                 ct);
             if (!callerCredential.Succeeded)
             {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.RunForks;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Abstractions;
@@ -66,7 +67,11 @@ public static class WorkflowCapabilityEndpoints
         ArgumentNullException.ThrowIfNull(chatRunService);
         ArgumentNullException.ThrowIfNull(multipartParser);
 
-        var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+        var serviceProvider = http.Features.Get<IServiceProvidersFeature>()?.RequestServices;
+        var callerCredential = await WorkflowCallerCredentialExtractor.ExtractAsync(
+            http,
+            serviceProvider?.GetService<IExternalIdentityBindingQueryPort>(),
+            ct);
         if (!callerCredential.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(callerCredential.Error);
@@ -179,7 +184,10 @@ public static class WorkflowCapabilityEndpoints
         try
         {
             var defaultMetadata = TryResolveRuntimeDefaultMetadata(serviceProvider, logger);
-            var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+            var callerCredential = await WorkflowCallerCredentialExtractor.ExtractAsync(
+                http,
+                serviceProvider?.GetService<IExternalIdentityBindingQueryPort>(),
+                ct);
             if (!callerCredential.Succeeded)
             {
                 var (code, message) = ChatRunStartErrorMapper.ToCommandError(callerCredential.Error);
@@ -280,7 +288,10 @@ public static class WorkflowCapabilityEndpoints
         try
         {
             var defaultMetadata = TryResolveRuntimeDefaultMetadata(serviceProvider, logger);
-            var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
+            var callerCredential = await WorkflowCallerCredentialExtractor.ExtractAsync(
+                http,
+                serviceProvider?.GetService<IExternalIdentityBindingQueryPort>(),
+                ct);
             if (!callerCredential.Succeeded)
             {
                 var (code, message) = ChatRunStartErrorMapper.ToCommandError(callerCredential.Error);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -67,11 +67,7 @@ public static class WorkflowCapabilityEndpoints
         ArgumentNullException.ThrowIfNull(chatRunService);
         ArgumentNullException.ThrowIfNull(multipartParser);
 
-        var serviceProvider = http.Features.Get<IServiceProvidersFeature>()?.RequestServices;
-        var callerCredential = await WorkflowCallerCredentialExtractor.ExtractAsync(
-            http,
-            serviceProvider?.GetService<IExternalIdentityBindingQueryPort>(),
-            ct);
+        var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
         if (!callerCredential.Succeeded)
         {
             var (code, message) = ChatRunStartErrorMapper.ToCommandError(callerCredential.Error);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
@@ -3,6 +3,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using WorkflowProtocol = Aevatar.Workflow.Abstractions;
 
@@ -27,6 +28,7 @@ public static class WorkflowCallerCredentialExtractor
     public static ValueTask<WorkflowCallerCredentialExtractionResult> ExtractAsync(
         HttpContext? http,
         IExternalIdentityBindingQueryPort? bindingQueryPort,
+        ILogger? logger = null,
         CancellationToken ct = default)
     {
         var token = ExtractCredentialToken(http);
@@ -34,7 +36,7 @@ public static class WorkflowCallerCredentialExtractor
             return ValueTask.FromResult(Invalid());
         return token.RawToken == null
             ? ValueTask.FromResult(WorkflowCallerCredentialExtractionResult.Success(null))
-            : ParseCredentialAsync(token.RawToken, http, bindingQueryPort, ct);
+            : ParseCredentialAsync(token.RawToken, http, bindingQueryPort, logger, ct);
     }
 
     private static CallerCredentialTokenExtractionResult ExtractCredentialToken(HttpContext? http)
@@ -76,6 +78,7 @@ public static class WorkflowCallerCredentialExtractor
         string? rawToken,
         HttpContext? http,
         IExternalIdentityBindingQueryPort? bindingQueryPort,
+        ILogger? logger,
         CancellationToken ct)
     {
         var parsed = WorkflowProtocol.WorkflowCallerCredentialTokens.ParseOptional(rawToken);
@@ -84,7 +87,7 @@ public static class WorkflowCallerCredentialExtractor
             return WorkflowCallerCredentialExtractionResult.Success(
                 new WorkflowCallerCredential(
                     parsed.NormalizedBearerToken,
-                    await ResolveAuthenticatedNyxIdAuthorityAsync(http, bindingQueryPort, ct)));
+                    await ResolveAuthenticatedNyxIdAuthorityAsync(http, bindingQueryPort, logger, ct)));
         }
 
         return Invalid();
@@ -115,6 +118,7 @@ public static class WorkflowCallerCredentialExtractor
     private static async ValueTask<WorkflowCallerNyxIdAuthority?> ResolveAuthenticatedNyxIdAuthorityAsync(
         HttpContext? http,
         IExternalIdentityBindingQueryPort? bindingQueryPort,
+        ILogger? logger,
         CancellationToken ct)
     {
         var principal = http?.User;
@@ -132,7 +136,7 @@ public static class WorkflowCallerCredentialExtractor
             return null;
 
         const string tenant = "";
-        var bindingId = await ResolveBindingIdAsync(bindingQueryPort, externalUserId, tenant, ct);
+        var bindingId = await ResolveBindingIdAsync(bindingQueryPort, externalUserId, tenant, logger, ct);
         return new WorkflowCallerNyxIdAuthority(
             OwnerScope.NyxIdPlatform,
             tenant,
@@ -145,22 +149,40 @@ public static class WorkflowCallerCredentialExtractor
         IExternalIdentityBindingQueryPort? bindingQueryPort,
         string externalUserId,
         string tenant,
+        ILogger? logger,
         CancellationToken ct)
     {
         if (bindingQueryPort == null)
             return null;
 
-        var bindingId = await bindingQueryPort.ResolveAsync(
-            new ExternalSubjectRef
-            {
-                Platform = OwnerScope.NyxIdPlatform,
-                Tenant = tenant,
-                ExternalUserId = externalUserId,
-            },
-            ct);
-        return string.IsNullOrWhiteSpace(bindingId?.Value)
-            ? null
-            : bindingId.Value.Trim();
+        var subject = new ExternalSubjectRef
+        {
+            Platform = OwnerScope.NyxIdPlatform,
+            Tenant = tenant,
+            ExternalUserId = externalUserId,
+        };
+
+        try
+        {
+            var bindingId = await bindingQueryPort.ResolveAsync(subject, ct);
+            return string.IsNullOrWhiteSpace(bindingId?.Value)
+                ? null
+                : bindingId.Value.Trim();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(
+                ex,
+                "Caller NyxID binding lookup failed; continuing workflow chat without verified sender binding. subject={Platform}:{Tenant}:{User}",
+                subject.Platform,
+                subject.Tenant,
+                subject.ExternalUserId);
+            return null;
+        }
     }
 
     private static string? ReadFirstClaim(ClaimsPrincipal principal, params string[] claimTypes)

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowCallerCredentialExtractor.cs
@@ -1,5 +1,7 @@
 using System.Security.Claims;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
 using Microsoft.AspNetCore.Http;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using WorkflowProtocol = Aevatar.Workflow.Abstractions;
@@ -14,23 +16,44 @@ public static class WorkflowCallerCredentialExtractor
 
     public static WorkflowCallerCredentialExtractionResult Extract(HttpContext? http)
     {
+        var token = ExtractCredentialToken(http);
+        if (!token.Succeeded)
+            return Invalid();
+        return token.RawToken == null
+            ? WorkflowCallerCredentialExtractionResult.Success(null)
+            : ParseCredential(token.RawToken, http);
+    }
+
+    public static ValueTask<WorkflowCallerCredentialExtractionResult> ExtractAsync(
+        HttpContext? http,
+        IExternalIdentityBindingQueryPort? bindingQueryPort,
+        CancellationToken ct = default)
+    {
+        var token = ExtractCredentialToken(http);
+        if (!token.Succeeded)
+            return ValueTask.FromResult(Invalid());
+        return token.RawToken == null
+            ? ValueTask.FromResult(WorkflowCallerCredentialExtractionResult.Success(null))
+            : ParseCredentialAsync(token.RawToken, http, bindingQueryPort, ct);
+    }
+
+    private static CallerCredentialTokenExtractionResult ExtractCredentialToken(HttpContext? http)
+    {
         if (http?.Request.Headers.TryGetValue(NyxIdDelegationTokenHeader, out var delegationValues) == true)
         {
-            if (delegationValues.Count != 1)
-                return Invalid();
-
-            return ParseCredential(delegationValues[0], http);
+            return delegationValues.Count != 1
+                ? CallerCredentialTokenExtractionResult.Invalid
+                : CallerCredentialTokenExtractionResult.Success(delegationValues[0]);
         }
 
         var auth = http?.Request.Headers.Authorization.FirstOrDefault();
         if (auth == null)
-            return WorkflowCallerCredentialExtractionResult.Success(null);
+            return CallerCredentialTokenExtractionResult.Missing;
         if (string.Equals(auth.Trim(), "Bearer", StringComparison.OrdinalIgnoreCase))
-            return Invalid();
-        if (!auth.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase))
-            return WorkflowCallerCredentialExtractionResult.Success(null);
-
-        return ParseCredential(auth[BearerPrefix.Length..], http);
+            return CallerCredentialTokenExtractionResult.Invalid;
+        return auth.StartsWith(BearerPrefix, StringComparison.OrdinalIgnoreCase)
+            ? CallerCredentialTokenExtractionResult.Success(auth[BearerPrefix.Length..])
+            : CallerCredentialTokenExtractionResult.Missing;
     }
 
     private static WorkflowCallerCredentialExtractionResult ParseCredential(
@@ -39,10 +62,30 @@ public static class WorkflowCallerCredentialExtractor
     {
         var parsed = WorkflowProtocol.WorkflowCallerCredentialTokens.ParseOptional(rawToken);
         if (parsed.IsValid)
+        {
             return WorkflowCallerCredentialExtractionResult.Success(
                 new WorkflowCallerCredential(
                     parsed.NormalizedBearerToken,
                     ResolveAuthenticatedNyxIdAuthority(http)));
+        }
+
+        return Invalid();
+    }
+
+    private static async ValueTask<WorkflowCallerCredentialExtractionResult> ParseCredentialAsync(
+        string? rawToken,
+        HttpContext? http,
+        IExternalIdentityBindingQueryPort? bindingQueryPort,
+        CancellationToken ct)
+    {
+        var parsed = WorkflowProtocol.WorkflowCallerCredentialTokens.ParseOptional(rawToken);
+        if (parsed.IsValid)
+        {
+            return WorkflowCallerCredentialExtractionResult.Success(
+                new WorkflowCallerCredential(
+                    parsed.NormalizedBearerToken,
+                    await ResolveAuthenticatedNyxIdAuthorityAsync(http, bindingQueryPort, ct)));
+        }
 
         return Invalid();
     }
@@ -69,6 +112,57 @@ public static class WorkflowCallerCredentialExtractor
                 DefaultNyxIdCapabilityScope);
     }
 
+    private static async ValueTask<WorkflowCallerNyxIdAuthority?> ResolveAuthenticatedNyxIdAuthorityAsync(
+        HttpContext? http,
+        IExternalIdentityBindingQueryPort? bindingQueryPort,
+        CancellationToken ct)
+    {
+        var principal = http?.User;
+        if (principal?.Identity?.IsAuthenticated != true)
+            return null;
+
+        var externalUserId = ReadFirstClaim(
+            principal,
+            "scope_id",
+            "uid",
+            "sub",
+            ClaimTypes.NameIdentifier,
+            "user_id");
+        if (string.IsNullOrWhiteSpace(externalUserId))
+            return null;
+
+        const string tenant = "";
+        var bindingId = await ResolveBindingIdAsync(bindingQueryPort, externalUserId, tenant, ct);
+        return new WorkflowCallerNyxIdAuthority(
+            OwnerScope.NyxIdPlatform,
+            tenant,
+            externalUserId,
+            DefaultNyxIdCapabilityScope,
+            bindingId);
+    }
+
+    private static async ValueTask<string?> ResolveBindingIdAsync(
+        IExternalIdentityBindingQueryPort? bindingQueryPort,
+        string externalUserId,
+        string tenant,
+        CancellationToken ct)
+    {
+        if (bindingQueryPort == null)
+            return null;
+
+        var bindingId = await bindingQueryPort.ResolveAsync(
+            new ExternalSubjectRef
+            {
+                Platform = OwnerScope.NyxIdPlatform,
+                Tenant = tenant,
+                ExternalUserId = externalUserId,
+            },
+            ct);
+        return string.IsNullOrWhiteSpace(bindingId?.Value)
+            ? null
+            : bindingId.Value.Trim();
+    }
+
     private static string? ReadFirstClaim(ClaimsPrincipal principal, params string[] claimTypes)
     {
         foreach (var claimType in claimTypes)
@@ -83,6 +177,13 @@ public static class WorkflowCallerCredentialExtractor
 
     private static WorkflowCallerCredentialExtractionResult Invalid() =>
         WorkflowCallerCredentialExtractionResult.Failure(WorkflowChatRunStartError.InvalidCallerCredential);
+}
+
+readonly record struct CallerCredentialTokenExtractionResult(string? RawToken, bool Succeeded)
+{
+    public static CallerCredentialTokenExtractionResult Missing => new(null, true);
+    public static CallerCredentialTokenExtractionResult Invalid => new(null, false);
+    public static CallerCredentialTokenExtractionResult Success(string? rawToken) => new(rawToken, true);
 }
 
 public readonly record struct WorkflowCallerCredentialExtractionResult(

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -1028,6 +1028,41 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
+    public async Task ScheduleMemberWorkflow_WhenChannelSenderContextPresent_ShouldUseBindingBackedChannelSubject()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(
+            scopeId: "registration-scope",
+            ownerSubject: "fallback-owner",
+            accessToken: "access-token-1",
+            ownerScopeId: "owner-scope",
+            senderBindingId: "binding-lark",
+            senderNyxUserId: "nyx-lark-user",
+            senderTenant: "tenant-lark",
+            channelPlatform: "lark",
+            channelSenderId: "ou_sender");
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "member-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().BeNull();
+        schedulePort.LastRequest.Should().NotBeNull();
+        schedulePort.LastRequest!.ScopeId.Should().Be("owner-scope");
+        var owner = schedulePort.LastRequest.AuthenticatedOwner;
+        owner.Owner.OwnerSubject.Should().Be("nyx-lark-user");
+        owner.SubjectPlatform.Should().Be("lark");
+        owner.SubjectTenant.Should().Be("tenant-lark");
+        owner.SubjectExternalUserId.Should().Be("ou_sender");
+        owner.VerifiedBindingId.Should().Be("binding-lark");
+    }
+
+    [Fact]
     public async Task ScheduleMemberWorkflow_WhenBearerMissingAndTypedNyxIdAuthorityPresent_ShouldDeferTokenIssuanceToPort()
     {
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
@@ -1674,14 +1709,19 @@ public sealed class ProvisionWorkflowScheduleToolTests
         string? idempotencyKey = null,
         string? ownerScopeId = null,
         AgentToolNyxIdAuthorityContext? nyxIdAuthority = null,
-        string? senderBindingId = "binding-alpha")
+        string? senderBindingId = "binding-alpha",
+        string? senderNyxUserId = null,
+        string? senderTenant = null,
+        string? channelPlatform = null,
+        string? channelSenderId = null,
+        string? channelRegistrationScopeId = null)
     {
         return AgentToolContextScope.Push(new AgentToolExecutionContext(
             new AgentToolRequestIdentity(requestId, callId, idempotencyKey),
             new AgentToolCredentials(accessToken, "org-token", "sender-token"),
             new AgentToolCallerContext(scopeId, ownerSubject, "response-1", ownerScopeId),
-            AgentToolChannelContext.Empty,
-            new AgentToolSenderBindingContext(senderBindingId),
+            new AgentToolChannelContext(channelPlatform, channelSenderId, channelRegistrationScopeId, null, null),
+            new AgentToolSenderBindingContext(senderBindingId, senderNyxUserId, senderTenant),
             LLMRequestRoutingContext.Empty,
             AgentToolConnectedServicesContext.Empty,
             AgentSkillRecoveryContext.Empty,

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -4,6 +4,8 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.RunForks;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -641,6 +643,52 @@ public sealed class ChatEndpointsInternalTests
     }
 
     [Fact]
+    public async Task HandleChat_ShouldAttachResolvedBindingToWorkflowCallerCredential()
+    {
+        var capturedCommand = default(WorkflowChatRunRequest);
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = (command, _, _, _) =>
+            {
+                capturedCommand = command;
+                return Task.FromResult(
+                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                        .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
+            },
+        };
+        var bindingQueryPort = new RecordingBindingQueryPort("bnd_sender");
+        var http = CreateHttpContext("Bearer trusted-token");
+        http.RequestServices = CreateRequestServices(bindingQueryPort: bindingQueryPort);
+        http.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("uid", "nyx-user-from-uid"),
+            new Claim("sub", "nyx-user-from-sub"),
+        ], "test"));
+
+        await WorkflowCapabilityEndpoints.HandleChat(
+            http,
+            new ChatInput { Prompt = "hello" },
+            interactionService,
+            CancellationToken.None);
+
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.CallerCredential!.BearerToken.Should().Be("trusted-token");
+        capturedCommand.CallerCredential.NyxIdAuthority.Should().BeEquivalentTo(
+            new Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerNyxIdAuthority(
+                "nyxid",
+                string.Empty,
+                "nyx-user-from-uid",
+                "proxy",
+                "bnd_sender"));
+        bindingQueryPort.Subject.Should().BeEquivalentTo(new ExternalSubjectRef
+        {
+            Platform = "nyxid",
+            Tenant = string.Empty,
+            ExternalUserId = "nyx-user-from-uid",
+        });
+    }
+
+    [Fact]
     public async Task HandleChat_ShouldUseDelegationCredentialAndAuthenticatedScope()
     {
         var capturedCommand = default(WorkflowChatRunRequest);
@@ -860,6 +908,53 @@ public sealed class ChatEndpointsInternalTests
         capturedCommand.SessionId.Should().Be("session-1");
         capturedCommand.ScopeId.Should().Be("scope-1");
         capturedCommand.CallerCredential!.BearerToken.Should().Be("trusted-token");
+    }
+
+    [Fact]
+    public async Task HandleChatPost_ShouldAttachResolvedBindingToWorkflowCallerCredential()
+    {
+        var capturedCommand = default(WorkflowChatRunRequest);
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = (command, _, _, _) =>
+            {
+                capturedCommand = command;
+                return Task.FromResult(
+                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                        .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
+            },
+        };
+        var parser = new WorkflowMultipartChatRequestParser(
+            new RecordingWorkflowFileIngressPort(),
+            Options.Create(new WorkflowMultipartFileIngressOptions()));
+        var bindingQueryPort = new RecordingBindingQueryPort("bnd_sender");
+        var http = CreateHttpContext("Bearer trusted-token");
+        http.RequestServices = CreateRequestServices(bindingQueryPort: bindingQueryPort);
+        http.User = AuthenticatedScopePrincipal("trusted-scope");
+        http.Request.ContentType = "application/json";
+        http.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(
+            """
+            {
+              "prompt": "describe the release plan",
+              "workflow": "direct"
+            }
+            """));
+
+        await WorkflowCapabilityEndpoints.HandleChatPost(
+            http,
+            interactionService,
+            parser,
+            CancellationToken.None);
+
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.ScopeId.Should().Be("trusted-scope");
+        capturedCommand.CallerCredential!.NyxIdAuthority!.BindingId.Should().Be("bnd_sender");
+        bindingQueryPort.Subject.Should().BeEquivalentTo(new ExternalSubjectRef
+        {
+            Platform = "nyxid",
+            Tenant = string.Empty,
+            ExternalUserId = "trusted-scope",
+        });
     }
 
     [Fact]
@@ -2414,13 +2509,14 @@ public sealed class ChatEndpointsInternalTests
 
     private static IServiceProvider CreateRequestServices(
         string? authenticationEnabled = null,
-        string environmentName = "Production")
+        string environmentName = "Production",
+        IExternalIdentityBindingQueryPort? bindingQueryPort = null)
     {
         var configurationValues = new Dictionary<string, string?>(StringComparer.Ordinal);
         if (authenticationEnabled != null)
             configurationValues["Aevatar:Authentication:Enabled"] = authenticationEnabled;
 
-        return new ServiceCollection()
+        var services = new ServiceCollection()
             .AddLogging()
             .AddOptions()
             .AddSingleton<IConfiguration>(new ConfigurationBuilder()
@@ -2429,8 +2525,11 @@ public sealed class ChatEndpointsInternalTests
             .AddSingleton<IHostEnvironment>(new StubHostEnvironment
             {
                 EnvironmentName = environmentName,
-            })
-            .BuildServiceProvider();
+            });
+        if (bindingQueryPort != null)
+            services.AddSingleton(bindingQueryPort);
+
+        return services.BuildServiceProvider();
     }
 
     private static ClaimsPrincipal AuthenticatedScopePrincipal(string scopeId) =>
@@ -2443,6 +2542,24 @@ public sealed class ChatEndpointsInternalTests
         public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
         public IFileProvider ContentRootFileProvider { get; set; } =
             new NullFileProvider();
+    }
+
+    private sealed class RecordingBindingQueryPort : IExternalIdentityBindingQueryPort
+    {
+        private readonly BindingId? _bindingId;
+
+        public RecordingBindingQueryPort(string bindingId)
+        {
+            _bindingId = new BindingId { Value = bindingId };
+        }
+
+        public ExternalSubjectRef? Subject { get; private set; }
+
+        public Task<BindingId?> ResolveAsync(ExternalSubjectRef externalSubject, CancellationToken ct = default)
+        {
+            Subject = externalSubject.Clone();
+            return Task.FromResult(_bindingId);
+        }
     }
 
     private static IFormFile CreateFormFile(

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -689,6 +689,50 @@ public sealed class ChatEndpointsInternalTests
     }
 
     [Fact]
+    public async Task HandleChat_WhenBindingLookupFails_ShouldContinueWithoutBinding()
+    {
+        var capturedCommand = default(WorkflowChatRunRequest);
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = (command, _, _, _) =>
+            {
+                capturedCommand = command;
+                return Task.FromResult(
+                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                        .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
+            },
+        };
+        var bindingQueryPort = new ThrowingBindingQueryPort(new TimeoutException("binding read timeout"));
+        var http = CreateHttpContext("Bearer trusted-token");
+        http.RequestServices = CreateRequestServices(bindingQueryPort: bindingQueryPort);
+        http.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("uid", "nyx-user-from-uid"),
+        ], "test"));
+
+        await WorkflowCapabilityEndpoints.HandleChat(
+            http,
+            new ChatInput { Prompt = "hello" },
+            interactionService,
+            CancellationToken.None);
+
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.CallerCredential!.BearerToken.Should().Be("trusted-token");
+        capturedCommand.CallerCredential.NyxIdAuthority.Should().BeEquivalentTo(
+            new Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerNyxIdAuthority(
+                "nyxid",
+                string.Empty,
+                "nyx-user-from-uid",
+                "proxy"));
+        bindingQueryPort.Subject.Should().BeEquivalentTo(new ExternalSubjectRef
+        {
+            Platform = "nyxid",
+            Tenant = string.Empty,
+            ExternalUserId = "nyx-user-from-uid",
+        });
+    }
+
+    [Fact]
     public async Task HandleChat_ShouldUseDelegationCredentialAndAuthenticatedScope()
     {
         var capturedCommand = default(WorkflowChatRunRequest);
@@ -2559,6 +2603,24 @@ public sealed class ChatEndpointsInternalTests
         {
             Subject = externalSubject.Clone();
             return Task.FromResult(_bindingId);
+        }
+    }
+
+    private sealed class ThrowingBindingQueryPort : IExternalIdentityBindingQueryPort
+    {
+        private readonly Exception _exception;
+
+        public ThrowingBindingQueryPort(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public ExternalSubjectRef? Subject { get; private set; }
+
+        public Task<BindingId?> ResolveAsync(ExternalSubjectRef externalSubject, CancellationToken ct = default)
+        {
+            Subject = externalSubject.Clone();
+            throw _exception;
         }
     }
 


### PR DESCRIPTION
## Summary
- Resolve the authenticated NyxID binding in `/api/chat` credential extraction through `IExternalIdentityBindingQueryPort`.
- Carry the resolved `BindingId` into `WorkflowCallerNyxIdAuthority` so Studio member schedule tools can authorize team workflow schedules from chat.
- Add regression coverage for both direct `HandleChat` and JSON `HandleChatPost` entry paths.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter ChatEndpointsInternalTests --verbosity minimal`
- [x] `bash tools/ci/query_projection_priming_guard.sh`
- [!] `bash tools/ci/test_stability_guards.sh` reached local Python `pyexpat`/`libexpat` ImportError after earlier guard steps passed.
- [!] `bash tools/ci/architecture_guards.sh` reached the same local Python `pyexpat`/`libexpat` ImportError in `project_reference_layer_guard.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)