### PR TITLE
fix(console): align chat history continuation contract

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -45,6 +45,8 @@ const enUSMessages = {
     'Describe the workflow you want, or ask about the current setup...',
   'pages.chat.index.confirmAndCreate': 'Confirm and create',
   'pages.chat.index.confirmPrompt': 'Confirm. Please create it now.',
+  'pages.chat.index.continuationContextMissing':
+    'The continuation may have been accepted, but its turn identity was not received. Reload this page before continuing.',
   'pages.chat.index.cancel': 'Cancel',
   'pages.chat.index.delete': 'Delete',
   'pages.chat.index.deleteChat': 'Delete {title}',

--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -63,6 +63,8 @@ const enUSMessages = {
   'pages.chat.index.historyTitle': 'Chat history',
   'pages.chat.index.loadingConversation': 'Loading conversation',
   'pages.chat.index.loadingHistory': 'Loading chat history',
+  'pages.chat.index.historySynchronizing':
+    'Conversation history is still synchronizing. Try again shortly.',
   'pages.chat.index.missingChatHistoryContext':
     'Chat completed without a conversation context.',
   'pages.chat.index.newChat': 'New chat',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -60,6 +60,7 @@ const zhCNMessages = {
   'pages.chat.index.historyTitle': '会话历史',
   'pages.chat.index.loadingConversation': '正在加载会话',
   'pages.chat.index.loadingHistory': '正在加载会话历史',
+  'pages.chat.index.historySynchronizing': '会话历史仍在同步，请稍后重试。',
   'pages.chat.index.missingChatHistoryContext': 'Chat 已完成，但未返回会话上下文。',
   'pages.chat.index.newChat': '新会话',
   'pages.chat.index.newChatAction': '新建会话',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -44,6 +44,8 @@ const zhCNMessages = {
   'pages.chat.index.composerPlaceholder': '描述你想要的 workflow，或询问当前配置...',
   'pages.chat.index.confirmAndCreate': '确认并创建',
   'pages.chat.index.confirmPrompt': '确认，请现在创建。',
+  'pages.chat.index.continuationContextMissing':
+    '续聊请求可能已经被接受，但未收到本轮身份。请重新加载此页面后再继续。',
   'pages.chat.index.cancel': '取消',
   'pages.chat.index.delete': '删除',
   'pages.chat.index.deleteChat': '删除 {title}',

--- a/apps/aevatar-console-web/src/pages/chat/chatApi.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatApi.test.ts
@@ -5,7 +5,7 @@ import {
   extractChatStreamArtifacts,
   readChatStreamFrames,
   startChatStream,
-  startChatStreamWithProjectionRetry,
+  startChatStreamWithHistoryRefreshRetry,
 } from "./chatApi";
 
 jest.mock("@/shared/auth/fetch", () => ({
@@ -43,6 +43,20 @@ function missingConversationResponse(): Response {
       JSON.stringify({
         code: "CONVERSATION_NOT_FOUND",
         message: "Conversation was not found.",
+      })
+    ),
+  } as unknown as Response;
+}
+
+function historyReservationUnavailableResponse(): Response {
+  return {
+    ok: false,
+    status: 503,
+    statusText: "Service Unavailable",
+    text: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        code: "CHAT_HISTORY_RESERVATION_UNAVAILABLE",
+        message: "Conversation history is still materializing.",
       })
     ),
   } as unknown as Response;
@@ -97,7 +111,10 @@ describe("chatApi", () => {
     );
     await startChatStream(
       {
-        conversation: { conversationId: " conversation-a " },
+        conversation: {
+          conversationId: " conversation-a ",
+          minimumStateVersion: 7,
+        },
         prompt: "Continue conversation",
         sessionId: "runtime-session-b",
       },
@@ -108,13 +125,16 @@ describe("chatApi", () => {
     const secondBody = JSON.parse((authFetch as jest.Mock).mock.calls[1][1].body);
     expect(firstBody).toEqual({
       commandId: "create-command-a",
-      conversation: {},
+      conversation: { conversationId: null },
       prompt: "New conversation",
       sessionId: "runtime-session-a",
       workflow: "studio",
     });
     expect(secondBody).toEqual({
-      conversation: { conversationId: "conversation-a" },
+      conversation: {
+        conversationId: "conversation-a",
+        minimumStateVersion: 7,
+      },
       prompt: "Continue conversation",
       sessionId: "runtime-session-b",
       workflow: "studio",
@@ -128,6 +148,7 @@ describe("chatApi", () => {
           conversation: {
             conversationId: "conversation-a",
             createIdempotencyKey: "create-key-a",
+            minimumStateVersion: 7,
           } as never,
           prompt: "Continue",
           sessionId: "session-a",
@@ -147,7 +168,10 @@ describe("chatApi", () => {
     await expect(
       startChatStream(
         {
-          conversation: { conversationId: "   " },
+          conversation: {
+            conversationId: "   ",
+            minimumStateVersion: 7,
+          },
           prompt: "Continue",
           sessionId: "session-a",
         },
@@ -186,7 +210,10 @@ describe("chatApi", () => {
     try {
       await startChatStream(
         {
-          conversation: { conversationId: "missing" },
+          conversation: {
+            conversationId: "missing",
+            minimumStateVersion: 3,
+          },
           prompt: "Continue",
           sessionId: "session-a",
         },
@@ -204,58 +231,103 @@ describe("chatApi", () => {
     });
   });
 
-  it("retries only a continuing conversation while its projection is unavailable", async () => {
+  it("refreshes the server watermark before retrying a 503 continuation", async () => {
     (authFetch as jest.Mock)
-      .mockResolvedValueOnce(missingConversationResponse())
-      .mockResolvedValueOnce(missingConversationResponse())
+      .mockResolvedValueOnce(historyReservationUnavailableResponse())
       .mockResolvedValueOnce(successfulStreamResponse());
+    const refreshMinimumStateVersion = jest.fn().mockResolvedValue(8);
 
     await expect(
-      startChatStreamWithProjectionRetry(
+      startChatStreamWithHistoryRefreshRetry(
         {
-          conversation: { conversationId: "conversation-a" },
+          conversation: {
+            conversationId: "conversation-a",
+            minimumStateVersion: 7,
+          },
           prompt: "Continue",
           sessionId: "session-a",
         },
         new AbortController().signal,
-        [0, 0, 0]
+        { refreshMinimumStateVersion, retryDelaysMs: [0] }
       )
     ).resolves.toEqual(successfulStreamResponse());
-    expect(authFetch).toHaveBeenCalledTimes(3);
+    expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(1);
+    expect(authFetch).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.parse((authFetch as jest.Mock).mock.calls[0][1].body).conversation
+    ).toEqual({ conversationId: "conversation-a", minimumStateVersion: 7 });
+    expect(
+      JSON.parse((authFetch as jest.Mock).mock.calls[1][1].body).conversation
+    ).toEqual({ conversationId: "conversation-a", minimumStateVersion: 8 });
   });
 
-  it("caps continuation retries and never retries a new conversation", async () => {
-    (authFetch as jest.Mock).mockImplementation(async () =>
-      missingConversationResponse()
-    );
+  it("does not retry a missing conversation or a new conversation", async () => {
+    const refreshMinimumStateVersion = jest.fn().mockResolvedValue(8);
+    (authFetch as jest.Mock).mockResolvedValue(missingConversationResponse());
 
     await expect(
-      startChatStreamWithProjectionRetry(
+      startChatStreamWithHistoryRefreshRetry(
         {
-          conversation: { conversationId: "conversation-a" },
+          conversation: {
+            conversationId: "conversation-a",
+            minimumStateVersion: 7,
+          },
           prompt: "Continue",
           sessionId: "session-a",
         },
         new AbortController().signal,
-        [0, 0, 0]
+        { refreshMinimumStateVersion, retryDelaysMs: [0, 0] }
       )
     ).rejects.toMatchObject({ code: "CONVERSATION_NOT_FOUND", status: 404 });
-    expect(authFetch).toHaveBeenCalledTimes(3);
+    expect(authFetch).toHaveBeenCalledTimes(1);
+    expect(refreshMinimumStateVersion).not.toHaveBeenCalled();
 
     jest.clearAllMocks();
-    (authFetch as jest.Mock).mockResolvedValue(missingConversationResponse());
+    (authFetch as jest.Mock).mockResolvedValue(
+      historyReservationUnavailableResponse()
+    );
     await expect(
-      startChatStreamWithProjectionRetry(
+      startChatStreamWithHistoryRefreshRetry(
         {
-          conversation: {},
+          conversation: { conversationId: null },
           prompt: "Create",
           sessionId: "session-b",
         },
         new AbortController().signal,
-        [0, 0, 0]
+        { refreshMinimumStateVersion, retryDelaysMs: [0, 0] }
       )
-    ).rejects.toMatchObject({ code: "CONVERSATION_NOT_FOUND", status: 404 });
+    ).rejects.toMatchObject({
+      code: "CHAT_HISTORY_RESERVATION_UNAVAILABLE",
+      status: 503,
+    });
     expect(authFetch).toHaveBeenCalledTimes(1);
+    expect(refreshMinimumStateVersion).not.toHaveBeenCalled();
+  });
+
+  it("never lowers a continuation watermark after a refresh", async () => {
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(historyReservationUnavailableResponse())
+      .mockResolvedValueOnce(successfulStreamResponse());
+
+    await startChatStreamWithHistoryRefreshRetry(
+      {
+        conversation: {
+          conversationId: "conversation-a",
+          minimumStateVersion: 7,
+        },
+        prompt: "Continue",
+        sessionId: "session-a",
+      },
+      new AbortController().signal,
+      {
+        refreshMinimumStateVersion: async () => 6,
+        retryDelaysMs: [0],
+      }
+    );
+
+    expect(
+      JSON.parse((authFetch as jest.Mock).mock.calls[1][1].body).conversation
+    ).toEqual({ conversationId: "conversation-a", minimumStateVersion: 7 });
   });
 
   it("extracts the exact flat chat history Any context", () => {
@@ -266,6 +338,7 @@ describe("chatApi", () => {
           "@type": CHAT_HISTORY_CONTEXT_TYPE,
           conversationId: "conversation-a",
           scopeId: "scope-a",
+          stateVersion: 7,
           turnId: "turn-a",
         },
       },
@@ -275,12 +348,14 @@ describe("chatApi", () => {
     expect(extractChatHistoryContext(frame)).toEqual({
       conversationId: "conversation-a",
       scopeId: "scope-a",
+      stateVersion: 7,
       turnId: "turn-a",
     });
     expect(extractChatStreamArtifacts([frame])).toEqual({
       chatHistoryContext: {
         conversationId: "conversation-a",
         scopeId: "scope-a",
+        stateVersion: 7,
         turnId: "turn-a",
       },
     });

--- a/apps/aevatar-console-web/src/pages/chat/chatApi.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatApi.test.ts
@@ -1,12 +1,18 @@
 import { authFetch } from "@/shared/auth/fetch";
 import {
   ChatApiError,
+  ChatRetryPreparationError,
+  chatRequestMayHaveBeenAccepted,
   extractChatHistoryContext,
   extractChatStreamArtifacts,
   readChatStreamFrames,
   startChatStream,
   startChatStreamWithHistoryRefreshRetry,
 } from "./chatApi";
+import {
+  ChatHistoryApiError,
+  ChatHistoryContractError,
+} from "./chatHistoryApi";
 
 jest.mock("@/shared/auth/fetch", () => ({
   authFetch: jest.fn(),
@@ -231,12 +237,40 @@ describe("chatApi", () => {
     });
   });
 
+  it("keeps a non-success response definitive when its error body cannot be read", async () => {
+    (authFetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      text: jest.fn().mockRejectedValue(new Error("Response body disconnected")),
+    } as unknown as Response);
+
+    await expect(
+      startChatStream(
+        {
+          conversation: {
+            conversationId: "conversation-a",
+            minimumStateVersion: 7,
+          },
+          prompt: "Continue",
+          sessionId: "session-a",
+        },
+        new AbortController().signal
+      )
+    ).rejects.toMatchObject({
+      message: "HTTP 409 Conflict",
+      name: "ChatApiError",
+      status: 409,
+    });
+  });
+
   it("refreshes the server watermark before retrying a 503 continuation", async () => {
     (authFetch as jest.Mock)
       .mockResolvedValueOnce(historyReservationUnavailableResponse())
       .mockResolvedValueOnce(successfulStreamResponse());
     const refreshMinimumStateVersion = jest.fn().mockResolvedValue(8);
 
+    const controller = new AbortController();
     await expect(
       startChatStreamWithHistoryRefreshRetry(
         {
@@ -247,11 +281,12 @@ describe("chatApi", () => {
           prompt: "Continue",
           sessionId: "session-a",
         },
-        new AbortController().signal,
+        controller.signal,
         { refreshMinimumStateVersion, retryDelaysMs: [0] }
       )
     ).resolves.toEqual(successfulStreamResponse());
     expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(1);
+    expect(refreshMinimumStateVersion).toHaveBeenCalledWith(controller.signal);
     expect(authFetch).toHaveBeenCalledTimes(2);
     expect(
       JSON.parse((authFetch as jest.Mock).mock.calls[0][1].body).conversation
@@ -304,10 +339,15 @@ describe("chatApi", () => {
     expect(refreshMinimumStateVersion).not.toHaveBeenCalled();
   });
 
-  it("never lowers a continuation watermark after a refresh", async () => {
+  it("accepts a zero refresh watermark and waits for 0 -> 6 -> 8 without sending a stale retry", async () => {
     (authFetch as jest.Mock)
       .mockResolvedValueOnce(historyReservationUnavailableResponse())
       .mockResolvedValueOnce(successfulStreamResponse());
+    const refreshMinimumStateVersion = jest
+      .fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(6)
+      .mockResolvedValueOnce(8);
 
     await startChatStreamWithHistoryRefreshRetry(
       {
@@ -320,15 +360,174 @@ describe("chatApi", () => {
       },
       new AbortController().signal,
       {
-        refreshMinimumStateVersion: async () => 6,
-        retryDelaysMs: [0],
+        refreshMinimumStateVersion,
+        retryDelaysMs: [0, 0, 0],
       }
     );
 
+    expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(3);
+    expect(authFetch).toHaveBeenCalledTimes(2);
     expect(
       JSON.parse((authFetch as jest.Mock).mock.calls[1][1].body).conversation
-    ).toEqual({ conversationId: "conversation-a", minimumStateVersion: 7 });
+    ).toEqual({ conversationId: "conversation-a", minimumStateVersion: 8 });
   });
+
+  it("preserves the reservation error when refreshed history never catches up", async () => {
+    (authFetch as jest.Mock).mockResolvedValueOnce(
+      historyReservationUnavailableResponse()
+    );
+    const refreshMinimumStateVersion = jest.fn().mockResolvedValue(6);
+
+    await expect(
+      startChatStreamWithHistoryRefreshRetry(
+        {
+          conversation: {
+            conversationId: "conversation-a",
+            minimumStateVersion: 7,
+          },
+          prompt: "Continue",
+          sessionId: "session-a",
+        },
+        new AbortController().signal,
+        {
+          refreshMinimumStateVersion,
+          retryDelaysMs: [0, 0],
+        }
+      )
+    ).rejects.toMatchObject({
+      code: "CHAT_HISTORY_RESERVATION_UNAVAILABLE",
+      status: 503,
+    });
+    expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(2);
+    expect(authFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch or lock after cancellation at the refresh boundary", async () => {
+    (authFetch as jest.Mock).mockResolvedValueOnce(
+      historyReservationUnavailableResponse()
+    );
+    const controller = new AbortController();
+    const refreshMinimumStateVersion = jest.fn(async () => {
+      controller.abort();
+      return 8;
+    });
+
+    let thrown: unknown;
+    try {
+      await startChatStreamWithHistoryRefreshRetry(
+        {
+          conversation: {
+            conversationId: "conversation-a",
+            minimumStateVersion: 7,
+          },
+          prompt: "Continue",
+          sessionId: "session-a",
+        },
+        controller.signal,
+        { refreshMinimumStateVersion, retryDelaysMs: [0] }
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ChatRetryPreparationError);
+    expect(chatRequestMayHaveBeenAccepted(thrown)).toBe(false);
+    expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(1);
+    expect(authFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["transport", new Error("History detail temporarily unavailable")],
+    [
+      "server",
+      new ChatHistoryApiError("History detail temporarily unavailable", 500),
+    ],
+  ])(
+    "uses the remaining retry budget after a transient %s history refresh failure",
+    async (_kind, refreshError) => {
+      (authFetch as jest.Mock)
+        .mockResolvedValueOnce(historyReservationUnavailableResponse())
+        .mockResolvedValueOnce(successfulStreamResponse());
+      const refreshMinimumStateVersion = jest
+        .fn()
+        .mockRejectedValueOnce(refreshError)
+        .mockResolvedValueOnce(8);
+
+      await expect(
+        startChatStreamWithHistoryRefreshRetry(
+          {
+            conversation: {
+              conversationId: "conversation-a",
+              minimumStateVersion: 7,
+            },
+            prompt: "Continue",
+            sessionId: "session-a",
+          },
+          new AbortController().signal,
+          {
+            refreshMinimumStateVersion,
+            retryDelaysMs: [0, 0],
+          }
+        )
+      ).resolves.toEqual(successfulStreamResponse());
+      expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(2);
+      expect(authFetch).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  it.each([
+    [
+      "a non-retryable history response",
+      new ChatHistoryApiError("History request was rejected", 422),
+    ],
+    [
+      "a malformed history contract",
+      new ChatHistoryContractError(
+        "$conversation.stateVersion",
+        "a non-negative safe integer"
+      ),
+    ],
+  ])(
+    "preserves %s as a definitive retry preparation failure",
+    async (_kind, refreshError) => {
+      (authFetch as jest.Mock).mockResolvedValueOnce(
+        historyReservationUnavailableResponse()
+      );
+      const refreshMinimumStateVersion = jest
+        .fn()
+        .mockRejectedValue(refreshError);
+
+      let error: unknown;
+      try {
+        await startChatStreamWithHistoryRefreshRetry(
+          {
+            conversation: {
+              conversationId: "conversation-a",
+              minimumStateVersion: 7,
+            },
+            prompt: "Continue",
+            sessionId: "session-a",
+          },
+          new AbortController().signal,
+          {
+            refreshMinimumStateVersion,
+            retryDelaysMs: [0, 0],
+          }
+        );
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeInstanceOf(ChatRetryPreparationError);
+      expect(error).toMatchObject({
+        cause: refreshError,
+        mayHaveBeenAccepted: false,
+        message: refreshError.message,
+      });
+      expect(refreshMinimumStateVersion).toHaveBeenCalledTimes(1);
+      expect(authFetch).toHaveBeenCalledTimes(1);
+    }
+  );
 
   it("extracts the exact flat chat history Any context", () => {
     const frame = {

--- a/apps/aevatar-console-web/src/pages/chat/chatApi.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatApi.ts
@@ -7,6 +7,10 @@ import type {
   ChatStudioTarget,
   ChatUsageSummary,
 } from "./chatTypes";
+import {
+  ChatHistoryApiError,
+  ChatHistoryContractError,
+} from "./chatHistoryApi";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -45,6 +49,23 @@ export class ChatApiError extends Error {
     this.code = code;
     this.status = status;
   }
+}
+
+export class ChatRetryPreparationError extends Error {
+  readonly cause: unknown;
+  readonly mayHaveBeenAccepted = false;
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "ChatRetryPreparationError";
+    this.cause = cause;
+  }
+}
+
+export function chatRequestMayHaveBeenAccepted(error: unknown): boolean {
+  return !(
+    error instanceof ChatApiError || error instanceof ChatRetryPreparationError
+  );
 }
 
 function compactObject<T extends Record<string, unknown>>(value: T): T {
@@ -376,7 +397,18 @@ export async function startChatStream(
   });
 
   if (!response.ok) {
-    const details = await readResponseErrorDetails(response);
+    let details: Awaited<ReturnType<typeof readResponseErrorDetails>>;
+    try {
+      details = await readResponseErrorDetails(response);
+    } catch {
+      const statusText = response.statusText.trim();
+      throw new ChatApiError(
+        statusText
+          ? `HTTP ${response.status} ${statusText}`
+          : `HTTP ${response.status}`,
+        response.status
+      );
+    }
     throw new ChatApiError(details.message, details.status, details.code);
   }
 
@@ -404,8 +436,42 @@ function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+function isAbortError(error: unknown, signal: AbortSignal): boolean {
+  return (
+    signal.aborted ||
+    (error instanceof DOMException && error.name === "AbortError")
+  );
+}
+
+function throwIfAbortedBeforeDispatch(signal: AbortSignal): void {
+  if (!signal.aborted) {
+    return;
+  }
+
+  throw new ChatRetryPreparationError(
+    signal.reason ?? new DOMException("Aborted", "AbortError")
+  );
+}
+
+function isRetryableHistoryRefreshError(error: unknown): boolean {
+  if (error instanceof ChatHistoryContractError) {
+    return false;
+  }
+
+  if (error instanceof ChatHistoryApiError) {
+    return error.status >= 500 && error.status < 600;
+  }
+
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as { status?: unknown }).status;
+    return typeof status === "number" && status >= 500 && status < 600;
+  }
+
+  return true;
+}
+
 export type ChatHistoryRefreshRetryOptions = {
-  refreshMinimumStateVersion?: () => Promise<number>;
+  refreshMinimumStateVersion?: (signal: AbortSignal) => Promise<number>;
   retryDelaysMs?: readonly number[];
 };
 
@@ -418,17 +484,34 @@ export async function startChatStreamWithHistoryRefreshRetry(
   const attempts = [0, ...retryDelaysMs];
   let requestForAttempt = request;
   let refreshBeforeAttempt = false;
+  let lastReservationError: ChatApiError | undefined;
 
   for (let attempt = 0; attempt < attempts.length; attempt += 1) {
     if (attempt > 0) {
-      await abortableDelay(attempts[attempt], signal);
+      try {
+        await abortableDelay(attempts[attempt], signal);
+      } catch (error) {
+        throw new ChatRetryPreparationError(error);
+      }
     }
 
     if (refreshBeforeAttempt && options.refreshMinimumStateVersion) {
-      const refreshedStateVersion = await options.refreshMinimumStateVersion();
+      let refreshedStateVersion: number;
+      try {
+        refreshedStateVersion = await options.refreshMinimumStateVersion(signal);
+      } catch (error) {
+        if (
+          isAbortError(error, signal) ||
+          !isRetryableHistoryRefreshError(error)
+        ) {
+          throw new ChatRetryPreparationError(error);
+        }
+
+        continue;
+      }
       if (
         !Number.isSafeInteger(refreshedStateVersion) ||
-        refreshedStateVersion <= 0
+        refreshedStateVersion < 0
       ) {
         throw new ChatApiError(
           "Conversation state version is invalid.",
@@ -445,6 +528,9 @@ export async function startChatStreamWithHistoryRefreshRetry(
           "INVALID_CONVERSATION_INPUT"
         );
       }
+      if (refreshedStateVersion < conversation.minimumStateVersion) {
+        continue;
+      }
       const minimumStateVersion = Math.max(
         conversation.minimumStateVersion,
         refreshedStateVersion
@@ -459,6 +545,7 @@ export async function startChatStreamWithHistoryRefreshRetry(
       refreshBeforeAttempt = false;
     }
 
+    throwIfAbortedBeforeDispatch(signal);
     try {
       return await startChatStream(requestForAttempt, signal);
     } catch (error) {
@@ -476,11 +563,14 @@ export async function startChatStreamWithHistoryRefreshRetry(
       if (!canRetry) {
         throw error;
       }
+      lastReservationError = error;
       refreshBeforeAttempt = true;
     }
   }
 
-  throw new Error("Chat stream could not be started.");
+  throw (
+    lastReservationError ?? new Error("Chat stream could not be started.")
+  );
 }
 
 export async function* readChatStreamFrames(

--- a/apps/aevatar-console-web/src/pages/chat/chatApi.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatApi.ts
@@ -14,9 +14,14 @@ const CHAT_HISTORY_CONTEXT_NAME = "aevatar.chat.context";
 const CHAT_HISTORY_CONTEXT_TYPE_URL =
   "type.googleapis.com/aevatar.workflow.runs.WorkflowChatContextPayload";
 
-export type ChatConversationIntent = {
-  conversationId?: string | null;
-};
+export type ChatConversationIntent =
+  | {
+      conversationId: null;
+    }
+  | {
+      conversationId: string;
+      minimumStateVersion: number;
+    };
 
 export type ChatStreamRequest = {
   commandId?: string;
@@ -231,10 +236,17 @@ export function extractChatHistoryContext(
   const context: ChatHistoryContext = {
     conversationId: readString(payload, "conversationId"),
     scopeId: readString(payload, "scopeId"),
+    stateVersion: readNumber(payload, "stateVersion") ?? Number.NaN,
     turnId: readString(payload, "turnId"),
   };
 
-  return Object.values(context).every(Boolean) ? context : null;
+  return context.conversationId &&
+    context.scopeId &&
+    context.turnId &&
+    Number.isSafeInteger(context.stateVersion) &&
+    context.stateVersion >= 0
+    ? context
+    : null;
 }
 
 export function extractChatStreamArtifacts(frames: readonly unknown[]): {
@@ -290,9 +302,9 @@ function normalizeConversationIntent(
   const record = asRecord(conversation);
   if (
     !record ||
-    Object.keys(record).some((key) => key !== "conversationId") ||
-    (record.conversationId != null &&
-      typeof record.conversationId !== "string")
+    Object.keys(record).some(
+      (key) => key !== "conversationId" && key !== "minimumStateVersion"
+    )
   ) {
     throw new ChatApiError(
       "Conversation input is invalid.",
@@ -301,11 +313,23 @@ function normalizeConversationIntent(
     );
   }
 
+  if (record.conversationId === null) {
+    if (record.minimumStateVersion !== undefined) {
+      throw new ChatApiError(
+        "Conversation input is invalid.",
+        400,
+        "INVALID_CONVERSATION_INPUT"
+      );
+    }
+
+    return { conversationId: null };
+  }
+
   const conversationId =
     typeof record.conversationId === "string"
       ? record.conversationId.trim()
-      : undefined;
-  if (record.conversationId != null && !conversationId) {
+      : "";
+  if (!conversationId) {
     throw new ChatApiError(
       "Conversation id is invalid.",
       400,
@@ -313,7 +337,20 @@ function normalizeConversationIntent(
     );
   }
 
-  return compactObject({ conversationId });
+  const minimumStateVersion = record.minimumStateVersion;
+  if (
+    typeof minimumStateVersion !== "number" ||
+    !Number.isSafeInteger(minimumStateVersion) ||
+    minimumStateVersion <= 0
+  ) {
+    throw new ChatApiError(
+      "Conversation state version is invalid.",
+      400,
+      "INVALID_CONVERSATION_STATE_VERSION"
+    );
+  }
+
+  return { conversationId, minimumStateVersion };
 }
 
 export async function startChatStream(
@@ -367,31 +404,79 @@ function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {
   });
 }
 
-export async function startChatStreamWithProjectionRetry(
+export type ChatHistoryRefreshRetryOptions = {
+  refreshMinimumStateVersion?: () => Promise<number>;
+  retryDelaysMs?: readonly number[];
+};
+
+export async function startChatStreamWithHistoryRefreshRetry(
   request: ChatStreamRequest,
   signal: AbortSignal,
-  retryDelaysMs: readonly number[] = [0, 300, 900]
+  options: ChatHistoryRefreshRetryOptions = {}
 ): Promise<Response> {
-  const attempts = retryDelaysMs.length > 0 ? retryDelaysMs : [0];
-  const isContinuation = Boolean(request.conversation?.conversationId?.trim());
+  const retryDelaysMs = options.retryDelaysMs ?? [300, 900];
+  const attempts = [0, ...retryDelaysMs];
+  let requestForAttempt = request;
+  let refreshBeforeAttempt = false;
 
   for (let attempt = 0; attempt < attempts.length; attempt += 1) {
     if (attempt > 0) {
       await abortableDelay(attempts[attempt], signal);
     }
 
+    if (refreshBeforeAttempt && options.refreshMinimumStateVersion) {
+      const refreshedStateVersion = await options.refreshMinimumStateVersion();
+      if (
+        !Number.isSafeInteger(refreshedStateVersion) ||
+        refreshedStateVersion <= 0
+      ) {
+        throw new ChatApiError(
+          "Conversation state version is invalid.",
+          400,
+          "INVALID_CONVERSATION_STATE_VERSION"
+        );
+      }
+
+      const conversation = requestForAttempt.conversation;
+      if (!conversation || conversation.conversationId === null) {
+        throw new ChatApiError(
+          "Conversation input is invalid.",
+          400,
+          "INVALID_CONVERSATION_INPUT"
+        );
+      }
+      const minimumStateVersion = Math.max(
+        conversation.minimumStateVersion,
+        refreshedStateVersion
+      );
+      requestForAttempt = {
+        ...requestForAttempt,
+        conversation: {
+          conversationId: conversation.conversationId,
+          minimumStateVersion,
+        },
+      };
+      refreshBeforeAttempt = false;
+    }
+
     try {
-      return await startChatStream(request, signal);
+      return await startChatStream(requestForAttempt, signal);
     } catch (error) {
+      const conversation = requestForAttempt.conversation;
+      const isContinuation = Boolean(
+        conversation && conversation.conversationId !== null
+      );
       const canRetry =
         isContinuation &&
         error instanceof ChatApiError &&
-        error.status === 404 &&
-        error.code === "CONVERSATION_NOT_FOUND" &&
+        error.status === 503 &&
+        error.code === "CHAT_HISTORY_RESERVATION_UNAVAILABLE" &&
+        Boolean(options.refreshMinimumStateVersion) &&
         attempt < attempts.length - 1;
       if (!canRetry) {
         throw error;
       }
+      refreshBeforeAttempt = true;
     }
   }
 

--- a/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts
@@ -7,6 +7,7 @@ import {
   ChatHistoryApiError,
   ChatHistoryContractError,
   chatHistoryApi,
+  decodeChatConversationDetail,
   decodeChatCreateRecovery,
   decodeChatHistoryIndex,
   decodeStoredChatMessages,
@@ -149,7 +150,29 @@ describe("chatHistoryApi", () => {
 
   it("preserves documented message fields and unknown role or status strings", async () => {
     (authFetch as jest.Mock).mockResolvedValue(
-      jsonResponse([
+      jsonResponse({
+        messages: [
+          {
+            authorId: null,
+            authorName: "Automation",
+            content: "Queued for review",
+            error: null,
+            id: "turn-a:observer",
+            role: "observer",
+            status: "queued",
+            thinking: null,
+            timestamp: 1784255700000,
+            turnId: "turn-a",
+          },
+        ],
+        stateVersion: 7,
+      })
+    );
+
+    await expect(
+      chatHistoryApi.loadConversation("scope/a", "conversation/a")
+    ).resolves.toEqual({
+      messages: [
         {
           authorId: null,
           authorName: "Automation",
@@ -162,25 +185,9 @@ describe("chatHistoryApi", () => {
           timestamp: 1784255700000,
           turnId: "turn-a",
         },
-      ])
-    );
-
-    await expect(
-      chatHistoryApi.loadConversation("scope/a", "conversation/a")
-    ).resolves.toEqual([
-      {
-        authorId: null,
-        authorName: "Automation",
-        content: "Queued for review",
-        error: null,
-        id: "turn-a:observer",
-        role: "observer",
-        status: "queued",
-        thinking: null,
-        timestamp: 1784255700000,
-        turnId: "turn-a",
-      },
-    ]);
+      ],
+      stateVersion: 7,
+    });
     expect(authFetch).toHaveBeenCalledWith(
       "/api/scopes/scope%2Fa/chat-history/conversations/conversation%2Fa",
       {
@@ -195,12 +202,21 @@ describe("chatHistoryApi", () => {
       conversations: [],
     });
     expect(decodeStoredChatMessages([])).toEqual([]);
+    expect(
+      decodeChatConversationDetail({ messages: [], stateVersion: 0 })
+    ).toEqual({ messages: [], stateVersion: 0 });
   });
 
   it("rejects malformed successful response bodies explicitly", () => {
     expect(() => decodeChatHistoryIndex({ conversations: {} })).toThrow(
       ChatHistoryContractError
     );
+    expect(() => decodeChatConversationDetail([])).toThrow(
+      ChatHistoryContractError
+    );
+    expect(() =>
+      decodeChatConversationDetail({ messages: [], stateVersion: -1 })
+    ).toThrow(expect.objectContaining({ path: "$conversation.stateVersion" }));
     expect(() =>
       decodeStoredChatMessages([
         {

--- a/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.test.ts
@@ -10,7 +10,6 @@ import {
   decodeChatConversationDetail,
   decodeChatCreateRecovery,
   decodeChatHistoryIndex,
-  decodeStoredChatMessages,
 } from "./chatHistoryApi";
 
 function jsonResponse(payload: unknown): Response {
@@ -97,11 +96,23 @@ describe("chatHistoryApi", () => {
         })
       );
 
-    await expect(chatHistoryApi.listConversationMetas("scope-a")).resolves.toEqual(
+    const controller = new AbortController();
+    await expect(
+      chatHistoryApi.listConversationMetas("scope-a", controller.signal)
+    ).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "conversation-new" }),
         expect.objectContaining({ id: "conversation-old" }),
       ])
+    );
+    expect(authFetch).toHaveBeenNthCalledWith(
+      1,
+      "/api/scopes/scope-a/chat-history",
+      {
+        headers: { Accept: "application/json" },
+        method: "GET",
+        signal: controller.signal,
+      }
     );
     expect(authFetch).toHaveBeenNthCalledWith(
       2,
@@ -109,6 +120,7 @@ describe("chatHistoryApi", () => {
       {
         headers: { Accept: "application/json" },
         method: "GET",
+        signal: controller.signal,
       }
     );
   });
@@ -169,8 +181,13 @@ describe("chatHistoryApi", () => {
       })
     );
 
+    const controller = new AbortController();
     await expect(
-      chatHistoryApi.loadConversation("scope/a", "conversation/a")
+      chatHistoryApi.loadConversation(
+        "scope/a",
+        "conversation/a",
+        controller.signal
+      )
     ).resolves.toEqual({
       messages: [
         {
@@ -193,6 +210,7 @@ describe("chatHistoryApi", () => {
       {
         headers: { Accept: "application/json" },
         method: "GET",
+        signal: controller.signal,
       }
     );
   });
@@ -201,7 +219,6 @@ describe("chatHistoryApi", () => {
     expect(decodeChatHistoryIndex({ conversations: [] })).toEqual({
       conversations: [],
     });
-    expect(decodeStoredChatMessages([])).toEqual([]);
     expect(
       decodeChatConversationDetail({ messages: [], stateVersion: 0 })
     ).toEqual({ messages: [], stateVersion: 0 });
@@ -218,19 +235,22 @@ describe("chatHistoryApi", () => {
       decodeChatConversationDetail({ messages: [], stateVersion: -1 })
     ).toThrow(expect.objectContaining({ path: "$conversation.stateVersion" }));
     expect(() =>
-      decodeStoredChatMessages([
-        {
-          content: "hello",
-          id: "message-a",
-          role: "user",
-          status: "complete",
-          timestamp: "not-a-number",
-        },
-      ])
+      decodeChatConversationDetail({
+        messages: [
+          {
+            content: "hello",
+            id: "message-a",
+            role: "user",
+            status: "complete",
+            timestamp: "not-a-number",
+          },
+        ],
+        stateVersion: 7,
+      })
     ).toThrow(
       expect.objectContaining({
         code: "INVALID_CHAT_HISTORY_RESPONSE",
-        path: "$messages[0].timestamp",
+        path: "$conversation.messages[0].timestamp",
       })
     );
   });

--- a/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts
@@ -218,10 +218,6 @@ function decodeStoredChatMessagesAtPath(
   );
 }
 
-export function decodeStoredChatMessages(value: unknown): StoredChatMessage[] {
-  return decodeStoredChatMessagesAtPath(value, "$messages");
-}
-
 export function decodeChatConversationDetail(
   value: unknown
 ): ChatConversationDetail {
@@ -278,11 +274,13 @@ async function createApiError(response: Response): Promise<ChatHistoryApiError> 
 
 async function requestJson<T>(
   path: string,
-  decoder: (value: unknown) => T
+  decoder: (value: unknown) => T,
+  signal?: AbortSignal
 ): Promise<T> {
   const response = await authFetch(path, {
     headers: JSON_HEADERS,
     method: "GET",
+    ...(signal ? { signal } : {}),
   });
   if (!response.ok) {
     throw await createApiError(response);
@@ -299,14 +297,18 @@ async function requestJson<T>(
 }
 
 export const chatHistoryApi = {
-  async listConversationMetas(scopeId: string): Promise<ConversationMeta[]> {
+  async listConversationMetas(
+    scopeId: string,
+    signal?: AbortSignal
+  ): Promise<ConversationMeta[]> {
     const conversations: ConversationMeta[] = [];
     const seenCursors = new Set<string>();
     let cursor: string | undefined;
     do {
       const index = await requestJson(
         buildIndexPagePath(scopeId, cursor),
-        decodeChatHistoryIndex
+        decodeChatHistoryIndex,
+        signal
       );
       conversations.push(...index.conversations);
       const nextCursor = index.nextCursor?.trim() || undefined;
@@ -326,21 +328,25 @@ export const chatHistoryApi = {
 
   async recoverCreate(
     scopeId: string,
-    commandId: string
+    commandId: string,
+    signal?: AbortSignal
   ): Promise<ChatCreateRecovery> {
     return requestJson(
       buildCreateRecoveryPath(scopeId, commandId),
-      decodeChatCreateRecovery
+      decodeChatCreateRecovery,
+      signal
     );
   },
 
   async loadConversation(
     scopeId: string,
-    conversationId: string
+    conversationId: string,
+    signal?: AbortSignal
   ): Promise<ChatConversationDetail> {
     return requestJson(
       buildConversationPath(scopeId, conversationId),
-      decodeChatConversationDetail
+      decodeChatConversationDetail,
+      signal
     );
   },
 

--- a/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatHistoryApi.ts
@@ -1,6 +1,7 @@
 import { readResponseErrorDetails } from "@/shared/api/http/error";
 import { authFetch } from "@/shared/auth/fetch";
 import type {
+  ChatConversationDetail,
   ChatCreateRecovery,
   ChatHistoryIndex,
   ConversationMeta,
@@ -204,14 +205,42 @@ export function decodeChatCreateRecovery(value: unknown): ChatCreateRecovery {
   };
 }
 
-export function decodeStoredChatMessages(value: unknown): StoredChatMessage[] {
+function decodeStoredChatMessagesAtPath(
+  value: unknown,
+  path: string
+): StoredChatMessage[] {
   if (!Array.isArray(value)) {
-    return failContract("$messages", "an array");
+    return failContract(path, "an array");
   }
 
   return value.map((message, index) =>
-    decodeStoredChatMessage(message, `$messages[${index}]`)
+    decodeStoredChatMessage(message, `${path}[${index}]`)
   );
+}
+
+export function decodeStoredChatMessages(value: unknown): StoredChatMessage[] {
+  return decodeStoredChatMessagesAtPath(value, "$messages");
+}
+
+export function decodeChatConversationDetail(
+  value: unknown
+): ChatConversationDetail {
+  const record = asRecord(value, "$conversation");
+  const stateVersion = readNumber(record, "stateVersion", "$conversation");
+  if (!Number.isSafeInteger(stateVersion) || stateVersion < 0) {
+    return failContract(
+      "$conversation.stateVersion",
+      "a non-negative safe integer"
+    );
+  }
+
+  return {
+    messages: decodeStoredChatMessagesAtPath(
+      record.messages,
+      "$conversation.messages"
+    ),
+    stateVersion,
+  };
 }
 
 function encodeSegment(value: string): string {
@@ -308,10 +337,10 @@ export const chatHistoryApi = {
   async loadConversation(
     scopeId: string,
     conversationId: string
-  ): Promise<StoredChatMessage[]> {
+  ): Promise<ChatConversationDetail> {
     return requestJson(
       buildConversationPath(scopeId, conversationId),
-      decodeStoredChatMessages
+      decodeChatConversationDetail
     );
   },
 

--- a/apps/aevatar-console-web/src/pages/chat/chatTypes.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatTypes.ts
@@ -107,6 +107,7 @@ export type ConversationSessionSnapshot = {
 export type ChatHistoryContext = {
   scopeId: string;
   conversationId: string;
+  stateVersion: number;
   turnId: string;
 };
 
@@ -140,6 +141,11 @@ export type StoredChatMessage = {
   authorId?: string | null;
   authorName?: string | null;
   thinking?: string | null;
+};
+
+export type ChatConversationDetail = {
+  messages: StoredChatMessage[];
+  stateVersion: number;
 };
 
 export type ChatHistoryIndex = {

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -93,10 +93,30 @@ const serverMessages = [
   },
 ];
 
+type StoredMessageFixture = {
+  authorName?: string;
+  content: string;
+  error?: string;
+  id: string;
+  role: string;
+  status: string;
+  thinking?: string;
+  timestamp: number;
+  turnId?: string;
+};
+
+function conversationDetail(
+  messages: StoredMessageFixture[] = serverMessages,
+  stateVersion = 7
+): { messages: StoredMessageFixture[]; stateVersion: number } {
+  return { messages, stateVersion };
+}
+
 function chatContextFrame(
   conversationId = "conversation-a",
   turnId = "turn-a",
-  scopeId = "scope-a"
+  scopeId = "scope-a",
+  stateVersion = 7
 ): unknown {
   return {
     custom: {
@@ -105,6 +125,7 @@ function chatContextFrame(
         "@type": CHAT_HISTORY_CONTEXT_TYPE,
         conversationId,
         scopeId,
+        stateVersion,
         turnId,
       },
     },
@@ -218,8 +239,12 @@ describe("ChatPage server-backed history", () => {
     window.history.replaceState({}, "", "/chat");
     window.localStorage.clear();
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue([]);
-    (chatHistoryApi.deleteConversation as jest.Mock).mockResolvedValue(undefined);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail([])
+    );
+    (chatHistoryApi.deleteConversation as jest.Mock).mockResolvedValue(
+      undefined
+    );
     const { ChatHistoryApiError } = jest.requireMock("./chatHistoryApi");
     (chatHistoryApi.recoverCreate as jest.Mock).mockRejectedValue(
       new ChatHistoryApiError("Recovery is not materialized.", 404)
@@ -230,7 +255,9 @@ describe("ChatPage server-backed history", () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(serverMessages);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail()
+    );
 
     renderWithQueryClient(<ChatPage />);
 
@@ -268,7 +295,7 @@ describe("ChatPage server-backed history", () => {
 
     expect(await screen.findByText("Recovered response")).toBeTruthy();
     const [body] = chatRequestBodies();
-    expect(body.conversation).toEqual({});
+    expect(body.conversation).toEqual({ conversationId: null });
     expect(body.commandId).toEqual(expect.any(String));
     const createCommandId = String(body.commandId);
     await waitFor(() =>
@@ -392,23 +419,25 @@ describe("ChatPage server-backed history", () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue([
-      {
-        authorName: "Release automation",
-        content: "Queued for review",
-        id: "turn-open:observer",
-        role: "observer",
-        status: "complete",
-        timestamp: 1784255700000,
-      },
-      {
-        content: "Review recorded",
-        id: "turn-open:auditor",
-        role: "auditor",
-        status: "complete",
-        timestamp: 1784255701000,
-      },
-    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail([
+        {
+          authorName: "Release automation",
+          content: "Queued for review",
+          id: "turn-open:observer",
+          role: "observer",
+          status: "complete",
+          timestamp: 1784255700000,
+        },
+        {
+          content: "Review recorded",
+          id: "turn-open:auditor",
+          role: "auditor",
+          status: "complete",
+          timestamp: 1784255701000,
+        },
+      ])
+    );
 
     renderWithQueryClient(<ChatPage />);
     fireEvent.click(
@@ -425,31 +454,33 @@ describe("ChatPage server-backed history", () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue([
-      ...serverMessages,
-      {
-        content: "The first attempt failed.",
-        error: "Dispatch failed.",
-        id: "turn-b:assistant",
-        role: "assistant",
-        status: "error",
-        timestamp: 1784255701000,
-      },
-      {
-        content: "Try again",
-        id: "turn-c:user",
-        role: "user",
-        status: "complete",
-        timestamp: 1784255702000,
-      },
-      {
-        content: "The retry succeeded.",
-        id: "turn-c:assistant",
-        role: "assistant",
-        status: "complete",
-        timestamp: 1784255703000,
-      },
-    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail([
+        ...serverMessages,
+        {
+          content: "The first attempt failed.",
+          error: "Dispatch failed.",
+          id: "turn-b:assistant",
+          role: "assistant",
+          status: "error",
+          timestamp: 1784255701000,
+        },
+        {
+          content: "Try again",
+          id: "turn-c:user",
+          role: "user",
+          status: "complete",
+          timestamp: 1784255702000,
+        },
+        {
+          content: "The retry succeeded.",
+          id: "turn-c:assistant",
+          role: "assistant",
+          status: "complete",
+          timestamp: 1784255703000,
+        },
+      ])
+    );
 
     renderWithQueryClient(<ChatPage />);
     fireEvent.click(
@@ -483,7 +514,7 @@ describe("ChatPage server-backed history", () => {
     const [body] = chatRequestBodies();
     expect(body).toEqual({
       commandId: expect.any(String),
-      conversation: {},
+      conversation: { conversationId: null },
       prompt: "Create a support team",
       sessionId: expect.any(String),
       workflow: "studio",
@@ -545,36 +576,86 @@ describe("ChatPage server-backed history", () => {
     expect(changedBody.commandId).not.toBe(firstBody.commandId);
   });
 
-  it("binds the server conversation id and reuses the independent session id", async () => {
+  it("uses the reconciled server watermark for a second Team-selection turn", async () => {
+    const firstProjectedConversation = {
+      ...serverConversation,
+      id: "server-conversation",
+      messageCount: 1,
+      title: "Create a fund analysis workflow",
+    };
+    const secondProjectedConversation = {
+      ...firstProjectedConversation,
+      messageCount: 2,
+    };
+    (chatHistoryApi.listConversationMetas as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([firstProjectedConversation])
+      .mockResolvedValue([secondProjectedConversation]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockResolvedValueOnce(
+        conversationDetail(
+          [
+            {
+              content: "Choose a Team: team01 or team02.",
+              id: "turn-1:assistant",
+              role: "assistant",
+              status: "complete",
+              timestamp: 1784255700000,
+              turnId: "turn-1",
+            },
+          ],
+          8
+        )
+      )
+      .mockResolvedValue(
+        conversationDetail(
+          [
+            {
+              content: "Continuing with team01.",
+              id: "turn-2:assistant",
+              role: "assistant",
+              status: "complete",
+              timestamp: 1784255701000,
+              turnId: "turn-2",
+            },
+          ],
+          9
+        )
+      );
     (authFetch as jest.Mock)
       .mockResolvedValueOnce(
         createSseResponse([
-          chatContextFrame("server-conversation", "turn-1"),
-          { runFinished: { result: { output: "First answer" } } },
+          chatContextFrame("server-conversation", "turn-1", "scope-a", 0),
+          {
+            runFinished: {
+              result: { output: "Choose a Team: team01 or team02." },
+            },
+          },
         ])
       )
       .mockResolvedValueOnce(
         createSseResponse([
-          chatContextFrame("server-conversation", "turn-2"),
-          { runFinished: { result: { output: "Second answer" } } },
+          chatContextFrame("server-conversation", "turn-2", "scope-a", 8),
+          { runFinished: { result: { output: "Continuing with team01." } } },
         ])
       );
 
     renderWithQueryClient(<ChatPage />);
-    await sendPrompt("First prompt");
-    await screen.findByText("First answer");
-    await sendPrompt("Second prompt");
-    await screen.findByText("Second answer");
+    await sendPrompt("Create a workflow that generates fund analysis reports");
+    await screen.findByText("Choose a Team: team01 or team02.");
+    await sendPrompt("team01");
+    await screen.findByText("Continuing with team01.");
 
     const [firstBody, secondBody] = chatRequestBodies();
     expect(firstBody.commandId).toEqual(expect.any(String));
-    expect(firstBody.conversation).toEqual({});
+    expect(firstBody.conversation).toEqual({ conversationId: null });
     expect(secondBody.conversation).toEqual({
       conversationId: "server-conversation",
+      minimumStateVersion: 8,
     });
     expect(secondBody).not.toHaveProperty("commandId");
     expect(secondBody.sessionId).toBe(firstBody.sessionId);
-    expect(secondBody.prompt).toBe("Second prompt");
+    expect(secondBody.prompt).toBe("team01");
     expect(String(secondBody.prompt)).not.toContain("<conversation_history>");
   });
 
@@ -582,7 +663,9 @@ describe("ChatPage server-backed history", () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(serverMessages);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail()
+    );
     (authFetch as jest.Mock).mockResolvedValue(
       createSseResponse([
         { runFinished: { result: { output: "Unbound follow-up" } } },
@@ -673,6 +756,18 @@ describe("ChatPage server-backed history", () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([projectedConversation]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail([
+        {
+          content: "Live response",
+          id: "turn-projected:assistant",
+          role: "assistant",
+          status: "complete",
+          timestamp: 1784255700000,
+          turnId: "turn-projected",
+        },
+      ])
+    );
     (authFetch as jest.Mock).mockResolvedValue(
       createSseResponse([
         chatContextFrame("server-projected", "turn-projected"),
@@ -712,7 +807,10 @@ describe("ChatPage server-backed history", () => {
     );
     expect(screen.queryByRole("button", { name: "Projection-safe prompt" })).toBeNull();
     expect(screen.getByText("Live response")).toBeTruthy();
-    expect(chatHistoryApi.loadConversation).not.toHaveBeenCalled();
+    expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
+      "scope-a",
+      "server-projected"
+    );
   });
 
   it("uses typed turn identity only when metadata cannot prove observation", async () => {
@@ -725,16 +823,18 @@ describe("ChatPage server-backed history", () => {
     (chatHistoryApi.listConversationMetas as jest.Mock)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([projectedConversation]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValueOnce([
-      {
-        content: "Projected response",
-        id: "opaque-message-id",
-        role: "assistant",
-        status: "complete",
-        timestamp: 1784255700000,
-        turnId: "turn-typed",
-      },
-    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValueOnce(
+      conversationDetail([
+        {
+          content: "Projected response",
+          id: "opaque-message-id",
+          role: "assistant",
+          status: "complete",
+          timestamp: 1784255700000,
+          turnId: "turn-typed",
+        },
+      ])
+    );
     (authFetch as jest.Mock).mockResolvedValue(
       createSseResponse([
         chatContextFrame("server-typed-turn", "turn-typed"),
@@ -772,6 +872,18 @@ describe("ChatPage server-backed history", () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([projectedConversation]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail([
+        {
+          content: "Chat stopped.",
+          id: "turn-stopped:assistant",
+          role: "assistant",
+          status: "error",
+          timestamp: 1784255700000,
+          turnId: "turn-stopped",
+        },
+      ])
+    );
 
     renderWithQueryClient(<ChatPage />);
     await screen.findByText("No chat history");
@@ -793,7 +905,10 @@ describe("ChatPage server-backed history", () => {
         { timeout: 1_500 }
       )
     ).toBeTruthy();
-    expect(chatHistoryApi.loadConversation).not.toHaveBeenCalled();
+    expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
+      "scope-a",
+      "server-stopped"
+    );
   });
 
   it("discards an old-scope stream before it can recreate pending history", async () => {
@@ -862,6 +977,21 @@ describe("ChatPage server-backed history", () => {
         title: "Late authoritative conversation",
       },
     ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValueOnce(
+      conversationDetail(
+        [
+          {
+            content: "Optimistic response",
+            id: "turn-late:assistant",
+            role: "assistant",
+            status: "complete",
+            timestamp: 1784255700000,
+            turnId: "turn-late",
+          },
+        ],
+        8
+      )
+    );
     fireEvent.click(
       screen.getByRole("button", {
         name: "Retry saving Late projection prompt",
@@ -873,7 +1003,10 @@ describe("ChatPage server-backed history", () => {
       })
     ).toBeTruthy();
     expect(screen.queryByText("History save was not confirmed")).toBeNull();
-    expect(chatHistoryApi.loadConversation).not.toHaveBeenCalled();
+    expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
+      "scope-a",
+      "server-late"
+    );
   });
 
   it("shows list failure separately and retries without disabling chat", async () => {
@@ -900,7 +1033,7 @@ describe("ChatPage server-backed history", () => {
     ]);
     (chatHistoryApi.loadConversation as jest.Mock)
       .mockRejectedValueOnce(new Error("Detail is not available"))
-      .mockResolvedValueOnce(serverMessages);
+      .mockResolvedValueOnce(conversationDetail());
 
     renderWithQueryClient(<ChatPage />);
     fireEvent.click(
@@ -914,10 +1047,13 @@ describe("ChatPage server-backed history", () => {
   });
 
   it("prevents sending while a selected conversation is still loading", async () => {
-    let resolveDetail: (messages: typeof serverMessages) => void = () => undefined;
-    const detailPromise = new Promise<typeof serverMessages>((resolve) => {
-      resolveDetail = resolve;
-    });
+    let resolveDetail: (detail: ReturnType<typeof conversationDetail>) => void =
+      () => undefined;
+    const detailPromise = new Promise<ReturnType<typeof conversationDetail>>(
+      (resolve) => {
+        resolveDetail = resolve;
+      }
+    );
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
@@ -929,16 +1065,22 @@ describe("ChatPage server-backed history", () => {
     );
 
     await waitFor(() => expect(screen.getByRole("textbox")).toBeDisabled());
-    act(() => resolveDetail(serverMessages));
-    expect(await screen.findByText("The support workflow is ready.")).toBeTruthy();
+    act(() => resolveDetail(conversationDetail()));
+    expect(
+      await screen.findByText("The support workflow is ready.")
+    ).toBeTruthy();
     expect(screen.getByRole("textbox")).toBeEnabled();
   });
 
   it("ignores an older detail response after the user selects another conversation", async () => {
-    let resolveFirst: ((value: typeof serverMessages) => void) | undefined;
-    const firstDetail = new Promise<typeof serverMessages>((resolve) => {
-      resolveFirst = resolve;
-    });
+    let resolveFirst:
+      | ((value: ReturnType<typeof conversationDetail>) => void)
+      | undefined;
+    const firstDetail = new Promise<ReturnType<typeof conversationDetail>>(
+      (resolve) => {
+        resolveFirst = resolve;
+      }
+    );
     const secondConversation = {
       ...serverConversation,
       id: "conversation-b",
@@ -952,13 +1094,13 @@ describe("ChatPage server-backed history", () => {
       async (_scopeId: string, conversationId: string) =>
         conversationId === "conversation-a"
           ? firstDetail
-          : [
+          : conversationDetail([
               {
                 ...serverMessages[1],
                 content: "Second conversation answer",
                 id: "turn-b:assistant",
               },
-            ]
+            ])
     );
 
     renderWithQueryClient(<ChatPage />);
@@ -971,7 +1113,7 @@ describe("ChatPage server-backed history", () => {
     expect(await screen.findByText("Second conversation answer")).toBeTruthy();
 
     await act(async () => {
-      resolveFirst?.(serverMessages);
+      resolveFirst?.(conversationDetail());
       await firstDetail;
     });
     expect(screen.queryByText("The support workflow is ready.")).toBeNull();
@@ -982,7 +1124,9 @@ describe("ChatPage server-backed history", () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(serverMessages);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail()
+    );
     (authFetch as jest.Mock).mockResolvedValue(
       createSseResponse([
         chatContextFrame("conversation-a", "turn-b"),
@@ -1000,7 +1144,10 @@ describe("ChatPage server-backed history", () => {
 
     const [body] = chatRequestBodies();
     expect(body).toMatchObject({
-      conversation: { conversationId: "conversation-a" },
+      conversation: {
+        conversationId: "conversation-a",
+        minimumStateVersion: 7,
+      },
       prompt: "Add retry handling",
     });
     expect(body).not.toHaveProperty("commandId");

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -22,6 +22,15 @@ jest.mock("./chatHistoryApi", () => ({
       this.status = status;
     }
   },
+  ChatHistoryContractError: class MockChatHistoryContractError extends Error {
+    code = "INVALID_CHAT_HISTORY_RESPONSE";
+    path: string;
+
+    constructor(path: string, expectation: string) {
+      super(`Invalid Chat History response at ${path}: expected ${expectation}.`);
+      this.path = path;
+    }
+  },
   chatHistoryApi: {
     deleteConversation: jest.fn(),
     listConversationMetas: jest.fn(),
@@ -150,9 +159,24 @@ function createSseResponse(frames: readonly unknown[]): Response {
   } as Response;
 }
 
+function historyReservationUnavailableResponse(): Response {
+  return {
+    ok: false,
+    status: 503,
+    statusText: "Service Unavailable",
+    text: jest.fn().mockResolvedValue(
+      JSON.stringify({
+        code: "CHAT_HISTORY_RESERVATION_UNAVAILABLE",
+        message: "Conversation history is still materializing.",
+      })
+    ),
+  } as unknown as Response;
+}
+
 function createControlledSseResponse(): {
   close: () => void;
   enqueue: (frame: unknown) => void;
+  fail: (error: Error) => void;
   response: Response;
 } {
   const encoder = new TextEncoder();
@@ -173,6 +197,7 @@ function createControlledSseResponse(): {
         encoder.encode(`data: ${JSON.stringify(frame)}\n\n`)
       );
     },
+    fail: (error: Error) => streamController?.error(error),
     response,
   };
 }
@@ -301,12 +326,89 @@ describe("ChatPage server-backed history", () => {
     await waitFor(() =>
       expect(chatHistoryApi.recoverCreate).toHaveBeenCalledWith(
         "scope-a",
-        createCommandId
+        createCommandId,
+        expect.any(AbortSignal)
       )
     );
     expect(
       await screen.findByRole("button", { name: "Recover this create" })
     ).toBeTruthy();
+  });
+
+  it("recovers an accepted create after the stream disconnects before context", async () => {
+    const stream = createControlledSseResponse();
+    const recoveredMeta = {
+      ...serverConversation,
+      id: "recovered-after-disconnect",
+      title: "Recover a disconnected create",
+    };
+    const recoveredMessages = [
+      {
+        content: "Recover a disconnected create",
+        id: "recovered-turn:user",
+        role: "user" as const,
+        status: "complete" as const,
+        timestamp: 1784255700000,
+        turnId: "recovered-turn",
+      },
+      {
+        content: "Recovered after the stream disconnected.",
+        id: "recovered-turn:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255700100,
+        turnId: "recovered-turn",
+      },
+    ];
+    (chatHistoryApi.listConversationMetas as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([recoveredMeta]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail(recoveredMessages, 2)
+    );
+    (chatHistoryApi.recoverCreate as jest.Mock).mockResolvedValue({
+      conversationId: "recovered-after-disconnect",
+      stateVersion: 2,
+      status: "append_committed",
+      turnId: "recovered-turn",
+    });
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(stream.response)
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame(
+            "recovered-after-disconnect",
+            "continued-turn",
+            "scope-a",
+            2
+          ),
+          { runFinished: { result: { output: "Continued recovered chat." } } },
+        ])
+      );
+
+    const view = renderWithQueryClient(<ChatPage />);
+    await sendPrompt("Recover a disconnected create");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(1));
+    act(() => stream.fail(new Error("Create stream disconnected")));
+
+    await waitFor(() =>
+      expect(chatHistoryApi.recoverCreate).toHaveBeenCalledWith(
+        "scope-a",
+        expect.any(String),
+        expect.any(AbortSignal)
+      )
+    );
+    await waitFor(() => expect(screen.getByRole("textbox")).toBeEnabled());
+    await sendPrompt("Continue the recovered chat");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2));
+    expect(chatRequestBodies()[1]).toMatchObject({
+      conversation: {
+        conversationId: "recovered-after-disconnect",
+        minimumStateVersion: 2,
+      },
+      prompt: "Continue the recovered chat",
+    });
+    view.unmount();
   });
 
   it("blocks reads and chat writes when the route scope differs from the authenticated scope", async () => {
@@ -659,6 +761,543 @@ describe("ChatPage server-backed history", () => {
     expect(String(secondBody.prompt)).not.toContain("<conversation_history>");
   });
 
+  it("does not let a stale accepted context move the continuation watermark backwards", async () => {
+    const continuedMeta = {
+      ...serverConversation,
+      messageCount: 4,
+    };
+    const continuedMessages = [
+      ...serverMessages,
+      {
+        content: "First continuation",
+        id: "turn-b:user",
+        role: "user" as const,
+        status: "complete" as const,
+        timestamp: 1784255700500,
+        turnId: "turn-b",
+      },
+      {
+        content: "First continuation answer",
+        id: "turn-b:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255700600,
+        turnId: "turn-b",
+      },
+    ];
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      continuedMeta,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockResolvedValueOnce(conversationDetail(serverMessages, 8))
+      .mockResolvedValueOnce(conversationDetail(continuedMessages, 7))
+      .mockResolvedValue(conversationDetail(continuedMessages, 8));
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame("conversation-a", "turn-b", "scope-a", 7),
+          {
+            runFinished: { result: { output: "First continuation answer" } },
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame("conversation-a", "turn-c", "scope-a", 8),
+          {
+            runFinished: { result: { output: "Second continuation answer" } },
+          },
+        ])
+      );
+
+    const view = renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("First continuation");
+    await screen.findByText("First continuation answer");
+    await waitFor(() => expect(screen.getByRole("textbox")).toBeEnabled());
+
+    await sendPrompt("Second continuation");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2));
+    expect(chatRequestBodies()[0].conversation).toEqual({
+      conversationId: "conversation-a",
+      minimumStateVersion: 8,
+    });
+    expect(chatRequestBodies()[1].conversation).toEqual({
+      conversationId: "conversation-a",
+      minimumStateVersion: 8,
+    });
+    view.unmount();
+  });
+
+  it("refreshes authoritative detail before retrying a 503 continuation", async () => {
+    const projectedConversation = {
+      ...serverConversation,
+      messageCount: 6,
+    };
+    const interveningMessages = [
+      {
+        content: "Question from another tab",
+        id: "turn-b:user",
+        role: "user" as const,
+        status: "complete" as const,
+        timestamp: 1784255700500,
+        turnId: "turn-b",
+      },
+      {
+        content: "Answer from another tab",
+        id: "turn-b:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255700600,
+        turnId: "turn-b",
+      },
+    ];
+    const projectedMessages = [
+      ...serverMessages,
+      ...interveningMessages,
+      {
+        content: "Continue after projection catches up",
+        id: "turn-c:user",
+        role: "user" as const,
+        status: "complete" as const,
+        timestamp: 1784255700900,
+        turnId: "turn-c",
+      },
+      {
+        content: "Follow-up answer",
+        id: "turn-c:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255701000,
+        turnId: "turn-c",
+      },
+    ];
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      projectedConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockResolvedValueOnce(conversationDetail(serverMessages, 7))
+      .mockResolvedValueOnce(
+        conversationDetail([...serverMessages, ...interveningMessages], 8)
+      )
+      .mockResolvedValue(conversationDetail(projectedMessages, 9));
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(historyReservationUnavailableResponse())
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame("conversation-a", "turn-c", "scope-a", 8),
+          { runFinished: { result: { output: "Follow-up answer" } } },
+        ])
+      );
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Continue after projection catches up");
+
+    expect(await screen.findByText("Follow-up answer")).toBeTruthy();
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2));
+    const [initialRequest, retryRequest] = chatRequestBodies();
+    expect(initialRequest.conversation).toEqual({
+      conversationId: "conversation-a",
+      minimumStateVersion: 7,
+    });
+    expect(retryRequest.conversation).toEqual({
+      conversationId: "conversation-a",
+      minimumStateVersion: 8,
+    });
+    expect(initialRequest.prompt).toBe("Continue after projection catches up");
+    expect(retryRequest.prompt).toBe("Continue after projection catches up");
+    expect(await screen.findByText("Answer from another tab")).toBeTruthy();
+    expect(screen.getByText("Question from another tab")).toBeTruthy();
+    expect(chatHistoryApi.loadConversation).toHaveBeenNthCalledWith(
+      2,
+      "scope-a",
+      "conversation-a",
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("keeps refreshed authoritative messages when an accepted retry stream fails", async () => {
+    const stream = createControlledSseResponse();
+    const interveningMessages = [
+      {
+        content: "Question committed in another tab",
+        id: "turn-b:user",
+        role: "user" as const,
+        status: "complete" as const,
+        timestamp: 1784255700500,
+        turnId: "turn-b",
+      },
+      {
+        content: "Answer committed in another tab",
+        id: "turn-b:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255700600,
+        turnId: "turn-b",
+      },
+    ];
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      serverConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockResolvedValueOnce(conversationDetail(serverMessages, 7))
+      .mockResolvedValueOnce(
+        conversationDetail([...serverMessages, ...interveningMessages], 8)
+      )
+      .mockRejectedValue(new Error("Projection temporarily unavailable"));
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(historyReservationUnavailableResponse())
+      .mockResolvedValueOnce(stream.response);
+
+    const view = renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Continue after refreshing history");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2));
+    act(() => {
+      stream.enqueue(chatContextFrame("conversation-a", "turn-c", "scope-a", 8));
+      stream.enqueue({
+        textMessageContent: {
+          delta: "Partial continuation",
+          messageId: "message-c",
+        },
+      });
+    });
+    await screen.findByText("Partial continuation");
+    act(() => stream.fail(new Error("Continuation stream disconnected")));
+
+    expect(
+      await screen.findByText("Question committed in another tab")
+    ).toBeTruthy();
+    expect(screen.getByText("Answer committed in another tab")).toBeTruthy();
+    expect(
+      screen.getAllByText("Continuation stream disconnected")
+    ).not.toHaveLength(0);
+    view.unmount();
+  });
+
+  it("keeps a refreshed authoritative watermark after reservation retries are rejected", async () => {
+    const interveningMessages = [
+      {
+        content: "Question accepted in another tab",
+        id: "turn-b:user",
+        role: "user" as const,
+        status: "complete" as const,
+        timestamp: 1784255700500,
+        turnId: "turn-b",
+      },
+      {
+        content: "Answer committed in another tab",
+        id: "turn-b:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255700600,
+        turnId: "turn-b",
+      },
+    ];
+    const refreshedDetail = conversationDetail(
+      [...serverMessages, ...interveningMessages],
+      8
+    );
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      serverConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockResolvedValueOnce(conversationDetail(serverMessages, 7))
+      .mockResolvedValueOnce(refreshedDetail)
+      .mockResolvedValueOnce(conversationDetail(serverMessages, 7))
+      .mockResolvedValue(
+        conversationDetail(
+          [
+            ...refreshedDetail.messages,
+            {
+              content: "Accepted after the explicit rejection",
+              id: "turn-d:assistant",
+              role: "assistant",
+              status: "complete",
+              timestamp: 1784255701000,
+              turnId: "turn-d",
+            },
+          ],
+          9
+        )
+      );
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(historyReservationUnavailableResponse())
+      .mockResolvedValueOnce(historyReservationUnavailableResponse())
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame("conversation-a", "turn-d", "scope-a", 8),
+          {
+            runFinished: {
+              result: { output: "Accepted after the explicit rejection" },
+            },
+          },
+        ])
+      );
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Continue from the stale tab");
+
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2), {
+      timeout: 4_000,
+    });
+    expect(await screen.findByText("Answer committed in another tab")).toBeTruthy();
+    expect(screen.getByText("Question accepted in another tab")).toBeTruthy();
+    expect(screen.getByRole("textbox")).toBeEnabled();
+
+    await sendPrompt("Continue after the explicit rejection");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(3));
+    expect(chatRequestBodies()[2]).toMatchObject({
+      conversation: {
+        conversationId: "conversation-a",
+        minimumStateVersion: 8,
+      },
+      prompt: "Continue after the explicit rejection",
+    });
+    expect(
+      await screen.findByText("Accepted after the explicit rejection")
+    ).toBeTruthy();
+  });
+
+  it("does not lock a continuation when history refresh is definitively rejected", async () => {
+    const { ChatHistoryApiError } = jest.requireMock("./chatHistoryApi");
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      serverConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockResolvedValueOnce(conversationDetail(serverMessages, 7))
+      .mockRejectedValueOnce(
+        new ChatHistoryApiError("Conversation history is unavailable.", 404)
+      );
+    (authFetch as jest.Mock).mockResolvedValueOnce(
+      historyReservationUnavailableResponse()
+    );
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Continue before history disappears");
+
+    expect(
+      await screen.findAllByText("Conversation history is unavailable.")
+    ).not.toHaveLength(0);
+    expect(screen.getByRole("textbox")).toBeEnabled();
+    expect(
+      screen.queryByText(
+        "The continuation may have been accepted, but its turn identity was not received. Reload this page before continuing."
+      )
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("does not lock a continuation when a rejected chat response body is unreadable", async () => {
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      serverConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail(serverMessages, 7)
+    );
+    (authFetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      text: jest.fn().mockRejectedValue(new Error("Response body disconnected")),
+    } as unknown as Response);
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Continue into a rejected response");
+
+    expect(await screen.findAllByText("HTTP 409 Conflict")).not.toHaveLength(0);
+    expect(screen.getByRole("textbox")).toBeEnabled();
+    expect(
+      screen.queryByText(
+        "The continuation may have been accepted, but its turn identity was not received. Reload this page before continuing."
+      )
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("does not lock a continuation stopped during reservation retry backoff", async () => {
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
+      serverConversation,
+    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue(
+      conversationDetail(serverMessages, 7)
+    );
+    (authFetch as jest.Mock).mockResolvedValueOnce(
+      historyReservationUnavailableResponse()
+    );
+
+    renderWithQueryClient(<ChatPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Server conversation" })
+    );
+    await screen.findByText("The support workflow is ready.");
+    await sendPrompt("Stop before retrying");
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(1));
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(await screen.findAllByText("Chat stopped.")).not.toHaveLength(0);
+    expect(screen.getByRole("textbox")).toBeEnabled();
+    expect(
+      screen.queryByText(
+        "The continuation may have been accepted, but its turn identity was not received. Reload this page before continuing."
+      )
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("keeps every chat action disabled until reconciliation reaches the known watermark", async () => {
+    let resolveZeroDetail: (
+      detail: ReturnType<typeof conversationDetail>
+    ) => void = () => undefined;
+    const zeroDetail = new Promise<ReturnType<typeof conversationDetail>>(
+      (resolve) => {
+        resolveZeroDetail = resolve;
+      }
+    );
+    let resolveRegressedDetail: (
+      detail: ReturnType<typeof conversationDetail>
+    ) => void = () => undefined;
+    const regressedDetail = new Promise<ReturnType<typeof conversationDetail>>(
+      (resolve) => {
+        resolveRegressedDetail = resolve;
+      }
+    );
+    let resolveCurrentDetail: (
+      detail: ReturnType<typeof conversationDetail>
+    ) => void = () => undefined;
+    const currentDetail = new Promise<ReturnType<typeof conversationDetail>>(
+      (resolve) => {
+        resolveCurrentDetail = resolve;
+      }
+    );
+    const projectedConversation = {
+      ...serverConversation,
+      id: "server-confirm",
+      messageCount: 1,
+      title: "Confirmation plan",
+    };
+    const projectedMessages = [
+      {
+        content: "Please confirm this plan.",
+        id: "turn-confirm:assistant",
+        role: "assistant" as const,
+        status: "complete" as const,
+        timestamp: 1784255700000,
+        turnId: "turn-confirm",
+      },
+    ];
+    (chatHistoryApi.listConversationMetas as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([projectedConversation]);
+    (chatHistoryApi.loadConversation as jest.Mock)
+      .mockReturnValueOnce(zeroDetail)
+      .mockReturnValueOnce(regressedDetail)
+      .mockReturnValueOnce(currentDetail)
+      .mockResolvedValue(
+        conversationDetail(
+          [
+            ...projectedMessages,
+            {
+              content: "Created.",
+              id: "turn-create:assistant",
+              role: "assistant",
+              status: "complete",
+              timestamp: 1784255701000,
+              turnId: "turn-create",
+            },
+          ],
+          9
+        )
+      );
+    (authFetch as jest.Mock)
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame("server-confirm", "turn-confirm", "scope-a", 7),
+          {
+            runFinished: {
+              result: { output: "Please confirm this plan." },
+            },
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        createSseResponse([
+          chatContextFrame("server-confirm", "turn-create", "scope-a", 8),
+          { runFinished: { result: { output: "Created." } } },
+        ])
+      );
+
+    renderWithQueryClient(<ChatPage />);
+    await sendPrompt("Draft a workflow plan");
+
+    const confirmButton = await screen.findByRole("button", {
+      name: "Confirm and create",
+    });
+    await waitFor(() =>
+      expect(chatHistoryApi.loadConversation).toHaveBeenCalledTimes(1)
+    );
+    expect(confirmButton).toBeDisabled();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+
+    act(() => resolveZeroDetail(conversationDetail(projectedMessages, 0)));
+    await waitFor(() =>
+      expect(chatHistoryApi.loadConversation).toHaveBeenCalledTimes(2)
+    );
+    expect(confirmButton).toBeDisabled();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+
+    act(() =>
+      resolveRegressedDetail(conversationDetail(projectedMessages, 6))
+    );
+    await waitFor(
+      () => expect(chatHistoryApi.loadConversation).toHaveBeenCalledTimes(3),
+      { timeout: 2_500 }
+    );
+    expect(confirmButton).toBeDisabled();
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(chatRequestBodies()).toHaveLength(1);
+
+    act(() => resolveCurrentDetail(conversationDetail(projectedMessages, 8)));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Confirm and create" })
+      ).toBeEnabled()
+    );
+    expect(screen.getByRole("textbox")).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm and create" }));
+    await waitFor(() => expect(chatRequestBodies()).toHaveLength(2));
+    expect(chatRequestBodies()[1]).toMatchObject({
+      conversation: {
+        conversationId: "server-confirm",
+        minimumStateVersion: 8,
+      },
+      prompt: "Confirm. Please create it now.",
+    });
+  });
+
   it("does not use create recovery for a continuation without context", async () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
@@ -679,9 +1318,16 @@ describe("ChatPage server-backed history", () => {
     await screen.findByText("The support workflow is ready.");
     await sendPrompt("Continue without context");
 
+    const missingContextMessage =
+      "The continuation may have been accepted, but its turn identity was not received. Reload this page before continuing.";
+    expect(await screen.findAllByText(missingContextMessage)).not.toHaveLength(0);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
     expect(
-      await screen.findByText("Chat completed without a conversation context.")
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: /Retry saving/ })
+    ).toBeNull();
+    expect(chatHistoryApi.listConversationMetas).toHaveBeenCalledTimes(1);
+    expect(chatHistoryApi.loadConversation).toHaveBeenCalledTimes(1);
     expect(chatHistoryApi.recoverCreate).not.toHaveBeenCalled();
   });
 
@@ -809,7 +1455,8 @@ describe("ChatPage server-backed history", () => {
     expect(screen.getByText("Live response")).toBeTruthy();
     expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
       "scope-a",
-      "server-projected"
+      "server-projected",
+      expect.any(AbortSignal)
     );
   });
 
@@ -846,11 +1493,12 @@ describe("ChatPage server-backed history", () => {
     await screen.findByText("No chat history");
     await sendPrompt("Use typed turn identity");
 
-    expect(await screen.findByText("Typed turn response")).toBeTruthy();
+    expect(await screen.findByText("Projected response")).toBeTruthy();
     await waitFor(() =>
       expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
         "scope-a",
-        "server-typed-turn"
+        "server-typed-turn",
+        expect.any(AbortSignal)
       )
     );
     expect(
@@ -907,8 +1555,64 @@ describe("ChatPage server-backed history", () => {
     ).toBeTruthy();
     expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
       "scope-a",
-      "server-stopped"
+      "server-stopped",
+      expect.any(AbortSignal)
     );
+  });
+
+  it("aborts reconciliation index and detail reads when the page unmounts", async () => {
+    const projectedConversation = {
+      ...serverConversation,
+      id: "server-aborted-reconciliation",
+      messageCount: 1,
+    };
+    let reconciliationListSignal: AbortSignal | undefined;
+    let reconciliationDetailSignal: AbortSignal | undefined;
+    (chatHistoryApi.listConversationMetas as jest.Mock).mockImplementation(
+      async (_scopeId: string, signal?: AbortSignal) => {
+        if (!signal) {
+          return [];
+        }
+
+        reconciliationListSignal = signal;
+        return [projectedConversation];
+      }
+    );
+    (chatHistoryApi.loadConversation as jest.Mock).mockImplementation(
+      (
+        _scopeId: string,
+        _conversationId: string,
+        signal?: AbortSignal
+      ) => {
+        reconciliationDetailSignal = signal;
+        return new Promise(() => undefined);
+      }
+    );
+    (authFetch as jest.Mock).mockResolvedValue(
+      createSseResponse([
+        chatContextFrame(
+          "server-aborted-reconciliation",
+          "turn-aborted-reconciliation"
+        ),
+        { runFinished: { result: { output: "Awaiting projection" } } },
+      ])
+    );
+
+    const view = renderWithQueryClient(<ChatPage />);
+    await screen.findByText("No chat history");
+    await sendPrompt("Abort reconciliation reads");
+    await waitFor(() =>
+      expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
+        "scope-a",
+        "server-aborted-reconciliation",
+        expect.any(AbortSignal)
+      )
+    );
+
+    view.unmount();
+
+    expect(reconciliationListSignal?.aborted).toBe(true);
+    expect(reconciliationDetailSignal?.aborted).toBe(true);
   });
 
   it("discards an old-scope stream before it can recreate pending history", async () => {
@@ -1005,7 +1709,8 @@ describe("ChatPage server-backed history", () => {
     expect(screen.queryByText("History save was not confirmed")).toBeNull();
     expect(chatHistoryApi.loadConversation).toHaveBeenCalledWith(
       "scope-a",
-      "server-late"
+      "server-late",
+      expect.any(AbortSignal)
     );
   });
 

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -40,7 +40,7 @@ import {
   extractChatHistoryContext,
   extractChatStreamArtifacts,
   readChatStreamFrames,
-  startChatStreamWithProjectionRetry,
+  startChatStreamWithHistoryRefreshRetry,
 } from "./chatApi";
 import { ChatHistoryApiError, chatHistoryApi } from "./chatHistoryApi";
 import { ChatInput, ChatMessageBubble } from "./chatPresentation";
@@ -72,6 +72,7 @@ type ConversationState = {
   latestTurnId?: string;
   messages: ChatMessage[];
   sessionId: string;
+  stateVersion?: number;
   status: LocalChatStatus;
   target?: ChatStudioTarget;
   title: string;
@@ -130,6 +131,12 @@ function createDraftConversation(): ConversationState {
     status: "draft",
     title: t("pages.chat.index.newChat", "New chat"),
   };
+}
+
+function isContinuationStateVersion(
+  value: number | undefined
+): value is number {
+  return Number.isSafeInteger(value) && (value ?? 0) > 0;
 }
 
 export function hydrateStoredMessages(
@@ -804,7 +811,7 @@ const ChatPage: React.FC = () => {
       setSession(createIdleSession(scopeId));
 
       try {
-        const storedMessages = await chatHistoryApi.loadConversation(
+        const detail = await chatHistoryApi.loadConversation(
           scopeId,
           conversationId
         );
@@ -814,15 +821,16 @@ const ChatPage: React.FC = () => {
 
         const restoredConversation: ConversationState = {
           ...placeholder,
-          messages: hydrateStoredMessages(storedMessages),
-          status: resolveStoredConversationStatus(storedMessages),
+          messages: hydrateStoredMessages(detail.messages),
+          stateVersion: detail.stateVersion,
+          status: resolveStoredConversationStatus(detail.messages),
         };
         activeConversationRef.current = restoredConversation;
         setActiveConversation(restoredConversation);
         setDetailLoadState({ status: "idle" });
         setSession({
           ...createIdleSession(scopeId),
-          status: storedMessages.length > 0 ? "success" : "idle",
+          status: detail.messages.length > 0 ? "success" : "idle",
           updatedAt: meta?.updatedAt ? Date.parse(meta.updatedAt) : undefined,
         });
       } catch (error) {
@@ -965,32 +973,32 @@ const ChatPage: React.FC = () => {
             const serverMeta = nextConversations.find(
               (item) => item.id === conversationId
             );
-            let observedExpectedTurn = Boolean(
-              serverMeta &&
-                serverMeta.messageCount >= conversation.expectedTurnCount
+            if (!serverMeta) {
+              continue;
+            }
+
+            const detail = await chatHistoryApi.loadConversation(
+              scopeId,
+              conversationId
             );
             if (
-              !observedExpectedTurn &&
-              serverMeta &&
-              conversation.latestTurnId
+              controller.signal.aborted ||
+              scopeEpochRef.current !== reconciliationScopeEpoch
             ) {
-              const storedMessages = await chatHistoryApi.loadConversation(
-                scopeId,
-                conversationId
-              );
-              if (
-                controller.signal.aborted ||
-                scopeEpochRef.current !== reconciliationScopeEpoch
-              ) {
-                return;
-              }
-              observedExpectedTurn = storedMessages.some(
-                (message) =>
-                  message.role === "assistant" &&
-                  message.turnId === conversation.latestTurnId
-              );
+              return;
             }
-            if (!serverMeta || !observedExpectedTurn) {
+            const observedExpectedTurn = conversation.latestTurnId
+              ? detail.messages.some(
+                  (message) =>
+                    message.role === "assistant" &&
+                    message.turnId === conversation.latestTurnId
+                )
+              : serverMeta.messageCount >= conversation.expectedTurnCount;
+            if (
+              !observedExpectedTurn ||
+              !isContinuationStateVersion(detail.stateVersion) ||
+              detail.stateVersion < (conversation.stateVersion ?? 0)
+            ) {
               continue;
             }
 
@@ -1009,6 +1017,10 @@ const ChatPage: React.FC = () => {
                 expectedTurnCount: Math.max(
                   serverMeta.messageCount,
                   conversation.expectedTurnCount
+                ),
+                stateVersion: Math.max(
+                  current.stateVersion ?? 0,
+                  detail.stateVersion
                 ),
                 title: serverMeta.title || current.title,
               };
@@ -1083,6 +1095,29 @@ const ChatPage: React.FC = () => {
         return;
       }
 
+      if (
+        conversation.conversationId &&
+        pendingConversations.has(conversation.conversationId)
+      ) {
+        return;
+      }
+      if (
+        conversation.conversationId &&
+        !isContinuationStateVersion(conversation.stateVersion)
+      ) {
+        setSession({
+          ...createIdleSession(scopeId),
+          error: t(
+            "pages.chat.index.historySynchronizing",
+            "Conversation history is still synchronizing. Try again shortly."
+          ),
+          status: "error",
+          updatedAt: Date.now(),
+        });
+        reconcileConversation(conversation);
+        return;
+      }
+
       const runScopeEpoch = scopeEpochRef.current;
       detailRequestRef.current = createClientId();
       setDetailLoadState({ status: "idle" });
@@ -1148,16 +1183,30 @@ const ChatPage: React.FC = () => {
       });
 
       try {
-        const response = await startChatStreamWithProjectionRetry(
+        const response = await startChatStreamWithHistoryRefreshRetry(
           {
             commandId: createCommandId,
             conversation: conversation.conversationId
-              ? { conversationId: conversation.conversationId }
-              : {},
+              ? {
+                  conversationId: conversation.conversationId,
+                  minimumStateVersion: conversation.stateVersion as number,
+                }
+              : { conversationId: null },
             prompt: trimmedInput,
             sessionId: conversation.sessionId,
           },
-          controller.signal
+          controller.signal,
+          conversation.conversationId
+            ? {
+                refreshMinimumStateVersion: async () => {
+                  const detail = await chatHistoryApi.loadConversation(
+                    scopeId,
+                    conversation.conversationId as string
+                  );
+                  return detail.stateVersion;
+                },
+              }
+            : undefined
         );
 
         for await (const frame of readChatStreamFrames(response, {
@@ -1185,7 +1234,10 @@ const ChatPage: React.FC = () => {
                 acceptedChatHistoryContext.scopeId ||
                 chatHistoryContext.conversationId !==
                   acceptedChatHistoryContext.conversationId ||
-                chatHistoryContext.turnId !== acceptedChatHistoryContext.turnId)
+                chatHistoryContext.turnId !==
+                  acceptedChatHistoryContext.turnId ||
+                chatHistoryContext.stateVersion !==
+                  acceptedChatHistoryContext.stateVersion)
             ) {
               throw new Error("Chat History context changed during the stream.");
             }
@@ -1197,6 +1249,7 @@ const ChatPage: React.FC = () => {
                 conversationId: chatHistoryContext.conversationId,
                 expectedTurnCount: conversation.expectedTurnCount + 1,
                 latestTurnId: chatHistoryContext.turnId,
+                stateVersion: chatHistoryContext.stateVersion,
               };
               activeConversationRef.current = streamingConversation;
               setActiveConversation((current) =>
@@ -1278,6 +1331,7 @@ const ChatPage: React.FC = () => {
               conversationId: recovery.conversationId,
               expectedTurnCount: conversation.expectedTurnCount + 1,
               latestTurnId: recovery.turnId,
+              stateVersion: recovery.stateVersion,
             };
             activeConversationRef.current = streamingConversation;
             setActiveConversation((current) =>
@@ -1376,7 +1430,13 @@ const ChatPage: React.FC = () => {
         }
       }
     },
-    [canStartChat, isStreaming, reconcileConversation, scopeId]
+    [
+      canStartChat,
+      isStreaming,
+      pendingConversations,
+      reconcileConversation,
+      scopeId,
+    ]
   );
 
   const handleSend = useCallback(() => {
@@ -1994,7 +2054,11 @@ const ChatPage: React.FC = () => {
               </Space>
             ) : null}
             <ChatInput
-              disabled={!canStartChat || detailLoadState.status === "loading"}
+              disabled={
+                !canStartChat ||
+                detailLoadState.status === "loading" ||
+                Boolean(activeHistoryReconciliation)
+              }
               isStreaming={isStreaming}
               onChange={setPrompt}
               onSend={handleSend}

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -37,6 +37,7 @@ import {
   isRawObserved,
 } from "./chatEventAdapter";
 import {
+  chatRequestMayHaveBeenAccepted,
   extractChatHistoryContext,
   extractChatStreamArtifacts,
   readChatStreamFrames,
@@ -49,6 +50,7 @@ import type {
   ChatSessionState,
   ChatStudioTarget,
   ChatUsageSummary,
+  ChatCreateRecovery,
   ConversationMeta,
   LocalChatStatus,
   RuntimeEvent,
@@ -83,7 +85,7 @@ const EMPTY_CONVERSATION_IDS: ReadonlySet<string> = new Set();
 
 type HistoryReconciliationState =
   | { status: "pending" }
-  | { message: string; status: "failed" };
+  | { message: string; retryable: boolean; status: "failed" };
 
 type PendingConversation = {
   conversation: ConversationState;
@@ -283,6 +285,38 @@ function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+async function recoverCreateIdentity(
+  scopeId: string,
+  commandId: string,
+  signal: AbortSignal
+): Promise<ChatCreateRecovery | null> {
+  for (const delayMs of [0, 300, 900, 1_800]) {
+    await abortableDelay(delayMs, signal);
+    try {
+      return await chatHistoryApi.recoverCreate(scopeId, commandId, signal);
+    } catch (error) {
+      if (!(error instanceof ChatHistoryApiError) || error.status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  return null;
+}
+
+function bindCreateRecovery(
+  conversation: ConversationState,
+  recovery: ChatCreateRecovery
+): ConversationState {
+  return {
+    ...conversation,
+    conversationId: recovery.conversationId,
+    expectedTurnCount: conversation.expectedTurnCount + 1,
+    latestTurnId: recovery.turnId,
+    stateVersion: Math.max(conversation.stateVersion ?? 0, recovery.stateVersion),
+  };
+}
+
 function createChatMessage(
   role: ChatMessage["role"],
   content: string,
@@ -317,6 +351,57 @@ function cloneStepInfo(steps?: readonly StepInfo[]): StepInfo[] {
 
 function cloneToolCallInfo(toolCalls?: readonly ToolCallInfo[]): ToolCallInfo[] {
   return (toolCalls ?? []).map((toolCall) => ({ ...toolCall }));
+}
+
+function hydrateAuthoritativeMessages(
+  storedMessages: readonly StoredChatMessage[],
+  localMessages: readonly ChatMessage[],
+  latestTurnId: string | undefined
+): ChatMessage[] {
+  const localMessagesById = new Map(
+    localMessages.map((message) => [message.id, message] as const)
+  );
+  const latestLocalAssistant = latestTurnId
+    ? [...localMessages]
+        .reverse()
+        .find((message) => message.role === "assistant")
+    : undefined;
+
+  return storedMessages.map((storedMessage) => {
+    const authoritativeMessage = hydrateStoredMessages([storedMessage])[0];
+    const localMessage =
+      localMessagesById.get(storedMessage.id) ??
+      (storedMessage.role === "assistant" &&
+      storedMessage.turnId === latestTurnId
+        ? latestLocalAssistant
+        : undefined);
+    if (!localMessage) {
+      return authoritativeMessage;
+    }
+
+    return {
+      ...authoritativeMessage,
+      ...(localMessage.events
+        ? { events: [...localMessage.events] }
+        : {}),
+      ...(localMessage.pendingApproval
+        ? { pendingApproval: { ...localMessage.pendingApproval } }
+        : {}),
+      ...(localMessage.pendingRunIntervention
+        ? {
+            pendingRunIntervention: {
+              ...localMessage.pendingRunIntervention,
+            },
+          }
+        : {}),
+      ...(localMessage.steps
+        ? { steps: cloneStepInfo(localMessage.steps) }
+        : {}),
+      ...(localMessage.toolCalls
+        ? { toolCalls: cloneToolCallInfo(localMessage.toolCalls) }
+        : {}),
+    };
+  });
 }
 
 function resolveEventTimestamp(events: readonly RuntimeEvent[]): number {
@@ -528,6 +613,7 @@ const ChatPage: React.FC = () => {
   const queryClient = useQueryClient();
   const activeConversationRef = useRef<ConversationState | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const createRecoveryControllerRef = useRef<AbortController | null>(null);
   const detailRequestRef = useRef("");
   const reconciliationControllersRef = useRef(
     new Map<string, AbortController>()
@@ -690,6 +776,10 @@ const ChatPage: React.FC = () => {
     ? scopedPendingConversations.get(activeConversation.conversationId)
         ?.reconciliation
     : undefined;
+  const isConversationActionDisabled =
+    !canStartChat ||
+    detailLoadState.status === "loading" ||
+    Boolean(activeHistoryReconciliation);
   const hasFailedHistoryReconciliation = [
     ...scopedPendingConversations.values(),
   ].some((pending) => pending.reconciliation.status === "failed");
@@ -699,6 +789,8 @@ const ChatPage: React.FC = () => {
 
   useLayoutEffect(() => {
     abortControllerRef.current?.abort();
+    createRecoveryControllerRef.current?.abort();
+    createRecoveryControllerRef.current = null;
     for (const controller of reconciliationControllersRef.current.values()) {
       controller.abort();
     }
@@ -723,28 +815,6 @@ const ChatPage: React.FC = () => {
   }, [activeConversation]);
 
   useEffect(() => {
-    const serverConversations = conversationsQuery.data ?? [];
-    setPendingConversations((current) => {
-      const next = new Map(current);
-      let changed = false;
-      for (const [conversationId, pendingConversation] of current) {
-        const serverMeta = serverConversations.find(
-          (conversation) => conversation.id === conversationId
-        );
-        if (
-          serverMeta &&
-          serverMeta.messageCount >=
-            pendingConversation.conversation.expectedTurnCount
-        ) {
-          next.delete(conversationId);
-          changed = true;
-        }
-      }
-      return changed ? next : current;
-    });
-  }, [conversationsQuery.data]);
-
-  useEffect(() => {
     scrollAnchorRef.current?.scrollIntoView?.({
       behavior: "smooth",
       block: "end",
@@ -755,6 +825,7 @@ const ChatPage: React.FC = () => {
     () => () => {
       scopeEpochRef.current += 1;
       abortControllerRef.current?.abort();
+      createRecoveryControllerRef.current?.abort();
       for (const controller of reconciliationControllersRef.current.values()) {
         controller.abort();
       }
@@ -781,6 +852,8 @@ const ChatPage: React.FC = () => {
       }
 
       abortControllerRef.current?.abort();
+      createRecoveryControllerRef.current?.abort();
+      createRecoveryControllerRef.current = null;
       const pendingConversation = pendingConversations.get(conversationId);
       if (pendingConversation) {
         detailRequestRef.current = createClientId();
@@ -856,6 +929,8 @@ const ChatPage: React.FC = () => {
     }
 
     abortControllerRef.current?.abort();
+    createRecoveryControllerRef.current?.abort();
+    createRecoveryControllerRef.current = null;
     detailRequestRef.current = createClientId();
     const conversation = createDraftConversation();
     activeConversationRef.current = conversation;
@@ -958,7 +1033,10 @@ const ChatPage: React.FC = () => {
           try {
             await abortableDelay(delayMs, controller.signal);
             const nextConversations =
-              await chatHistoryApi.listConversationMetas(scopeId);
+              await chatHistoryApi.listConversationMetas(
+                scopeId,
+                controller.signal
+              );
             if (
               controller.signal.aborted ||
               scopeEpochRef.current !== reconciliationScopeEpoch
@@ -979,7 +1057,8 @@ const ChatPage: React.FC = () => {
 
             const detail = await chatHistoryApi.loadConversation(
               scopeId,
-              conversationId
+              conversationId,
+              controller.signal
             );
             if (
               controller.signal.aborted ||
@@ -1022,6 +1101,11 @@ const ChatPage: React.FC = () => {
                   current.stateVersion ?? 0,
                   detail.stateVersion
                 ),
+                messages: hydrateAuthoritativeMessages(
+                  detail.messages,
+                  current.messages,
+                  conversation.latestTurnId
+                ),
                 title: serverMeta.title || current.title,
               };
               activeConversationRef.current = next;
@@ -1056,6 +1140,7 @@ const ChatPage: React.FC = () => {
             conversation: pending.conversation,
             reconciliation: {
               message: failureMessage,
+              retryable: true,
               status: "failed",
             },
           });
@@ -1075,7 +1160,11 @@ const ChatPage: React.FC = () => {
   const handleRetryReconciliation = useCallback(
     (conversationId: string) => {
       const pending = pendingConversations.get(conversationId);
-      if (!pending) {
+      if (
+        !pending ||
+        pending.reconciliation.status !== "failed" ||
+        !pending.reconciliation.retryable
+      ) {
         return;
       }
 
@@ -1152,6 +1241,7 @@ const ChatPage: React.FC = () => {
         createRequestPrompt: conversation.conversationId
           ? undefined
           : trimmedInput,
+        latestTurnId: undefined,
         messages: [...conversation.messages, userMessage, assistantMessage],
         status: nextStatus,
         title,
@@ -1162,9 +1252,15 @@ const ChatPage: React.FC = () => {
       let acceptedChatHistoryContext: ReturnType<
         typeof extractChatHistoryContext
       > = null;
+      let createRecoveryAttempted = false;
+      let latestRefreshedDetail:
+        | Awaited<ReturnType<typeof chatHistoryApi.loadConversation>>
+        | undefined;
       let streamingConversation = startedConversation;
 
       abortControllerRef.current?.abort();
+      createRecoveryControllerRef.current?.abort();
+      createRecoveryControllerRef.current = null;
       if (conversation.conversationId) {
         reconciliationControllersRef.current
           .get(conversation.conversationId)
@@ -1198,11 +1294,19 @@ const ChatPage: React.FC = () => {
           controller.signal,
           conversation.conversationId
             ? {
-                refreshMinimumStateVersion: async () => {
+                refreshMinimumStateVersion: async (signal) => {
                   const detail = await chatHistoryApi.loadConversation(
                     scopeId,
-                    conversation.conversationId as string
+                    conversation.conversationId as string,
+                    signal
                   );
+                  if (
+                    detail.stateVersion >= (conversation.stateVersion as number) &&
+                    (!latestRefreshedDetail ||
+                      detail.stateVersion > latestRefreshedDetail.stateVersion)
+                  ) {
+                    latestRefreshedDetail = detail;
+                  }
                   return detail.stateVersion;
                 },
               }
@@ -1249,7 +1353,11 @@ const ChatPage: React.FC = () => {
                 conversationId: chatHistoryContext.conversationId,
                 expectedTurnCount: conversation.expectedTurnCount + 1,
                 latestTurnId: chatHistoryContext.turnId,
-                stateVersion: chatHistoryContext.stateVersion,
+                stateVersion: Math.max(
+                  streamingConversation.stateVersion ?? 0,
+                  latestRefreshedDetail?.stateVersion ?? 0,
+                  chatHistoryContext.stateVersion
+                ),
               };
               activeConversationRef.current = streamingConversation;
               setActiveConversation((current) =>
@@ -1305,34 +1413,18 @@ const ChatPage: React.FC = () => {
           return;
         }
         if (!receivedChatHistoryContext && createCommandId) {
-          let recovery: Awaited<ReturnType<typeof chatHistoryApi.recoverCreate>> | null =
-            null;
-          for (const delayMs of [0, 300, 900, 1_800]) {
-            await abortableDelay(delayMs, controller.signal);
-            try {
-              recovery = await chatHistoryApi.recoverCreate(
-                scopeId,
-                createCommandId
-              );
-              break;
-            } catch (error) {
-              if (
-                !(error instanceof ChatHistoryApiError) ||
-                error.status !== 404
-              ) {
-                throw error;
-              }
-            }
-          }
+          createRecoveryAttempted = true;
+          const recovery = await recoverCreateIdentity(
+            scopeId,
+            createCommandId,
+            controller.signal
+          );
           if (recovery) {
             receivedChatHistoryContext = true;
-            streamingConversation = {
-              ...streamingConversation,
-              conversationId: recovery.conversationId,
-              expectedTurnCount: conversation.expectedTurnCount + 1,
-              latestTurnId: recovery.turnId,
-              stateVersion: recovery.stateVersion,
-            };
+            streamingConversation = bindCreateRecovery(
+              streamingConversation,
+              recovery
+            );
             activeConversationRef.current = streamingConversation;
             setActiveConversation((current) =>
               current?.clientId === conversation.clientId
@@ -1397,23 +1489,87 @@ const ChatPage: React.FC = () => {
         if (scopeEpochRef.current !== runScopeEpoch) {
           return;
         }
-        const message =
-          controller.signal.aborted && !accumulator.errorText
+        const shouldRecoverCreate = Boolean(
+          !conversation.conversationId &&
+            !receivedChatHistoryContext &&
+            !createRecoveryAttempted &&
+            createCommandId &&
+            chatRequestMayHaveBeenAccepted(error)
+        );
+        if (shouldRecoverCreate && !controller.signal.aborted) {
+          try {
+            const recovery = await recoverCreateIdentity(
+              scopeId,
+              createCommandId as string,
+              controller.signal
+            );
+            if (recovery) {
+              receivedChatHistoryContext = true;
+              streamingConversation = bindCreateRecovery(
+                streamingConversation,
+                recovery
+              );
+            }
+          } catch {
+            // Preserve the accepted request's original stream failure.
+          }
+        }
+        const isAmbiguousContinuation = Boolean(
+          conversation.conversationId &&
+            !receivedChatHistoryContext &&
+            chatRequestMayHaveBeenAccepted(error)
+        );
+        const message = isAmbiguousContinuation
+          ? t(
+              "pages.chat.index.continuationContextMissing",
+              "The continuation may have been accepted, but its turn identity was not received. Reload this page before continuing."
+            )
+          : controller.signal.aborted && !accumulator.errorText
             ? t("pages.chat.index.chatStopped", "Chat stopped.")
             : error instanceof Error
               ? error.message
               : String(error);
         accumulator.errorText = message;
+        const failedMessages = streamingConversation.messages.map((entry) =>
+          entry.id === assistantMessageId
+            ? {
+                ...entry,
+                ...buildAssistantMessagePatch(accumulator, "error"),
+              }
+            : entry
+        );
+        const refreshedDetail = latestRefreshedDetail;
+        const authoritativeMessages = refreshedDetail
+          ? hydrateAuthoritativeMessages(
+              refreshedDetail.messages,
+              streamingConversation.messages,
+              undefined
+            )
+          : undefined;
+        const authoritativeMessageIds = new Set(
+          authoritativeMessages?.map((entry) => entry.id) ?? []
+        );
+        const failedAttemptMessages = failedMessages.filter(
+          (entry) =>
+            (entry.id === userMessage.id || entry.id === assistantMessageId) &&
+            !authoritativeMessageIds.has(entry.id)
+        );
         const failedConversation: ConversationState = {
           ...streamingConversation,
-          messages: streamingConversation.messages.map((entry) =>
-            entry.id === assistantMessageId
-              ? {
-                  ...entry,
-                  ...buildAssistantMessagePatch(accumulator, "error"),
-                }
-              : entry
-          ),
+          ...(refreshedDetail
+            ? {
+                ...(receivedChatHistoryContext
+                  ? {}
+                  : { latestTurnId: undefined }),
+                stateVersion: Math.max(
+                  streamingConversation.stateVersion ?? 0,
+                  refreshedDetail.stateVersion
+                ),
+              }
+            : {}),
+          messages: authoritativeMessages
+            ? [...authoritativeMessages, ...failedAttemptMessages]
+            : failedMessages,
           status: "error",
         };
         activeConversationRef.current = failedConversation;
@@ -1421,8 +1577,67 @@ const ChatPage: React.FC = () => {
           current?.clientId === conversation.clientId ? failedConversation : current
         );
         setSession(buildSessionFromAccumulator(scopeId, accumulator, "error"));
-        if (failedConversation.conversationId) {
+        if (
+          failedConversation.conversationId &&
+          receivedChatHistoryContext
+        ) {
           reconcileConversation(failedConversation);
+        } else if (
+          failedConversation.conversationId &&
+          isAmbiguousContinuation
+        ) {
+          setPendingConversations((current) => {
+            const next = new Map(current);
+            next.set(failedConversation.conversationId as string, {
+              conversation: failedConversation,
+              reconciliation: {
+                message,
+                retryable: false,
+                status: "failed",
+              },
+            });
+            return next;
+          });
+        } else if (shouldRecoverCreate && controller.signal.aborted) {
+          const recoveryController = new AbortController();
+          createRecoveryControllerRef.current = recoveryController;
+          void recoverCreateIdentity(
+            scopeId,
+            createCommandId as string,
+            recoveryController.signal
+          )
+            .then((recovery) => {
+              if (
+                !recovery ||
+                recoveryController.signal.aborted ||
+                scopeEpochRef.current !== runScopeEpoch
+              ) {
+                return;
+              }
+
+              void queryClient.invalidateQueries({
+                queryKey: ["chat-history", scopeId],
+              });
+              const current = activeConversationRef.current;
+              if (
+                current?.clientId !== conversation.clientId ||
+                current.conversationId ||
+                current.createCommandId !== createCommandId
+              ) {
+                return;
+              }
+
+              const recoveredConversation = bindCreateRecovery(current, recovery);
+              activeConversationRef.current = recoveredConversation;
+              setActiveConversation(recoveredConversation);
+              reconcileConversation(recoveredConversation);
+            })
+            .catch(() => undefined)
+            .finally(() => {
+              if (createRecoveryControllerRef.current === recoveryController) {
+                createRecoveryControllerRef.current = null;
+              }
+            });
         }
       } finally {
         if (abortControllerRef.current === controller) {
@@ -1434,6 +1649,7 @@ const ChatPage: React.FC = () => {
       canStartChat,
       isStreaming,
       pendingConversations,
+      queryClient,
       reconcileConversation,
       scopeId,
     ]
@@ -1661,7 +1877,8 @@ const ChatPage: React.FC = () => {
                       </span>
                     </span>
                   </button>
-                  {conversation.historyReconciliation?.status === "failed" ? (
+                  {conversation.historyReconciliation?.status === "failed" &&
+                  conversation.historyReconciliation.retryable ? (
                     <Tooltip
                       title={t(
                         "pages.chat.index.retryHistorySave",
@@ -1871,17 +2088,19 @@ const ChatPage: React.FC = () => {
             activeConversation?.conversationId ? (
             <Alert
               action={
-                <Button
-                  icon={<ReloadOutlined />}
-                  onClick={() =>
-                    handleRetryReconciliation(
-                      activeConversation.conversationId as string
-                    )
-                  }
-                  size="small"
-                >
-                  {t("pages.chat.index.retry", "Retry")}
-                </Button>
+                activeHistoryReconciliation.retryable ? (
+                  <Button
+                    icon={<ReloadOutlined />}
+                    onClick={() =>
+                      handleRetryReconciliation(
+                        activeConversation.conversationId as string
+                      )
+                    }
+                    size="small"
+                  >
+                    {t("pages.chat.index.retry", "Retry")}
+                  </Button>
+                ) : undefined
               }
               banner
               description={activeHistoryReconciliation.message}
@@ -2009,6 +2228,7 @@ const ChatPage: React.FC = () => {
                         )}
                       </Typography.Text>
                       <Button
+                        disabled={isConversationActionDisabled}
                         icon={<SendOutlined />}
                         onClick={handleConfirmCreate}
                         type="primary"
@@ -2054,11 +2274,7 @@ const ChatPage: React.FC = () => {
               </Space>
             ) : null}
             <ChatInput
-              disabled={
-                !canStartChat ||
-                detailLoadState.status === "loading" ||
-                Boolean(activeHistoryReconciliation)
-              }
+              disabled={isConversationActionDisabled}
               isStreaming={isStreaming}
               onChange={setPrompt}
               onSend={handleSend}

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
@@ -2688,12 +2688,12 @@ const StudioFilesDetailPane: React.FC<Props> = ({
               message={t("pages.studio.studiofilesdetailpane.failed.to.load.conversation", "Failed to load conversation")}
               description={describeError(selectedConversationMessages.error)}
             />
-          ) : (selectedConversationMessages.data?.length ?? 0) === 0 ? (
+          ) : (selectedConversationMessages.data?.messages.length ?? 0) === 0 ? (
             <div style={emptyCardStyle}>{t("pages.studio.studiofilesdetailpane.no.messages.in.this.conversation", "No messages in this conversation")}</div>
           ) : (
             <section aria-label={t("pages.studio.studiofilesdetailpane.chat.history.messages", "Chat history messages")} style={chatMessageListStyle}>
               {(
-                (selectedConversationMessages.data ?? []) as ChatHistoryMessageView[]
+                (selectedConversationMessages.data?.messages ?? []) as ChatHistoryMessageView[]
               ).map(
                 (message) => (
                   <article

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioFilesPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioFilesPage.test.tsx
@@ -216,39 +216,42 @@ describe('StudioFilesPage', () => {
         messageCount: 2,
       },
     ]);
-    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue([
-      {
-        id: 'message-1',
-        role: 'user',
-        content: 'hello from user',
-        authorName: 'Alice',
-        timestamp: Date.parse('2026-03-18T01:00:00Z'),
-        status: 'complete',
-      },
-      {
-        id: 'message-2',
-        role: 'assistant',
-        content: 'assistant reply',
-        thinking: 'Planning the response',
-        timestamp: Date.parse('2026-03-18T01:01:00Z'),
-        status: 'complete',
-      },
-      {
-        id: 'message-3',
-        role: 'user',
-        content: 'run it now',
-        timestamp: Date.parse('2026-03-18T01:02:00Z'),
-        status: 'complete',
-      },
-      {
-        id: 'message-4',
-        role: 'assistant',
-        content: '',
-        error: 'workflow_run_error: Dispatch failed.',
-        timestamp: Date.parse('2026-03-18T01:03:00Z'),
-        status: 'error',
-      },
-    ]);
+    (chatHistoryApi.loadConversation as jest.Mock).mockResolvedValue({
+      messages: [
+        {
+          id: 'message-1',
+          role: 'user',
+          content: 'hello from user',
+          authorName: 'Alice',
+          timestamp: Date.parse('2026-03-18T01:00:00Z'),
+          status: 'complete',
+        },
+        {
+          id: 'message-2',
+          role: 'assistant',
+          content: 'assistant reply',
+          thinking: 'Planning the response',
+          timestamp: Date.parse('2026-03-18T01:01:00Z'),
+          status: 'complete',
+        },
+        {
+          id: 'message-3',
+          role: 'user',
+          content: 'run it now',
+          timestamp: Date.parse('2026-03-18T01:02:00Z'),
+          status: 'complete',
+        },
+        {
+          id: 'message-4',
+          role: 'assistant',
+          content: '',
+          error: 'workflow_run_error: Dispatch failed.',
+          timestamp: Date.parse('2026-03-18T01:03:00Z'),
+          status: 'error',
+        },
+      ],
+      stateVersion: 7,
+    });
     (chatHistoryApi.deleteConversation as jest.Mock).mockResolvedValue(undefined);
     (explorerApi.putFile as jest.Mock).mockResolvedValue(undefined);
     (explorerApi.deleteFile as jest.Mock).mockResolvedValue(undefined);


### PR DESCRIPTION
## Problem

Fixes #2920.

Restored chat conversations still used the previous continuation contract. The frontend replayed history in the prompt, had no authoritative server watermark, and could either retry with stale state or leave the conversation in the wrong interaction state after an ambiguous request failure.

Backend contract dependency: #2923 defines the required conversation-detail and SSE watermark contract. It was merged into `auto-work-dev-0701`, not `dev`, so integration and deployment of this PR require that backend contract to be present in the target environment.

## Solution

- Decode conversation detail as `{ messages, stateVersion }` and keep the server transcript authoritative.
- Send `{ conversationId: null }` for a new conversation and `{ conversationId, minimumStateVersion }` for a continuation.
- Send only the current prompt; remove client-side `<conversation_history>` replay.
- Read typed `stateVersion` from `aevatar.chat.context` and retain watermarks monotonically.
- Retry only typed `503 CHAT_HISTORY_RESERVATION_UNAVAILABLE` responses after refreshing authoritative history.
- Distinguish definitive rejection, retry-preparation failure, and potentially accepted POST failure.
- Recover accepted creates when the stream disconnects before context, and fail closed for ambiguous continuations without typed context.
- Keep composer and confirmation actions disabled while reconciliation is in progress.
- Update Studio Files detail loading for the new conversation-detail response shape.

## Impact paths

- Console chat request and SSE handling
- Conversation history loading and reconciliation
- Restored-conversation composer state
- Studio Files conversation detail view
- English and Chinese error copy

## Verification

- Focused affected suites: 4/4 suites, 77/77 tests passed.
- TypeScript: passed.
- Biome lint for all changed frontend files: passed.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `git diff --check`: passed.
- Frontend production build: passed.
- A prior local full Jest run completed 129/130 suites and 1147/1148 tests. The only failure was an unrelated timeout in `src/pages/runs/index.test.tsx:762`; the selected test passed in isolation in 471 ms. Full-suite validation is left to PR CI per repository workflow.

## Recurrence prevention

- Root cause: the client lacked a typed authoritative watermark and inferred request acceptance from broad error classes.
- General failure pattern: eventually consistent retries mixed authoritative state, transient preparation failures, and potentially accepted POST failures.
- Guard added: typed detail decoding, positive continuation validation, pre-dispatch abort classification, monotonic watermark retention, phase-aware retry errors, authoritative refresh merging, create recovery, and an ambiguous-continuation lock.
- Regression coverage: new and continuation payloads, `0 -> 6 -> 8` refresh, transient and terminal refresh failures, refresh-to-dispatch cancellation, stale context rollback, refreshed transcript retention after stream failure, create recovery after disconnect, unreadable error bodies, cross-tab turns, abort propagation, ambiguous no-context handling, and watermark reuse on the next turn.
