### PR TITLE
Narrow WorkOrder to durable intent coordination

### DIFF
--- a/agents/Aevatar.GAgents.WorkOrder/WorkOrderConventions.cs
+++ b/agents/Aevatar.GAgents.WorkOrder/WorkOrderConventions.cs
@@ -18,9 +18,6 @@ public static class WorkOrderConventions
     public static string BuildActorId(string scopeId, string workOrderId) =>
         $"{ActorIdPrefix}:{NormalizeScopeId(scopeId)}:{NormalizeWorkOrderId(workOrderId)}";
 
-    public static string BuildApprovalId(string workOrderId) =>
-        $"approval-{NormalizeWorkOrderId(workOrderId)}";
-
     public static string BuildDispatchCommandId(string workOrderId) =>
         $"work-order-dispatch-{NormalizeWorkOrderId(workOrderId)}";
 

--- a/agents/Aevatar.GAgents.WorkOrder/WorkOrderGAgent.State.cs
+++ b/agents/Aevatar.GAgents.WorkOrder/WorkOrderGAgent.State.cs
@@ -10,9 +10,8 @@ public sealed partial class WorkOrderGAgent
         StateTransitionMatcher
             .Match(current, evt)
             .On<WorkOrderCreatedEvent>(ApplyCreated)
-            .On<WorkOrderPlannedEvent>(ApplyPlanned)
+            .On<WorkOrderReadyEvent>(ApplyReady)
             .On<WorkOrderReassignedEvent>(ApplyReassigned)
-            .On<WorkOrderApprovalDecidedEvent>(ApplyApprovalDecided)
             .On<WorkOrderDispatchRequestedEvent>(ApplyDispatchRequested)
             .On<WorkOrderExecutionRetryScheduledEvent>(ApplyExecutionRetryScheduled)
             .On<WorkOrderRunAcceptedEvent>(ApplyRunAccepted)
@@ -20,8 +19,8 @@ public sealed partial class WorkOrderGAgent
             .On<WorkOrderDispatchFailedEvent>(ApplyDispatchFailed)
             .On<WorkOrderCancelledEvent>(ApplyCancelled)
             .On<WorkOrderTimedOutEvent>(ApplyTimedOut)
-            .On<WorkOrderTerminalEvidenceRecordedEvent>(ApplyTerminalEvidence)
-            .On<WorkOrderLateTerminalEvidenceRecordedEvent>(ApplyLateTerminalEvidence)
+            .On<WorkOrderRunOutcomeObservedEvent>(ApplyRunOutcome)
+            .On<WorkOrderLateRunOutcomeObservedEvent>(ApplyLateRunOutcome)
             .OrCurrent();
 
     private static WorkOrderState ApplyCreated(WorkOrderState _, WorkOrderCreatedEvent evt)
@@ -43,7 +42,6 @@ public sealed partial class WorkOrderGAgent
             EndpointId = request.EndpointId,
             Intent = request.Intent,
             Input = request.Input?.Clone(),
-            PermissionPlan = request.PermissionPlan?.Clone(),
             LifecycleStatus = WorkOrderLifecycleStatus.Accepted,
             LifecycleVersion = 1,
             CreatedAtUtc = createdAt.Clone(),
@@ -53,12 +51,11 @@ public sealed partial class WorkOrderGAgent
         };
     }
 
-    private static WorkOrderState ApplyPlanned(WorkOrderState current, WorkOrderPlannedEvent evt)
+    private static WorkOrderState ApplyReady(WorkOrderState current, WorkOrderReadyEvent evt)
     {
         var next = current.Clone();
-        next.LifecycleStatus = evt.LifecycleStatus;
-        next.Approval = evt.Approval?.Clone();
-        Advance(next, current, evt.PlannedAtUtc);
+        next.LifecycleStatus = WorkOrderLifecycleStatus.Ready;
+        Advance(next, current, evt.ReadyAtUtc);
         return next;
     }
 
@@ -74,34 +71,12 @@ public sealed partial class WorkOrderGAgent
         return next;
     }
 
-    private static WorkOrderState ApplyApprovalDecided(WorkOrderState current, WorkOrderApprovalDecidedEvent evt)
-    {
-        var next = current.Clone();
-        next.Approval ??= new WorkOrderApprovalState();
-        next.Approval.Status = evt.ApprovalStatus;
-        next.Approval.DecisionId = evt.DecisionId;
-        next.Approval.DecidedBy = evt.DecidedBy?.Clone();
-        next.Approval.Reason = evt.Reason;
-        next.Approval.DecidedAtUtc = evt.DecidedAtUtc?.Clone();
-        next.LifecycleStatus = evt.ApprovalStatus == WorkOrderApprovalStatus.Approved
-            ? WorkOrderLifecycleStatus.Ready
-            : WorkOrderLifecycleStatus.Denied;
-        if (next.LifecycleStatus == WorkOrderLifecycleStatus.Denied)
-        {
-            next.TerminalReason = evt.Reason;
-            ClearExecutionRetry(next);
-        }
-        Advance(next, current, evt.DecidedAtUtc);
-        return next;
-    }
-
     private static WorkOrderState ApplyDispatchRequested(WorkOrderState current, WorkOrderDispatchRequestedEvent evt)
     {
         var next = current.Clone();
         next.DispatchCommandId = evt.DispatchCommandId;
         next.RequestedRunId = evt.RequestedRunId;
         next.TerminalDeliveryId = evt.TerminalDeliveryId;
-        next.Execution ??= new WorkOrderExecutionProvenance();
         next.LifecycleStatus = WorkOrderLifecycleStatus.DispatchPending;
         Advance(next, current, evt.RequestedAtUtc);
         return next;
@@ -131,7 +106,7 @@ public sealed partial class WorkOrderGAgent
     {
         var next = current.Clone();
         var accepted = evt.Accepted ?? new WorkOrderExecutionAccepted();
-        next.Execution = new WorkOrderExecutionProvenance
+        next.Run = new WorkOrderRunLink
         {
             RunId = accepted.RunId,
             RunActorId = accepted.RunActorId,
@@ -149,8 +124,6 @@ public sealed partial class WorkOrderGAgent
     private static WorkOrderState ApplyRunStarted(WorkOrderState current, WorkOrderRunStartedEvent evt)
     {
         var next = current.Clone();
-        next.Execution ??= new WorkOrderExecutionProvenance();
-        next.Execution.StartedAtUtc = evt.StartedAtUtc?.Clone();
         if (current.LifecycleStatus == WorkOrderLifecycleStatus.DispatchPending)
             next.LifecycleStatus = WorkOrderLifecycleStatus.Running;
         Advance(next, current, evt.StartedAtUtc);
@@ -188,36 +161,26 @@ public sealed partial class WorkOrderGAgent
         return next;
     }
 
-    private static WorkOrderState ApplyTerminalEvidence(
+    private static WorkOrderState ApplyRunOutcome(
         WorkOrderState current,
-        WorkOrderTerminalEvidenceRecordedEvent evt)
+        WorkOrderRunOutcomeObservedEvent evt)
     {
         var next = current.Clone();
         next.LifecycleStatus = evt.LifecycleStatus;
-        next.TerminalEvidence = evt.Evidence?.Clone();
+        next.RunOutcome = evt.Outcome?.Clone();
         ClearExecutionRetry(next);
-        if (evt.LifecycleStatus == WorkOrderLifecycleStatus.Failed)
-        {
-            next.Failure = new WorkOrderFailureReference
-            {
-                Code = "WORK_ORDER_RUN_FAILED",
-                Message = evt.Evidence?.Error ?? string.Empty,
-                Source = "run",
-                ReferenceId = evt.Evidence?.RunId ?? string.Empty,
-            };
-        }
-        Advance(next, current, evt.Evidence?.TerminalAtUtc);
+        Advance(next, current, evt.Outcome?.TerminalAtUtc);
         return next;
     }
 
-    private static WorkOrderState ApplyLateTerminalEvidence(
+    private static WorkOrderState ApplyLateRunOutcome(
         WorkOrderState current,
-        WorkOrderLateTerminalEvidenceRecordedEvent evt)
+        WorkOrderLateRunOutcomeObservedEvent evt)
     {
         var next = current.Clone();
-        next.LateTerminalEvidence = evt.Evidence?.Clone();
+        next.LateRunOutcome = evt.Outcome?.Clone();
         ClearExecutionRetry(next);
-        Advance(next, current, evt.Evidence?.TerminalAtUtc);
+        Advance(next, current, evt.Outcome?.TerminalAtUtc);
         return next;
     }
 

--- a/agents/Aevatar.GAgents.WorkOrder/WorkOrderGAgent.cs
+++ b/agents/Aevatar.GAgents.WorkOrder/WorkOrderGAgent.cs
@@ -36,7 +36,7 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
             return;
 
         if (State.LifecycleStatus == WorkOrderLifecycleStatus.DispatchPending &&
-            string.IsNullOrWhiteSpace(State.Execution?.RunId))
+            string.IsNullOrWhiteSpace(State.Run?.RunId))
         {
             await ScheduleExecutionAndWatchdogAsync(ct);
         }
@@ -56,15 +56,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         }
 
         var now = command.RequestedAtUtc ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
-        var approvalRequired = RequiresApproval(command.PermissionPlan);
-        var approval = new WorkOrderApprovalState
-        {
-            ApprovalId = approvalRequired ? command.ApprovalId : string.Empty,
-            Status = approvalRequired
-                ? WorkOrderApprovalStatus.Pending
-                : WorkOrderApprovalStatus.NotRequired,
-        };
-
         await PersistDomainEventsAsync(
         [
             new WorkOrderCreatedEvent
@@ -72,13 +63,9 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
                 Request = command.Clone(),
                 CreatedAtUtc = now,
             },
-            new WorkOrderPlannedEvent
+            new WorkOrderReadyEvent
             {
-                LifecycleStatus = approvalRequired
-                    ? WorkOrderLifecycleStatus.WaitingApproval
-                    : WorkOrderLifecycleStatus.Ready,
-                Approval = approval,
-                PlannedAtUtc = now,
+                ReadyAtUtc = now,
             },
         ]);
 
@@ -98,7 +85,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         EnsureExpectedVersion(command.ExpectedLifecycleVersion);
         if (State.LifecycleStatus is not (
                 WorkOrderLifecycleStatus.Accepted or
-                WorkOrderLifecycleStatus.WaitingApproval or
                 WorkOrderLifecycleStatus.Ready))
         {
             throw new InvalidOperationException(
@@ -122,28 +108,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
                 ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         });
     }
-
-    [EventHandler(EndpointName = "approveWorkOrder")]
-    public Task HandleApproveAsync(ApproveWorkOrder command) =>
-        HandleApprovalDecisionAsync(
-            command.WorkOrderId,
-            command.ExpectedLifecycleVersion,
-            command.DecisionId,
-            command.DecidedBy,
-            command.Reason,
-            command.DecidedAtUtc,
-            WorkOrderApprovalStatus.Approved);
-
-    [EventHandler(EndpointName = "denyWorkOrder")]
-    public Task HandleDenyAsync(DenyWorkOrder command) =>
-        HandleApprovalDecisionAsync(
-            command.WorkOrderId,
-            command.ExpectedLifecycleVersion,
-            command.DecisionId,
-            command.DecidedBy,
-            command.Reason,
-            command.DecidedAtUtc,
-            WorkOrderApprovalStatus.Denied);
 
     [EventHandler(EndpointName = "dispatchWorkOrder")]
     public async Task HandleDispatchAsync(DispatchWorkOrder command)
@@ -207,7 +171,7 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
             return;
         }
 
-        if (State.Execution != null && !string.IsNullOrWhiteSpace(State.Execution.RunId))
+        if (State.Run != null && !string.IsNullOrWhiteSpace(State.Run.RunId))
             return;
 
         await ScheduleExecutionAndWatchdogAsync();
@@ -259,10 +223,10 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         if (!MatchesPendingExecution(
                 evt.WorkOrderId,
                 evt.DispatchCommandId,
-                evt.RequestedRunId) ||
+            evt.RequestedRunId) ||
             evt.Attempt <= 0 ||
             evt.Attempt != State.ExecutionRetryAttempt ||
-            !string.IsNullOrWhiteSpace(State.Execution?.RunId))
+            !string.IsNullOrWhiteSpace(State.Run?.RunId))
         {
             return;
         }
@@ -283,7 +247,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         EnsureExpectedVersion(command.ExpectedLifecycleVersion);
         if (State.LifecycleStatus is not (
                 WorkOrderLifecycleStatus.Accepted or
-                WorkOrderLifecycleStatus.WaitingApproval or
                 WorkOrderLifecycleStatus.Ready))
         {
             throw new InvalidOperationException(
@@ -330,7 +293,7 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
     public Task HandleWorkflowTerminalAsync(WorkflowRunTerminalNotification notification)
     {
         ArgumentNullException.ThrowIfNull(notification);
-        return RecordTerminalEvidenceAsync(new WorkOrderTerminalEvidence
+        return RecordRunOutcomeAsync(new WorkOrderRunOutcomeReference
         {
             DeliveryId = notification.DeliveryId,
             RunId = notification.WorkflowRunId,
@@ -344,10 +307,7 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
                 WorkflowRunTerminalStatus.Stopped => WorkOrderTerminalOutcome.Stopped,
                 _ => WorkOrderTerminalOutcome.Unspecified,
             },
-            Output = notification.Output,
-            Error = notification.Error,
             TerminalAtUtc = notification.TerminalAt?.Clone(),
-            ResultArtifacts = { CloneDeclaredResultArtifacts() },
         }, notification.WorkflowActorId);
     }
 
@@ -367,17 +327,10 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         if (notification.StartedAt == null)
             throw new InvalidOperationException("workflow Run started notification requires started_at.");
 
-        if (State.Execution!.StartedAtUtc != null)
-        {
-            if (State.Execution.StartedAtUtc.Equals(notification.StartedAt))
-                return;
+        if (State.LifecycleStatus == WorkOrderLifecycleStatus.Running || IsTerminal(State.LifecycleStatus))
+            return;
 
-            throw new InvalidOperationException("conflicting workflow Run started evidence was received.");
-        }
-
-        if (State.LifecycleStatus != WorkOrderLifecycleStatus.DispatchPending &&
-            State.LifecycleStatus != WorkOrderLifecycleStatus.Running &&
-            !IsTerminal(State.LifecycleStatus))
+        if (State.LifecycleStatus != WorkOrderLifecycleStatus.DispatchPending)
         {
             throw new InvalidOperationException(
                 $"workflow Run started evidence cannot advance work order from '{State.LifecycleStatus}'.");
@@ -398,7 +351,7 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
     public Task HandleServiceRunTerminalAsync(ServiceRunTerminalNotification notification)
     {
         ArgumentNullException.ThrowIfNull(notification);
-        return RecordTerminalEvidenceAsync(new WorkOrderTerminalEvidence
+        return RecordRunOutcomeAsync(new WorkOrderRunOutcomeReference
         {
             DeliveryId = notification.DeliveryId,
             RunId = notification.RunId,
@@ -412,105 +365,65 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
                 ServiceRunStatus.Stopped => WorkOrderTerminalOutcome.Stopped,
                 _ => WorkOrderTerminalOutcome.Unspecified,
             },
-            Output = notification.Output,
-            Error = notification.Error,
             TerminalAtUtc = notification.TerminalAt?.Clone(),
-            ResultArtifacts = { CloneDeclaredResultArtifacts() },
         }, BuildExpectedServiceRunPublisherActorId());
     }
 
-    private async Task HandleApprovalDecisionAsync(
-        string workOrderId,
-        long expectedLifecycleVersion,
-        string decisionId,
-        WorkOrderPrincipal decidedBy,
-        string reason,
-        Timestamp? decidedAtUtc,
-        WorkOrderApprovalStatus decision)
-    {
-        EnsureInitialized(workOrderId);
-        EnsureRequired(decisionId, nameof(decisionId));
-        EnsureApprover(decidedBy);
-
-        if (State.Approval != null &&
-            State.Approval.Status == decision &&
-            string.Equals(State.Approval.DecisionId, decisionId, StringComparison.Ordinal) &&
-            PrincipalsEqual(State.Approval.DecidedBy, decidedBy))
-        {
-            return;
-        }
-
-        EnsureExpectedVersion(expectedLifecycleVersion);
-        if (State.LifecycleStatus != WorkOrderLifecycleStatus.WaitingApproval ||
-            State.Approval?.Status != WorkOrderApprovalStatus.Pending)
-        {
-            throw new InvalidOperationException(
-                $"work order '{State.WorkOrderId}' is not waiting for approval.");
-        }
-
-        await PersistDomainEventAsync(new WorkOrderApprovalDecidedEvent
-        {
-            DecisionId = decisionId.Trim(),
-            ApprovalStatus = decision,
-            DecidedBy = decidedBy.Clone(),
-            Reason = reason?.Trim() ?? string.Empty,
-            DecidedAtUtc = decidedAtUtc ?? Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-        });
-    }
-
-    private async Task RecordTerminalEvidenceAsync(
-        WorkOrderTerminalEvidence evidence,
+    private async Task RecordRunOutcomeAsync(
+        WorkOrderRunOutcomeReference outcome,
         string expectedPublisherActorId)
     {
-        ArgumentNullException.ThrowIfNull(evidence);
-        if (evidence.Outcome == WorkOrderTerminalOutcome.Unspecified)
-            throw new InvalidOperationException("terminal evidence outcome is required.");
+        ArgumentNullException.ThrowIfNull(outcome);
+        if (outcome.Outcome == WorkOrderTerminalOutcome.Unspecified)
+            throw new InvalidOperationException("Run outcome is required.");
+        if (outcome.TerminalAtUtc == null)
+            throw new InvalidOperationException("Run outcome terminal_at_utc is required.");
         EnsureAcceptedRunIdentity(
-            evidence.DeliveryId,
-            evidence.RunId,
-            evidence.RunActorId,
-            evidence.CommandId,
-            evidence.CorrelationId);
-        EnsureInboundPublisherMatches(expectedPublisherActorId, "Run terminal evidence");
+            outcome.DeliveryId,
+            outcome.RunId,
+            outcome.RunActorId,
+            outcome.CommandId,
+            outcome.CorrelationId);
+        EnsureInboundPublisherMatches(expectedPublisherActorId, "Run outcome");
 
         if (State.LifecycleStatus == WorkOrderLifecycleStatus.TimedOut)
         {
-            if (EvidenceEqual(State.LateTerminalEvidence, evidence))
+            if (RunOutcomesEqual(State.LateRunOutcome, outcome))
                 return;
-            if (State.LateTerminalEvidence != null)
-                throw new InvalidOperationException("conflicting late terminal evidence was received.");
+            if (State.LateRunOutcome != null)
+                throw new InvalidOperationException("conflicting late Run outcome was received.");
 
-            await PersistDomainEventAsync(new WorkOrderLateTerminalEvidenceRecordedEvent
+            await PersistDomainEventAsync(new WorkOrderLateRunOutcomeObservedEvent
             {
-                Evidence = evidence.Clone(),
+                Outcome = outcome.Clone(),
             });
             return;
         }
 
         if (IsTerminal(State.LifecycleStatus))
         {
-            if (EvidenceEqual(State.TerminalEvidence, evidence))
+            if (RunOutcomesEqual(State.RunOutcome, outcome))
                 return;
-            throw new InvalidOperationException("conflicting terminal evidence was received.");
+            throw new InvalidOperationException("conflicting Run outcome was received.");
         }
 
         if (State.LifecycleStatus != WorkOrderLifecycleStatus.DispatchPending &&
             State.LifecycleStatus != WorkOrderLifecycleStatus.Running)
         {
             throw new InvalidOperationException(
-                $"terminal evidence cannot advance work order from '{State.LifecycleStatus}'.");
+                $"Run outcome cannot advance work order from '{State.LifecycleStatus}'.");
         }
 
-        await PersistDomainEventAsync(new WorkOrderTerminalEvidenceRecordedEvent
+        await PersistDomainEventAsync(new WorkOrderRunOutcomeObservedEvent
         {
-            LifecycleStatus = evidence.Outcome switch
+            LifecycleStatus = outcome.Outcome switch
             {
                 WorkOrderTerminalOutcome.Succeeded => WorkOrderLifecycleStatus.Completed,
                 WorkOrderTerminalOutcome.Failed => WorkOrderLifecycleStatus.Failed,
                 WorkOrderTerminalOutcome.Stopped => WorkOrderLifecycleStatus.Stopped,
                 _ => throw new InvalidOperationException("terminal outcome is unsupported."),
             },
-            Evidence = evidence.Clone(),
+            Outcome = outcome.Clone(),
         });
     }
 
@@ -565,33 +478,36 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
     private async Task ScheduleExecutionRetryAsync(CancellationToken ct)
     {
         if (State.LifecycleStatus != WorkOrderLifecycleStatus.DispatchPending ||
-            State.TimeoutAtUtc == null ||
-            !string.IsNullOrWhiteSpace(State.Execution?.RunId))
+            !string.IsNullOrWhiteSpace(State.Run?.RunId))
         {
             return;
         }
 
         var now = DateTimeOffset.UtcNow;
-        var remaining = State.TimeoutAtUtc.ToDateTimeOffset() - now;
-        if (remaining <= TimeSpan.Zero)
-        {
-            await SendToAsync(
-                Id,
-                new WorkOrderTimeoutFired
-                {
-                    WorkOrderId = State.WorkOrderId,
-                    TimeoutAtUtc = State.TimeoutAtUtc.Clone(),
-                },
-                ct);
-            return;
-        }
-
         var attempt = checked(State.ExecutionRetryAttempt + 1);
         var exponent = Math.Min(attempt - 1, 30);
         var exponentialDelay = ExecutionRetryInitialDelayMilliseconds * Math.Pow(2, exponent);
         var delayMilliseconds = Math.Min(ExecutionRetryMaxDelayMilliseconds, exponentialDelay);
         var backoff = TimeSpan.FromMilliseconds(delayMilliseconds);
-        var due = remaining < backoff ? remaining : backoff;
+        var due = backoff;
+        if (State.TimeoutAtUtc != null)
+        {
+            var remaining = State.TimeoutAtUtc.ToDateTimeOffset() - now;
+            if (remaining <= TimeSpan.Zero)
+            {
+                await SendToAsync(
+                    Id,
+                    new WorkOrderTimeoutFired
+                    {
+                        WorkOrderId = State.WorkOrderId,
+                        TimeoutAtUtc = State.TimeoutAtUtc.Clone(),
+                    },
+                    ct);
+                return;
+            }
+
+            due = remaining < backoff ? remaining : backoff;
+        }
         var retryAt = Timestamp.FromDateTimeOffset(now.Add(due));
         var callbackId = BuildExecutionRetryCallbackId(
             State.WorkOrderId,
@@ -668,7 +584,7 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
 
     private bool MatchesPendingExecution(string workOrderId, string dispatchCommandId, string requestedRunId) =>
         State.LifecycleStatus == WorkOrderLifecycleStatus.DispatchPending &&
-        string.IsNullOrWhiteSpace(State.Execution?.RunId) &&
+        string.IsNullOrWhiteSpace(State.Run?.RunId) &&
         string.Equals(State.WorkOrderId, workOrderId, StringComparison.Ordinal) &&
         string.Equals(State.DispatchCommandId, dispatchCommandId, StringComparison.Ordinal) &&
         string.Equals(State.RequestedRunId, requestedRunId, StringComparison.Ordinal);
@@ -680,13 +596,13 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         string commandId,
         string correlationId)
     {
-        if (State.Execution == null || string.IsNullOrWhiteSpace(State.Execution.RunId))
+        if (State.Run == null || string.IsNullOrWhiteSpace(State.Run.RunId))
             throw new InvalidOperationException("Run evidence arrived before Run acceptance was recorded.");
         if (!string.Equals(State.TerminalDeliveryId, deliveryId, StringComparison.Ordinal) ||
-            !string.Equals(State.Execution.RunId, runId, StringComparison.Ordinal) ||
-            !string.Equals(State.Execution.RunActorId, runActorId, StringComparison.Ordinal) ||
-            !string.Equals(State.Execution.CommandId, commandId, StringComparison.Ordinal) ||
-            !string.Equals(State.Execution.CorrelationId, correlationId, StringComparison.Ordinal))
+            !string.Equals(State.Run.RunId, runId, StringComparison.Ordinal) ||
+            !string.Equals(State.Run.RunActorId, runActorId, StringComparison.Ordinal) ||
+            !string.Equals(State.Run.CommandId, commandId, StringComparison.Ordinal) ||
+            !string.Equals(State.Run.CorrelationId, correlationId, StringComparison.Ordinal))
         {
             throw new InvalidOperationException(
                 $"Run evidence does not match work order '{State.WorkOrderId}' Run identity.");
@@ -708,15 +624,12 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
 
     private string BuildExpectedServiceRunPublisherActorId()
     {
-        var runId = State.Execution?.RunId;
+        var runId = State.Run?.RunId;
         if (string.IsNullOrWhiteSpace(runId))
             return string.Empty;
 
         return ServiceRunIds.BuildActorId(State.ScopeId, State.PublishedServiceId, runId);
     }
-
-    private IEnumerable<WorkOrderArtifactReference> CloneDeclaredResultArtifacts() =>
-        State.Input?.DeclaredResultArtifacts.Select(static artifact => artifact.Clone()) ?? [];
 
     private void EnsureInitialized(string workOrderId)
     {
@@ -742,14 +655,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
             throw new InvalidOperationException("work order command principal is not the requester.");
     }
 
-    private void EnsureApprover(WorkOrderPrincipal principal)
-    {
-        ArgumentNullException.ThrowIfNull(principal);
-        EnsureRequired(principal.PrincipalId, "principalId");
-        if (State.PermissionPlan?.ApproverPrincipalIds.Contains(principal.PrincipalId) != true)
-            throw new InvalidOperationException("work order approval principal is not authorized by the permission plan.");
-    }
-
     private void ValidateCreate(CreateWorkOrder command)
     {
         if (command.ExpectedLifecycleVersion != 0)
@@ -768,11 +673,8 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         EnsureRequired(command.Requester?.PrincipalKind, "requester.principal_kind");
         if (command.Input?.Chat == null)
             throw new InvalidOperationException("work order chat input is required.");
-        if (command.TimeoutAtUtc == null)
-            throw new InvalidOperationException("timeout_at_utc is required.");
-
         var requestedAt = command.RequestedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow;
-        if (command.TimeoutAtUtc.ToDateTimeOffset() <= requestedAt)
+        if (command.TimeoutAtUtc != null && command.TimeoutAtUtc.ToDateTimeOffset() <= requestedAt)
         {
             throw new InvalidOperationException(
                 "timeout_at_utc must be later than requested_at_utc.");
@@ -792,16 +694,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
                 $"work order actor '{Id}' does not match canonical identity '{canonicalActorId}'.");
         }
 
-        if (RequiresApproval(command.PermissionPlan))
-        {
-            EnsureRequired(command.ApprovalId, nameof(command.ApprovalId));
-            EnsureCanonicalIdentity(
-                "approval_id",
-                command.ApprovalId,
-                WorkOrderConventions.BuildApprovalId(canonicalWorkOrderId));
-            if (command.PermissionPlan.ApproverPrincipalIds.Count == 0)
-                throw new InvalidOperationException("an approval-requiring permission plan must name an approver principal.");
-        }
     }
 
     private static void EnsureCanonicalIdentity(string fieldName, string? actual, string expected)
@@ -810,9 +702,6 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         if (!string.Equals(actual!.Trim(), expected, StringComparison.Ordinal))
             throw new InvalidOperationException($"{fieldName} must use canonical identity '{expected}'.");
     }
-
-    private static bool RequiresApproval(WorkOrderPermissionPlan? plan) =>
-        plan?.Requirements.Any(static requirement => requirement.RequiresApproval) == true;
 
     private static void EnsureSameCreate(WorkOrderState state, CreateWorkOrder command)
     {
@@ -844,14 +733,13 @@ public sealed partial class WorkOrderGAgent : GAgentBase<WorkOrderState>, IProje
         string.Equals(left.PrincipalId, right.PrincipalId, StringComparison.Ordinal) &&
         string.Equals(left.PrincipalKind, right.PrincipalKind, StringComparison.Ordinal);
 
-    private static bool EvidenceEqual(WorkOrderTerminalEvidence? left, WorkOrderTerminalEvidence right) =>
+    private static bool RunOutcomesEqual(WorkOrderRunOutcomeReference? left, WorkOrderRunOutcomeReference right) =>
         left != null && left.Equals(right);
 
     private static bool IsTerminal(WorkOrderLifecycleStatus status) =>
         status is WorkOrderLifecycleStatus.Completed or
             WorkOrderLifecycleStatus.Failed or
             WorkOrderLifecycleStatus.Stopped or
-            WorkOrderLifecycleStatus.Denied or
             WorkOrderLifecycleStatus.Cancelled or
             WorkOrderLifecycleStatus.TimedOut;
 

--- a/agents/Aevatar.GAgents.WorkOrder/work_order_messages.proto
+++ b/agents/Aevatar.GAgents.WorkOrder/work_order_messages.proto
@@ -8,24 +8,16 @@ import "google/protobuf/timestamp.proto";
 enum WorkOrderLifecycleStatus {
   WORK_ORDER_LIFECYCLE_STATUS_UNSPECIFIED = 0;
   WORK_ORDER_LIFECYCLE_STATUS_ACCEPTED = 1;
-  WORK_ORDER_LIFECYCLE_STATUS_WAITING_APPROVAL = 2;
+  reserved 2;
   WORK_ORDER_LIFECYCLE_STATUS_READY = 3;
   WORK_ORDER_LIFECYCLE_STATUS_DISPATCH_PENDING = 4;
   WORK_ORDER_LIFECYCLE_STATUS_RUNNING = 5;
   WORK_ORDER_LIFECYCLE_STATUS_COMPLETED = 6;
   WORK_ORDER_LIFECYCLE_STATUS_FAILED = 7;
   WORK_ORDER_LIFECYCLE_STATUS_STOPPED = 8;
-  WORK_ORDER_LIFECYCLE_STATUS_DENIED = 9;
+  reserved 9;
   WORK_ORDER_LIFECYCLE_STATUS_CANCELLED = 10;
   WORK_ORDER_LIFECYCLE_STATUS_TIMED_OUT = 11;
-}
-
-enum WorkOrderApprovalStatus {
-  WORK_ORDER_APPROVAL_STATUS_UNSPECIFIED = 0;
-  WORK_ORDER_APPROVAL_STATUS_NOT_REQUIRED = 1;
-  WORK_ORDER_APPROVAL_STATUS_PENDING = 2;
-  WORK_ORDER_APPROVAL_STATUS_APPROVED = 3;
-  WORK_ORDER_APPROVAL_STATUS_DENIED = 4;
 }
 
 enum WorkOrderTerminalOutcome {
@@ -47,26 +39,6 @@ message WorkOrderArtifactReference {
   string revision_id = 4;
 }
 
-message WorkOrderExternalActionReference {
-  string action_id = 1;
-  string system = 2;
-  string action = 3;
-  string resource_id = 4;
-}
-
-message WorkOrderPermissionRequirement {
-  string permission_id = 1;
-  string action_id = 2;
-  string capability = 3;
-  bool requires_approval = 4;
-}
-
-message WorkOrderPermissionPlan {
-  repeated WorkOrderExternalActionReference external_actions = 1;
-  repeated WorkOrderPermissionRequirement requirements = 2;
-  repeated string approver_principal_ids = 3;
-}
-
 message WorkOrderChatInput {
   string prompt = 1;
 }
@@ -77,16 +49,7 @@ message WorkOrderServiceInput {
   repeated WorkOrderArtifactReference declared_result_artifacts = 3;
 }
 
-message WorkOrderApprovalState {
-  string approval_id = 1;
-  WorkOrderApprovalStatus status = 2;
-  string decision_id = 3;
-  WorkOrderPrincipal decided_by = 4;
-  string reason = 5;
-  google.protobuf.Timestamp decided_at_utc = 6;
-}
-
-message WorkOrderExecutionProvenance {
+message WorkOrderRunLink {
   string run_id = 1;
   string run_actor_id = 2;
   string command_id = 3;
@@ -94,7 +57,6 @@ message WorkOrderExecutionProvenance {
   string revision_id = 5;
   string deployment_id = 6;
   google.protobuf.Timestamp accepted_at_utc = 7;
-  google.protobuf.Timestamp started_at_utc = 8;
 }
 
 message WorkOrderFailureReference {
@@ -104,17 +66,14 @@ message WorkOrderFailureReference {
   string reference_id = 4;
 }
 
-message WorkOrderTerminalEvidence {
+message WorkOrderRunOutcomeReference {
   string delivery_id = 1;
   string run_id = 2;
   string run_actor_id = 3;
   string command_id = 4;
-  WorkOrderTerminalOutcome outcome = 5;
-  string output = 6;
-  string error = 7;
-  google.protobuf.Timestamp terminal_at_utc = 8;
-  repeated WorkOrderArtifactReference result_artifacts = 9;
-  string correlation_id = 10;
+  string correlation_id = 5;
+  WorkOrderTerminalOutcome outcome = 6;
+  google.protobuf.Timestamp terminal_at_utc = 7;
 }
 
 message WorkOrderState {
@@ -131,8 +90,7 @@ message WorkOrderState {
   string endpoint_id = 11;
   string intent = 12;
   WorkOrderServiceInput input = 13;
-  WorkOrderPermissionPlan permission_plan = 14;
-  WorkOrderApprovalState approval = 15;
+  reserved 14, 15;
   WorkOrderLifecycleStatus lifecycle_status = 16;
   int64 lifecycle_version = 17;
   google.protobuf.Timestamp created_at_utc = 18;
@@ -141,9 +99,9 @@ message WorkOrderState {
   string dispatch_command_id = 21;
   string requested_run_id = 22;
   string terminal_delivery_id = 23;
-  WorkOrderExecutionProvenance execution = 24;
-  WorkOrderTerminalEvidence terminal_evidence = 25;
-  WorkOrderTerminalEvidence late_terminal_evidence = 26;
+  WorkOrderRunLink run = 24;
+  WorkOrderRunOutcomeReference run_outcome = 25;
+  WorkOrderRunOutcomeReference late_run_outcome = 26;
   WorkOrderFailureReference failure = 27;
   string terminal_reason = 28;
   CreateWorkOrder creation_request = 29;
@@ -166,8 +124,7 @@ message CreateWorkOrder {
   string endpoint_id = 11;
   string intent = 12;
   WorkOrderServiceInput input = 13;
-  WorkOrderPermissionPlan permission_plan = 14;
-  string approval_id = 15;
+  reserved 14, 15;
   google.protobuf.Timestamp requested_at_utc = 16;
   google.protobuf.Timestamp timeout_at_utc = 17;
   int64 expected_lifecycle_version = 18;
@@ -178,10 +135,8 @@ message WorkOrderCreatedEvent {
   google.protobuf.Timestamp created_at_utc = 2;
 }
 
-message WorkOrderPlannedEvent {
-  WorkOrderLifecycleStatus lifecycle_status = 1;
-  WorkOrderApprovalState approval = 2;
-  google.protobuf.Timestamp planned_at_utc = 3;
+message WorkOrderReadyEvent {
+  google.protobuf.Timestamp ready_at_utc = 1;
 }
 
 message ReassignWorkOrder {
@@ -204,32 +159,6 @@ message WorkOrderReassignedEvent {
   string implementation_kind = 5;
   WorkOrderPrincipal reassigned_by = 6;
   google.protobuf.Timestamp reassigned_at_utc = 7;
-}
-
-message ApproveWorkOrder {
-  string work_order_id = 1;
-  int64 expected_lifecycle_version = 2;
-  string decision_id = 3;
-  WorkOrderPrincipal decided_by = 4;
-  string reason = 5;
-  google.protobuf.Timestamp decided_at_utc = 6;
-}
-
-message DenyWorkOrder {
-  string work_order_id = 1;
-  int64 expected_lifecycle_version = 2;
-  string decision_id = 3;
-  WorkOrderPrincipal decided_by = 4;
-  string reason = 5;
-  google.protobuf.Timestamp decided_at_utc = 6;
-}
-
-message WorkOrderApprovalDecidedEvent {
-  string decision_id = 1;
-  WorkOrderApprovalStatus approval_status = 2;
-  WorkOrderPrincipal decided_by = 3;
-  string reason = 4;
-  google.protobuf.Timestamp decided_at_utc = 5;
 }
 
 message DispatchWorkOrder {
@@ -367,11 +296,11 @@ message WorkOrderTimedOutEvent {
   google.protobuf.Timestamp timed_out_at_utc = 2;
 }
 
-message WorkOrderTerminalEvidenceRecordedEvent {
+message WorkOrderRunOutcomeObservedEvent {
   WorkOrderLifecycleStatus lifecycle_status = 1;
-  WorkOrderTerminalEvidence evidence = 2;
+  WorkOrderRunOutcomeReference outcome = 2;
 }
 
-message WorkOrderLateTerminalEvidenceRecordedEvent {
-  WorkOrderTerminalEvidence evidence = 1;
+message WorkOrderLateRunOutcomeObservedEvent {
+  WorkOrderRunOutcomeReference outcome = 1;
 }

--- a/docs/canon/work-orders.md
+++ b/docs/canon/work-orders.md
@@ -6,46 +6,94 @@ owner: eanzhao
 
 # Work Orders
 
-A `WorkOrder` is the durable, scope-owned intent to have one Team member invoke one validated published service. It connects the requester, assignment, permission plan, approval, Run, and terminal evidence without making any of those identities aliases of another.
+A `WorkOrder` is a durable, Scope-owned, user-visible request to have one Team
+member invoke one validated published service. It owns the user intent and the
+coordination lifecycle around that request. It does not own the execution,
+approval, Team binding, or result content referenced by the request.
 
-`WorkOrderGAgent` is the only authority for a WorkOrder lifecycle. Its committed Protobuf events and state are authoritative; `WorkOrderCurrentStateDocument` is an actor-scoped current-state replica used only for queries.
+`WorkOrderGAgent` is the only authority for WorkOrder state and lifecycle
+transitions. Its committed Protobuf events and state are authoritative.
+`WorkOrderCurrentStateDocument` is an actor-scoped current-state replica used
+only for queries.
+
+## Independent Product Requirement
+
+A WorkOrder is not reducible to a dispatch receipt, schedule, or Run:
+
+- it exists before any Run and does not require dispatch at creation time;
+- it can be reassigned or cancelled before dispatch without creating a Run;
+- it may omit a deadline and remain durable indefinitely;
+- it recovers pending coordination from committed state after an Actor or Host
+  restart; and
+- its committed history remains after terminal completion.
+
+A dispatch receipt answers whether one command was accepted. A Run answers what
+happened during one execution. A schedule owns recurring trigger and automation
+policy. None of those resources naturally owns the durable user request above.
+
+## Authority Boundaries
+
+| Authority | Owned facts |
+|---|---|
+| `WorkOrderGAgent` | Requester intent, typed input and declared-output references as intent, validated assignment snapshot, deterministic dispatch identities, reassignment, cancellation, optional timeout, dispatch coordination, WorkOrder lifecycle, accepted Run link, and validated Run outcome reference. |
+| Team/member read models | Membership, Team ownership, exact `publishedServiceId`, binding revision, implementation kind, deployment readiness, and current callability. |
+| Workflow/Run execution owner | Approval plan, approvers, suspended external-action continuation, approval decisions, execution state, start time, output, error, and terminal execution facts. |
+| `ContentArtifactGAgent` | Actual result content, revisions, provenance, citations, retention, and redaction. |
+| `ScheduledDispatchGAgent` | Recurring triggers, credentials, authorization refresh, automation policy, and scheduled invocation lifecycle. |
+| `WorkOrderCurrentStateDocument` | Read-only projection of committed WorkOrder state; never an authority. |
+
+The WorkOrder contract contains no permission plan, approver identity,
+approve/deny decision, Run output, Run error, Run start timestamp, or actual
+result artifact. Declared output references remain declarations of user intent;
+they are never promoted into actual results.
 
 ## Identity Model
 
-The following identities remain separate typed fields throughout the command, actor state, projection, and API contracts:
+The following identities remain separate typed fields throughout commands,
+Actor state, projection, and API contracts:
 
 | Identity | Meaning |
 |---|---|
 | `workOrderId` | Stable logical WorkOrder identity derived from canonical `scopeId + dedupKey`. |
-| requester principal | The authenticated principal that requested the work. It is not implicitly a Team member. |
-| `teamId` | Team that owns the assignment. |
-| `memberId` | Stable Team member responsible for the work. |
-| `workflowId` | Optional workflow definition identity for workflow-backed members. |
+| requester principal | Authenticated principal that requested the work; not implicitly a Team member. |
+| `teamId` | Team against which the assignment is validated. |
+| `memberId` | Stable Team member assigned responsibility. |
+| `workflowId` | Workflow definition identity for a workflow-backed member. |
 | `publishedServiceId` | Exact callable service identity returned by the authoritative member read model. |
-| `serviceRevisionId` | Service revision validated when the assignment is accepted. |
-| `approvalId` and `decisionId` | Approval resource and decision identities. |
-| `dispatchCommandId` | Stable command identity for the one authorized dispatch. |
+| `serviceRevisionId` | Service revision validated with the assignment. |
+| `dispatchCommandId` | Stable identity for the authorized dispatch. |
 | `requestedRunId` | Stable logical Run identity requested by the WorkOrder. |
-| `runActorId` | Opaque actor address returned by accepted execution. |
-| `terminalDeliveryId` | Stable idempotency identity for terminal evidence delivery. |
-| artifact references | Typed input and declared-result artifact identities; they do not become Run or WorkOrder identities. |
+| `runActorId` | Opaque Actor address returned by accepted execution. |
+| `terminalDeliveryId` | Stable idempotency identity for Run outcome delivery. |
+| artifact references | Typed input and declared-output identities owned as request intent only. |
 
-Callers must not derive `publishedServiceId` from `memberId`, `workflowId`, display names, actor-id text, or route structure.
+Callers must not derive `publishedServiceId` from `memberId`, `workflowId`,
+display names, Actor id text, or route structure. They must not treat a declared
+artifact reference as proof that an actual artifact exists.
 
 ## Creation And Assignment Validation
 
-`POST /api/scopes/{scopeId}/work-orders` accepts a typed intent, chat input, optional artifact references, permission plan, deadline, and `dedupKey`. The application service validates the assignment against current read models before dispatching the actor command:
+`POST /api/scopes/{scopeId}/work-orders` accepts a typed intent, chat input,
+optional artifact references, optional deadline, and `dedupKey`. The
+application service validates the assignment against current read models before
+dispatching the Actor command:
 
 1. The Team exists in the requested Scope and is active.
 2. The member exists in the same Scope and belongs to that Team.
 3. The member read model names the exact requested `publishedServiceId`.
 4. The member has an authoritative binding with a service revision.
-5. Scope binding readiness proves the requested endpoint is callable at that revision.
+5. Scope binding readiness proves the requested endpoint is callable at that
+   revision.
 6. Workflow-backed members have an explicit `workflowId`.
 
-Any missing, cross-Scope, cross-Team, stale, or non-callable relationship fails closed. Reassignment repeats the same validation, and dispatch revalidates the stored assignment immediately before invocation.
+Missing, cross-Scope, cross-Team, stale, or non-callable relationships fail
+closed. Reassignment repeats the same validation. Dispatch revalidates the
+stored assignment immediately before invocation.
 
-The create response is `202 Accepted` with a stable `workOrderId`, `commandId`, and `correlationId`. Its stage is `dispatch_accepted`; it does not claim that the actor committed the command, that the read model observed it, that a Run started, or that execution completed.
+The create response is `202 Accepted` with stable `workOrderId`, `commandId`,
+and `correlationId` values. Its stage is `dispatch_accepted`; it does not claim
+that the Actor committed the command, a read model observed it, a Run started,
+or execution completed.
 
 ## Lifecycle
 
@@ -53,67 +101,120 @@ The Actor owns and versions every transition:
 
 | State | Meaning and allowed progression |
 |---|---|
-| `accepted` | The create event was committed. Planning immediately determines whether approval is required. |
-| `waiting_approval` | At least one typed permission requirement needs approval. An authorized decision advances to `ready` or terminal `denied`. |
-| `ready` | Assignment and approval facts permit dispatch. Reassignment and requester cancellation remain eligible. |
-| `dispatch_pending` | Stable dispatch, Run, and terminal-delivery identities were committed. An accepted Run receipt may already have supplied provenance, but no matching committed start evidence has been recorded. |
-| `running` | Matching committed start evidence was recorded. An accepted dispatch receipt alone never advances a WorkOrder to this state. |
-| `completed` | Matching authoritative Run evidence reported success. |
-| `failed` | Dispatch failed or matching Run evidence reported failure. |
-| `stopped` | Matching Run evidence reported a stopped execution. |
-| `denied` | An authorized approver denied the permission plan. |
+| `accepted` | The create event was committed. The same command records readiness without requiring a Run or approval resource. |
+| `ready` | The WorkOrder can be reassigned, cancelled, or authorized for dispatch. |
+| `dispatch_pending` | Stable dispatch, requested Run, and terminal-delivery identities were committed. An accepted Run link may exist, but no matching committed start observation has advanced the WorkOrder. |
+| `running` | A matching authoritative Run-start notification advanced the WorkOrder lifecycle. WorkOrder does not copy the Run start timestamp. |
+| `completed` | A matching authoritative Run outcome reported success. |
+| `failed` | Dispatch failed, or a matching authoritative Run outcome reported failure. A Run error remains in the Run authority. |
+| `stopped` | A matching authoritative Run outcome reported a stopped execution. |
 | `cancelled` | The requester cancelled before dispatch authorization. |
-| `timed_out` | The WorkOrder deadline elapsed. This does not claim that a linked Run was cancelled. |
+| `timed_out` | A supplied WorkOrder deadline elapsed. This does not claim that a linked Run was cancelled. |
 
-Reassign and cancel commands are eligible only in `accepted`, `waiting_approval`, or `ready`. Every mutable command carries `expectedLifecycleVersion`; stale concurrent commands fail closed in the Actor even when an application-side read model was stale.
+Reassign and cancel are eligible only before dispatch authorization. Every
+mutable command carries `expectedLifecycleVersion`; stale concurrent commands
+fail closed in the Actor even when an application-side read model is stale.
 
-## Permission And Approval Facts
+There is no WorkOrder `waiting_approval` or `denied` state. Execution-level
+approval belongs to the Workflow/Run owner that holds the exact external action
+and suspended continuation.
 
-Permission plans use typed external-action and permission-requirement records. Requirements identify their action and capability and explicitly state whether approval is required. Approval-requiring plans must name at least one approver principal id.
+## Dispatch And Run References
 
-The Actor accepts an approval decision only while the WorkOrder is `waiting_approval`, only from a configured approver, and only at the expected lifecycle version. The approval id, decision id, principal, reason, and decision time remain committed facts and survive Actor restart.
+Dispatch uses deterministic identities derived from `workOrderId`. Duplicate
+create and dispatch deliveries therefore address the same WorkOrder and Run.
+The Actor stores the original create request and rejects a different request
+that reuses the same logical identity.
 
-## Dispatch And Run Evidence
+After committing `dispatch_pending`, the Actor sends an internal execute command
+to itself. Activation redrives pending execution. The execution adapter
+revalidates the authoritative assignment, invokes the exact
+`publishedServiceId`, and requires the accepted receipt to preserve the
+requested Run and dispatch command identities.
 
-Dispatch uses deterministic identities derived from `workOrderId`. Duplicate create and dispatch delivery therefore addresses the same WorkOrder and Run. The Actor stores the original create request and rejects a different request that reuses the same logical identity.
+The accepted receipt is stored only as `WorkOrderRunLink`:
 
-After committing `dispatch_pending`, the Actor sends an internal execute command to itself. Activation redrives that command when a restart recovers a pending dispatch. The execution adapter revalidates the authoritative assignment, invokes the exact `publishedServiceId`, and requires the accepted receipt to preserve both the requested Run id and dispatch command id. The accepted receipt records Run provenance without changing the lifecycle state. A matching committed workflow start notification advances the WorkOrder to `running`. Terminal evidence may legitimately arrive while the WorkOrder is still `dispatch_pending` when execution commits a terminal fact before a separate start fact is observed.
+- `runId`
+- `runActorId`
+- `commandId`
+- `correlationId`
+- `revisionId`
+- `deploymentId`
+- `acceptedAtUtc`
 
-Terminal evidence has one authority per implementation:
+Run start and terminal notifications remain facts owned by their Run producers.
+WorkOrder observes them only to advance its own lifecycle. A terminal outcome
+may arrive before a separate start notification; the terminal lifecycle wins,
+and a later start notification cannot rewrite it.
 
-- workflow services use committed start and terminal facts owned by `WorkflowRunGAgent`, delivered through its durable notification state;
-- static services use `RoleGAgent`'s committed `RoleChatSessionCompletedEvent`, which is delivered to the registered `ServiceRunGAgent`;
-- script services use `ScriptBehaviorGAgent`'s committed `ScriptRunOutcomeRecordedEvent`, which is delivered to the registered `ServiceRunGAgent`;
-- `ServiceRunGAgent` validates implementation kind, source Actor, Run, command, correlation, and target identity before mapping a static or script terminal fact, then delivers the mapped terminal notification to the WorkOrder through its own durable outbox.
+The only terminal observation stored by WorkOrder is
+`WorkOrderRunOutcomeReference`, containing exactly:
 
-Accepted ServiceRun registration does not itself prove that execution started or guarantee a terminal result. Recovery depends on the implementation Actor replaying its committed but undispatched terminal fact and on `ServiceRunGAgent` replaying its prepared but undispatched WorkOrder notification.
+- `deliveryId`
+- `runId`
+- `runActorId`
+- `commandId`
+- `correlationId`
+- `outcome`
+- `terminalAtUtc`
 
-The WorkOrder accepts terminal evidence only when `deliveryId`, `runId`, `runActorId`, `commandId`, and `correlationId` all match the committed accepted Run provenance. On runtime envelope paths, workflow evidence must be published by the matching workflow Run Actor, while static and script evidence must be published by the canonical ServiceRun Actor derived from the WorkOrder's authoritative scope, published service, and Run identities. Duplicate identical evidence is a no-op; conflicting evidence fails closed. A terminal notification received after WorkOrder timeout is recorded separately as late evidence and does not rewrite the `timed_out` outcome.
+The WorkOrder accepts the reference only when delivery, Run, Actor, command, and
+correlation identities all match the accepted Run link and the envelope
+publisher is the authoritative Run producer. Duplicate identical references are
+idempotent; conflicting references fail closed. A reference received after a
+WorkOrder timeout is stored as `lateRunOutcome` without rewriting `timed_out`.
 
-## Idempotency And Recovery
+Consumers resolve the Run authority for start time, output, error, and detailed
+execution status. They resolve `ContentArtifactGAgent` for actual result content
+and provenance.
 
-- `workOrderId` is a deterministic SHA-256-based identity over normalized Scope and dedup key.
-- Create, dispatch, requested Run, and terminal delivery use distinct stable ids.
-- Duplicate identical create commands do not reset reassignment or lifecycle state.
-- Conflicting create requests at the same logical identity are rejected.
-- Workflow exact-id provisioning ensures an existing Run has the same definition, Scope, origin, and inline definitions before reuse.
-- A Workflow Run records its first command id; replay of that command after execution starts is a no-op, while a different command for the same Run fails closed.
-- `dispatch_pending` is redriven on WorkOrder activation.
-- Workflow, Role, Script, and ServiceRun notifications use actor-owned durable dispatch facts and stable delivery deduplication.
+## Deadline And Recovery
 
-No process-local dictionary, query-time event replay, or query-time projection priming participates in these guarantees.
+`timeoutAtUtc` is optional. When supplied, it must be later than
+`requestedAtUtc`, and the Actor schedules its durable timeout. When omitted, the
+Actor stores no deadline and schedules no WorkOrder timeout.
+
+The existing Workflow and ServiceRun completion-notification contracts require
+a positive numeric expiration. At that transport boundary only, an omitted
+WorkOrder deadline maps to `long.MaxValue`. That transport sentinel is not
+persisted or exposed as a WorkOrder product deadline.
+
+Dispatch retry uses the existing bounded exponential backoff. A supplied
+deadline caps the retry delay and eventually drives `timed_out`. Without a
+deadline, retries use the normal per-attempt delay without inventing product
+expiry.
+
+Workflow, Role, Script, and ServiceRun producers retain their actor-owned
+durable delivery facts and stable deduplication identities. WorkOrder does not
+copy their payloads to gain recovery.
 
 ## Read Model And API
 
-The Studio projection pipeline consumes committed `WorkOrderState` facts and overwrites `WorkOrderCurrentStateDocument` monotonically by the authoritative state-event version. `StateVersion` comes from the committed actor stream. `UpdatedAtUtc` comes from `WorkOrderState.UpdatedAtUtc`; projection observation time remains a separate infrastructure field.
+The Studio projection pipeline consumes committed `WorkOrderState` facts and
+monotonically overwrites `WorkOrderCurrentStateDocument` by authoritative Actor
+state-event version. `StateVersion` comes from the committed Actor stream.
+`UpdatedAtUtc` comes from `WorkOrderState.UpdatedAtUtc`; projection observation
+time remains a separate infrastructure field.
 
 Queries read only the current-state document provider:
 
 - `GET /api/scopes/{scopeId}/work-orders/{workOrderId}` returns one WorkOrder.
-- `GET /api/scopes/{scopeId}/work-orders` supports cursor pagination and filters for status, requester, Team, member, published service, workflow, Run, and creation time window.
+- `GET /api/scopes/{scopeId}/work-orders` supports cursor pagination and filters
+  for status, requester, Team, member, published service, workflow, Run, and
+  creation time window.
 
-Mutation endpoints use `:reassign`, `:approve`, `:deny`, `:dispatch`, and `:cancel` suffixes under the WorkOrder resource. All mutation responses remain accepted-only receipts; callers observe committed lifecycle changes through the read model.
+Mutation endpoints use `:reassign`, `:dispatch`, and `:cancel` suffixes. There
+are no WorkOrder `:approve` or `:deny` endpoints. All mutation responses remain
+accepted-only receipts; callers observe committed lifecycle changes through the
+read model.
 
-## Boundaries
+No process-local dictionary, query-time event replay, query-time projection
+priming, compatibility endpoint, deprecated message, or parallel old/new
+contract participates in the WorkOrder path.
 
-A WorkOrder does not replace Team membership, workflow definitions, published services, Runs, approvals, or artifact resources. It records typed references and coordination facts owned by its own lifecycle. It is not a general project-management or ticketing resource, and it never infers completion from command acceptance, approval, logs, or display names.
+## Non-Goals
+
+A WorkOrder is not a project-management ticket, recurring schedule, approval
+resource, Run mirror, or artifact store. It never infers completion from command
+acceptance, approval, logs, display names, declared result references, or copied
+terminal payloads.

--- a/docs/superpowers/plans/2026-07-23-work-order-product-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-23-work-order-product-lifecycle.md
@@ -1,0 +1,375 @@
+# WorkOrder Product Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep WorkOrder as a first-class, indefinitely durable user-intent resource while removing duplicate approval, Run-payload, and artifact authorities from its contract.
+
+**Architecture:** `WorkOrderGAgent` owns only durable intent, validated assignment snapshots, dispatch coordination, its independent lifecycle, and typed references to the accepted Run and observed Run outcome. Team/member read models remain the assignment authority, Workflow/Run actors remain approval and execution authorities, and ContentArtifact remains content/revision authority. A WorkOrder may omit a deadline, so it can exist before a Run and survive until an explicit lifecycle transition.
+
+**Tech Stack:** .NET 10, C#, Protobuf, actor-owned event sourcing, CQRS projection, xUnit, FluentAssertions.
+
+## Global Constraints
+
+- Preserve one actor-owned WorkOrder lifecycle and the existing `Command -> committed event -> current-state read model` path.
+- A WorkOrder owns user intent, requester identity, assignment coordination, dispatch identity, cancellation, reassignment, timeout when supplied, and its own terminal lifecycle.
+- Team/member read models own membership, exact `publishedServiceId`, revision, implementation kind, and callability.
+- Workflow/Run actors own approval plans, approvers, decisions, output, error, and execution facts.
+- ContentArtifact owns result content, revisions, provenance, citations, retention, and redaction.
+- WorkOrder stores only input/declared-output references supplied as intent plus a minimal validated Run outcome reference; it never promotes a declared output reference into an actual result.
+- A missing `timeoutAtUtc` means no WorkOrder deadline. A supplied deadline must still be later than the request time.
+- Persisted state, commands, events, continuations, and projection documents remain Protobuf.
+- Remove old approval and terminal-payload surfaces completely; do not add compatibility endpoints, aliases, or deprecated messages.
+- Source, tests, documentation, commit messages, PR text, and GitHub comments are English.
+- Interface and Protobuf changes remain unapproved until two independent reviewers explicitly approve them; green tests are not review evidence.
+
+---
+
+### Task 1: Freeze The Independent Product And Authority Boundaries In Tests
+
+**Files:**
+- Create: `test/Aevatar.Studio.Tests/WorkOrders/WorkOrderAuthorityBoundaryTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/WorkOrders/WorkOrderCommandServiceTests.cs`
+
+**Interfaces:**
+- Verifies: WorkOrder can be created without a deadline, reassigned, recovered, and cancelled before any Run exists.
+- Verifies: public WorkOrder service and DTO contracts expose no approval decision authority.
+- Verifies: the target Protobuf contract contains `WorkOrderRunOutcomeReference` without Run payload or artifact fields.
+
+- [x] **Step 1: Add the actor lifecycle test with a missing deadline**
+
+Create a focused test fixture with the same `InMemoryEventStore`, `DefaultEventSourcingBehaviorFactory<WorkOrderState>`, reflected `GAgentBase.SetId`, no-op publisher, and callback scheduler pattern already used by `WorkOrderGAgentTests`. Add this exact behavior:
+
+```csharp
+[Fact]
+public async Task WorkOrderWithoutDeadline_ShouldSurviveReassignmentRecoveryAndCancellationBeforeAnyRun()
+{
+    var store = new InMemoryEventStore();
+    var created = await CreateAgentAsync(store);
+
+    await created.HandleCreateAsync(BuildCreate(timeoutAtUtc: null));
+    created.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Ready);
+    created.State.TimeoutAtUtc.Should().BeNull();
+    created.State.Run.Should().BeNull();
+
+    await created.HandleReassignAsync(BuildReassign(created.State.LifecycleVersion));
+
+    var recovered = await CreateAgentAsync(store);
+    recovered.State.MemberId.Should().Be("member-2");
+    recovered.State.Run.Should().BeNull();
+    await recovered.HandleCancelAsync(BuildCancel(recovered.State.LifecycleVersion));
+
+    var terminal = await CreateAgentAsync(store);
+    terminal.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Cancelled);
+    terminal.State.Run.Should().BeNull();
+}
+```
+
+- [x] **Step 2: Add authority-surface tests**
+
+Add reflection and descriptor assertions:
+
+```csharp
+[Fact]
+public void PublicContract_ShouldNotExposeApprovalAuthority()
+{
+    typeof(IWorkOrderService).GetMethods().Select(static method => method.Name)
+        .Should().NotContain(["ApproveAsync", "DenyAsync"]);
+    typeof(CreateWorkOrderRequest).GetProperties().Select(static property => property.Name)
+        .Should().NotContain("PermissionPlan");
+    typeof(WorkOrderCurrentStateResponse).GetProperties().Select(static property => property.Name)
+        .Should().NotContain(["PermissionPlan", "Approval"]);
+    typeof(WorkOrderGAgent).GetMethods().Select(static method => method.Name)
+        .Should().NotContain(["HandleApproveAsync", "HandleDenyAsync"]);
+}
+
+[Fact]
+public void RunOutcomeReference_ShouldContainOnlyValidatedCoordinationFacts()
+{
+    var descriptor = WorkOrderState.Descriptor.File.MessageTypes
+        .SingleOrDefault(static message => message.Name == "WorkOrderRunOutcomeReference");
+
+    descriptor.Should().NotBeNull();
+    descriptor!.Fields.InDeclarationOrder().Select(static field => field.Name)
+        .Should().BeEquivalentTo(
+            "delivery_id",
+            "run_id",
+            "run_actor_id",
+            "command_id",
+            "correlation_id",
+            "outcome",
+            "terminal_at_utc");
+}
+```
+
+- [x] **Step 3: Change the command-service deadline test to require accepted dispatch**
+
+Replace `CreateAsync_WhenDeadlineMissing_ShouldRejectBeforeActorDispatch` with:
+
+```csharp
+[Fact]
+public async Task CreateAsync_WhenDeadlineMissing_ShouldDispatchWithoutInventingOne()
+{
+    var bootstrap = new RecordingBootstrap();
+    var dispatchPort = new RecordingDispatchPort();
+    var service = new ActorDispatchWorkOrderCommandService(
+        bootstrap,
+        CreateCommandDispatch(dispatchPort));
+
+    await service.CreateAsync(
+        ScopeId,
+        CreateRequest() with { TimeoutAtUtc = null },
+        new WorkOrderPrincipalContract("requester-1", "user"),
+        CreateAssignment());
+
+    bootstrap.ActorIds.Should().ContainSingle();
+    var command = dispatchPort.Envelopes.Should().ContainSingle().Subject.Payload!
+        .Unpack<CreateWorkOrder>();
+    command.TimeoutAtUtc.Should().BeNull();
+}
+```
+
+- [x] **Step 4: Run the focused tests and verify RED**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo \
+  --filter 'FullyQualifiedName~WorkOrderAuthorityBoundaryTests|FullyQualifiedName~WorkOrderCommandServiceTests'
+```
+
+Expected: compilation fails because `WorkOrderState.Run` is not generated yet, and the current deadline/approval/descriptor behavior also contradicts the new assertions.
+
+---
+
+### Task 2: Narrow The Actor-Owned Protobuf Lifecycle
+
+**Files:**
+- Modify: `agents/Aevatar.GAgents.WorkOrder/work_order_messages.proto`
+- Modify: `agents/Aevatar.GAgents.WorkOrder/WorkOrderGAgent.cs`
+- Modify: `agents/Aevatar.GAgents.WorkOrder/WorkOrderGAgent.State.cs`
+- Modify: `agents/Aevatar.GAgents.WorkOrder/WorkOrderConventions.cs`
+- Modify: `test/Aevatar.Studio.Tests/WorkOrders/WorkOrderGAgentTests.cs`
+- Modify: `test/Aevatar.GAgentService.Tests/Core/ServiceRunWorkOrderIntegrationTests.cs`
+
+**Interfaces:**
+- Produces: `WorkOrderRunLink` as the accepted Run identity snapshot.
+- Produces: `WorkOrderRunOutcomeReference` as the minimal terminal observation.
+- Removes: permission plans, approver identities, approve/deny commands, and copied terminal payload/artifact fields.
+- Keeps: deterministic WorkOrder/dispatch/Run/delivery identities and exact publisher/identity validation.
+
+- [x] **Step 1: Replace duplicate authorities in Protobuf**
+
+Delete `WorkOrderApprovalStatus`, `WorkOrderExternalActionReference`, `WorkOrderPermissionRequirement`, `WorkOrderPermissionPlan`, `WorkOrderApprovalState`, `ApproveWorkOrder`, `DenyWorkOrder`, and `WorkOrderApprovalDecidedEvent`. Remove `WAITING_APPROVAL` and `DENIED` lifecycle values.
+
+Replace execution and terminal messages with:
+
+```proto
+message WorkOrderRunLink {
+  string run_id = 1;
+  string run_actor_id = 2;
+  string command_id = 3;
+  string correlation_id = 4;
+  string revision_id = 5;
+  string deployment_id = 6;
+  google.protobuf.Timestamp accepted_at_utc = 7;
+}
+
+message WorkOrderRunOutcomeReference {
+  string delivery_id = 1;
+  string run_id = 2;
+  string run_actor_id = 3;
+  string command_id = 4;
+  string correlation_id = 5;
+  WorkOrderTerminalOutcome outcome = 6;
+  google.protobuf.Timestamp terminal_at_utc = 7;
+}
+```
+
+In `WorkOrderState`, reserve deleted field numbers `14` and `15`, rename field `24` to `run`, field `25` to `run_outcome`, and field `26` to `late_run_outcome`. In `CreateWorkOrder`, reserve deleted fields `14` and `15`. Replace `WorkOrderPlannedEvent` with a timestamp-only `WorkOrderReadyEvent`, and replace terminal-evidence events with Run-outcome-observed events.
+
+- [x] **Step 2: Make creation always enter the independent ready state**
+
+`HandleCreateAsync` persists `WorkOrderCreatedEvent` followed by `WorkOrderReadyEvent`. It does not inspect permissions or create approval state. `ValidateCreate` permits a missing `timeout_at_utc`; when present, it still verifies the deadline is later than `requested_at_utc`.
+
+- [x] **Step 3: Keep terminal observations reference-only**
+
+Map workflow and ServiceRun notifications into `WorkOrderRunOutcomeReference` using only the seven fields in the contract. Preserve exact delivery/Run/actor/command/correlation checks, envelope publisher validation, duplicate idempotency, conflict rejection, and late-outcome handling after WorkOrder timeout. Do not read notification `Output`, `Error`, or declared result artifacts.
+
+- [x] **Step 4: Support dispatch retry without a WorkOrder deadline**
+
+In `ScheduleExecutionRetryAsync`, compute exponential backoff as today. If a deadline exists, cap the delay at the remaining duration and trigger timeout when elapsed. If no deadline exists, schedule the normal capped backoff without manufacturing an expiry. Keep `deadline_at_utc` absent in the execution request.
+
+- [x] **Step 5: Update existing actor and cross-actor tests**
+
+Remove approval-owner tests and assertions. Replace them with assertions that create reaches `Ready` at lifecycle version `2`, reassignment/cancellation remain available before dispatch, and Run terminal notifications populate `RunOutcome` without storing payload. Rename `Execution` assertions to `Run`, and `TerminalEvidence`/`LateTerminalEvidence` assertions to `RunOutcome`/`LateRunOutcome`.
+
+- [x] **Step 6: Run actor and integration tests and verify GREEN**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo \
+  --filter FullyQualifiedName~WorkOrder
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo \
+  --filter FullyQualifiedName~ServiceRunWorkOrderIntegrationTests
+```
+
+Expected: both commands pass. Existing unrelated analyzer warnings may remain, but there are no test failures or new WorkOrder warnings.
+
+---
+
+### Task 3: Remove Approval And Run-Payload Surfaces From Application, API, And Projection
+
+**Files:**
+- Modify: `src/Aevatar.Studio.Application/Studio/Contracts/WorkOrderContracts.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Abstractions/IWorkOrderCommandPort.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Abstractions/IWorkOrderService.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Services/WorkOrderService.cs`
+- Modify: `src/Aevatar.Studio.Application/Studio/Services/ValidatedWorkOrderExecutionPort.cs`
+- Modify: `src/Aevatar.Studio.Projection/CommandServices/ActorDispatchWorkOrderCommandService.cs`
+- Modify: `src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto`
+- Modify: `src/Aevatar.Studio.Projection/Projectors/WorkOrderCurrentStateProjector.cs`
+- Modify: `src/Aevatar.Studio.Projection/QueryPorts/ProjectionWorkOrderQueryPort.cs`
+- Modify: `src/Aevatar.Studio.Hosting/Endpoints/WorkOrderEndpoints.cs`
+- Modify: `test/Aevatar.Studio.Tests/WorkOrders/WorkOrderAssignmentAndExecutionTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/WorkOrders/WorkOrderEndpointsTests.cs`
+- Modify: `test/Aevatar.Studio.Tests/WorkOrders/WorkOrderProjectionTests.cs`
+
+**Interfaces:**
+- Removes: `ApproveAsync`, `DenyAsync`, `DecideWorkOrderApprovalRequest`, permission-plan DTOs, approval DTOs, and `:approve`/`:deny` routes.
+- Produces: `WorkOrderRunLinkResponse` and `WorkOrderRunOutcomeReferenceResponse` with reference-only fields.
+- Keeps: create/list/get/reassign/dispatch/cancel APIs and query filters over WorkOrder-owned fields.
+
+- [x] **Step 1: Shrink application contracts and ports**
+
+Remove approval/permission records and members. Replace execution/terminal response records with:
+
+```csharp
+public sealed record WorkOrderRunLinkResponse(
+    string RunId,
+    string RunActorId,
+    string CommandId,
+    string CorrelationId,
+    string RevisionId,
+    string DeploymentId,
+    DateTimeOffset AcceptedAtUtc);
+
+public sealed record WorkOrderRunOutcomeReferenceResponse(
+    string DeliveryId,
+    string RunId,
+    string RunActorId,
+    string CommandId,
+    string CorrelationId,
+    string Outcome,
+    DateTimeOffset TerminalAtUtc);
+```
+
+`WorkOrderCurrentStateResponse` exposes `Run`, `RunOutcome`, and `LateRunOutcome`. It no longer exposes `PermissionPlan` or `Approval`.
+
+- [x] **Step 2: Remove approval mutation paths completely**
+
+Delete approve/deny methods from service and command ports, their command mapping and canonicalization cases, and the `:approve`/`:deny` endpoint mappings and handlers. Keep requester authorization for reassign/dispatch/cancel unchanged.
+
+- [x] **Step 3: Project only WorkOrder-owned facts and references**
+
+Delete permission and approval projection messages/fields. Replace `WorkOrderTerminalEvidenceDocument` with `WorkOrderRunOutcomeReferenceDocument` containing the seven reference fields. Map `state.Run`, `state.RunOutcome`, and `state.LateRunOutcome`; do not materialize Run output, error, or result artifact lists.
+
+- [x] **Step 4: Represent no deadline without an artificial timeout**
+
+The command service leaves `CreateWorkOrder.TimeoutAtUtc` unset when the request omits it. `ValidatedWorkOrderExecutionPort` maps an absent deadline to `long.MaxValue` only at the existing completion-notification transport boundary, whose contract requires a positive expiration; a supplied deadline remains the exact expiration.
+
+- [x] **Step 5: Update service, endpoint, projection, and execution tests**
+
+Delete approval endpoint fakes/assertions, update DTO constructors, and verify that projected Run outcomes contain identities/outcome/time only. Keep different fixtures for `memberId`, `workflowId`, and `publishedServiceId`.
+
+- [x] **Step 6: Run Studio tests and required test guard**
+
+```bash
+dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo \
+  --filter FullyQualifiedName~WorkOrder
+bash tools/ci/test_stability_guards.sh
+```
+
+Expected: `81` baseline WorkOrder tests adjusted by deliberate removals/additions all pass, and the stability guard exits `0`.
+
+---
+
+### Task 4: Update Canonical Architecture And Verify The Branch
+
+**Files:**
+- Modify: `docs/canon/work-orders.md`
+- Modify: `docs/superpowers/plans/2026-07-23-work-order-product-lifecycle.md`
+
+**Interfaces:**
+- Documents: the product requirement that makes WorkOrder irreducible to dispatch/Run.
+- Documents: exact authority ownership and query composition boundaries.
+- Provides: fresh local verification evidence for the PR.
+
+- [x] **Step 1: Rewrite the canonical boundary and lifecycle sections**
+
+Document these exact invariants:
+
+- WorkOrder exists before a Run and may have no deadline.
+- It can be reassigned or cancelled before dispatch independently of a Run.
+- Its committed history remains after terminal completion.
+- It is not a schedule and does not own recurring trigger/credential automation.
+- It does not approve connector actions; Workflow/Run owns suspended approval continuation.
+- It stores no Run output/error and no claimed result artifacts; consumers resolve Run and ContentArtifact authorities through typed references.
+- Its Run outcome enum is a validated observation used only to advance WorkOrder's own lifecycle.
+
+Remove the permission/approval sections and `:approve`/`:deny` endpoint documentation.
+
+- [x] **Step 2: Run targeted format, diff, and architecture checks**
+
+```bash
+dotnet format test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --no-restore
+git diff --check
+bash tools/ci/test_stability_guards.sh
+bash tools/ci/architecture_guards.sh
+```
+
+Expected: every command exits `0`.
+
+- [x] **Step 3: Run build and full solution tests**
+
+```bash
+dotnet build aevatar.slnx --nologo --no-restore
+dotnet test aevatar.slnx --nologo --no-build
+```
+
+Expected: build has `0` errors and the full solution has `0` failed tests. Existing warnings are reported separately and are not represented as new failures.
+
+Fresh verification on 2026-07-23 after rebasing onto `origin/feature/integrate`:
+
+- `dotnet build aevatar.slnx --nologo --no-restore` exited `0` with `0` errors and `226` existing warnings.
+- `dotnet test aevatar.slnx --nologo --no-build` ran the full solution. Every test project passed except five positive-path cases in `AgentProfileRolloutProvisioningTests`, which returned `1` because the copied `Grpc.Tools` `protoc` is a macOS x86_64 executable on an Apple Silicon host (`Bad CPU type in executable`). The WorkOrder branch does not change the failing test, rollout tool, or project file.
+- With `PROTOC=/opt/homebrew/bin/protoc`, `AgentProfileRolloutProvisioningTests` passed `22/23`; only the case that deliberately clears `PROTOC` and `PATH` to force the incompatible bundled executable remained red. This is recorded as a host-specific baseline limitation, not represented as a WorkOrder failure or a green full-solution run. Linux PR CI remains the authority for the full-solution result.
+- WorkOrder-focused verification passed `84/84` Studio tests and `1/1` ServiceRun integration test. The no-deadline queue-full retry test was verified red against the former deadline-required guard (`expected 1, found 0`) and green after restoring the deadline-independent retry path.
+- `test_stability_guards.sh`, `architecture_guards.sh` (`15/15` architecture tests), docs lint, and `git diff --check` exited `0`.
+
+- [x] **Step 4: Commit the coherent contract change**
+
+```bash
+git add agents/Aevatar.GAgents.WorkOrder \
+  src/Aevatar.Studio.Application \
+  src/Aevatar.Studio.Hosting \
+  src/Aevatar.Studio.Projection \
+  test/Aevatar.Studio.Tests/WorkOrders \
+  test/Aevatar.GAgentService.Tests/Core/ServiceRunWorkOrderIntegrationTests.cs \
+  docs/canon/work-orders.md \
+  docs/superpowers/plans/2026-07-23-work-order-product-lifecycle.md
+git commit -m "Narrow WorkOrder to durable intent coordination"
+```
+
+- [ ] **Step 5: Push and open the review PR**
+
+```bash
+git push -u origin feat/2026-07-23_work-order-product-lifecycle
+gh pr create --repo aevatarAI/aevatar \
+  --base feature/integrate \
+  --head feat/2026-07-23_work-order-product-lifecycle \
+  --title "Narrow WorkOrder to durable intent coordination" \
+  --body-file /tmp/work-order-product-lifecycle-pr.md
+```
+
+The PR body states the product requirement, authority removals, affected paths, every verification command/result, #2789, and Discussion #2878. It requests two independent interface approvals and does not claim merge readiness.
+
+- [ ] **Step 6: Update the Discussion and issue with evidence**
+
+Post an English Discussion reply explaining how the implementation keeps first-class WorkOrder while addressing the duplicate-authority concern. Post a concise #2789 progress comment linking the PR and verification. Do not close #2789 and do not merge into `feature/integrate` until two independent approvals are recorded.

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkOrderCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkOrderCommandPort.cs
@@ -19,20 +19,6 @@ public interface IWorkOrderCommandPort
         WorkOrderValidatedAssignment assignment,
         CancellationToken ct = default);
 
-    Task<WorkOrderAcceptedReceipt> ApproveAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default);
-
-    Task<WorkOrderAcceptedReceipt> DenyAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default);
-
     Task<WorkOrderAcceptedReceipt> DispatchAsync(
         string scopeId,
         string workOrderId,

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkOrderService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkOrderService.cs
@@ -27,20 +27,6 @@ public interface IWorkOrderService
         WorkOrderPrincipalContract requester,
         CancellationToken ct = default);
 
-    Task<WorkOrderAcceptedReceipt> ApproveAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default);
-
-    Task<WorkOrderAcceptedReceipt> DenyAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default);
-
     Task<WorkOrderAcceptedReceipt> DispatchAsync(
         string scopeId,
         string workOrderId,

--- a/src/Aevatar.Studio.Application/Studio/Contracts/WorkOrderContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/WorkOrderContracts.cs
@@ -3,24 +3,14 @@ namespace Aevatar.Studio.Application.Studio.Contracts;
 public static class WorkOrderLifecycleStatusNames
 {
     public const string Accepted = "accepted";
-    public const string WaitingApproval = "waiting_approval";
     public const string Ready = "ready";
     public const string DispatchPending = "dispatch_pending";
     public const string Running = "running";
     public const string Completed = "completed";
     public const string Failed = "failed";
     public const string Stopped = "stopped";
-    public const string Denied = "denied";
     public const string Cancelled = "cancelled";
     public const string TimedOut = "timed_out";
-}
-
-public static class WorkOrderApprovalStatusNames
-{
-    public const string NotRequired = "not_required";
-    public const string Pending = "pending";
-    public const string Approved = "approved";
-    public const string Denied = "denied";
 }
 
 public static class WorkOrderCommandStageNames
@@ -35,23 +25,6 @@ public sealed record WorkOrderArtifactReferenceContract(
     string ArtifactKind,
     string? Uri = null,
     string? RevisionId = null);
-
-public sealed record WorkOrderExternalActionReferenceContract(
-    string ActionId,
-    string System,
-    string Action,
-    string ResourceId);
-
-public sealed record WorkOrderPermissionRequirementContract(
-    string PermissionId,
-    string ActionId,
-    string Capability,
-    bool RequiresApproval = false);
-
-public sealed record WorkOrderPermissionPlanContract(
-    IReadOnlyList<WorkOrderExternalActionReferenceContract>? ExternalActions = null,
-    IReadOnlyList<WorkOrderPermissionRequirementContract>? Requirements = null,
-    IReadOnlyList<string>? ApproverPrincipalIds = null);
 
 public sealed record WorkOrderChatInputContract(string Prompt);
 
@@ -68,18 +41,12 @@ public sealed record CreateWorkOrderRequest(
     string Intent,
     string DedupKey,
     WorkOrderServiceInputContract Input,
-    WorkOrderPermissionPlanContract? PermissionPlan = null,
     DateTimeOffset? TimeoutAtUtc = null);
 
 public sealed record ReassignWorkOrderRequest(
     string MemberId,
     string PublishedServiceId,
     long ExpectedLifecycleVersion);
-
-public sealed record DecideWorkOrderApprovalRequest(
-    string DecisionId,
-    long ExpectedLifecycleVersion,
-    string? Reason = null);
 
 public sealed record DispatchWorkOrderRequest(long ExpectedLifecycleVersion);
 
@@ -94,23 +61,14 @@ public sealed record WorkOrderAcceptedReceipt(
     string Stage,
     DateTimeOffset? AcceptedAtUtc = null);
 
-public sealed record WorkOrderApprovalResponse(
-    string? ApprovalId,
-    string Status,
-    string? DecisionId,
-    WorkOrderPrincipalContract? DecidedBy,
-    string? Reason,
-    DateTimeOffset? DecidedAtUtc);
-
-public sealed record WorkOrderExecutionResponse(
+public sealed record WorkOrderRunLinkResponse(
     string RunId,
     string RunActorId,
     string CommandId,
     string CorrelationId,
     string RevisionId,
     string DeploymentId,
-    DateTimeOffset AcceptedAtUtc,
-    DateTimeOffset? StartedAtUtc);
+    DateTimeOffset AcceptedAtUtc);
 
 public sealed record WorkOrderFailureResponse(
     string Code,
@@ -118,17 +76,14 @@ public sealed record WorkOrderFailureResponse(
     string Source,
     string? ReferenceId);
 
-public sealed record WorkOrderTerminalEvidenceResponse(
+public sealed record WorkOrderRunOutcomeReferenceResponse(
     string DeliveryId,
     string RunId,
     string RunActorId,
     string CommandId,
     string CorrelationId,
     string Outcome,
-    string? Output,
-    string? Error,
-    DateTimeOffset TerminalAtUtc,
-    IReadOnlyList<WorkOrderArtifactReferenceContract> ResultArtifacts);
+    DateTimeOffset TerminalAtUtc);
 
 public sealed record WorkOrderCurrentStateResponse(
     string WorkOrderId,
@@ -147,11 +102,9 @@ public sealed record WorkOrderCurrentStateResponse(
     long LifecycleVersion,
     long StateVersion,
     WorkOrderServiceInputContract Input,
-    WorkOrderPermissionPlanContract PermissionPlan,
-    WorkOrderApprovalResponse Approval,
-    WorkOrderExecutionResponse? Execution,
-    WorkOrderTerminalEvidenceResponse? TerminalEvidence,
-    WorkOrderTerminalEvidenceResponse? LateTerminalEvidence,
+    WorkOrderRunLinkResponse? Run,
+    WorkOrderRunOutcomeReferenceResponse? RunOutcome,
+    WorkOrderRunOutcomeReferenceResponse? LateRunOutcome,
     WorkOrderFailureResponse? Failure,
     string? TerminalReason,
     DateTimeOffset CreatedAtUtc,

--- a/src/Aevatar.Studio.Application/Studio/Services/ValidatedWorkOrderExecutionPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ValidatedWorkOrderExecutionPort.cs
@@ -93,11 +93,12 @@ public sealed class ValidatedWorkOrderExecutionPort : IWorkOrderExecutionPort
     {
         if (request.Input?.Chat == null)
             throw new InvalidOperationException("WorkOrder chat input is required for dispatch.");
-        if (request.DeadlineAtUtc == null ||
+        if (request.DeadlineAtUtc != null &&
             request.DeadlineAtUtc.ToDateTimeOffset().ToUnixTimeMilliseconds() <= 0)
             throw new InvalidOperationException("WorkOrder execution requires a positive deadline_at_utc.");
 
-        var expiresAtUnixMs = request.DeadlineAtUtc.ToDateTimeOffset().ToUnixTimeMilliseconds();
+        var expiresAtUnixMs = request.DeadlineAtUtc?.ToDateTimeOffset().ToUnixTimeMilliseconds()
+                              ?? long.MaxValue;
 
         var invocationRequest = new ServiceInvocationRequest
         {

--- a/src/Aevatar.Studio.Application/Studio/Services/WorkOrderService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/WorkOrderService.cs
@@ -104,38 +104,6 @@ public sealed class WorkOrderService : IWorkOrderService
             ct);
     }
 
-    public async Task<WorkOrderAcceptedReceipt> ApproveAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default)
-    {
-        var current = await GetCurrentAtVersionAsync(scopeId, workOrderId, request.ExpectedLifecycleVersion, ct);
-        return await _commandPort.ApproveAsync(
-            current.ScopeId,
-            current.WorkOrderId,
-            NormalizeDecision(request),
-            NormalizePrincipal(approver),
-            ct);
-    }
-
-    public async Task<WorkOrderAcceptedReceipt> DenyAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default)
-    {
-        var current = await GetCurrentAtVersionAsync(scopeId, workOrderId, request.ExpectedLifecycleVersion, ct);
-        return await _commandPort.DenyAsync(
-            current.ScopeId,
-            current.WorkOrderId,
-            NormalizeDecision(request),
-            NormalizePrincipal(approver),
-            ct);
-    }
-
     public async Task<WorkOrderAcceptedReceipt> DispatchAsync(
         string scopeId,
         string workOrderId,
@@ -237,45 +205,7 @@ public sealed class WorkOrderService : IWorkOrderService
                 new WorkOrderChatInputContract(NormalizeRequired(request.Input.Chat.Prompt, "input.chat.prompt")),
                 NormalizeArtifacts(request.Input.InputArtifacts),
                 NormalizeArtifacts(request.Input.DeclaredResultArtifacts)),
-            PermissionPlan = NormalizePermissionPlan(request.PermissionPlan),
         };
-    }
-
-    private static WorkOrderPermissionPlanContract NormalizePermissionPlan(WorkOrderPermissionPlanContract? plan)
-    {
-        var actions = (plan?.ExternalActions ?? [])
-            .Select(action => new WorkOrderExternalActionReferenceContract(
-                NormalizeRequired(action.ActionId, "permissionPlan.externalActions.actionId"),
-                NormalizeRequired(action.System, "permissionPlan.externalActions.system"),
-                NormalizeRequired(action.Action, "permissionPlan.externalActions.action"),
-                NormalizeRequired(action.ResourceId, "permissionPlan.externalActions.resourceId")))
-            .OrderBy(static action => action.ActionId, StringComparer.Ordinal)
-            .ToArray();
-        EnsureUnique(actions.Select(static action => action.ActionId), "external action id");
-
-        var requirements = (plan?.Requirements ?? [])
-            .Select(requirement => new WorkOrderPermissionRequirementContract(
-                NormalizeRequired(requirement.PermissionId, "permissionPlan.requirements.permissionId"),
-                NormalizeRequired(requirement.ActionId, "permissionPlan.requirements.actionId"),
-                NormalizeRequired(requirement.Capability, "permissionPlan.requirements.capability"),
-                requirement.RequiresApproval))
-            .OrderBy(static requirement => requirement.PermissionId, StringComparer.Ordinal)
-            .ToArray();
-        EnsureUnique(requirements.Select(static requirement => requirement.PermissionId), "permission id");
-
-        var actionIds = actions.Select(static action => action.ActionId).ToHashSet(StringComparer.Ordinal);
-        if (requirements.Any(requirement => !actionIds.Contains(requirement.ActionId)))
-            throw new InvalidOperationException("Every permission requirement must reference a declared external action.");
-
-        var approvers = (plan?.ApproverPrincipalIds ?? [])
-            .Select(id => NormalizeRequired(id, "permissionPlan.approverPrincipalIds"))
-            .Distinct(StringComparer.Ordinal)
-            .Order(StringComparer.Ordinal)
-            .ToArray();
-        if (requirements.Any(static requirement => requirement.RequiresApproval) && approvers.Length == 0)
-            throw new InvalidOperationException("Approval-requiring permissions must declare at least one approver principal.");
-
-        return new WorkOrderPermissionPlanContract(actions, requirements, approvers);
     }
 
     private static IReadOnlyList<WorkOrderArtifactReferenceContract> NormalizeArtifacts(
@@ -291,16 +221,6 @@ public sealed class WorkOrderService : IWorkOrderService
             .ToArray();
         EnsureUnique(normalized.Select(static artifact => artifact.ArtifactId), "artifact id");
         return normalized;
-    }
-
-    private static DecideWorkOrderApprovalRequest NormalizeDecision(DecideWorkOrderApprovalRequest request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        return request with
-        {
-            DecisionId = NormalizeRequired(request.DecisionId, nameof(request.DecisionId)),
-            Reason = NormalizeOptional(request.Reason),
-        };
     }
 
     private static WorkOrderPrincipalContract NormalizePrincipal(WorkOrderPrincipalContract principal)

--- a/src/Aevatar.Studio.Hosting/Endpoints/WorkOrderEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/WorkOrderEndpoints.cs
@@ -23,10 +23,6 @@ internal static class WorkOrderEndpoints
             .WithTags("WorkOrders");
         app.MapPost("/api/scopes/{scopeId}/work-orders/{workOrderId}:reassign", HandleReassignAsync)
             .WithTags("WorkOrders");
-        app.MapPost("/api/scopes/{scopeId}/work-orders/{workOrderId}:approve", HandleApproveAsync)
-            .WithTags("WorkOrders");
-        app.MapPost("/api/scopes/{scopeId}/work-orders/{workOrderId}:deny", HandleDenyAsync)
-            .WithTags("WorkOrders");
         app.MapPost("/api/scopes/{scopeId}/work-orders/{workOrderId}:dispatch", HandleDispatchAsync)
             .WithTags("WorkOrders");
         app.MapPost("/api/scopes/{scopeId}/work-orders/{workOrderId}:cancel", HandleCancelAsync)
@@ -147,36 +143,6 @@ internal static class WorkOrderEndpoints
             workOrderId,
             service,
             (principal, token) => service.ReassignAsync(scopeId, workOrderId, request, principal, token),
-            ct);
-
-    internal static Task<IResult> HandleApproveAsync(
-        HttpContext http,
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        [FromServices] IWorkOrderService service,
-        CancellationToken ct) =>
-        HandleRequesterCommandAsync(
-            http,
-            scopeId,
-            workOrderId,
-            service,
-            (principal, token) => service.ApproveAsync(scopeId, workOrderId, request, principal, token),
-            ct);
-
-    internal static Task<IResult> HandleDenyAsync(
-        HttpContext http,
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        [FromServices] IWorkOrderService service,
-        CancellationToken ct) =>
-        HandleRequesterCommandAsync(
-            http,
-            scopeId,
-            workOrderId,
-            service,
-            (principal, token) => service.DenyAsync(scopeId, workOrderId, request, principal, token),
             ct);
 
     internal static Task<IResult> HandleDispatchAsync(

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchWorkOrderCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchWorkOrderCommandService.cs
@@ -30,9 +30,7 @@ internal sealed class ActorDispatchWorkOrderCommandService : IWorkOrderCommandPo
         CancellationToken ct = default)
     {
         var requestedAt = DateTimeOffset.UtcNow;
-        if (!request.TimeoutAtUtc.HasValue)
-            throw new InvalidOperationException("WorkOrder deadline is required before actor dispatch.");
-        if (request.TimeoutAtUtc.Value <= requestedAt)
+        if (request.TimeoutAtUtc.HasValue && request.TimeoutAtUtc.Value <= requestedAt)
             throw new InvalidOperationException("WorkOrder deadline must be later than the request time.");
 
         var workOrderId = WorkOrderConventions.BuildWorkOrderId(scopeId, request.DedupKey);
@@ -51,12 +49,11 @@ internal sealed class ActorDispatchWorkOrderCommandService : IWorkOrderCommandPo
             EndpointId = request.EndpointId,
             Intent = request.Intent,
             Input = ToInput(request.Input),
-            PermissionPlan = ToPermissionPlan(request.PermissionPlan),
-            ApprovalId = WorkOrderConventions.BuildApprovalId(workOrderId),
             RequestedAtUtc = Timestamp.FromDateTimeOffset(requestedAt),
-            TimeoutAtUtc = Timestamp.FromDateTimeOffset(request.TimeoutAtUtc.Value),
             ExpectedLifecycleVersion = 0,
         };
+        if (request.TimeoutAtUtc.HasValue)
+            command.TimeoutAtUtc = Timestamp.FromDateTimeOffset(request.TimeoutAtUtc.Value);
 
         return await DispatchAsync(
             scopeId,
@@ -90,50 +87,6 @@ internal sealed class ActorDispatchWorkOrderCommandService : IWorkOrderCommandPo
                 RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             },
             "reassign",
-            request.ExpectedLifecycleVersion,
-            ct);
-
-    public Task<WorkOrderAcceptedReceipt> ApproveAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default) =>
-        DispatchAsync(
-            scopeId,
-            workOrderId,
-            new ApproveWorkOrder
-            {
-                WorkOrderId = workOrderId,
-                ExpectedLifecycleVersion = request.ExpectedLifecycleVersion,
-                DecisionId = request.DecisionId,
-                DecidedBy = ToPrincipal(approver),
-                Reason = request.Reason ?? string.Empty,
-                DecidedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            },
-            "approve",
-            request.ExpectedLifecycleVersion,
-            ct);
-
-    public Task<WorkOrderAcceptedReceipt> DenyAsync(
-        string scopeId,
-        string workOrderId,
-        DecideWorkOrderApprovalRequest request,
-        WorkOrderPrincipalContract approver,
-        CancellationToken ct = default) =>
-        DispatchAsync(
-            scopeId,
-            workOrderId,
-            new DenyWorkOrder
-            {
-                WorkOrderId = workOrderId,
-                ExpectedLifecycleVersion = request.ExpectedLifecycleVersion,
-                DecisionId = request.DecisionId,
-                DecidedBy = ToPrincipal(approver),
-                Reason = request.Reason ?? string.Empty,
-                DecidedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            },
-            "deny",
             request.ExpectedLifecycleVersion,
             ct);
 
@@ -222,29 +175,6 @@ internal sealed class ActorDispatchWorkOrderCommandService : IWorkOrderCommandPo
         return result;
     }
 
-    private static WorkOrderPermissionPlan ToPermissionPlan(WorkOrderPermissionPlanContract? plan)
-    {
-        var result = new WorkOrderPermissionPlan();
-        result.ExternalActions.Add((plan?.ExternalActions ?? []).Select(action =>
-            new WorkOrderExternalActionReference
-            {
-                ActionId = action.ActionId,
-                System = action.System,
-                Action = action.Action,
-                ResourceId = action.ResourceId,
-            }));
-        result.Requirements.Add((plan?.Requirements ?? []).Select(requirement =>
-            new WorkOrderPermissionRequirement
-            {
-                PermissionId = requirement.PermissionId,
-                ActionId = requirement.ActionId,
-                Capability = requirement.Capability,
-                RequiresApproval = requirement.RequiresApproval,
-            }));
-        result.ApproverPrincipalIds.Add(plan?.ApproverPrincipalIds ?? []);
-        return result;
-    }
-
     private static WorkOrderArtifactReference ToArtifact(WorkOrderArtifactReferenceContract artifact) =>
         new()
         {
@@ -285,18 +215,6 @@ internal sealed class ActorDispatchWorkOrderCommandService : IWorkOrderCommandPo
             {
                 var canonical = command.Clone();
                 canonical.RequestedAtUtc = null;
-                return canonical.ToByteArray();
-            }
-            case ApproveWorkOrder command:
-            {
-                var canonical = command.Clone();
-                canonical.DecidedAtUtc = null;
-                return canonical.ToByteArray();
-            }
-            case DenyWorkOrder command:
-            {
-                var canonical = command.Clone();
-                canonical.DecidedAtUtc = null;
                 return canonical.ToByteArray();
             }
             case DispatchWorkOrder command:

--- a/src/Aevatar.Studio.Projection/Projectors/WorkOrderCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/WorkOrderCurrentStateProjector.cs
@@ -51,9 +51,7 @@ public sealed class WorkOrderCurrentStateProjector
 
         AddArtifacts(document.InputArtifacts, state.Input?.InputArtifacts);
         AddArtifacts(document.DeclaredResultArtifacts, state.Input?.DeclaredResultArtifacts);
-        AddPermissionPlan(document, state.PermissionPlan);
-        ApplyApproval(document, state.Approval);
-        ApplyExecution(document, state.Execution);
+        ApplyRun(document, state.Run);
         ApplyTerminalState(document, state);
         await _writeDispatcher.UpsertAsync(document, ct);
     }
@@ -91,71 +89,30 @@ public sealed class WorkOrderCurrentStateProjector
             InputPrompt = state.Input?.Chat?.Prompt ?? string.Empty,
         };
 
-    private static void ApplyApproval(
+    private static void ApplyRun(
         WorkOrderCurrentStateDocument document,
-        WorkOrderApprovalState? approval)
+        WorkOrderRunLink? run)
     {
-        document.ApprovalId = approval?.ApprovalId ?? string.Empty;
-        document.ApprovalStatus = ToWireName(
-            approval?.Status ?? WorkOrderApprovalStatus.Unspecified);
-        document.ApprovalDecisionId = approval?.DecisionId ?? string.Empty;
-        document.ApprovalDecidedById = approval?.DecidedBy?.PrincipalId ?? string.Empty;
-        document.ApprovalDecidedByKind = approval?.DecidedBy?.PrincipalKind ?? string.Empty;
-        document.ApprovalReason = approval?.Reason ?? string.Empty;
-        document.ApprovalDecidedAtUnixMs = ToUnixTimeMilliseconds(approval?.DecidedAtUtc);
-    }
-
-    private static void ApplyExecution(
-        WorkOrderCurrentStateDocument document,
-        WorkOrderExecutionProvenance? execution)
-    {
-        document.RunId = execution?.RunId ?? string.Empty;
-        document.RunActorId = execution?.RunActorId ?? string.Empty;
-        document.RunCommandId = execution?.CommandId ?? string.Empty;
-        document.RunCorrelationId = execution?.CorrelationId ?? string.Empty;
-        document.RunRevisionId = execution?.RevisionId ?? string.Empty;
-        document.RunDeploymentId = execution?.DeploymentId ?? string.Empty;
-        document.RunAcceptedAtUnixMs = ToUnixTimeMilliseconds(execution?.AcceptedAtUtc);
-        document.RunStartedAtUnixMs = ToUnixTimeMilliseconds(execution?.StartedAtUtc);
+        document.RunId = run?.RunId ?? string.Empty;
+        document.RunActorId = run?.RunActorId ?? string.Empty;
+        document.RunCommandId = run?.CommandId ?? string.Empty;
+        document.RunCorrelationId = run?.CorrelationId ?? string.Empty;
+        document.RunRevisionId = run?.RevisionId ?? string.Empty;
+        document.RunDeploymentId = run?.DeploymentId ?? string.Empty;
+        document.RunAcceptedAtUnixMs = ToUnixTimeMilliseconds(run?.AcceptedAtUtc);
     }
 
     private static void ApplyTerminalState(
         WorkOrderCurrentStateDocument document,
         WorkOrderState state)
     {
-        document.TerminalEvidence = ToTerminalEvidence(state.TerminalEvidence);
-        document.LateTerminalEvidence = ToTerminalEvidence(state.LateTerminalEvidence);
+        document.RunOutcome = ToRunOutcome(state.RunOutcome);
+        document.LateRunOutcome = ToRunOutcome(state.LateRunOutcome);
         document.FailureCode = state.Failure?.Code ?? string.Empty;
         document.FailureMessage = state.Failure?.Message ?? string.Empty;
         document.FailureSource = state.Failure?.Source ?? string.Empty;
         document.FailureReferenceId = state.Failure?.ReferenceId ?? string.Empty;
         document.TerminalReason = state.TerminalReason;
-    }
-
-    private static void AddPermissionPlan(
-        WorkOrderCurrentStateDocument document,
-        WorkOrderPermissionPlan? plan)
-    {
-        if (plan == null)
-            return;
-
-        document.ExternalActions.Add(plan.ExternalActions.Select(action =>
-            new WorkOrderExternalActionReferenceDocument
-            {
-                ActionId = action.ActionId,
-                System = action.System,
-                Action = action.Action,
-                ResourceId = action.ResourceId,
-            }));
-        document.PermissionRequirements.Add(plan.Requirements.Select(requirement =>
-            new WorkOrderPermissionRequirementDocument
-            {
-                PermissionId = requirement.PermissionId,
-                ActionId = requirement.ActionId,
-                Capability = requirement.Capability,
-                RequiresApproval = requirement.RequiresApproval,
-            }));
-        document.ApproverPrincipalIds.Add(plan.ApproverPrincipalIds);
     }
 
     private static void AddArtifacts(
@@ -177,56 +134,41 @@ public sealed class WorkOrderCurrentStateProjector
             RevisionId = artifact.RevisionId,
         };
 
-    private static WorkOrderTerminalEvidenceDocument? ToTerminalEvidence(
-        WorkOrderTerminalEvidence? evidence)
+    private static WorkOrderRunOutcomeReferenceDocument? ToRunOutcome(
+        WorkOrderRunOutcomeReference? outcome)
     {
-        if (evidence == null || string.IsNullOrWhiteSpace(evidence.DeliveryId))
+        if (outcome == null || string.IsNullOrWhiteSpace(outcome.DeliveryId))
             return null;
 
-        var document = new WorkOrderTerminalEvidenceDocument
+        return new WorkOrderRunOutcomeReferenceDocument
         {
-            DeliveryId = evidence.DeliveryId,
-            RunId = evidence.RunId,
-            RunActorId = evidence.RunActorId,
-            CommandId = evidence.CommandId,
-            CorrelationId = evidence.CorrelationId,
-            Outcome = evidence.Outcome switch
+            DeliveryId = outcome.DeliveryId,
+            RunId = outcome.RunId,
+            RunActorId = outcome.RunActorId,
+            CommandId = outcome.CommandId,
+            CorrelationId = outcome.CorrelationId,
+            Outcome = outcome.Outcome switch
             {
                 WorkOrderTerminalOutcome.Succeeded => "succeeded",
                 WorkOrderTerminalOutcome.Failed => "failed",
                 WorkOrderTerminalOutcome.Stopped => "stopped",
                 _ => string.Empty,
             },
-            Output = evidence.Output,
-            Error = evidence.Error,
-            TerminalAtUnixMs = ToUnixTimeMilliseconds(evidence.TerminalAtUtc),
+            TerminalAtUnixMs = ToUnixTimeMilliseconds(outcome.TerminalAtUtc),
         };
-        document.ResultArtifacts.Add(evidence.ResultArtifacts.Select(ToArtifact));
-        return document;
     }
 
     private static string ToWireName(WorkOrderLifecycleStatus status) => status switch
     {
         WorkOrderLifecycleStatus.Accepted => WorkOrderLifecycleStatusNames.Accepted,
-        WorkOrderLifecycleStatus.WaitingApproval => WorkOrderLifecycleStatusNames.WaitingApproval,
         WorkOrderLifecycleStatus.Ready => WorkOrderLifecycleStatusNames.Ready,
         WorkOrderLifecycleStatus.DispatchPending => WorkOrderLifecycleStatusNames.DispatchPending,
         WorkOrderLifecycleStatus.Running => WorkOrderLifecycleStatusNames.Running,
         WorkOrderLifecycleStatus.Completed => WorkOrderLifecycleStatusNames.Completed,
         WorkOrderLifecycleStatus.Failed => WorkOrderLifecycleStatusNames.Failed,
         WorkOrderLifecycleStatus.Stopped => WorkOrderLifecycleStatusNames.Stopped,
-        WorkOrderLifecycleStatus.Denied => WorkOrderLifecycleStatusNames.Denied,
         WorkOrderLifecycleStatus.Cancelled => WorkOrderLifecycleStatusNames.Cancelled,
         WorkOrderLifecycleStatus.TimedOut => WorkOrderLifecycleStatusNames.TimedOut,
-        _ => string.Empty,
-    };
-
-    private static string ToWireName(WorkOrderApprovalStatus status) => status switch
-    {
-        WorkOrderApprovalStatus.NotRequired => WorkOrderApprovalStatusNames.NotRequired,
-        WorkOrderApprovalStatus.Pending => WorkOrderApprovalStatusNames.Pending,
-        WorkOrderApprovalStatus.Approved => WorkOrderApprovalStatusNames.Approved,
-        WorkOrderApprovalStatus.Denied => WorkOrderApprovalStatusNames.Denied,
         _ => string.Empty,
     };
 

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionWorkOrderQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionWorkOrderQueryPort.cs
@@ -13,14 +13,12 @@ public sealed class ProjectionWorkOrderQueryPort : IWorkOrderQueryPort
     private static readonly IReadOnlySet<string> KnownStatuses = new HashSet<string>(StringComparer.Ordinal)
     {
         WorkOrderLifecycleStatusNames.Accepted,
-        WorkOrderLifecycleStatusNames.WaitingApproval,
         WorkOrderLifecycleStatusNames.Ready,
         WorkOrderLifecycleStatusNames.DispatchPending,
         WorkOrderLifecycleStatusNames.Running,
         WorkOrderLifecycleStatusNames.Completed,
         WorkOrderLifecycleStatusNames.Failed,
         WorkOrderLifecycleStatusNames.Stopped,
-        WorkOrderLifecycleStatusNames.Denied,
         WorkOrderLifecycleStatusNames.Cancelled,
         WorkOrderLifecycleStatusNames.TimedOut,
     };
@@ -132,71 +130,39 @@ public sealed class ProjectionWorkOrderQueryPort : IWorkOrderQueryPort
                 new WorkOrderChatInputContract(document.InputPrompt),
                 document.InputArtifacts.Select(ToArtifact).ToArray(),
                 document.DeclaredResultArtifacts.Select(ToArtifact).ToArray()),
-            new WorkOrderPermissionPlanContract(
-                document.ExternalActions.Select(action =>
-                    new WorkOrderExternalActionReferenceContract(
-                        action.ActionId,
-                        action.System,
-                        action.Action,
-                        action.ResourceId)).ToArray(),
-                document.PermissionRequirements.Select(requirement =>
-                    new WorkOrderPermissionRequirementContract(
-                        requirement.PermissionId,
-                        requirement.ActionId,
-                        requirement.Capability,
-                        requirement.RequiresApproval)).ToArray(),
-                document.ApproverPrincipalIds.ToArray()),
-            ToApproval(document),
-            ToExecution(document),
-            ToTerminalEvidence(document.TerminalEvidence),
-            ToTerminalEvidence(document.LateTerminalEvidence),
+            ToRun(document),
+            ToRunOutcome(document.RunOutcome),
+            ToRunOutcome(document.LateRunOutcome),
             ToFailure(document),
             NormalizeOptional(document.TerminalReason),
             FromUnixTimeMilliseconds(document.CreatedAtUnixMs) ?? DateTimeOffset.MinValue,
             document.WorkOrderUpdatedAtUtc?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
             FromUnixTimeMilliseconds(document.TimeoutAtUnixMs));
 
-    private static WorkOrderApprovalResponse ToApproval(WorkOrderCurrentStateDocument document) =>
-        new(
-            NormalizeOptional(document.ApprovalId),
-            document.ApprovalStatus,
-            NormalizeOptional(document.ApprovalDecisionId),
-            string.IsNullOrWhiteSpace(document.ApprovalDecidedById)
-                ? null
-                : new WorkOrderPrincipalContract(
-                    document.ApprovalDecidedById,
-                    document.ApprovalDecidedByKind),
-            NormalizeOptional(document.ApprovalReason),
-            FromUnixTimeMilliseconds(document.ApprovalDecidedAtUnixMs));
-
-    private static WorkOrderExecutionResponse? ToExecution(WorkOrderCurrentStateDocument document) =>
+    private static WorkOrderRunLinkResponse? ToRun(WorkOrderCurrentStateDocument document) =>
         string.IsNullOrWhiteSpace(document.RunId)
             ? null
-            : new WorkOrderExecutionResponse(
+            : new WorkOrderRunLinkResponse(
                 document.RunId,
                 document.RunActorId,
                 document.RunCommandId,
                 document.RunCorrelationId,
                 document.RunRevisionId,
                 document.RunDeploymentId,
-                FromUnixTimeMilliseconds(document.RunAcceptedAtUnixMs) ?? DateTimeOffset.MinValue,
-                FromUnixTimeMilliseconds(document.RunStartedAtUnixMs));
+                FromUnixTimeMilliseconds(document.RunAcceptedAtUnixMs) ?? DateTimeOffset.MinValue);
 
-    private static WorkOrderTerminalEvidenceResponse? ToTerminalEvidence(
-        WorkOrderTerminalEvidenceDocument? document) =>
+    private static WorkOrderRunOutcomeReferenceResponse? ToRunOutcome(
+        WorkOrderRunOutcomeReferenceDocument? document) =>
         document == null || string.IsNullOrWhiteSpace(document.DeliveryId)
             ? null
-            : new WorkOrderTerminalEvidenceResponse(
+            : new WorkOrderRunOutcomeReferenceResponse(
                 document.DeliveryId,
                 document.RunId,
                 document.RunActorId,
                 document.CommandId,
                 document.CorrelationId,
                 document.Outcome,
-                NormalizeOptional(document.Output),
-                NormalizeOptional(document.Error),
-                FromUnixTimeMilliseconds(document.TerminalAtUnixMs) ?? DateTimeOffset.MinValue,
-                document.ResultArtifacts.Select(ToArtifact).ToArray());
+                FromUnixTimeMilliseconds(document.TerminalAtUnixMs) ?? DateTimeOffset.MinValue);
 
     private static WorkOrderFailureResponse? ToFailure(WorkOrderCurrentStateDocument document) =>
         string.IsNullOrWhiteSpace(document.FailureCode)

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -12,31 +12,14 @@ message WorkOrderArtifactReferenceDocument {
   string revision_id = 4;
 }
 
-message WorkOrderExternalActionReferenceDocument {
-  string action_id = 1;
-  string system = 2;
-  string action = 3;
-  string resource_id = 4;
-}
-
-message WorkOrderPermissionRequirementDocument {
-  string permission_id = 1;
-  string action_id = 2;
-  string capability = 3;
-  bool requires_approval = 4;
-}
-
-message WorkOrderTerminalEvidenceDocument {
+message WorkOrderRunOutcomeReferenceDocument {
   string delivery_id = 1;
   string run_id = 2;
   string run_actor_id = 3;
   string command_id = 4;
-  string outcome = 5;
-  string output = 6;
-  string error = 7;
-  int64 terminal_at_unix_ms = 8;
-  repeated WorkOrderArtifactReferenceDocument result_artifacts = 9;
-  string correlation_id = 10;
+  string correlation_id = 5;
+  string outcome = 6;
+  int64 terminal_at_unix_ms = 7;
 }
 
 // Actor-scoped current-state replica for WorkOrderGAgent. Business lifecycle
@@ -71,17 +54,9 @@ message WorkOrderCurrentStateDocument {
   string input_prompt = 40;
   repeated WorkOrderArtifactReferenceDocument input_artifacts = 41;
   repeated WorkOrderArtifactReferenceDocument declared_result_artifacts = 42;
-  repeated WorkOrderExternalActionReferenceDocument external_actions = 43;
-  repeated WorkOrderPermissionRequirementDocument permission_requirements = 44;
-  repeated string approver_principal_ids = 45;
+  reserved 43 to 45;
 
-  string approval_id = 50;
-  string approval_status = 51;
-  string approval_decision_id = 52;
-  string approval_decided_by_id = 53;
-  string approval_decided_by_kind = 54;
-  string approval_reason = 55;
-  int64 approval_decided_at_unix_ms = 56;
+  reserved 50 to 56;
 
   string run_id = 60;
   string run_actor_id = 61;
@@ -90,10 +65,10 @@ message WorkOrderCurrentStateDocument {
   string run_revision_id = 64;
   string run_deployment_id = 65;
   int64 run_accepted_at_unix_ms = 66;
-  int64 run_started_at_unix_ms = 67;
+  reserved 67;
 
-  WorkOrderTerminalEvidenceDocument terminal_evidence = 70;
-  WorkOrderTerminalEvidenceDocument late_terminal_evidence = 71;
+  WorkOrderRunOutcomeReferenceDocument run_outcome = 70;
+  WorkOrderRunOutcomeReferenceDocument late_run_outcome = 71;
   string failure_code = 72;
   string failure_message = 73;
   string failure_source = 74;

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceRunWorkOrderIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceRunWorkOrderIntegrationTests.cs
@@ -124,7 +124,6 @@ public sealed class ServiceRunWorkOrderIntegrationTests
             {
                 Chat = new WorkOrderChatInput { Prompt = "perform the work" },
             },
-            PermissionPlan = new WorkOrderPermissionPlan(),
             ExpectedLifecycleVersion = 0,
             RequestedAtUtc = Timestamp.FromDateTimeOffset(requestedAt),
             TimeoutAtUtc = Timestamp.FromDateTimeOffset(requestedAt.AddHours(1)),
@@ -158,8 +157,7 @@ public sealed class ServiceRunWorkOrderIntegrationTests
         });
 
         workOrder.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        workOrder.State.Execution.RunId.Should().Be(requestedRunId);
-        workOrder.State.Execution.StartedAtUtc.Should().BeNull();
+        workOrder.State.Run.RunId.Should().Be(requestedRunId);
 
         await serviceRun.HandleRegisterAsync(new RegisterServiceRunRequested
         {
@@ -233,12 +231,11 @@ public sealed class ServiceRunWorkOrderIntegrationTests
         serviceRun.State.PendingTerminalNotification.Should().BeNull();
 
         workOrder.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Completed);
-        workOrder.State.Execution.StartedAtUtc.Should().BeNull();
-        workOrder.State.TerminalEvidence.RunId.Should().Be(requestedRunId);
-        workOrder.State.TerminalEvidence.RunActorId.Should().Be(scriptActorId);
-        workOrder.State.TerminalEvidence.CommandId.Should().Be(dispatchCommandId);
-        workOrder.State.TerminalEvidence.Outcome.Should().Be(WorkOrderTerminalOutcome.Succeeded);
-        workOrder.State.TerminalEvidence.TerminalAtUtc.Should().Be(
+        workOrder.State.RunOutcome.RunId.Should().Be(requestedRunId);
+        workOrder.State.RunOutcome.RunActorId.Should().Be(scriptActorId);
+        workOrder.State.RunOutcome.CommandId.Should().Be(dispatchCommandId);
+        workOrder.State.RunOutcome.Outcome.Should().Be(WorkOrderTerminalOutcome.Succeeded);
+        workOrder.State.RunOutcome.TerminalAtUtc.Should().Be(
             Timestamp.FromDateTimeOffset(
                 DateTimeOffset.FromUnixTimeMilliseconds(committedTerminal.OccurredAtUnixTimeMs)));
 

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderAssignmentAndExecutionTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderAssignmentAndExecutionTests.cs
@@ -5,9 +5,9 @@ using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.GAgents.WorkOrder;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.GAgents.WorkOrder;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Application.Studio.Services;
@@ -320,6 +320,42 @@ public sealed class ValidatedWorkOrderExecutionPortTests
         invocation.ServiceRunCompletionNotificationTarget.ExpiresAtUnixMs.Should().Be(deadline.ToUnixTimeMilliseconds());
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WithoutDeadline_ShouldUseNonExpiringWorkflowCompletionTarget()
+    {
+        var invocationPort = new RecordingInvocationPort();
+        var port = new ValidatedWorkOrderExecutionPort(
+            WorkOrderAssignmentValidatorTests.CreateValidator(),
+            invocationPort);
+        var request = BuildExecutionRequest();
+        request.DeadlineAtUtc = null;
+
+        await port.ExecuteAsync(request);
+
+        var invocation = invocationPort.Requests.Should().ContainSingle().Subject;
+        invocation.WorkflowCompletionNotificationTarget.ExpiresAtUnixMs.Should().Be(long.MaxValue);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutDeadline_ShouldUseNonExpiringServiceRunCompletionTarget()
+    {
+        var invocationPort = new RecordingInvocationPort();
+        var port = new ValidatedWorkOrderExecutionPort(
+            WorkOrderAssignmentValidatorTests.CreateValidator(
+                workflowId: null,
+                implementationKind: MemberImplementationKindNames.GAgent),
+            invocationPort);
+        var request = BuildExecutionRequest();
+        request.WorkflowId = string.Empty;
+        request.ImplementationKind = MemberImplementationKindNames.GAgent;
+        request.DeadlineAtUtc = null;
+
+        await port.ExecuteAsync(request);
+
+        var invocation = invocationPort.Requests.Should().ContainSingle().Subject;
+        invocation.ServiceRunCompletionNotificationTarget.ExpiresAtUnixMs.Should().Be(long.MaxValue);
+    }
+
     private static WorkOrderExecutionRequest BuildExecutionRequest() =>
         new()
         {
@@ -630,7 +666,6 @@ public sealed class WorkOrderExecutionInfrastructureTests
             {
                 Chat = new WorkOrderChatInput { Prompt = "do the work" },
             },
-            PermissionPlan = new WorkOrderPermissionPlan(),
             RequestedAtUtc = Timestamp.FromDateTimeOffset(requestedAt),
             TimeoutAtUtc = Timestamp.FromDateTimeOffset(requestedAt.AddMinutes(1)),
         });

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderAuthorityBoundaryTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderAuthorityBoundaryTests.cs
@@ -1,0 +1,202 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Hooks;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.GAgents.WorkOrder;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Studio.Tests.WorkOrders;
+
+public sealed class WorkOrderAuthorityBoundaryTests
+{
+    private const string ScopeId = "scope-1";
+    private const string DedupKey = "durable-intent-1";
+    private static readonly string WorkOrderId = WorkOrderConventions.BuildWorkOrderId(ScopeId, DedupKey);
+    private static readonly string ActorId = WorkOrderConventions.BuildActorId(ScopeId, WorkOrderId);
+    private static readonly MethodInfo SetIdMethod = typeof(GAgentBase)
+        .GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("GAgentBase.SetId was not found.");
+
+    [Fact]
+    public async Task WorkOrderWithoutDeadline_ShouldSurviveReassignmentRecoveryAndCancellationBeforeAnyRun()
+    {
+        var eventStore = new InMemoryEventStore();
+        var created = await CreateAgentAsync(eventStore);
+
+        await created.HandleCreateAsync(BuildCreate(timeoutAtUtc: null));
+
+        created.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Ready);
+        created.State.TimeoutAtUtc.Should().BeNull();
+        created.State.Run.Should().BeNull();
+
+        await created.HandleReassignAsync(BuildReassign(created.State.LifecycleVersion));
+
+        var recovered = await CreateAgentAsync(eventStore);
+        recovered.State.MemberId.Should().Be("member-2");
+        recovered.State.PublishedServiceId.Should().Be("service-2");
+        recovered.State.Run.Should().BeNull();
+
+        await recovered.HandleCancelAsync(BuildCancel(recovered.State.LifecycleVersion));
+
+        var terminal = await CreateAgentAsync(eventStore);
+        terminal.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Cancelled);
+        terminal.State.Run.Should().BeNull();
+    }
+
+    [Fact]
+    public void PublicContract_ShouldNotExposeApprovalAuthority()
+    {
+        typeof(IWorkOrderService).GetMethods().Select(static method => method.Name)
+            .Should().NotContain(["ApproveAsync", "DenyAsync"]);
+        typeof(CreateWorkOrderRequest).GetProperties().Select(static property => property.Name)
+            .Should().NotContain("PermissionPlan");
+        typeof(WorkOrderCurrentStateResponse).GetProperties().Select(static property => property.Name)
+            .Should().NotContain(["PermissionPlan", "Approval"]);
+        typeof(WorkOrderGAgent).GetMethods().Select(static method => method.Name)
+            .Should().NotContain(["HandleApproveAsync", "HandleDenyAsync"]);
+    }
+
+    [Fact]
+    public void RunOutcomeReference_ShouldContainOnlyValidatedCoordinationFacts()
+    {
+        var descriptor = WorkOrderState.Descriptor.File.MessageTypes
+            .SingleOrDefault(static message => message.Name == "WorkOrderRunOutcomeReference");
+
+        descriptor.Should().NotBeNull();
+        descriptor!.Fields.InDeclarationOrder().Select(static field => field.Name)
+            .Should().Equal(
+                "delivery_id",
+                "run_id",
+                "run_actor_id",
+                "command_id",
+                "correlation_id",
+                "outcome",
+                "terminal_at_utc");
+    }
+
+    private static async Task<WorkOrderGAgent> CreateAgentAsync(InMemoryEventStore eventStore)
+    {
+        var agent = new WorkOrderGAgent
+        {
+            EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<WorkOrderState>(eventStore),
+            EventPublisher = new NoOpEventPublisher(),
+            Services = new ServiceCollection()
+                .AddSingleton<IEnumerable<IGAgentExecutionHook>>([])
+                .AddSingleton<IActorRuntimeCallbackScheduler>(new NoOpCallbackScheduler())
+                .BuildServiceProvider(),
+        };
+        SetIdMethod.Invoke(agent, [ActorId]);
+        await agent.ActivateAsync();
+        return agent;
+    }
+
+    private static CreateWorkOrder BuildCreate(Timestamp? timeoutAtUtc)
+    {
+        var requestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        return new CreateWorkOrder
+        {
+            WorkOrderId = WorkOrderId,
+            DedupKey = DedupKey,
+            ScopeId = ScopeId,
+            TeamId = "team-1",
+            Requester = Principal("requester-1"),
+            MemberId = "member-1",
+            PublishedServiceId = "service-1",
+            WorkflowId = "workflow-1",
+            ServiceRevisionId = "revision-1",
+            ImplementationKind = "workflow",
+            EndpointId = "run",
+            Intent = "Complete the durable work",
+            Input = new WorkOrderServiceInput
+            {
+                Chat = new WorkOrderChatInput { Prompt = "Do the work" },
+            },
+            RequestedAtUtc = requestedAt,
+            TimeoutAtUtc = timeoutAtUtc,
+            ExpectedLifecycleVersion = 0,
+        };
+    }
+
+    private static ReassignWorkOrder BuildReassign(long expectedLifecycleVersion) =>
+        new()
+        {
+            WorkOrderId = WorkOrderId,
+            ExpectedLifecycleVersion = expectedLifecycleVersion,
+            RequestedBy = Principal("requester-1"),
+            MemberId = "member-2",
+            PublishedServiceId = "service-2",
+            WorkflowId = "workflow-2",
+            ServiceRevisionId = "revision-2",
+            ImplementationKind = "workflow",
+        };
+
+    private static CancelWorkOrder BuildCancel(long expectedLifecycleVersion) =>
+        new()
+        {
+            WorkOrderId = WorkOrderId,
+            ExpectedLifecycleVersion = expectedLifecycleVersion,
+            RequestedBy = Principal("requester-1"),
+            Reason = "No longer needed",
+        };
+
+    private static WorkOrderPrincipal Principal(string principalId) =>
+        new()
+        {
+            PrincipalId = principalId,
+            PrincipalKind = "user",
+        };
+
+    private sealed class NoOpCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class NoOpEventPublisher : IEventPublisher
+    {
+        public Task PublishAsync<T>(
+            T evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where T : IMessage => Task.CompletedTask;
+
+        public Task SendToAsync<T>(
+            string targetActorId,
+            T evt,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where T : IMessage => Task.CompletedTask;
+    }
+}

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderCommandServiceTests.cs
@@ -91,7 +91,7 @@ public sealed class WorkOrderCommandServiceTests
     }
 
     [Fact]
-    public async Task CreateAsync_WhenDeadlineMissing_ShouldRejectBeforeActorDispatch()
+    public async Task CreateAsync_WhenDeadlineMissing_ShouldDispatchWithoutInventingOne()
     {
         var bootstrap = new RecordingBootstrap();
         var dispatchPort = new RecordingDispatchPort();
@@ -99,16 +99,16 @@ public sealed class WorkOrderCommandServiceTests
             bootstrap,
             CreateCommandDispatch(dispatchPort));
 
-        var create = () => service.CreateAsync(
+        await service.CreateAsync(
             ScopeId,
             CreateRequest() with { TimeoutAtUtc = null },
             new WorkOrderPrincipalContract("requester-1", "user"),
             CreateAssignment());
 
-        await create.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*deadline*required*");
-        bootstrap.ActorIds.Should().BeEmpty();
-        dispatchPort.Envelopes.Should().BeEmpty();
+        bootstrap.ActorIds.Should().ContainSingle();
+        var command = dispatchPort.Envelopes.Should().ContainSingle().Subject.Payload!
+            .Unpack<CreateWorkOrder>();
+        command.TimeoutAtUtc.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderEndpointsTests.cs
@@ -221,12 +221,6 @@ public sealed class WorkOrderEndpointsTests
         public Task<WorkOrderAcceptedReceipt> ReassignAsync(string scopeId, string workOrderId, ReassignWorkOrderRequest request, WorkOrderPrincipalContract requester, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkOrderAcceptedReceipt> ApproveAsync(string scopeId, string workOrderId, DecideWorkOrderApprovalRequest request, WorkOrderPrincipalContract approver, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkOrderAcceptedReceipt> DenyAsync(string scopeId, string workOrderId, DecideWorkOrderApprovalRequest request, WorkOrderPrincipalContract approver, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
         public Task<WorkOrderAcceptedReceipt> DispatchAsync(string scopeId, string workOrderId, DispatchWorkOrderRequest request, WorkOrderPrincipalContract requester, CancellationToken ct = default) =>
             DispatchException is null
                 ? throw new NotSupportedException()

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderGAgentTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderGAgentTests.cs
@@ -5,8 +5,8 @@ using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Runtime.Persistence;
-using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgents.WorkOrder;
+using Aevatar.GAgentService.Abstractions;
 using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Google.Protobuf;
@@ -31,83 +31,6 @@ public sealed class WorkOrderGAgentTests
     private static readonly MethodInfo TransitionStateMethod = typeof(WorkOrderGAgent)
         .GetMethod("TransitionState", BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("WorkOrderGAgent.TransitionState was not found.");
-
-    [Fact]
-    public async Task CreateAndApprove_ShouldPreserveSeparateIdentitiesAndAdvanceVersion()
-    {
-        var agent = await CreateAgentAsync();
-        var create = BuildCreate(requiresApproval: true);
-
-        await agent.HandleCreateAsync(create);
-
-        agent.State.WorkOrderId.Should().Be(WorkOrderId);
-        agent.State.ScopeId.Should().Be(ScopeId);
-        agent.State.TeamId.Should().Be("team-1");
-        agent.State.Requester.PrincipalId.Should().Be("requester-1");
-        agent.State.MemberId.Should().Be("member-1");
-        agent.State.WorkflowId.Should().Be("workflow-1");
-        agent.State.PublishedServiceId.Should().Be("service-1");
-        agent.State.Approval.ApprovalId.Should().Be(WorkOrderConventions.BuildApprovalId(WorkOrderId));
-        agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.WaitingApproval);
-        agent.State.LifecycleVersion.Should().Be(2);
-
-        await agent.HandleApproveAsync(new ApproveWorkOrder
-        {
-            WorkOrderId = WorkOrderId,
-            ExpectedLifecycleVersion = 2,
-            DecisionId = "decision-1",
-            DecidedBy = Principal("approver-1"),
-            Reason = "approved",
-        });
-
-        agent.State.Approval.Status.Should().Be(WorkOrderApprovalStatus.Approved);
-        agent.State.Approval.DecisionId.Should().Be("decision-1");
-        agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Ready);
-        agent.State.LifecycleVersion.Should().Be(3);
-    }
-
-    [Fact]
-    public async Task Deny_ShouldBecomeTerminalWithoutAuthorizingDispatch()
-    {
-        var agent = await CreateAgentAsync();
-        await agent.HandleCreateAsync(BuildCreate(requiresApproval: true));
-
-        await agent.HandleDenyAsync(new DenyWorkOrder
-        {
-            WorkOrderId = WorkOrderId,
-            ExpectedLifecycleVersion = 2,
-            DecisionId = "decision-denied",
-            DecidedBy = Principal("approver-1"),
-            Reason = "not authorized",
-        });
-
-        agent.State.Approval.Status.Should().Be(WorkOrderApprovalStatus.Denied);
-        agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Denied);
-        agent.State.TerminalReason.Should().Be("not authorized");
-    }
-
-    [Fact]
-    public async Task Approval_ShouldContinueAfterActorRestart()
-    {
-        var eventStore = new InMemoryEventStore();
-        var original = await CreateAgentAsync(eventStore: eventStore);
-        await original.HandleCreateAsync(BuildCreate(requiresApproval: true));
-
-        var recovered = await CreateAgentAsync(eventStore: eventStore);
-        await recovered.HandleApproveAsync(new ApproveWorkOrder
-        {
-            WorkOrderId = WorkOrderId,
-            ExpectedLifecycleVersion = 2,
-            DecisionId = "decision-after-restart",
-            DecidedBy = Principal("approver-1"),
-            Reason = "approved after recovery",
-        });
-
-        recovered.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Ready);
-        recovered.State.Approval.Status.Should().Be(WorkOrderApprovalStatus.Approved);
-        recovered.State.Approval.DecisionId.Should().Be("decision-after-restart");
-        recovered.State.Approval.DecidedBy.PrincipalId.Should().Be("approver-1");
-    }
 
     [Fact]
     public async Task Reassign_ShouldRejectStaleConcurrentCommand()
@@ -205,19 +128,20 @@ public sealed class WorkOrderGAgentTests
     }
 
     [Fact]
-    public async Task CreateWorkOrder_WithoutDeadline_ShouldRejectBeforePersisting()
+    public async Task CreateWorkOrder_WithoutDeadline_ShouldPersistReadyStateWithoutInventingDeadline()
     {
         var eventStore = new InMemoryEventStore();
         var agent = await CreateAgentAsync(eventStore: eventStore);
         var command = BuildCreate();
         command.TimeoutAtUtc = null;
 
-        var create = () => agent.HandleCreateAsync(command);
+        await agent.HandleCreateAsync(command);
 
-        await create.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*timeout_at_utc*required*");
-        agent.State.WorkOrderId.Should().BeEmpty();
-        (await eventStore.GetEventsAsync(ActorId, ct: CancellationToken.None)).Should().BeEmpty();
+        agent.State.WorkOrderId.Should().Be(WorkOrderId);
+        agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Ready);
+        agent.State.LifecycleVersion.Should().Be(2);
+        agent.State.TimeoutAtUtc.Should().BeNull();
+        (await eventStore.GetEventsAsync(ActorId, ct: CancellationToken.None)).Should().HaveCount(2);
     }
 
     [Fact]
@@ -237,7 +161,7 @@ public sealed class WorkOrderGAgentTests
     }
 
     [Fact]
-    public async Task DispatchAndTerminalEvidence_ShouldLinkRunAndDeclaredArtifacts()
+    public async Task DispatchAndRunOutcome_ShouldLinkRunWithoutCopyingTerminalPayload()
     {
         var scheduler = new RecordingExecutionScheduler();
         var agent = await CreateDispatchPendingAgentAsync(scheduler);
@@ -249,8 +173,8 @@ public sealed class WorkOrderGAgentTests
         await agent.HandleExecutionAcceptedAsync(BuildAcceptedContinuation(agent.State));
 
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        agent.State.Execution.RunId.Should().Be(RequestedRunId);
-        agent.State.Execution.CommandId.Should().Be(DispatchCommandId);
+        agent.State.Run.RunId.Should().Be(RequestedRunId);
+        agent.State.Run.CommandId.Should().Be(DispatchCommandId);
         scheduler.Requests.Should().ContainSingle();
 
         await agent.HandleWorkflowStartedAsync(BuildWorkflowStarted());
@@ -270,11 +194,9 @@ public sealed class WorkOrderGAgentTests
         });
 
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Completed);
-        agent.State.TerminalEvidence.RunId.Should().Be(RequestedRunId);
-        agent.State.TerminalEvidence.CorrelationId.Should().Be(DispatchCommandId);
-        agent.State.TerminalEvidence.Output.Should().Be("done");
-        agent.State.TerminalEvidence.ResultArtifacts.Should().ContainSingle()
-            .Which.ArtifactId.Should().Be("result-1");
+        agent.State.RunOutcome.RunId.Should().Be(RequestedRunId);
+        agent.State.RunOutcome.CorrelationId.Should().Be(DispatchCommandId);
+        agent.State.RunOutcome.Outcome.Should().Be(WorkOrderTerminalOutcome.Succeeded);
     }
 
     [Fact]
@@ -284,8 +206,7 @@ public sealed class WorkOrderGAgentTests
 
         await agent.HandleExecutionAcceptedAsync(BuildAcceptedContinuation(agent.State));
 
-        agent.State.Execution.RunId.Should().Be(RequestedRunId);
-        agent.State.Execution.StartedAtUtc.Should().BeNull();
+        agent.State.Run.RunId.Should().Be(RequestedRunId);
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
     }
 
@@ -303,7 +224,7 @@ public sealed class WorkOrderGAgentTests
 
         scheduler.Requests.Should().ContainSingle();
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        agent.State.Execution.RunId.Should().BeEmpty();
+        agent.State.Run.Should().BeNull();
     }
 
     [Fact]
@@ -398,6 +319,31 @@ public sealed class WorkOrderGAgentTests
         var retry = callbackScheduler.Timeouts.Should().ContainSingle().Subject;
         retry.CallbackId.Should().Be(agent.State.ExecutionRetryCallbackId);
         retry.TriggerEnvelope.Payload.Unpack<WorkOrderExecutionRetryFired>().Attempt.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteWorkOrder_WhenQueueFullWithoutDeadline_ShouldScheduleDurableRetry()
+    {
+        var scheduler = new RecordingExecutionScheduler(queueFull: true);
+        var callbackScheduler = new RecordingCallbackScheduler();
+        var create = BuildCreate();
+        create.TimeoutAtUtc = null;
+        var agent = await CreateDispatchPendingAgentAsync(
+            scheduler,
+            callbackScheduler,
+            create: create);
+
+        await agent.HandleExecuteAsync(new ExecuteWorkOrder
+        {
+            WorkOrderId = agent.State.WorkOrderId,
+            DispatchCommandId = agent.State.DispatchCommandId,
+        });
+
+        agent.State.TimeoutAtUtc.Should().BeNull();
+        agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
+        agent.State.ExecutionRetryAttempt.Should().Be(1);
+        callbackScheduler.Timeouts.Should().ContainSingle()
+            .Which.TriggerEnvelope.Payload.Unpack<WorkOrderExecutionRetryFired>().Attempt.Should().Be(1);
     }
 
     [Fact]
@@ -623,17 +569,17 @@ public sealed class WorkOrderGAgentTests
     {
         var current = BuildRetryState(attempt: 4);
         current.LifecycleStatus = WorkOrderLifecycleStatus.Running;
-        current.Execution = new WorkOrderExecutionProvenance
+        current.Run = new WorkOrderRunLink
         {
             RunId = RequestedRunId,
             RunActorId = "workflow-run-actor-1",
             CommandId = DispatchCommandId,
             CorrelationId = DispatchCommandId,
         };
-        var terminal = new WorkOrderTerminalEvidenceRecordedEvent
+        var terminal = new WorkOrderRunOutcomeObservedEvent
         {
             LifecycleStatus = WorkOrderLifecycleStatus.Completed,
-            Evidence = new WorkOrderTerminalEvidence
+            Outcome = new WorkOrderRunOutcomeReference
             {
                 DeliveryId = TerminalDeliveryId,
                 RunId = RequestedRunId,
@@ -701,12 +647,11 @@ public sealed class WorkOrderGAgentTests
         await agent.HandleWorkflowStartedAsync(started.Clone());
 
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Running);
-        agent.State.Execution.StartedAtUtc.Should().Be(started.StartedAt);
         agent.State.LifecycleVersion.Should().Be(startedVersion);
     }
 
     [Fact]
-    public async Task TerminalEvidenceBeforeStarted_ShouldConvergeWithoutInventingStartTime()
+    public async Task RunOutcomeBeforeStarted_ShouldRemainTerminalWhenStartedArrivesLate()
     {
         var agent = await CreateAcceptedDispatchAgentAsync();
 
@@ -723,15 +668,16 @@ public sealed class WorkOrderGAgentTests
         });
 
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Completed);
-        agent.State.Execution.StartedAtUtc.Should().BeNull();
+        agent.State.RunOutcome.Outcome.Should().Be(WorkOrderTerminalOutcome.Succeeded);
         var terminalUpdatedAt = agent.State.UpdatedAtUtc.Clone();
+        var terminalVersion = agent.State.LifecycleVersion;
 
         var started = BuildWorkflowStarted();
         await agent.HandleWorkflowStartedAsync(started);
 
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Completed);
-        agent.State.Execution.StartedAtUtc.Should().Be(started.StartedAt);
         agent.State.UpdatedAtUtc.Should().Be(terminalUpdatedAt);
+        agent.State.LifecycleVersion.Should().Be(terminalVersion);
     }
 
     [Fact]
@@ -755,7 +701,7 @@ public sealed class WorkOrderGAgentTests
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*publisher*does not match*");
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        agent.State.TerminalEvidence.Should().BeNull();
+        agent.State.RunOutcome.Should().BeNull();
     }
 
     [Fact]
@@ -769,7 +715,6 @@ public sealed class WorkOrderGAgentTests
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*publisher*does not match*");
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        agent.State.Execution.StartedAtUtc.Should().BeNull();
     }
 
     [Fact]
@@ -796,11 +741,11 @@ public sealed class WorkOrderGAgentTests
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*publisher*does not match*");
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        agent.State.TerminalEvidence.Should().BeNull();
+        agent.State.RunOutcome.Should().BeNull();
     }
 
     [Fact]
-    public async Task TerminalEvidence_ShouldRejectMismatchedRunActorIdentity()
+    public async Task RunOutcome_ShouldRejectMismatchedRunActorIdentity()
     {
         var agent = await CreateAcceptedDispatchAgentAsync();
         await agent.HandleWorkflowStartedAsync(BuildWorkflowStarted());
@@ -819,7 +764,7 @@ public sealed class WorkOrderGAgentTests
         await record.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*does not match*Run identity*");
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.Running);
-        agent.State.TerminalEvidence.Should().BeNull();
+        agent.State.RunOutcome.Should().BeNull();
     }
 
     [Fact]
@@ -841,7 +786,7 @@ public sealed class WorkOrderGAgentTests
 
         scheduler.Requests.Should().ContainSingle();
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.DispatchPending);
-        agent.State.Execution.RunId.Should().Be(RequestedRunId);
+        agent.State.Run.RunId.Should().Be(RequestedRunId);
     }
 
     [Fact]
@@ -856,7 +801,6 @@ public sealed class WorkOrderGAgentTests
         create.ScopeId = scopeId;
         create.DedupKey = dedupKey;
         create.WorkOrderId = workOrderId;
-        create.ApprovalId = WorkOrderConventions.BuildApprovalId(workOrderId);
         await agent.HandleCreateAsync(create);
         var dispatch = new DispatchWorkOrder
         {
@@ -902,7 +846,7 @@ public sealed class WorkOrderGAgentTests
     }
 
     [Fact]
-    public async Task TimeoutThenTerminalEvidence_ShouldKeepTimedOutAndRecordLateEvidence()
+    public async Task TimeoutThenRunOutcome_ShouldKeepTimedOutAndRecordLateReference()
     {
         var requestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(-2));
         var past = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(-1));
@@ -930,8 +874,9 @@ public sealed class WorkOrderGAgentTests
         });
 
         agent.State.LifecycleStatus.Should().Be(WorkOrderLifecycleStatus.TimedOut);
-        agent.State.TerminalEvidence.Should().BeNull();
-        agent.State.LateTerminalEvidence.Error.Should().Be("late failure");
+        agent.State.RunOutcome.Should().BeNull();
+        agent.State.LateRunOutcome.DeliveryId.Should().Be(TerminalDeliveryId);
+        agent.State.LateRunOutcome.Outcome.Should().Be(WorkOrderTerminalOutcome.Failed);
     }
 
     [Fact]
@@ -961,7 +906,7 @@ public sealed class WorkOrderGAgentTests
     }
 
     [Fact]
-    public void ProtobufContracts_ShouldRoundTripDistinctIdentityAndEvidenceFields()
+    public void ProtobufContracts_ShouldRoundTripDistinctIdentityAndRunReferenceFields()
     {
         var state = new WorkOrderState
         {
@@ -972,13 +917,12 @@ public sealed class WorkOrderGAgentTests
             MemberId = "member-1",
             WorkflowId = "workflow-1",
             PublishedServiceId = "service-1",
-            Approval = new WorkOrderApprovalState { ApprovalId = "approval-1" },
-            Execution = new WorkOrderExecutionProvenance { RunId = "run-1" },
+            Run = new WorkOrderRunLink { RunId = "run-1" },
             ExecutionRetryAttempt = 3,
             ExecutionRetryCallbackId = "retry-3",
             ExecutionRetryAtUtc = Timestamp.FromDateTimeOffset(
                 DateTimeOffset.Parse("2099-01-01T00:00:03Z")),
-            TerminalEvidence = new WorkOrderTerminalEvidence
+            RunOutcome = new WorkOrderRunOutcomeReference
             {
                 DeliveryId = "delivery-1",
                 RunId = "run-1",
@@ -993,12 +937,11 @@ public sealed class WorkOrderGAgentTests
         restored.MemberId.Should().Be("member-1");
         restored.WorkflowId.Should().Be("workflow-1");
         restored.PublishedServiceId.Should().Be("service-1");
-        restored.Approval.ApprovalId.Should().Be("approval-1");
-        restored.Execution.RunId.Should().Be("run-1");
+        restored.Run.RunId.Should().Be("run-1");
         restored.ExecutionRetryAttempt.Should().Be(3);
         restored.ExecutionRetryCallbackId.Should().Be("retry-3");
-        restored.TerminalEvidence.DeliveryId.Should().Be("delivery-1");
-        restored.TerminalEvidence.CorrelationId.Should().Be("correlation-1");
+        restored.RunOutcome.DeliveryId.Should().Be("delivery-1");
+        restored.RunOutcome.CorrelationId.Should().Be("correlation-1");
     }
 
     private static async Task<WorkOrderGAgent> CreateDispatchPendingAgentAsync(
@@ -1075,7 +1018,7 @@ public sealed class WorkOrderGAgentTests
         return agent;
     }
 
-    private static CreateWorkOrder BuildCreate(bool requiresApproval = false)
+    private static CreateWorkOrder BuildCreate()
     {
         var requestedAt = DateTimeOffset.UtcNow;
         var command = new CreateWorkOrder
@@ -1096,8 +1039,6 @@ public sealed class WorkOrderGAgentTests
             {
                 Chat = new WorkOrderChatInput { Prompt = "do the work" },
             },
-            PermissionPlan = new WorkOrderPermissionPlan(),
-            ApprovalId = WorkOrderConventions.BuildApprovalId(WorkOrderId),
             RequestedAtUtc = Timestamp.FromDateTimeOffset(requestedAt),
             TimeoutAtUtc = Timestamp.FromDateTimeOffset(requestedAt.AddHours(1)),
             ExpectedLifecycleVersion = 0,
@@ -1107,24 +1048,6 @@ public sealed class WorkOrderGAgentTests
             ArtifactId = "result-1",
             ArtifactKind = "report",
         });
-        if (requiresApproval)
-        {
-            command.PermissionPlan.ExternalActions.Add(new WorkOrderExternalActionReference
-            {
-                ActionId = "action-1",
-                System = "github",
-                Action = "write",
-                ResourceId = "repo-1",
-            });
-            command.PermissionPlan.Requirements.Add(new WorkOrderPermissionRequirement
-            {
-                PermissionId = "permission-1",
-                ActionId = "action-1",
-                Capability = "repository.write",
-                RequiresApproval = true,
-            });
-            command.PermissionPlan.ApproverPrincipalIds.Add("approver-1");
-        }
         return command;
     }
 
@@ -1210,7 +1133,6 @@ public sealed class WorkOrderGAgentTests
             RequestedRunId = RequestedRunId,
             LifecycleStatus = WorkOrderLifecycleStatus.DispatchPending,
             LifecycleVersion = 7,
-            Execution = new WorkOrderExecutionProvenance(),
             ExecutionRetryAttempt = attempt,
             ExecutionRetryCallbackId = $"retry-{attempt}",
             ExecutionRetryAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderProjectionTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderProjectionTests.cs
@@ -69,8 +69,8 @@ public sealed class WorkOrderProjectionTests
         document.WorkflowId.Should().Be("workflow-1");
         document.PublishedServiceId.Should().Be("service-1");
         document.RunId.Should().Be("run-1");
-        document.RunStartedAtUnixMs.Should().Be(workOrderUpdatedAt.AddMinutes(-2).ToUnixTimeMilliseconds());
-        document.TerminalEvidence!.CorrelationId.Should().Be("correlation-1");
+        document.RunAcceptedAtUnixMs.Should().Be(workOrderUpdatedAt.AddMinutes(-1).ToUnixTimeMilliseconds());
+        document.RunOutcome!.CorrelationId.Should().Be("correlation-1");
         document.UpdatedAt!.ToDateTimeOffset().Should().Be(projectionObservedAt);
         document.WorkOrderUpdatedAtUtc!.ToDateTimeOffset().Should().Be(workOrderUpdatedAt);
     }
@@ -100,10 +100,9 @@ public sealed class WorkOrderProjectionTests
             EndpointId = "chat",
             Intent = "Produce the report",
             DedupKey = "dedup-1",
-            LifecycleStatus = WorkOrderLifecycleStatusNames.Running,
+            LifecycleStatus = WorkOrderLifecycleStatusNames.Completed,
             LifecycleVersion = 5,
             CreatedAtUnixMs = workOrderUpdatedAt.AddHours(-1).ToUnixTimeMilliseconds(),
-            ApprovalStatus = WorkOrderApprovalStatusNames.NotRequired,
             RunId = "run-1",
             RunActorId = "run-1",
             RunCommandId = "command-1",
@@ -111,8 +110,7 @@ public sealed class WorkOrderProjectionTests
             RunRevisionId = "revision-1",
             RunDeploymentId = "deployment-1",
             RunAcceptedAtUnixMs = workOrderUpdatedAt.AddMinutes(-1).ToUnixTimeMilliseconds(),
-            RunStartedAtUnixMs = workOrderUpdatedAt.ToUnixTimeMilliseconds(),
-            TerminalEvidence = new WorkOrderTerminalEvidenceDocument
+            RunOutcome = new WorkOrderRunOutcomeReferenceDocument
             {
                 DeliveryId = "delivery-1",
                 RunId = "run-1",
@@ -130,7 +128,7 @@ public sealed class WorkOrderProjectionTests
             ScopeId,
             new WorkOrderQueryRequest(
                 PageSize: 25,
-                Status: WorkOrderLifecycleStatusNames.Running,
+                Status: WorkOrderLifecycleStatusNames.Completed,
                 RequesterPrincipalId: "requester-1",
                 TeamId: "team-1",
                 MemberId: "member-1",
@@ -147,9 +145,8 @@ public sealed class WorkOrderProjectionTests
         response.MemberId.Should().Be("member-1");
         response.WorkflowId.Should().Be("workflow-1");
         response.PublishedServiceId.Should().Be("service-1");
-        response.Execution!.RunId.Should().Be("run-1");
-        response.Execution.StartedAtUtc.Should().Be(workOrderUpdatedAt);
-        response.TerminalEvidence!.CorrelationId.Should().Be("correlation-1");
+        response.Run!.RunId.Should().Be("run-1");
+        response.RunOutcome!.CorrelationId.Should().Be("correlation-1");
         reader.LastQuery!.Take.Should().Be(25);
         reader.LastQuery.Filters.Select(static filter => filter.FieldPath).Should().BeEquivalentTo(
             "scope_id",
@@ -187,16 +184,11 @@ public sealed class WorkOrderProjectionTests
             {
                 Chat = new WorkOrderChatInput { Prompt = "Create it" },
             },
-            PermissionPlan = new WorkOrderPermissionPlan(),
-            Approval = new WorkOrderApprovalState
-            {
-                Status = WorkOrderApprovalStatus.NotRequired,
-            },
-            LifecycleStatus = WorkOrderLifecycleStatus.Running,
+            LifecycleStatus = WorkOrderLifecycleStatus.Completed,
             LifecycleVersion = 5,
             CreatedAtUtc = Timestamp.FromDateTimeOffset(updatedAt.AddHours(-1)),
             UpdatedAtUtc = Timestamp.FromDateTimeOffset(updatedAt),
-            Execution = new WorkOrderExecutionProvenance
+            Run = new WorkOrderRunLink
             {
                 RunId = "run-1",
                 RunActorId = "run-1",
@@ -205,9 +197,8 @@ public sealed class WorkOrderProjectionTests
                 RevisionId = "revision-1",
                 DeploymentId = "deployment-1",
                 AcceptedAtUtc = Timestamp.FromDateTimeOffset(updatedAt.AddMinutes(-1)),
-                StartedAtUtc = Timestamp.FromDateTimeOffset(updatedAt.AddMinutes(-2)),
             },
-            TerminalEvidence = new WorkOrderTerminalEvidence
+            RunOutcome = new WorkOrderRunOutcomeReference
             {
                 DeliveryId = "delivery-1",
                 RunId = "run-1",

--- a/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderProjectionTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkOrders/WorkOrderProjectionTests.cs
@@ -76,6 +76,72 @@ public sealed class WorkOrderProjectionTests
     }
 
     [Fact]
+    public async Task ProjectAsync_ShouldNotInventRunOrDeadlineForPreDispatchWorkOrder()
+    {
+        var projectionObservedAt = DateTimeOffset.Parse("2026-07-17T10:00:00Z");
+        var dispatcher = new RecordingWriteDispatcher();
+        var projector = new WorkOrderCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(projectionObservedAt));
+        var state = BuildState(projectionObservedAt);
+        state.LifecycleStatus = WorkOrderLifecycleStatus.Ready;
+        state.Run = null;
+        state.RunOutcome = null;
+        state.LateRunOutcome = null;
+        state.TimeoutAtUtc = null;
+
+        await projector.ProjectAsync(
+            new StudioMaterializationContext
+            {
+                RootActorId = ActorId,
+                ProjectionKind = WorkOrderGAgent.ProjectionKind,
+            },
+            WrapCommitted(state, projectionObservedAt));
+
+        var document = dispatcher.Upserts.Should().ContainSingle().Subject;
+        document.LifecycleStatus.Should().Be(WorkOrderLifecycleStatusNames.Ready);
+        document.RunId.Should().BeEmpty();
+        document.RunActorId.Should().BeEmpty();
+        document.RunCommandId.Should().BeEmpty();
+        document.RunCorrelationId.Should().BeEmpty();
+        document.RunRevisionId.Should().BeEmpty();
+        document.RunDeploymentId.Should().BeEmpty();
+        document.RunAcceptedAtUnixMs.Should().Be(0);
+        document.RunOutcome.Should().BeNull();
+        document.LateRunOutcome.Should().BeNull();
+        document.TimeoutAtUnixMs.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(WorkOrderTerminalOutcome.Succeeded, "succeeded")]
+    [InlineData(WorkOrderTerminalOutcome.Failed, "failed")]
+    [InlineData(WorkOrderTerminalOutcome.Stopped, "stopped")]
+    [InlineData(WorkOrderTerminalOutcome.Unspecified, "")]
+    public async Task ProjectAsync_ShouldMapRunOutcomeToWireName(
+        WorkOrderTerminalOutcome outcome,
+        string expectedWireName)
+    {
+        var projectionObservedAt = DateTimeOffset.Parse("2026-07-17T10:00:00Z");
+        var dispatcher = new RecordingWriteDispatcher();
+        var projector = new WorkOrderCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(projectionObservedAt));
+        var state = BuildState(projectionObservedAt);
+        state.RunOutcome!.Outcome = outcome;
+
+        await projector.ProjectAsync(
+            new StudioMaterializationContext
+            {
+                RootActorId = ActorId,
+                ProjectionKind = WorkOrderGAgent.ProjectionKind,
+            },
+            WrapCommitted(state, projectionObservedAt));
+
+        dispatcher.Upserts.Should().ContainSingle().Subject.RunOutcome!.Outcome
+            .Should().Be(expectedWireName);
+    }
+
+    [Fact]
     public async Task ListAsync_ShouldFilterCurrentStateAndReturnAuthoritativeUpdatedAt()
     {
         var workOrderUpdatedAt = DateTimeOffset.Parse("2026-07-17T09:00:00Z");


### PR DESCRIPTION
## Problem

WorkOrder must remain a first-class, indefinitely durable user-intent resource: it can exist before any Run, omit a deadline, and be reassigned or cancelled before dispatch. Its previous contract also duplicated approval authority, Run payloads, and artifact outcomes that belong to Workflow/Run and ContentArtifact authorities.

## Solution

- Keep one actor-owned WorkOrder lifecycle for intent, requester identity, validated assignment snapshots, dispatch coordination, optional timeout, cancellation, and reassignment.
- Replace copied execution and terminal payload state with `WorkOrderRunLink` and a seven-field `WorkOrderRunOutcomeReference`.
- Remove WorkOrder permission plans, approval commands/states, approval service methods, and `:approve` / `:deny` endpoints without compatibility aliases.
- Preserve approval and execution authority in Workflow/Run, result content and provenance in ContentArtifact, and membership/callability authority in Team/member read models.
- Allow `timeoutAtUtc` to remain absent. Only the existing completion-notification transport boundary maps an absent deadline to `long.MaxValue` because that boundary requires a positive expiration.
- Preserve the existing `Command -> committed event -> current-state read model` projection path and exact Run/publisher identity validation.

## Affected paths

- `agents/Aevatar.GAgents.WorkOrder`
- `src/Aevatar.Studio.Application`
- `src/Aevatar.Studio.Hosting`
- `src/Aevatar.Studio.Projection`
- WorkOrder and ServiceRun integration tests
- `docs/canon/work-orders.md`

## Verification

Passed locally after rebasing onto `origin/feature/integrate`:

- `dotnet build aevatar.slnx --nologo --no-restore`: `0` errors, `226` existing warnings.
- Studio WorkOrder tests: `84/84` passed.
- ServiceRun WorkOrder integration: `1/1` passed.
- No-deadline queue-full retry regression: verified RED against the former deadline-required guard and GREEN with the deadline-independent retry path.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `bash tools/ci/architecture_guards.sh`: passed, including `15/15` architecture tests and the query/projection guards.
- `bash tools/docs/lint.sh`: passed, `82` files checked with `0` errors.
- `git diff --check`: passed.

`dotnet test aevatar.slnx --nologo --no-build` ran the full solution locally. Every test project passed except five positive-path `AgentProfileRolloutProvisioningTests`: the copied `Grpc.Tools` `protoc` is a macOS x86_64 executable and fails on this Apple Silicon host with `Bad CPU type in executable`. With `PROTOC=/opt/homebrew/bin/protoc`, that fixture passed `22/23`; only the test that deliberately clears `PROTOC` and `PATH` to force the incompatible bundled executable remained red. This branch does not change the failing test, rollout tool, or project file. Linux PR CI is the authority for the full-solution result.

## Review requirement

This PR changes Protobuf and public WorkOrder interfaces. It requires two explicit, independent interface approvals before merge. It is not merge-ready until those approvals and required CI checks are recorded.

Related: #2789

Design review: https://github.com/aevatarAI/aevatar/discussions/2878

⟦AI:FKST⟧
