### PR TITLE
fix: show all workflow nodes in execution overview

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -1100,6 +1100,7 @@ const enUSMessages = {
     'Select a log entry to inspect its input, output, and raw event data.',
   'teamMemberWorkflowStudio.executionPanel.steps': 'Steps',
   'teamMemberWorkflowStudio.executionPanel.status.error': 'Error',
+  'teamMemberWorkflowStudio.executionPanel.status.pending': 'Pending',
   'teamMemberWorkflowStudio.executionPanel.status.recorded': 'Recorded',
   'teamMemberWorkflowStudio.executionPanel.status.running': 'Running',
   'teamMemberWorkflowStudio.executionPanel.status.success': 'Success',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -1037,6 +1037,7 @@ const zhCNMessages = {
     '选择一条日志查看它的输入、输出和原始事件数据。',
   'teamMemberWorkflowStudio.executionPanel.steps': '步骤',
   'teamMemberWorkflowStudio.executionPanel.status.error': '错误',
+  'teamMemberWorkflowStudio.executionPanel.status.pending': '待运行',
   'teamMemberWorkflowStudio.executionPanel.status.recorded': '已记录',
   'teamMemberWorkflowStudio.executionPanel.status.running': '运行中',
   'teamMemberWorkflowStudio.executionPanel.status.success': '成功',

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
@@ -7,17 +7,18 @@ import {
   LoadingOutlined,
   PauseCircleOutlined,
 } from "@ant-design/icons";
-import { Alert, Button, Segmented, Tag, Tooltip, Typography, message } from "antd";
+import { Alert, Button, message, Segmented, Tag, Tooltip, Typography } from "antd";
 import React from "react";
 import { t } from "@/shared/i18n/messages";
 import {
   buildExecutionTrace,
+  type ExecutionLogItem,
+  type ExecutionLogStatus,
   formatDurationBetween,
   formatExecutionLogsClipboard,
   normalizeExecutionLogStatus,
-  type ExecutionLogItem,
-  type ExecutionLogStatus,
 } from "@/shared/studio/execution";
+import type { StudioGraphNodeData } from "@/shared/studio/graph";
 import type { StudioExecutionDetail } from "@/shared/studio/models";
 import {
   getUserFacingIdentifierLabel,
@@ -26,16 +27,22 @@ import {
 
 type WorkflowStudioExecutionPanelProps = {
   readonly activeLogIndex?: number | null;
+  readonly clearDisabled?: boolean;
   readonly detail: StudioExecutionDetail | null;
   readonly error?: string;
   readonly height?: number;
   readonly onClear?: () => void;
   readonly onSelectLog?: (index: number | null) => void;
+  readonly workflowNodes?: readonly Pick<
+    StudioGraphNodeData,
+    "stepId" | "stepType" | "subtitle" | "targetRole" | "title"
+  >[];
 };
 
 type OverviewMode = "nodes" | "events";
 type DetailPanelState = "both" | "input" | "output";
 type OverviewEntryType = "node" | "run" | "event";
+type ExecutionOverviewStatus = ExecutionLogStatus | "pending";
 
 type ExecutionOverviewEntry = {
   readonly category: NonNullable<ExecutionLogItem["category"]>;
@@ -46,6 +53,7 @@ type ExecutionOverviewEntry = {
   readonly inputText: string;
   readonly interactionText: string;
   readonly logIndex: number;
+  readonly logIndexes: readonly number[];
   readonly meta: string;
   readonly outputText: string;
   readonly payloadText: string;
@@ -54,8 +62,8 @@ type ExecutionOverviewEntry = {
   readonly rawText: string;
   readonly rowType: OverviewEntryType;
   readonly startedAt: string;
-  readonly status: ExecutionLogStatus;
-  readonly statusLog: ExecutionLogItem;
+  readonly status: ExecutionOverviewStatus;
+  readonly statusLog?: ExecutionLogItem;
   readonly stepId: string;
   readonly subtitle: string;
   readonly title: string;
@@ -70,6 +78,7 @@ type MutableExecutionOverviewEntry = {
   inputText: string;
   interactionText: string;
   logIndex: number;
+  logIndexes: number[];
   meta: string;
   outputText: string;
   payloadText: string;
@@ -78,8 +87,8 @@ type MutableExecutionOverviewEntry = {
   rawText: string;
   rowType: OverviewEntryType;
   startedAt: string;
-  status: ExecutionLogStatus;
-  statusLog: ExecutionLogItem;
+  status: ExecutionOverviewStatus;
+  statusLog?: ExecutionLogItem;
   stepId: string;
   subtitle: string;
   title: string;
@@ -90,6 +99,9 @@ type ExecutionTokenUsage = {
   readonly promptTokens: number;
   readonly totalTokens: number;
 };
+
+type ExecutionPanelCssVariables = React.CSSProperties &
+  Record<`--${string}`, string | number>;
 
 const categoryLabels: Record<NonNullable<ExecutionLogItem["category"]>, string> = {
   custom: "Custom",
@@ -111,8 +123,9 @@ const categoryColors: Record<NonNullable<ExecutionLogItem["category"]>, string> 
   usage: "gold",
 };
 
-const statusColors: Record<ExecutionLogStatus, string> = {
+const statusColors: Record<ExecutionOverviewStatus, string> = {
   error: "red",
+  pending: "default",
   recorded: "default",
   running: "processing",
   success: "green",
@@ -120,6 +133,36 @@ const statusColors: Record<ExecutionLogStatus, string> = {
 };
 
 const nodeDetailBlockHeight = 230;
+const overviewRowHeight = 80;
+const workflowStudioExecutionPanelCss = `
+.workflow-studio-execution-panel__body {
+  grid-template-columns: var(--workflow-execution-panel-columns);
+}
+
+.workflow-studio-execution-panel__overview {
+  border-right: var(--workflow-execution-panel-overview-border-right);
+  grid-template-rows: min-content minmax(0, 1fr);
+}
+
+@media (max-width: 720px) {
+  .workflow-studio-execution-panel__body {
+    align-content: start;
+    grid-auto-rows: max-content;
+    grid-template-columns: minmax(0, 1fr);
+    overflow-y: auto;
+  }
+
+  .workflow-studio-execution-panel__overview {
+    border-bottom: 1px solid #edf2f7;
+    border-right: 0;
+    grid-template-rows: min-content max-content;
+  }
+
+  .workflow-studio-execution-panel__details {
+    min-height: 280px;
+  }
+}
+`;
 
 function formatConsoleDateTime(value: string | null | undefined): string {
   if (!value) {
@@ -164,7 +207,7 @@ function isTerminalStepLog(log: ExecutionLogItem | undefined): boolean {
   return log?.tone === "completed" || log?.tone === "failed";
 }
 
-function readStatusLabel(status: ExecutionLogStatus): string {
+function readStatusLabel(status: ExecutionOverviewStatus): string {
   switch (status) {
     case "error":
       return t("teamMemberWorkflowStudio.executionPanel.status.error", "Error");
@@ -173,6 +216,8 @@ function readStatusLabel(status: ExecutionLogStatus): string {
         "teamMemberWorkflowStudio.executionPanel.status.recorded",
         "Recorded",
       );
+    case "pending":
+      return t("teamMemberWorkflowStudio.executionPanel.status.pending", "Pending");
     case "success":
       return t("teamMemberWorkflowStudio.executionPanel.status.success", "Success");
     case "waiting":
@@ -182,12 +227,14 @@ function readStatusLabel(status: ExecutionLogStatus): string {
   }
 }
 
-function renderStatusIcon(status: ExecutionLogStatus): React.ReactNode {
+function renderStatusIcon(status: ExecutionOverviewStatus): React.ReactNode {
   switch (status) {
     case "error":
       return <CloseCircleOutlined style={{ color: "#dc2626" }} />;
     case "recorded":
       return <CheckCircleOutlined style={{ color: "#64748b" }} />;
+    case "pending":
+      return <ClockCircleOutlined style={{ color: "#94a3b8" }} />;
     case "success":
       return <CheckCircleOutlined style={{ color: "#16a34a" }} />;
     case "waiting":
@@ -301,6 +348,7 @@ function buildOverviewEntries(
         inputText: "",
         interactionText: "",
         logIndex,
+        logIndexes: [logIndex],
         meta: log.meta,
         outputText: category === "output" ? log.clipboardText.trim() : "",
         payloadText: (log.payloadText || log.clipboardText || "").trim(),
@@ -331,6 +379,7 @@ function buildOverviewEntries(
       inputText: log.tone === "started" ? log.clipboardText.trim() : "",
       interactionText: log.tone === "run" ? log.clipboardText.trim() : "",
       logIndex,
+      logIndexes: [logIndex],
       meta: log.meta,
       outputText:
         log.tone === "completed" || log.tone === "failed"
@@ -362,6 +411,7 @@ function buildOverviewEntries(
       activeEntry.eventCount += 1;
       activeEntry.eventType = log.eventType || activeEntry.eventType;
       activeEntry.logIndex = logIndex;
+      activeEntry.logIndexes.push(logIndex);
       activeEntry.meta = log.meta || activeEntry.meta;
       activeEntry.payloadText = (log.payloadText || activeEntry.payloadText).trim();
       activeEntry.previewText = log.previewText || activeEntry.previewText;
@@ -398,41 +448,88 @@ function buildOverviewEntries(
   return entries;
 }
 
+function buildNodeOverviewEntries(
+  entries: readonly ExecutionOverviewEntry[],
+  workflowNodes: WorkflowStudioExecutionPanelProps["workflowNodes"],
+): ExecutionOverviewEntry[] {
+  const loggedNodeEntries = entries.filter((entry) => entry.rowType === "node");
+  if (!workflowNodes?.length) {
+    return loggedNodeEntries;
+  }
+
+  const loggedEntriesByStepId = new Map<string, ExecutionOverviewEntry[]>();
+  loggedNodeEntries.forEach((entry) => {
+    const matchingEntries = loggedEntriesByStepId.get(entry.stepId) ?? [];
+    matchingEntries.push(entry);
+    loggedEntriesByStepId.set(entry.stepId, matchingEntries);
+  });
+
+  const definitionStepIds = new Set<string>();
+  const orderedEntries: ExecutionOverviewEntry[] = [];
+  workflowNodes.forEach((node) => {
+    const stepId = node.stepId.trim();
+    if (!stepId || definitionStepIds.has(stepId)) {
+      return;
+    }
+
+    definitionStepIds.add(stepId);
+    const matchingEntries = loggedEntriesByStepId.get(stepId);
+    if (matchingEntries?.length) {
+      orderedEntries.push(...matchingEntries);
+      return;
+    }
+
+    orderedEntries.push({
+      category: "step",
+      completedAt: "",
+      entryId: `node:${stepId}:pending`,
+      eventCount: 0,
+      eventType: "",
+      inputText: "",
+      interactionText: "",
+      logIndex: -1,
+      logIndexes: [],
+      meta: [node.stepType, node.targetRole].filter(Boolean).join(" · "),
+      outputText: "",
+      payloadText: "",
+      pendingText: "",
+      previewText: "",
+      rawText: "",
+      rowType: "node",
+      startedAt: "",
+      status: "pending",
+      stepId,
+      subtitle: [node.subtitle, node.targetRole].filter(Boolean).join(" · "),
+      title: node.title || stepId,
+    });
+  });
+
+  orderedEntries.push(
+    ...loggedNodeEntries.filter((entry) => !definitionStepIds.has(entry.stepId)),
+  );
+  return orderedEntries;
+}
+
 function findSelectedEntry(
   entries: readonly ExecutionOverviewEntry[],
-  logs: readonly ExecutionLogItem[],
   activeLogIndex: number | null | undefined,
 ): ExecutionOverviewEntry | null {
   if (typeof activeLogIndex !== "number") {
     return null;
   }
 
-  const direct = entries.find((entry) => entry.logIndex === activeLogIndex);
+  const direct = entries.find((entry) => entry.logIndexes.includes(activeLogIndex));
   if (direct) {
     return direct;
   }
-
-  const activeLog = logs[activeLogIndex];
-  if (!activeLog?.stepId) {
-    return null;
-  }
-
-  return entries.find((entry) => entry.stepId === activeLog.stepId) || null;
+  return null;
 }
 
 function isEntrySelected(
   entry: ExecutionOverviewEntry,
   selectedEntry: ExecutionOverviewEntry | null,
 ): boolean {
-  if (!selectedEntry) {
-    return false;
-  }
-
-  if (entry.logIndex === selectedEntry.logIndex) {
-    return true;
-  }
-
-  return Boolean(entry.stepId && entry.stepId === selectedEntry.stepId);
+  return entry.entryId === selectedEntry?.entryId;
 }
 
 function renderMetric(label: string, value: React.ReactNode): React.ReactNode {
@@ -544,6 +641,7 @@ function renderOverviewRow(
   selected: boolean,
   onSelectLog?: (index: number | null) => void,
 ): React.ReactNode {
+  const selectable = entry.logIndex >= 0;
   const duration =
     entry.startedAt && entry.completedAt
       ? formatDurationBetween(entry.startedAt, entry.completedAt)
@@ -553,17 +651,26 @@ function renderOverviewRow(
     <button
       aria-pressed={selected}
       data-testid={`workflow-execution-log-row-${entry.rowType}-${entry.stepId || entry.logIndex}`}
+      disabled={!selectable}
       key={entry.entryId}
-      onClick={() => onSelectLog?.(entry.logIndex)}
+      onClick={() => {
+        if (selectable) {
+          onSelectLog?.(entry.logIndex);
+        }
+      }}
       style={{
         appearance: "none",
         background: selected ? "#eef4ff" : "#ffffff",
         border: `1px solid ${selected ? "#b7cdfd" : "#e5e7eb"}`,
         borderRadius: 6,
+        boxSizing: "border-box",
         color: "inherit",
-        cursor: "pointer",
+        cursor: selectable ? "pointer" : "default",
         display: "grid",
         gap: 6,
+        height: overviewRowHeight,
+        minHeight: overviewRowHeight,
+        overflow: "hidden",
         padding: "8px 10px",
         textAlign: "left",
         width: "100%",
@@ -591,8 +698,12 @@ function renderOverviewRow(
             strong
             style={{
               color: "#111827",
+              display: "block",
               fontSize: 12,
               lineHeight: "17px",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
             }}
           >
             {entry.title}
@@ -618,9 +729,10 @@ function renderOverviewRow(
         style={{
           alignItems: "center",
           display: "flex",
-          flexWrap: "wrap",
+          flexWrap: "nowrap",
           gap: 5,
           minWidth: 0,
+          overflow: "hidden",
         }}
       >
         <Tag color={statusColors[entry.status]} style={{ marginInlineEnd: 0 }}>
@@ -792,11 +904,13 @@ function renderSelectedDetails(
 
 const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> = ({
   activeLogIndex,
+  clearDisabled = false,
   detail,
   error,
   height = 210,
   onClear,
   onSelectLog,
+  workflowNodes,
 }) => {
   const [overviewMode, setOverviewMode] = React.useState<OverviewMode>("nodes");
   const [detailPanelState, setDetailPanelState] =
@@ -804,13 +918,16 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
   const trace = React.useMemo(() => buildExecutionTrace(detail), [detail]);
   const logs = trace?.logs ?? [];
   const entries = React.useMemo(() => buildOverviewEntries(logs), [logs]);
-  const nodeEntries = entries.filter((entry) => entry.rowType === "node");
+  const nodeEntries = React.useMemo(
+    () => buildNodeOverviewEntries(entries, workflowNodes),
+    [entries, workflowNodes],
+  );
   const eventEntries = entries.filter((entry) => entry.rowType !== "node");
   const baseSelectedEntry =
-    findSelectedEntry(entries, logs, activeLogIndex) ||
+    findSelectedEntry(entries, activeLogIndex) ||
     entries.find((entry) => entry.status === "error") ||
-    nodeEntries[0] ||
-    entries[0] ||
+    nodeEntries.find((entry) => entry.logIndex >= 0) ||
+    entries.find((entry) => entry.logIndex >= 0) ||
     null;
   const rawFrames = detail?.frames ?? [];
   const hasExecutionContent = Boolean(error || detail);
@@ -828,8 +945,9 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
       : eventEntries;
   const selectedEntry =
     visibleEntries.find((entry) => isEntrySelected(entry, baseSelectedEntry)) ||
-    visibleEntries[0] ||
-    baseSelectedEntry;
+    visibleEntries.find((entry) => entry.logIndex >= 0) ||
+    (baseSelectedEntry?.status === "error" ? baseSelectedEntry : null);
+  const selectableEntries = visibleEntries.filter((entry) => entry.logIndex >= 0);
   const runStatus: ExecutionLogStatus =
     detail?.status === "failed"
       ? "error"
@@ -838,7 +956,7 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
         : "running";
   const handleOverviewKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      if (!visibleEntries.length || !onSelectLog) {
+      if (!selectableEntries.length || !onSelectLog) {
         return;
       }
 
@@ -847,20 +965,20 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
       }
 
       event.preventDefault();
-      const selectedVisibleIndex = visibleEntries.findIndex((entry) =>
+      const selectedVisibleIndex = selectableEntries.findIndex((entry) =>
         isEntrySelected(entry, selectedEntry),
       );
-      const fallbackIndex = event.key === "ArrowDown" ? -1 : visibleEntries.length;
+      const fallbackIndex = event.key === "ArrowDown" ? -1 : selectableEntries.length;
       const currentIndex =
         selectedVisibleIndex >= 0 ? selectedVisibleIndex : fallbackIndex;
       const nextIndex =
         event.key === "ArrowDown"
-          ? Math.min(currentIndex + 1, visibleEntries.length - 1)
+          ? Math.min(currentIndex + 1, selectableEntries.length - 1)
           : Math.max(currentIndex - 1, 0);
 
-      onSelectLog(visibleEntries[nextIndex]?.logIndex ?? null);
+      onSelectLog(selectableEntries[nextIndex]?.logIndex ?? null);
     },
-    [onSelectLog, selectedEntry, visibleEntries],
+    [onSelectLog, selectableEntries, selectedEntry],
   );
 
   if (!hasExecutionContent) {
@@ -1008,6 +1126,7 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                       "teamMemberWorkflowStudio.executionPanel.clear",
                       "Clear logs",
                     )}
+                    disabled={clearDisabled}
                     icon={<CloseOutlined />}
                     onClick={onClear}
                     size="small"
@@ -1018,25 +1137,33 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
             </div>
 
             <div
-              style={{
-                display: "grid",
-                gap: 0,
-                gridTemplateColumns: selectedEntry
-                  ? "minmax(300px, 0.82fr) minmax(420px, 1.18fr)"
-                  : "minmax(420px, 1fr)",
-                minHeight: 0,
-                minWidth: 0,
-              }}
-            >
-              <section
-                style={{
-                  borderRight: selectedEntry ? "1px solid #edf2f7" : 0,
+              className="workflow-studio-execution-panel__body"
+              style={
+                {
+                  "--workflow-execution-panel-columns": visibleEntries.length
+                    ? "minmax(300px, 0.82fr) minmax(420px, 1.18fr)"
+                    : "minmax(420px, 1fr)",
                   display: "grid",
-                  gridTemplateRows: "min-content minmax(0, 1fr)",
+                  gap: 0,
                   minHeight: 0,
                   minWidth: 0,
-                  padding: "10px 12px 12px",
-                }}
+                } as ExecutionPanelCssVariables
+              }
+            >
+              <section
+                className="workflow-studio-execution-panel__overview"
+                style={
+                  {
+                    "--workflow-execution-panel-overview-border-right":
+                      visibleEntries.length
+                        ? "1px solid #edf2f7"
+                        : "0",
+                    display: "grid",
+                    minHeight: 0,
+                    minWidth: 0,
+                    padding: "10px 12px 12px",
+                  } as ExecutionPanelCssVariables
+                }
               >
                 <div
                   style={{
@@ -1097,6 +1224,8 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                   style={{
                     display: "grid",
                     gap: 8,
+                    alignContent: "start",
+                    gridAutoRows: `${overviewRowHeight}px`,
                     minHeight: 0,
                     overflow: "auto",
                     paddingRight: 3,
@@ -1132,12 +1261,13 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                 </div>
               </section>
 
-              {selectedEntry ? (
+              {visibleEntries.length ? (
                 <section
                   aria-label={t(
                     "teamMemberWorkflowStudio.executionPanel.logDetails",
                     "Log details",
                   )}
+                  className="workflow-studio-execution-panel__details"
                   style={{
                     display: "grid",
                     gridTemplateRows: "min-content minmax(0, 1fr)",
@@ -1165,24 +1295,28 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                         minWidth: 0,
                       }}
                     >
-                      {renderStatusIcon(selectedEntry.status)}
-                      <Typography.Text
-                        strong
-                        style={{
-                          fontSize: 13,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {selectedEntry.title}
-                      </Typography.Text>
-                      <Tag
-                        color={statusColors[selectedEntry.status]}
-                        style={{ marginInlineEnd: 0 }}
-                      >
-                        {readStatusLabel(selectedEntry.status)}
-                      </Tag>
+                      {selectedEntry ? (
+                        <>
+                          {renderStatusIcon(selectedEntry.status)}
+                          <Typography.Text
+                            strong
+                            style={{
+                              fontSize: 13,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {selectedEntry.title}
+                          </Typography.Text>
+                          <Tag
+                            color={statusColors[selectedEntry.status]}
+                            style={{ marginInlineEnd: 0 }}
+                          >
+                            {readStatusLabel(selectedEntry.status)}
+                          </Tag>
+                        </>
+                      ) : null}
                     </div>
                     <div
                       style={{
@@ -1192,7 +1326,7 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                         gap: 8,
                       }}
                     >
-                      {selectedEntry.rowType === "node" ? (
+                      {selectedEntry?.rowType === "node" ? (
                         <div
                           style={{
                             alignItems: "center",
@@ -1247,7 +1381,7 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                           })}
                         </div>
                       ) : null}
-                      {overviewMode === "events" ? (
+                      {overviewMode === "events" && selectedEntry ? (
                         <Tooltip
                           title={t(
                             "teamMemberWorkflowStudio.executionPanel.copySelected",
@@ -1288,6 +1422,7 @@ const WorkflowStudioExecutionPanel: React.FC<WorkflowStudioExecutionPanelProps> 
                 </section>
               ) : null}
             </div>
+            <style>{workflowStudioExecutionPanelCss}</style>
           </>
         ) : null}
       </section>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
@@ -14,11 +14,11 @@ import {
   buildExecutionTrace,
   type ExecutionLogItem,
   type ExecutionLogStatus,
+  type WorkflowExecutionNodeSnapshot,
   formatDurationBetween,
   formatExecutionLogsClipboard,
   normalizeExecutionLogStatus,
 } from "@/shared/studio/execution";
-import type { StudioGraphNodeData } from "@/shared/studio/graph";
 import type { StudioExecutionDetail } from "@/shared/studio/models";
 import {
   getUserFacingIdentifierLabel,
@@ -33,10 +33,7 @@ type WorkflowStudioExecutionPanelProps = {
   readonly height?: number;
   readonly onClear?: () => void;
   readonly onSelectLog?: (index: number | null) => void;
-  readonly workflowNodes?: readonly Pick<
-    StudioGraphNodeData,
-    "stepId" | "stepType" | "subtitle" | "targetRole" | "title"
-  >[];
+  readonly workflowNodes?: readonly WorkflowExecutionNodeSnapshot[];
 };
 
 type OverviewMode = "nodes" | "events";

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -33,17 +33,18 @@ import {
 } from "@/shared/studio/document";
 import {
   buildExecutionTrace,
+  buildWorkflowExecutionNodeSnapshots,
   createStudioExecutionFrame,
   decorateEdgesForExecution,
   decorateNodesForExecution,
   findExecutionLogIndexForStep,
   type ExecutionTrace,
+  type WorkflowExecutionNodeSnapshot,
 } from "@/shared/studio/execution";
 import {
   buildStudioGraphElements,
   buildStudioWorkflowLayout,
   STUDIO_GRAPH_CATEGORIES,
-  type StudioGraphNodeData,
 } from "@/shared/studio/graph";
 import { isStudioApiStatus, studioApi } from "@/shared/studio/api";
 import {
@@ -67,10 +68,6 @@ import type {
 type TeamMemberWorkflowStudioMode = "new" | "existing";
 type WorkflowPublishTone = "default" | "processing" | "success" | "warning" | "error";
 type WorkflowExecutionStatus = "idle" | "running" | "succeeded" | "failed";
-type WorkflowExecutionNode = Pick<
-  StudioGraphNodeData,
-  "stepId" | "stepType" | "subtitle" | "targetRole" | "title"
->;
 
 type SaveWorkflowDraftVariables = {
   readonly document: StudioWorkflowDocument;
@@ -215,7 +212,7 @@ type TeamMemberWorkflowStudioState = {
   readonly currentDraftRunPlaceholderReason: string;
   readonly executionDetail: StudioExecutionDetail | null;
   readonly executionError: string;
-  readonly executionWorkflowNodes: readonly WorkflowExecutionNode[];
+  readonly executionWorkflowNodes: readonly WorkflowExecutionNodeSnapshot[];
   readonly draftRunFiles: readonly File[];
   readonly executionRunMessage: string;
   readonly executionStatus: WorkflowExecutionStatus;
@@ -1098,7 +1095,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     React.useState<StudioExecutionDetail | null>(null);
   const [executionError, setExecutionError] = React.useState("");
   const [executionWorkflowNodes, setExecutionWorkflowNodes] = React.useState<
-    WorkflowExecutionNode[]
+    WorkflowExecutionNodeSnapshot[]
   >([]);
   const [activeExecutionLogIndex, setActiveExecutionLogIndex] =
     React.useState<number | null>(null);
@@ -2353,9 +2350,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       setExecutionDetail(null);
       setExecutionError("");
       setActiveExecutionLogIndex(null);
-      setExecutionWorkflowNodes(
-        buildStudioGraphElements(document).nodes.map((node) => node.data),
-      );
+      setExecutionWorkflowNodes(buildWorkflowExecutionNodeSnapshots(document));
     },
     onSuccess: (detail) => {
       setExecutionDetail(detail);

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -43,6 +43,7 @@ import {
   buildStudioGraphElements,
   buildStudioWorkflowLayout,
   STUDIO_GRAPH_CATEGORIES,
+  type StudioGraphNodeData,
 } from "@/shared/studio/graph";
 import { isStudioApiStatus, studioApi } from "@/shared/studio/api";
 import {
@@ -66,6 +67,10 @@ import type {
 type TeamMemberWorkflowStudioMode = "new" | "existing";
 type WorkflowPublishTone = "default" | "processing" | "success" | "warning" | "error";
 type WorkflowExecutionStatus = "idle" | "running" | "succeeded" | "failed";
+type WorkflowExecutionNode = Pick<
+  StudioGraphNodeData,
+  "stepId" | "stepType" | "subtitle" | "targetRole" | "title"
+>;
 
 type SaveWorkflowDraftVariables = {
   readonly document: StudioWorkflowDocument;
@@ -210,6 +215,7 @@ type TeamMemberWorkflowStudioState = {
   readonly currentDraftRunPlaceholderReason: string;
   readonly executionDetail: StudioExecutionDetail | null;
   readonly executionError: string;
+  readonly executionWorkflowNodes: readonly WorkflowExecutionNode[];
   readonly draftRunFiles: readonly File[];
   readonly executionRunMessage: string;
   readonly executionStatus: WorkflowExecutionStatus;
@@ -1091,6 +1097,9 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const [executionDetail, setExecutionDetail] =
     React.useState<StudioExecutionDetail | null>(null);
   const [executionError, setExecutionError] = React.useState("");
+  const [executionWorkflowNodes, setExecutionWorkflowNodes] = React.useState<
+    WorkflowExecutionNode[]
+  >([]);
   const [activeExecutionLogIndex, setActiveExecutionLogIndex] =
     React.useState<number | null>(null);
   const [executionRunMessage, setExecutionRunMessage] = React.useState("");
@@ -2340,8 +2349,13 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           : "Failed to run workflow draft.",
       );
     },
-    onMutate: () => {
+    onMutate: ({ document }: RunCurrentDraftVariables) => {
+      setExecutionDetail(null);
       setExecutionError("");
+      setActiveExecutionLogIndex(null);
+      setExecutionWorkflowNodes(
+        buildStudioGraphElements(document).nodes.map((node) => node.data),
+      );
     },
     onSuccess: (detail) => {
       setExecutionDetail(detail);
@@ -3209,6 +3223,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     currentDraftRunPlaceholderReason,
     executionDetail,
     executionError,
+    executionWorkflowNodes,
     draftRunFiles,
     executionRunMessage,
     executionStatus,
@@ -3216,6 +3231,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     clearExecutionLogs: () => {
       setExecutionDetail(null);
       setExecutionError("");
+      setExecutionWorkflowNodes([]);
       setActiveExecutionLogIndex(null);
     },
     addDraftRunFiles: (files: readonly File[]) => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1,16 +1,16 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
+import { parseBackendSSEStream } from "@/shared/agui/sseFrameNormalizer";
+import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
+import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
+import { history } from "@/shared/navigation/history";
+import { StudioApiError, studioApi } from "@/shared/studio/api";
 import {
   cleanupTestQueryClients,
   createTestQueryClient,
   renderWithQueryClient,
 } from "../../../tests/reactQueryTestUtils";
-import { parseBackendSSEStream } from "@/shared/agui/sseFrameNormalizer";
-import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
-import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
-import { history } from "@/shared/navigation/history";
 import TeamMemberWorkflowStudioPage from "./index";
-import { StudioApiError, studioApi } from "@/shared/studio/api";
 
 jest.mock("@/shared/graphs/GraphCanvas", () => ({
   __esModule: true,
@@ -4430,7 +4430,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
       name: "Workflow Alpha",
       workflowId: "workflow-alpha",
       yaml: "name: Workflow Alpha\nsteps: []\n",
-      document: mockWorkflowDocument,
+      document: mockBranchingWorkflowDocument,
       updatedAtUtc: "2026-06-08T00:00:00Z",
     });
     (runtimeRunsApi.streamDraftRun as jest.Mock).mockResolvedValue(
@@ -4459,6 +4459,21 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     const consolePanel = await screen.findByLabelText("Draft run console");
     expect(consolePanel).toHaveTextContent("running");
+    expect(
+      within(consolePanel).getByRole("button", { name: "Clear logs" }),
+    ).toBeDisabled();
+    const executionPanelResponsiveRules = findRenderedStyleText(
+      ".workflow-studio-execution-panel__body",
+    );
+    expect(executionPanelResponsiveRules).toContain("@media (max-width: 720px)");
+    expect(executionPanelResponsiveRules).toContain(
+      "grid-template-columns: minmax(0, 1fr);",
+    );
+    expect(executionPanelResponsiveRules).toContain("grid-auto-rows: max-content;");
+    expect(executionPanelResponsiveRules).toContain(
+      "grid-template-rows: min-content max-content;",
+    );
+    expect(executionPanelResponsiveRules).not.toContain("!important");
 
     await act(async () => {
       stream.emit({
@@ -4472,11 +4487,43 @@ describe("TeamMemberWorkflowStudioPage", () => {
       });
       await flushAsyncWork();
     });
-    expect(consolePanel).toHaveTextContent("Run started");
-    expect(consolePanel).toHaveTextContent("RUN_STARTED");
+    fireEvent.click(within(consolePanel).getByRole("radio", { name: "Events" }));
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "Run started",
+    );
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "RUN_STARTED",
+    );
+    fireEvent.click(within(consolePanel).getByRole("radio", { name: "Nodes" }));
+    const pendingTriageRow = within(consolePanel).getByTestId(
+      "workflow-execution-log-row-node-triage",
+    );
+    const pendingGuardRow = within(consolePanel).getByTestId(
+      "workflow-execution-log-row-node-guard",
+    );
+    expect(pendingTriageRow).toHaveTextContent("Pending");
+    expect(pendingGuardRow).toHaveTextContent("Pending");
+    expect(pendingTriageRow).toBeDisabled();
+    expect(pendingGuardRow).toBeDisabled();
+    expect(pendingTriageRow).toHaveStyle({ height: "80px", minHeight: "80px" });
+    expect(pendingGuardRow).toHaveStyle({ height: "80px", minHeight: "80px" });
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "Select a log entry",
+    );
+
+    const confirmSpy = jest
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+    fireEvent.click(screen.getByRole("button", { name: "node:step:guard" }));
+    clickMoreAction("Delete selected node");
+    await waitFor(() => {
+      expect(screen.getByText("nodes:1")).toBeTruthy();
+    });
     expect(
-      within(consolePanel).queryByTestId("workflow-execution-log-row-node-triage"),
-    ).toBeNull();
+      within(consolePanel).getByTestId("workflow-execution-log-row-node-guard"),
+    ).toHaveTextContent("Pending");
+    expect(consolePanel).toHaveTextContent(/Steps\s*2/);
+    confirmSpy.mockRestore();
 
     await act(async () => {
       stream.emit({
@@ -4496,6 +4543,10 @@ describe("TeamMemberWorkflowStudioPage", () => {
       "workflow-execution-log-row-node-triage",
     );
     expect(runningTriageRow).toHaveTextContent("Running");
+    expect(runningTriageRow).toBeEnabled();
+    expect(
+      within(consolePanel).getByTestId("workflow-execution-log-row-node-guard"),
+    ).toHaveTextContent("Pending");
     expect(runningTriageRow).not.toHaveTextContent("Run the workflow");
     fireEvent.click(runningTriageRow);
     expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
@@ -4504,8 +4555,15 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
       "No output captured for this node.",
     );
+    fireEvent.keyDown(within(consolePanel).getByLabelText("Logs overview"), {
+      key: "ArrowDown",
+    });
+    expect(runningTriageRow).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(consolePanel).getByTestId("workflow-execution-log-row-node-guard"),
+    ).toBeDisabled();
     expect(consolePanel).toHaveTextContent(/Events\s*2/);
-    expect(consolePanel).toHaveTextContent(/Steps\s*1/);
+    expect(consolePanel).toHaveTextContent(/Steps\s*2/);
 
     await act(async () => {
       stream.emit({
@@ -4531,11 +4589,71 @@ describe("TeamMemberWorkflowStudioPage", () => {
 
     await act(async () => {
       stream.emit({
+        name: "aevatar.step.request",
+        payload: {
+          input: "Second pass input",
+          stepId: "triage",
+          stepType: "llm_call",
+          targetRole: "assistant",
+        },
+        timestamp: Date.parse("2026-06-08T00:00:03Z"),
+        type: "CUSTOM",
+      });
+      await flushAsyncWork();
+    });
+    let triageAttemptRows = within(consolePanel).getAllByTestId(
+      "workflow-execution-log-row-node-triage",
+    );
+    expect(triageAttemptRows).toHaveLength(2);
+    fireEvent.click(triageAttemptRows[1]);
+    expect(
+      triageAttemptRows.filter((row) => row.getAttribute("aria-pressed") === "true"),
+    ).toHaveLength(1);
+    expect(triageAttemptRows[0]).toHaveAttribute("aria-pressed", "false");
+    expect(triageAttemptRows[1]).toHaveAttribute("aria-pressed", "true");
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "Second pass input",
+    );
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "No output captured for this node.",
+    );
+
+    await act(async () => {
+      stream.emit({
+        name: "aevatar.step.completed",
+        payload: {
+          output: "Second pass output",
+          stepId: "triage",
+          success: true,
+        },
+        timestamp: Date.parse("2026-06-08T00:00:04Z"),
+        type: "CUSTOM",
+      });
+      await flushAsyncWork();
+    });
+    triageAttemptRows = within(consolePanel).getAllByTestId(
+      "workflow-execution-log-row-node-triage",
+    );
+    expect(
+      triageAttemptRows.filter((row) => row.getAttribute("aria-pressed") === "true"),
+    ).toHaveLength(1);
+    expect(triageAttemptRows[0]).toHaveAttribute("aria-pressed", "false");
+    expect(triageAttemptRows[1]).toHaveAttribute("aria-pressed", "true");
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "Second pass input",
+    );
+    expect(within(consolePanel).getByLabelText("Log details")).toHaveTextContent(
+      "Second pass output",
+    );
+    expect(consolePanel).toHaveTextContent(/Steps\s*2/);
+
+    await act(async () => {
+      stream.emit({
         result: {
-          output: "Workflow complete",
+          output: "Second pass output",
         },
         runId: "run-1",
-        timestamp: Date.parse("2026-06-08T00:00:03Z"),
+        timestamp: Date.parse("2026-06-08T00:00:05Z"),
         type: "RUN_FINISHED",
       });
       stream.finish();
@@ -4544,6 +4662,56 @@ describe("TeamMemberWorkflowStudioPage", () => {
     await waitFor(() => {
       expect(consolePanel).toHaveTextContent("succeeded");
     });
+    expect(
+      within(consolePanel).getByRole("button", { name: "Clear logs" }),
+    ).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    const settledDraftRunPanel = await screen.findByLabelText("Draft run panel");
+    await waitFor(() => {
+      expect(
+        within(settledDraftRunPanel).getByRole("button", {
+          name: /Start draft run/,
+        }),
+      ).toBeEnabled();
+    });
+    const startSecondRunButton = within(settledDraftRunPanel).getByRole("button", {
+      name: /Start draft run/,
+    });
+
+    let finishSecondSerialization: (() => void) | undefined;
+    (studioApi.serializeYaml as jest.Mock).mockImplementationOnce(
+      ({ document }) =>
+        new Promise((resolve) => {
+          finishSecondSerialization = () => {
+            resolve({
+              document,
+              findings: [],
+              yaml: `name: ${document.name}\nsteps:\n${(document.steps ?? [])
+                .map(
+                  (step: { id?: string; type?: string }) =>
+                    `  - id: ${step.id}\n    type: ${step.type}`,
+                )
+                .join("\n")}`,
+            });
+          };
+        }),
+    );
+    fireEvent.click(startSecondRunButton);
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Draft run console")).toBeNull();
+    });
+    await act(async () => {
+      finishSecondSerialization?.();
+      await flushAsyncWork();
+    });
+    const secondRunConsole = await screen.findByLabelText("Draft run console");
+    expect(
+      within(secondRunConsole).getByTestId("workflow-execution-log-row-node-triage"),
+    ).toHaveTextContent("Pending");
+    expect(
+      within(secondRunConsole).queryByTestId("workflow-execution-log-row-node-guard"),
+    ).toBeNull();
+    expect(secondRunConsole).toHaveTextContent(/Steps\s*1/);
   });
 
   it("starts a failed draft run from the draft run panel and keeps the error visible", async () => {
@@ -4615,6 +4783,9 @@ describe("TeamMemberWorkflowStudioPage", () => {
       );
     });
     expect(resultPanel).toHaveTextContent("failed");
+    expect(
+      within(resultPanel).getByTestId("workflow-execution-log-row-node-triage"),
+    ).toHaveTextContent("Pending");
     expect(screen.queryByTestId("member-run-summary")).toBeNull();
     expect(resultPanel).not.toHaveTextContent("Member run");
     expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -1,14 +1,14 @@
 import { Alert, Spin } from "antd";
 import React from "react";
+import { t } from "@/shared/i18n/messages";
 import WorkflowStudioCanvas from "./components/WorkflowStudioCanvas";
+import WorkflowStudioDraftRunPanel from "./components/WorkflowStudioDraftRunPanel";
 import WorkflowStudioExecutionPanel from "./components/WorkflowStudioExecutionPanel";
 import WorkflowStudioHeader from "./components/WorkflowStudioHeader";
 import WorkflowStudioNodeDetailPanel from "./components/WorkflowStudioNodeDetailPanel";
 import WorkflowStudioNodeLibrary from "./components/WorkflowStudioNodeLibrary";
-import WorkflowStudioDraftRunPanel from "./components/WorkflowStudioDraftRunPanel";
 import WorkflowStudioYamlPanel from "./components/WorkflowStudioYamlPanel";
 import { useTeamMemberWorkflowStudio } from "./hooks/useTeamMemberWorkflowStudio";
-import { t } from "@/shared/i18n/messages";
 
 const SIDE_PANEL_DEFAULT_WIDTH = 420;
 const SIDE_PANEL_MIN_WIDTH = 320;
@@ -453,11 +453,13 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
       ) : null}
       <WorkflowStudioExecutionPanel
         activeLogIndex={studio.activeExecutionLogIndex}
+        clearDisabled={studio.currentDraftRunPending}
         detail={studio.executionDetail}
         error={studio.executionError}
         height={executionPanelHeight}
         onClear={studio.clearExecutionLogs}
         onSelectLog={studio.selectExecutionLog}
+        workflowNodes={studio.executionWorkflowNodes}
       />
     </main>
   );

--- a/apps/aevatar-console-web/src/shared/studio/execution.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/execution.test.ts
@@ -1,6 +1,7 @@
 import type { Node } from '@xyflow/react';
 import {
   buildExecutionTrace,
+  buildWorkflowExecutionNodeSnapshots,
   decorateNodesForExecution,
   type ExecutionTrace,
 } from './execution';
@@ -49,6 +50,47 @@ describe('buildExecutionTrace', () => {
     expect(outputLog?.clipboardText).toBe('Final answer');
     expect(outputLog?.previewText).toBe('Final answer');
     expect(outputLog?.payloadText).toContain('"stateVersion": 7');
+  });
+});
+
+describe('buildWorkflowExecutionNodeSnapshots', () => {
+  it('builds the submitted node snapshot directly from the workflow document', () => {
+    const snapshots = buildWorkflowExecutionNodeSnapshots({
+      name: 'Workflow Alpha',
+      steps: [
+        {
+          id: ' triage ',
+          type: 'llm_call',
+          targetRole: ' assistant ',
+        },
+        {
+          id: 'validate',
+          originalType: 'workflow_yaml_validate',
+          target_role: ' reviewer ',
+        },
+        {
+          id: '',
+          type: 'emit',
+        },
+      ],
+    });
+
+    expect(snapshots).toEqual([
+      {
+        stepId: 'triage',
+        stepType: 'llm_call',
+        subtitle: 'LLM call',
+        targetRole: 'assistant',
+        title: 'triage',
+      },
+      {
+        stepId: 'validate',
+        stepType: 'workflow_yaml_validate',
+        subtitle: 'Workflow YAML validation',
+        targetRole: 'reviewer',
+        title: 'validate',
+      },
+    ]);
   });
 });
 

--- a/apps/aevatar-console-web/src/shared/studio/execution.ts
+++ b/apps/aevatar-console-web/src/shared/studio/execution.ts
@@ -5,9 +5,56 @@ import {
 } from '@xyflow/react';
 import { AGUIEventType } from '@aevatar-react-sdk/types';
 import type { RuntimeEvent } from "@/shared/agui/runtimeEventSemantics";
-import type { StudioGraphEdgeData, StudioGraphNodeData } from './graph';
-import type { StudioExecutionDetail, StudioExecutionFrame } from './models';
+import {
+  formatStudioStepTypeLabel,
+  type StudioGraphEdgeData,
+  type StudioGraphNodeData,
+} from './graph';
+import type {
+  StudioExecutionDetail,
+  StudioExecutionFrame,
+  StudioWorkflowDocument,
+} from './models';
 import { t } from "@/shared/i18n/messages";
+
+export type WorkflowExecutionNodeSnapshot = {
+  readonly stepId: string;
+  readonly stepType: string;
+  readonly subtitle: string;
+  readonly targetRole: string;
+  readonly title: string;
+};
+
+export function buildWorkflowExecutionNodeSnapshots(
+  document: StudioWorkflowDocument,
+): WorkflowExecutionNodeSnapshot[] {
+  if (!Array.isArray(document.steps)) {
+    return [];
+  }
+
+  return document.steps.flatMap((step) => {
+    const stepId = String(step?.id ?? '').trim();
+    if (!stepId) {
+      return [];
+    }
+
+    const stepType =
+      String(step.type ?? '').trim() ||
+      String(step.originalType ?? '').trim() ||
+      'step';
+    const targetRole = String(step.targetRole ?? step.target_role ?? '').trim();
+
+    return [
+      {
+        stepId,
+        stepType,
+        subtitle: formatStudioStepTypeLabel(stepType),
+        targetRole,
+        title: stepId,
+      },
+    ];
+  });
+}
 
 export type ExecutionLogItem = {
   readonly category?:


### PR DESCRIPTION
## Problem

The Workflow Studio execution Overview was derived only from runtime logs. At run start, untouched workflow nodes were missing and the UI emphasized one oversized first-node detail instead of presenting the submitted graph. Row height was also content-dependent, so the Overview could shift as statuses and long labels arrived.

## Solution

- Capture a run-scoped snapshot of every submitted workflow node before YAML serialization and keep it independent from subsequent canvas edits.
- Reconcile submitted nodes with runtime attempts: definition nodes appear immediately as Pending, matching runtime attempts replace them, and runtime-only nodes append after the definition order.
- Keep distinct retries for the same step selectable through stable per-attempt log-index membership.
- Render every Overview row at a fixed 80px height with clipped, ellipsized content.
- Skip disabled Pending rows during keyboard navigation and disable Clear logs while a draft run is still streaming.
- Stack Overview and details below 720px without changing the desktop information architecture.
- Add localized Pending labels for English and Chinese.

## Impacted paths

- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx`
- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts`
- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx`
- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx`
- `apps/aevatar-console-web/src/locales/en-US.ts`
- `apps/aevatar-console-web/src/locales/zh-CN.ts`

## Verification

- `bash tools/ci/test_stability_guards.sh`: passed.
- Touched-file Biome lint for all six changed files: passed, 6 files checked with no fixes.
- `pnpm --dir apps/aevatar-console-web tsc`: passed on the latest `dev` base.
- Focused Workflow Studio and i18n suites: 97/97 passed.
- `pnpm --dir apps/aevatar-console-web test --runInBand --no-watchman`: 130/130 suites and 1148/1148 tests passed.
- After fast-forwarding the latest unrelated Chat commit from `dev`, Chat and i18n tests passed. A later combined rerun hit two existing Workflow Studio 30-second timeouts under host contention; both unrelated cases passed immediately in isolated reruns, 2/2.
- `pnpm --dir apps/aevatar-console-web build`: passed on the latest `dev` base.
- `git diff --check`: passed.

The full-repository Biome scan has a pre-existing baseline of 89 errors, 82 warnings, and 9 infos outside these touched files. This PR does not change that baseline.

## Coverage

```text
CODE PATH COVERAGE
===========================
[+] Definition reconciliation
    [+] All submitted nodes render Pending at RUN_STARTED
    [+] Runtime entries replace matching Pending nodes
    [+] Runtime-only nodes append after definition nodes
    [+] Repeated step attempts remain separate

[+] Run-scoped lifecycle
    [+] Live canvas edits do not mutate active-run Overview
    [+] Failed runs retain submitted-node context
    [+] New runs clear previous logs before serialization completes
    [+] Clear logs removes the completed execution UI and snapshot
    [+] Clear logs is disabled while a run is streaming

[+] Interaction and layout
    [+] Pending rows are disabled and skipped by keyboard navigation
    [+] Retry selection survives completion frames
    [+] Rows stay at 80px and hide overflowing content
    [+] Mobile breakpoint stacks Overview and details

COVERAGE: 13/13 paths tested (100%)
Coverage gate: PASS
```

## Review results

- Structured review found retry selection could jump to the first attempt. Fixed with per-attempt `logIndexes` membership and a completion-frame regression test.
- Run-lifecycle review found a new snapshot could temporarily pair with previous-run logs. Fixed by resetting execution detail, error, and selection in `onMutate`.
- Adversarial review found live Clear logs could be repopulated by the next SSE frame. Fixed by disabling Clear logs while the mutation is pending.
- Adversarial review found the original 76px geometry could clip Ant Design tags. Fixed by using a measured fixed height of 80px.
- A suggestion to label terminal unvisited branches as Skipped was intentionally not implemented. The backend currently provides no authoritative skipped-node state; step-level `nextStepId` or `branchKey` is not sufficient to infer all terminal node outcomes.

## Manual browser QA

| Viewport | Result |
| --- | --- |
| 1440x900 | All nodes visible; fixed rows; side-by-side details; no overflow |
| 1024x768 | All nodes visible; fixed rows; no overlap |
| 768x1024 | Responsive layout stable; no document overflow |
| 390x844 | Overview stacks above details; no overlap or console errors |

Browser QA observed four nodes, fixed row geometry, no horizontal document overflow, correct mobile stacking, and zero console errors.

## Recurrence prevention

- Immediate symptom: Overview initially omitted untouched nodes and emphasized one large node detail.
- Root cause: Overview was derived only from runtime logs and read the mutable editor graph.
- General failure pattern: execution-scoped UI state was derived from incomplete events and live editor state.
- Similar locations searched: WorkflowStudioExecutionPanel callers, execution selection helpers, and run mutation lifecycle; no sibling implementation found.
- Guard added: run-scoped node snapshot plus unique per-attempt log membership.
- Regression test added: Pending nodes, live graph edits, retry selection, failure context, rerun isolation, live-clear protection, fixed rows, and responsive CSS.
- Hard gate: touched-file Biome, TypeScript, Jest, production build, i18n audit, and test-stability guard.
- Remaining risk: no backend-authored Skipped state for terminal unvisited branches.

## Documentation

No public API, route, configuration, or operator workflow changed. Documentation review is expected to require no repository documentation update.