### PR TITLE
fix(console): scope team automation schedule queries

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -2507,8 +2507,13 @@ describe("TeamDetailPage", () => {
     await waitFor(() => {
       expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
         includeTotalCount: true,
+        scopeId: "scope-1",
         take: 200,
+        teamId: "t-alpha",
       });
+      expect((scheduledDispatchApi.listAll as jest.Mock).mock.calls[0]?.[0]).not.toHaveProperty(
+        "memberId",
+      );
       expect(scopeRuntimeApi.listServices).toHaveBeenCalledWith("scope-1", {
         appId: "default",
       });
@@ -2544,7 +2549,9 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("Other team first page task")).toBeNull();
     expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
       includeTotalCount: true,
+      scopeId: "scope-1",
       take: 200,
+      teamId: "t-alpha",
     });
   });
 
@@ -2704,7 +2711,7 @@ describe("TeamDetailPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/scopes/scope-1/teams/t-alpha?memberId=member-team-alpha&tab=automations",
+      "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/automations",
     );
     (scheduledDispatchApi.listAll as jest.Mock)
       .mockResolvedValueOnce({
@@ -2719,6 +2726,16 @@ describe("TeamDetailPage", () => {
       });
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await waitFor(() => {
+      expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
+        includeTotalCount: true,
+        memberId: "member-team-alpha",
+        scopeId: "scope-1",
+        take: 200,
+        teamId: "t-alpha",
+      });
+    });
 
     fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
     expect(await screen.findByText("1. 目标成员")).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -9,6 +9,7 @@ import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
 import { scheduledDispatchApi } from "@/shared/api/scheduledDispatchApi";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
+import { history } from "@/shared/navigation/history";
 import { studioApi } from "@/shared/studio/api";
 import {
   createTestQueryClient,
@@ -258,6 +259,55 @@ function mockCreateTeamMembersCatalog() {
     ],
     nextPageToken: null,
   };
+}
+
+function mockCreateTeamMembersCatalogWithSecondPublishedMember() {
+  return {
+    ...mockCreateTeamMembersCatalog(),
+    members: [
+      ...mockCreateTeamMembersCatalog().members,
+      {
+        memberId: "member-team-beta",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        displayName: "Team Beta Operator",
+        description: "Handles second-line escalations",
+        implementationKind: "workflow",
+        implementationRef: {
+          implementationKind: "workflow",
+          workflowId: "wf-team-beta",
+          workflowRevision: "rev-beta",
+        },
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "beta-service",
+        lastBoundRevisionId: "rev-beta",
+        createdAt: "2026-04-09T08:00:00Z",
+        updatedAt: "2026-04-09T09:00:00Z",
+      },
+    ],
+  };
+}
+
+function mockCreateServiceCatalogWithSecondPublishedMember() {
+  return [
+    ...mockCreateServiceCatalog(),
+    {
+      serviceKey: "scope-1:default:default:beta-service",
+      tenantId: "scope-1",
+      appId: "default",
+      namespace: "default",
+      serviceId: "beta-service",
+      displayName: "Team Beta Runtime",
+      defaultServingRevisionId: "rev-beta",
+      activeServingRevisionId: "rev-beta",
+      deploymentId: "dep-beta",
+      primaryActorId: "actor-beta",
+      deploymentStatus: "Active",
+      endpoints: [],
+      policyIds: [],
+      updatedAt: "2026-04-09T09:00:00Z",
+    },
+  ];
 }
 
 function mockCreateTeamMembersCatalogWithUnpublishedReadyMember() {
@@ -2555,6 +2605,28 @@ describe("TeamDetailPage", () => {
     });
   });
 
+  it("does not scope Team automations from a query-only member candidate", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha?memberId=member-team-alpha&tab=automations",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await waitFor(() => {
+      expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
+        includeTotalCount: true,
+        scopeId: "scope-1",
+        take: 200,
+        teamId: "t-alpha",
+      });
+    });
+    expect((scheduledDispatchApi.listAll as jest.Mock).mock.calls[0]?.[0]).not.toHaveProperty(
+      "memberId",
+    );
+  });
+
   it("retries schedule list while the schedule read model catches up", async () => {
     window.history.replaceState(
       {},
@@ -2807,6 +2879,97 @@ describe("TeamDetailPage", () => {
         0,
       );
     });
+  });
+
+  it("keeps member creation and optimistic rows inside the canonical member route", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/automations",
+    );
+    (studioApi.listTeamMembers as jest.Mock).mockResolvedValue(
+      mockCreateTeamMembersCatalogWithSecondPublishedMember(),
+    );
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValue(
+      mockCreateServiceCatalogWithSecondPublishedMember(),
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await waitFor(() => {
+      expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
+        includeTotalCount: true,
+        memberId: "member-team-alpha",
+        scopeId: "scope-1",
+        take: 200,
+        teamId: "t-alpha",
+      });
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
+    let dialog = await screen.findByRole("dialog", {
+      name: "新建成员自动化",
+    });
+    expect(within(dialog).getByLabelText("自动化成员")).toBeDisabled();
+    expect(within(dialog).getByText("Team Alpha Operator")).toBeTruthy();
+    expect(within(dialog).queryByText("Team Beta Operator")).toBeNull();
+
+    fireEvent.change(within(dialog).getByLabelText("自动化名称"), {
+      target: { value: "Alpha pending automation" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "创建自动化" }));
+
+    expect(await screen.findByText("Alpha pending automation")).toBeTruthy();
+
+    act(() => {
+      history.push(
+        "/scopes/scope-1/teams/t-alpha/members/member-team-beta/automations",
+      );
+    });
+
+    await waitFor(() => {
+      expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
+        includeTotalCount: true,
+        memberId: "member-team-beta",
+        scopeId: "scope-1",
+        take: 200,
+        teamId: "t-alpha",
+      });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha pending automation")).toBeNull();
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "添加周期任务" }));
+    dialog = await screen.findByRole("dialog", {
+      name: "新建成员自动化",
+    });
+    expect(within(dialog).getByLabelText("自动化成员")).toBeDisabled();
+    expect(within(dialog).getByText("Team Beta Operator")).toBeTruthy();
+    expect(within(dialog).queryByText("Team Alpha Operator")).toBeNull();
+  });
+
+  it("does not fall back to another member for an unknown canonical member route", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/member-team-missing/automations",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await waitFor(() => {
+      expect(scheduledDispatchApi.listAll).toHaveBeenCalledWith({
+        includeTotalCount: true,
+        memberId: "member-team-missing",
+        scopeId: "scope-1",
+        take: 200,
+        teamId: "t-alpha",
+      });
+    });
+    expect(
+      await screen.findByRole("button", { name: "添加周期任务" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "新建自动化" })).toBeDisabled();
   });
 
   it("previews next runs from the automation form", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1977,6 +1977,11 @@ const TeamDetailPage: React.FC = () => {
   const renderAutomationsTab = () => {
     return (
       <TeamAutomationsTab
+        key={JSON.stringify([
+          scopeId,
+          selectedTeamId,
+          routeState.routeMemberId,
+        ])}
         members={teamRosterRows.map((row) => ({
           automationsHref: row.automationsHref,
           canAutomateMember: row.canAutomateMember,
@@ -1993,7 +1998,7 @@ const TeamDetailPage: React.FC = () => {
           serviceRevisionId: row.serviceRevisionId,
           workflowSupported: row.workflowSupported,
         }))}
-        routeMemberId={routeState.memberId}
+        routeMemberId={routeState.routeMemberId}
         scopeId={scopeId}
         serviceIdentitiesLoading={automationsServicesQuery.isLoading}
         teamId={selectedTeamId}

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1993,6 +1993,7 @@ const TeamDetailPage: React.FC = () => {
           serviceRevisionId: row.serviceRevisionId,
           workflowSupported: row.workflowSupported,
         }))}
+        routeMemberId={routeState.memberId}
         scopeId={scopeId}
         serviceIdentitiesLoading={automationsServicesQuery.isLoading}
         teamId={selectedTeamId}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -71,6 +71,7 @@ export type TeamAutomationMemberRow = {
 
 type TeamAutomationsTabProps = {
   readonly members?: readonly TeamAutomationMemberRow[];
+  readonly routeMemberId?: string;
   readonly scopeId: string;
   readonly serviceIdentitiesLoading?: boolean;
   readonly teamId: string;
@@ -680,6 +681,7 @@ function hasBackendObservedManualRun(
 
 const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   members = [],
+  routeMemberId: routeMemberIdInput = "",
   scopeId,
   serviceIdentitiesLoading = false,
   teamId,
@@ -687,6 +689,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const intl = useIntl();
   const queryClient = useQueryClient();
   const { token } = theme.useToken();
+  const routeMemberId = trimText(routeMemberIdInput);
   const automatableMembers = React.useMemo(
     () => members.filter((member) => member.canAutomateMember),
     [members],
@@ -726,8 +729,9 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     timezone: resolveDefaultTimezone(),
   }));
   const scheduleQueryKey = React.useMemo(
-    () => ["scheduled-dispatches", "team", scopeId, teamId] as const,
-    [scopeId, teamId],
+    () =>
+      ["scheduled-dispatches", "team", scopeId, teamId, routeMemberId] as const,
+    [routeMemberId, scopeId, teamId],
   );
   const serviceKeyToMember = React.useMemo(() => {
     const next = new Map<string, TeamAutomationMemberRow>();
@@ -750,7 +754,10 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
     queryFn: () =>
       scheduledDispatchApi.listAll({
         includeTotalCount: true,
+        ...(routeMemberId ? { memberId: routeMemberId } : {}),
+        scopeId,
         take: scheduleListTake,
+        teamId,
       }),
     queryKey: scheduleQueryKey,
     retry: (failureCount) => failureCount < scheduleListRetryLimit,
@@ -1915,7 +1922,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
               : schedule.displayName;
 
           return (
-            <div
+            <article
               aria-label={rowAriaLabel}
               className="team-automation-row"
               key={scheduleId}
@@ -2075,7 +2082,7 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   onClick: () => deleteMutation.mutate(scheduleId),
                 })}
               </div>
-            </div>
+            </article>
           );
         })}
       </div>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -690,15 +690,26 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
   const queryClient = useQueryClient();
   const { token } = theme.useToken();
   const routeMemberId = trimText(routeMemberIdInput);
+  const surfaceMembers = React.useMemo(
+    () =>
+      routeMemberId
+        ? members.filter(
+            (member) => trimText(member.memberId) === routeMemberId,
+          )
+        : members,
+    [members, routeMemberId],
+  );
   const automatableMembers = React.useMemo(
-    () => members.filter((member) => member.canAutomateMember),
-    [members],
+    () => surfaceMembers.filter((member) => member.canAutomateMember),
+    [surfaceMembers],
   );
   const selectedMember =
     automatableMembers.find((member) => member.isSelectedMember) ??
     automatableMembers[0] ??
     null;
-  const unavailableMembers = members.filter((member) => !member.canAutomateMember);
+  const unavailableMembers = surfaceMembers.filter(
+    (member) => !member.canAutomateMember,
+  );
   const [createOpen, setCreateOpen] = React.useState(false);
   const [editingSchedule, setEditingSchedule] =
     React.useState<ScheduledDispatchSummary | null>(null);
@@ -2375,7 +2386,9 @@ const TeamAutomationsTab: React.FC<TeamAutomationsTabProps> = ({
                   id: "teams.automations.form.memberAria",
                   defaultMessage: "Automation member",
                 })}
-                disabled={formSubmitting || isEditingAutomation}
+                disabled={
+                  formSubmitting || isEditingAutomation || Boolean(routeMemberId)
+                }
                 onChange={(memberId) => updateForm({ memberId })}
                 options={automatableMembers.map((member) => ({
                   label: member.name,

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.test.ts
@@ -165,7 +165,32 @@ describe("scheduledDispatchApi", () => {
     );
   });
 
-  it("lists every schedule page when requested", async () => {
+  it("serializes scoped schedule list filters", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [],
+        nextCursor: null,
+        totalCount: 0,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await scheduledDispatchApi.list({
+      includeTotalCount: true,
+      memberId: "member+alpha",
+      scopeId: "scope/alpha",
+      take: 25,
+      teamId: "team alpha",
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/schedules?scopeId=scope%2Falpha&teamId=team+alpha&memberId=member%2Balpha&includeTotalCount=true&take=25",
+    );
+  });
+
+  it("preserves scoped schedule filters across every requested page", async () => {
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce({
@@ -191,7 +216,10 @@ describe("scheduledDispatchApi", () => {
     await expect(
       scheduledDispatchApi.listAll({
         includeTotalCount: true,
+        memberId: "member-alpha",
+        scopeId: "scope-alpha",
         take: 200,
+        teamId: "team-alpha",
       }),
     ).resolves.toEqual({
       items: [
@@ -203,8 +231,8 @@ describe("scheduledDispatchApi", () => {
     });
 
     expect(fetchMock.mock.calls.map(([input]) => input)).toEqual([
-      "/api/schedules?includeTotalCount=true&take=200",
-      "/api/schedules?cursor=cursor-2&includeTotalCount=true&take=200",
+      "/api/schedules?scopeId=scope-alpha&teamId=team-alpha&memberId=member-alpha&includeTotalCount=true&take=200",
+      "/api/schedules?scopeId=scope-alpha&teamId=team-alpha&memberId=member-alpha&cursor=cursor-2&includeTotalCount=true&take=200",
     ]);
   });
 

--- a/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts
@@ -121,7 +121,10 @@ export type ScheduledDispatchListResult = {
 export type ScheduledDispatchListQuery = {
   readonly cursor?: string;
   readonly includeTotalCount?: boolean;
+  readonly memberId?: string;
+  readonly scopeId?: string;
   readonly take?: number;
+  readonly teamId?: string;
 };
 
 const missingOwnerBindingMessage =
@@ -505,6 +508,9 @@ function listScheduledDispatches(
 ): Promise<ScheduledDispatchListResult> {
   return requestJson(
     withQuery("/api/schedules", {
+      scopeId: trimOptional(query?.scopeId),
+      teamId: trimOptional(query?.teamId),
+      memberId: trimOptional(query?.memberId),
       cursor: query?.cursor,
       includeTotalCount: query?.includeTotalCount,
       take: query?.take,

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
@@ -224,7 +224,7 @@ describe("teamRoutes", () => {
     );
   });
 
-  it("reads the canonical team detail route state from path and query", () => {
+  it("keeps query member candidates separate from canonical member path identity", () => {
     expect(
       readTeamDetailRouteState(
         "?memberId=member-alpha&teamId=stale-team&workflowId=wf-1&serviceId=service-1&runId=run-1&tab=members",
@@ -232,6 +232,7 @@ describe("teamRoutes", () => {
       ),
     ).toEqual({
       memberId: "member-alpha",
+      routeMemberId: "",
       runId: "run-1",
       scopeId: "scope-alpha",
       serviceId: "service-1",
@@ -250,6 +251,7 @@ describe("teamRoutes", () => {
       ),
     ).toMatchObject({
       memberId: "member-alpha",
+      routeMemberId: "member-alpha",
       scopeId: "scope-alpha",
       teamId: "t-alpha",
       workflowId: "wf-alpha",
@@ -264,6 +266,7 @@ describe("teamRoutes", () => {
       ),
     ).toMatchObject({
       memberId: "member-alpha",
+      routeMemberId: "member-alpha",
       scopeId: "scope-alpha",
       tab: "automations",
       teamId: "t-alpha",
@@ -278,6 +281,7 @@ describe("teamRoutes", () => {
       ),
     ).toMatchObject({
       memberId: "",
+      routeMemberId: "",
       scopeId: "",
       teamId: "",
       workflowId: "wf-alpha",
@@ -292,6 +296,7 @@ describe("teamRoutes", () => {
       ),
     ).toMatchObject({
       memberId: "member-alpha",
+      routeMemberId: "",
       scopeId: "scope-alpha",
       teamId: "t-alpha",
       testTeam: true,
@@ -319,6 +324,7 @@ describe("teamRoutes", () => {
       ),
     ).toEqual({
       memberId: "",
+      routeMemberId: "",
       runId: "",
       scopeId: "scope-query",
       serviceId: "",
@@ -337,6 +343,7 @@ describe("teamRoutes", () => {
       ),
     ).toEqual({
       memberId: "",
+      routeMemberId: "",
       runId: "",
       scopeId: "scope-query",
       serviceId: "",

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
@@ -10,6 +10,7 @@ type TeamToStudioMode = 'create-member' | 'edit-member' | 'build-member';
 type QueryValue = string | undefined;
 type TeamDetailRouteState = {
   readonly memberId: string;
+  readonly routeMemberId: string;
   readonly runId: string;
   readonly scopeId: string;
   readonly serviceId: string;
@@ -311,10 +312,8 @@ export function readTeamDetailRouteState(
       ? decodePathSegment(pathnameSegments[membersIndex + 1])
       : '';
   const defaultTab: TeamDetailTab = 'overview';
-  const memberId =
-    memberIdFromPath === 'new'
-      ? ''
-      : memberIdFromPath || trimOptional(params.get('memberId'));
+  const routeMemberId = memberIdFromPath === 'new' ? '' : memberIdFromPath;
+  const memberId = routeMemberId || trimOptional(params.get('memberId'));
   const memberSurfaceFromPath =
     membersIndex >= 0 && pathnameSegments[membersIndex + 2]
       ? decodePathSegment(pathnameSegments[membersIndex + 2])
@@ -324,6 +323,7 @@ export function readTeamDetailRouteState(
 
   return {
     memberId,
+    routeMemberId,
     runId: trimOptional(params.get('runId')),
     scopeId: scopeIdFromPath || trimOptional(params.get('scopeId')),
     serviceId: trimOptional(params.get('serviceId')),


### PR DESCRIPTION
## Problem

Team Automation pages queried the generic `/api/schedules` collection and filtered results only in the client. After backend PR #2937 added scoped schedule reads, the console still did not pass the authoritative scope/team/member query context.

Closes #2942.

## Solution

- Extend `ScheduledDispatchListQuery` with `scopeId`, optional `teamId`, and optional `memberId`, and serialize those values into `/api/schedules`.
- Preserve the scoped filters through every `listAll` cursor page while leaving unscoped callers unchanged.
- Pass route-derived `scopeId` and `teamId` from Team Automation pages, and pass `routeMemberId` only on member-scoped routes.
- Include the route member identity in the React Query key so team-level and member-level results cannot share a cache entry.
- Keep schedule create/update authorization and owner payloads unchanged.
- Use a semantic `article` for each labeled automation row so its existing accessible name is valid.

## Impact paths

- `apps/aevatar-console-web/src/shared/api/scheduledDispatchApi.ts`
- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx`
- Focused API and Team detail tests

No backend, root configuration, dependency, or documentation changes are required.

## Validation

- [x] `pnpm --dir apps/aevatar-console-web jest --runInBand src/shared/api/scheduledDispatchApi.test.ts src/pages/teams/detail.test.tsx` - 94 passed
- [x] `pnpm --dir apps/aevatar-console-web jest --runInBand src/shared/api/scheduledDispatchApi.test.ts` - 17 passed on final source
- [x] Focused Team Automation page cases - 2 passed on final source
- [x] `pnpm --dir apps/aevatar-console-web tsc`
- [x] `pnpm --dir apps/aevatar-console-web build`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] Targeted Biome lint for all 5 changed files - exit 0; 2 existing warnings and 2 existing infos in `detail.tsx`
- [ ] Full frontend Jest suite was not run, per the machine-local Incremental Unit Test Policy.
- [ ] Full frontend Biome lint is blocked by 89 pre-existing `origin/dev` errors outside this diff.

## Browser QA

The debug app started at `http://localhost:5174`, but `/scopes` redirected to `/login?redirect=%2Fscopes`. No authenticated Console session was available, so the Team Automation user journey was not substituted with jsdom evidence or reported as browser E2E.

- Console errors on the login surface: none
- Blocker screenshot: `/Users/xiezixin/.fkst/artifacts/aevatar-frontend/20260724T022022Z-97ab53bc/screenshots/browser-qa-auth-blocker.png`

## FKST provenance

- Skill: aevatar-frontend-fkst
- Issue: #2942
- Worktree: `/Users/xiezixin/.fkst/runtime/aevatar-frontend/manual/fix-2026-07-24_scoped-schedule-queries`
- Branch: `fix/2026-07-24_scoped-schedule-queries`
- Operator: AbigailDeng
- Freshness: `origin/dev@af89911ebe844045b54d80af4852050037b3a9a1`, fetched 2026-07-24 before commit
- Workflow run: `20260724T022022Z-97ab53bc`

## Backend dependency

This frontend contract depends on backend PR #2937 (`Support scoped schedule queries`), merged as `51d6e2fef` into `feature/integrate`. That merge is not yet an ancestor of `origin/dev` as of 2026-07-24. The frontend branch intentionally remains based on `dev` per the requested workflow; deploy/release this change with #2937 so `/api/schedules?scopeId=...&teamId=...&memberId=...` is handled by the scoped backend query path. The parameter names and generic fallback behavior were verified against #2937 endpoint tests.
