### PR TITLE
[codex] Hide Platform navigation

### DIFF
--- a/apps/aevatar-console-web/src/app.navigation.test.ts
+++ b/apps/aevatar-console-web/src/app.navigation.test.ts
@@ -27,13 +27,11 @@ describe("app navigation groups", () => {
     expect(groups.map((group) => group.label)).toEqual([
       "Teams",
       "Chat",
-      "Platform",
       "Settings",
     ]);
     expect(groups.map((group) => group.labelMessageId)).toEqual([
       "nav.groups.teams",
       "nav.groups.chat",
-      "nav.groups.platform",
       "nav.groups.settings",
     ]);
     expect(groups.find((group) => group.key === "chat")?.flattenSingleItem).toBe(true);
@@ -79,7 +77,6 @@ describe("app navigation groups", () => {
     expect(menuItems.map((item) => item.path ?? item.key)).toEqual([
       "menu-group:teams",
       "/chat",
-      "menu-group:platform",
       "/settings",
     ]);
     expect(menuItems[0].children?.map((child) => child.path)).toEqual([

--- a/apps/aevatar-console-web/src/shared/navigation/navigationGroups.tsx
+++ b/apps/aevatar-console-web/src/shared/navigation/navigationGroups.tsx
@@ -1,5 +1,4 @@
 import {
-  DashboardOutlined,
   SettingOutlined,
   TeamOutlined,
 } from "@ant-design/icons";
@@ -27,12 +26,6 @@ const TEAM_FIRST_NAVIGATION_GROUP_ORDER: readonly NavigationGroup[] = [
     key: "chat",
     label: "Chat",
     labelMessageId: "nav.groups.chat",
-  },
-  {
-    icon: <DashboardOutlined />,
-    key: "platform",
-    label: "Platform",
-    labelMessageId: "nav.groups.platform",
   },
   {
     flattenSingleItem: true,


### PR DESCRIPTION
## What changed

- Removed the Platform group from the console navigation group whitelist.
- Kept Platform page routes available for direct access.
- Updated navigation tests to verify Platform entries are filtered.

## Why

Temporarily hide the Platform section and its Event Stream, Services, Governance, Deployments, and Topology entries from the sidebar.

## Impact

The sidebar now shows Teams, Chat, and Settings only. Existing Platform URLs and page implementations are unchanged.

## Validation

- `pnpm --dir apps/aevatar-console-web test --runInBand src/app.navigation.test.ts`
- `pnpm --dir apps/aevatar-console-web tsc`
- `bash tools/ci/test_stability_guards.sh`
- `pnpm --dir apps/aevatar-console-web build`