### PR TITLE
Keep public toolsets skill-first

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Aevatar.CQRS.Projection.Runtime.DependencyInjection;
 using Aevatar.AI.ToolProviders.Lark;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Skills;
+using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions.Slash;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
@@ -250,7 +251,12 @@ public static class ServiceCollectionExtensions
 
     private static IEnumerable<IAgentToolSource> ResolveChannelToolSources(IServiceProvider serviceProvider)
     {
-        foreach (var source in serviceProvider.GetServices<IAgentToolSource>())
+        var registry = serviceProvider.GetRequiredService<IToolSetRegistry>();
+        var workspace = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.WorkspaceDefault });
+        var sources = workspace.IsSuccess
+            ? workspace.Sources
+            : serviceProvider.GetServices<IAgentToolSource>();
+        foreach (var source in sources)
             yield return source;
 
         var inventory = serviceProvider.GetService<ChannelNyxIdConnectedServiceInventoryToolSource>();

--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -134,7 +134,7 @@ Responses、Messages 和 Chat Completions 三条直连入口都把模型调用�
 
 ## 5. 直连工具行为
 
-`/v1/responses`、`/v1/messages`、`/v1/chat/completions` 使用同一套 `IResponsesDirectToolPlanService` + `IResponsesToolClassificationService` 抽象组装 tool sources 并做工具分类。三条 create 入口都会合并同一批全局 `IResponsesToolProvider`，并按 chat-route `ForwardToModel.ToolSetRef` 追加同一个 route tool set。Mainnet 的 direct LLM ingress 默认补 `workspace.default`；`lark.self_notify`、`voice.realtime` 也必须组合 `workspace.default`，所以 NyxID/Aevatar workspace tools 是默认可见能力，不依赖调用方显式配置 route tool set。最终工具分成三类：
+`/v1/responses`、`/v1/messages`、`/v1/chat/completions` 使用同一套 `IResponsesDirectToolPlanService` + `IResponsesToolClassificationService` 抽象组装 tool sources 并做工具分类。三条 create 入口都会合并同一批全局 `IResponsesToolProvider`，并按 chat-route `ForwardToModel.ToolSetRef` 追加同一个 route tool set。Mainnet 的 direct LLM ingress 默认补 `workspace.default`；`lark.self_notify`、`voice.realtime` 也必须组合 `workspace.default`，所以 NyxID/Aevatar workspace tools 是默认可见能力，不依赖调用方显式配置 route tool set。`workspace.default` 是 public/default surface，不包含 Studio provisioning/member/bind/schedule/query sources；这些 Studio-local tools 只通过显式 `studio.local` tool set 和受 workflow `allowed_tools` 约束的内置 Studio workflow 入口可达。最终工具分成三类：
 
 - Aevatar substitute tools：由服务端接管执行并记录状态。
 - Aevatar additive tools：由服务端额外注入，供模型主动调用。

--- a/docs/superpowers/specs/2026-07-23-chat-workflow-resource-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-23-chat-workflow-resource-semantics-design.md
@@ -122,11 +122,18 @@ the resource boundary enforceable without relying on prompt compliance.
 
 ### Host Composition
 
-Register `StudioWorkflowQueryToolSource` through
-`AddStudioProvisioningTools()` and compose it into `workspace.default` alongside
-the existing Studio query sources. Keep `WorkflowCatalogAgentToolSource` in the
-same tool set because explicit template discovery remains supported under its
-new tool names.
+Register `StudioWorkflowQueryToolSource` as part of the explicit `studio.local`
+tool set alongside the existing Studio provisioning, member, binding, schedule,
+and query sources. `workspace.default` stays the public/default workspace
+surface and must not include Studio-local sources. Keep
+`WorkflowCatalogAgentToolSource` in `workspace.default` because explicit
+template discovery remains supported under its new tool names.
+
+The built-in Studio workflow reaches `studio.local` through a workflow-only
+source that is gated by the workflow's explicit `allowed_tools` list. This keeps
+normal direct/default workflow runs and public chat routes from inheriting
+Studio-local tools while preserving Studio authoring requests that select the
+built-in `studio` workflow.
 
 ## Error Semantics
 

--- a/src/Aevatar.AI.ToolProviders.ToolSetRegistry/ToolSetNames.cs
+++ b/src/Aevatar.AI.ToolProviders.ToolSetRegistry/ToolSetNames.cs
@@ -4,6 +4,7 @@ public static class ToolSetNames
 {
     public const string WorkspaceDefault = "workspace.default";
     public const string LarkSelfNotify = "lark.self_notify";
+    public const string StudioLocal = "studio.local";
 
     /// <summary>
     /// Opt-in tool set that exposes the caller's <c>x-aevatar-tool</c>-marked NyxID

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Application.CodexExecution;
 using Aevatar.AI.Infrastructure.ChronoSandbox;
+using Aevatar.AI.Core.Hooks;
 using Aevatar.AI.Core.Middleware;
 using Aevatar.AI.ToolProviders.AgentCatalog;
 using Aevatar.AI.ToolProviders.AevatarInvocation;
@@ -26,6 +27,7 @@ using Aevatar.Audit.Hosting;
 using Aevatar.BackendConsole.Hosting;
 using Aevatar.Bootstrap.Extensions.AI;
 using Aevatar.Bootstrap.Hosting;
+using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
@@ -66,6 +68,7 @@ using Aevatar.Mainnet.Host.Api.Voice;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Hosting;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Extensions.Hosting;
 using Aevatar.Workflow.Integration.AI;
 using Microsoft.AspNetCore.Builder;
@@ -74,6 +77,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Aevatar.Mainnet.Host.Api.Hosting;
@@ -409,6 +413,20 @@ public static class MainnetHostBuilderExtensions
             agentProfileRolloutSelector.AddReviewedRouteToolSet(
                 options,
                 ToolSetNames.WorkspaceDefault);
+        });
+        builder.Services.AddSingleton<IWorkflowToolSource>(serviceProvider =>
+        {
+            var studioLocal = serviceProvider.GetRequiredService<IToolSetRegistry>()
+                .Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.StudioLocal });
+            if (!studioLocal.IsSuccess)
+                throw new InvalidOperationException(studioLocal.Error?.Message);
+
+            return new VisibleAgentWorkflowToolSource(
+                studioLocal.Sources,
+                serviceProvider.GetServices<IToolCallMiddleware>(),
+                serviceProvider.GetService<IToolApprovalHandler>(),
+                serviceProvider.GetServices<IAIGAgentExecutionHook>(),
+                serviceProvider.GetService<ILogger<VisibleAgentWorkflowToolSource>>());
         });
 
         return builder;

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -290,12 +290,6 @@ public static class MainnetHostBuilderExtensions
         builder.Services.AddChannelAdminTools();
         builder.Services.AddAgentCatalogTools();
         builder.Services.AddAevatarInvocationTools();
-        // Studio workflow scheduling tool (aevatar_provision_workflow_schedule): the channel-free,
-        // Observatory-delivered analogue of the Lark scheduled_agent_creator. Registered as an
-        // IAgentToolSource here; the studio workflow's allowed_tools allowlist (W2) scopes it to
-        // studio runs. The narrow IWorkflowScheduleProvisioningPort it depends on is registered by
-        // AddStudioApplication (via AddStudioCapability), composed in the same host container.
-        builder.Services.AddStudioProvisioningTools();
         builder.Services.Configure<DeviceEventOptions>(
             builder.Configuration.GetSection("Aevatar:DeviceEvents"));
         // Fail-fast: device HMAC verification must never be disabled in production.
@@ -373,15 +367,6 @@ public static class MainnetHostBuilderExtensions
                     CreateToolSource<ObserveRunToolSource>,
                     CreateToolSource<ReadWorkflowRunArtifactToolSource>,
                     CreateToolSource<WorkflowCatalogAgentToolSource>,
-                    CreateToolSource<ProvisionWorkflowScheduleToolSource>,
-                    CreateToolSource<CreateStudioTeamToolSource>,
-                    CreateToolSource<StudioTeamQueryToolSource>,
-                    CreateToolSource<CreateStudioMemberToolSource>,
-                    CreateToolSource<StudioMemberQueryToolSource>,
-                    CreateToolSource<StudioScheduleQueryToolSource>,
-                    CreateToolSource<StudioWorkflowQueryToolSource>,
-                    CreateToolSource<BindStudioMemberWorkflowToolSource>,
-                    CreateToolSource<ScheduleStudioMemberWorkflowToolSource>,
                     CreateToolSource<ResponsesAevatarToolProvider>,
                     CreateToolSource<ChannelInteractiveReplyToolSource>,
                     CreateToolSource<ChannelRegistrationToolSource>,
@@ -400,6 +385,20 @@ public static class MainnetHostBuilderExtensions
                 [ToolSetNames.WorkspaceDefault],
                 [],
                 "Lark route tool composition with the default workspace tools.");
+            options.AddToolSet(
+                ToolSetNames.StudioLocal,
+                [
+                    CreateToolSource<ProvisionWorkflowScheduleToolSource>,
+                    CreateToolSource<CreateStudioTeamToolSource>,
+                    CreateToolSource<StudioTeamQueryToolSource>,
+                    CreateToolSource<CreateStudioMemberToolSource>,
+                    CreateToolSource<StudioMemberQueryToolSource>,
+                    CreateToolSource<StudioWorkflowQueryToolSource>,
+                    CreateToolSource<StudioScheduleQueryToolSource>,
+                    CreateToolSource<BindStudioMemberWorkflowToolSource>,
+                    CreateToolSource<ScheduleStudioMemberWorkflowToolSource>,
+                ],
+                "Studio-owned local provisioning, member, binding, schedule, and query tools.");
             // Opt-in only: connected-service tools carry per-user NyxID surfaces, so this set
             // is referenced by route policy (not folded into workspace.default) to avoid
             // injecting every caller's connected services by default.

--- a/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/AgentWorkflowToolSourceAdapter.cs
@@ -41,124 +41,159 @@ public sealed class AgentWorkflowToolSourceAdapter(
         return workflowTools;
     }
 
-    private sealed class AgentWorkflowToolAdapter(
-        IAgentTool tool,
-        IReadOnlyList<IToolCallMiddleware> toolMiddlewares,
-        ILogger logger) : IWorkflowTool
+}
+
+public sealed class VisibleAgentWorkflowToolSource(
+    IEnumerable<IAgentToolSource> agentToolSources,
+    IEnumerable<IToolCallMiddleware>? toolMiddlewares = null,
+    IToolApprovalHandler? approvalHandler = null,
+    IEnumerable<IAIGAgentExecutionHook>? hooks = null,
+    ILogger<VisibleAgentWorkflowToolSource>? logger = null) : IWorkflowToolSource
+{
+    private readonly IEnumerable<IAgentToolSource> _agentToolSources =
+        agentToolSources ?? throw new ArgumentNullException(nameof(agentToolSources));
+    private readonly IReadOnlyList<IToolCallMiddleware> _toolMiddlewares =
+        ToolCallMiddlewareChainFactory.ForAgentRuntime(
+            toolMiddlewares ?? [],
+            approvalHandler,
+            hooks == null ? null : new AgentHookPipeline(hooks));
+    private readonly ILogger<VisibleAgentWorkflowToolSource> _logger =
+        logger ?? NullLogger<VisibleAgentWorkflowToolSource>.Instance;
+
+    public async Task<IReadOnlyList<IWorkflowTool>> GetToolsAsync(CancellationToken ct = default)
     {
-        private readonly IAgentTool _tool = tool ?? throw new ArgumentNullException(nameof(tool));
-        private readonly IReadOnlyList<IToolCallMiddleware> _toolMiddlewares =
-            toolMiddlewares ?? throw new ArgumentNullException(nameof(toolMiddlewares));
-        private readonly ILogger _logger = logger ?? NullLogger.Instance;
+        var visibility = AgentToolRequestContext.ToolVisibility;
+        if (!visibility.IsRestricted)
+            return [];
 
-        public string Name => _tool.Name;
-
-        public async Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+        var workflowTools = new List<IWorkflowTool>();
+        foreach (var source in _agentToolSources)
         {
-            ArgumentNullException.ThrowIfNull(request);
+            var tools = await source.DiscoverToolsAsync(ct).ConfigureAwait(false);
+            foreach (var tool in tools.Where(tool => visibility.Allows(tool.Name)))
+                workflowTools.Add(new AgentWorkflowToolAdapter(tool, _toolMiddlewares, _logger));
+        }
 
-            var workflowRuntimeContext = new AgentWorkflowRuntimeContext(
-                Normalize(request.RuntimeContext.ParentActorId),
-                Normalize(request.RuntimeContext.ParentRunId),
-                Normalize(request.RuntimeContext.ParentStepId),
-                Normalize(request.RuntimeContext.RootRunId),
-                Math.Max(0, request.RuntimeContext.Depth));
-            var credentialContext = WorkflowCallerCredentialToolContextMapper.FromCredential(
-                request.CallerCredential,
-                workflowRuntimeContext);
-            var toolContext = credentialContext with
+        return workflowTools;
+    }
+}
+
+file sealed class AgentWorkflowToolAdapter(
+    IAgentTool tool,
+    IReadOnlyList<IToolCallMiddleware> toolMiddlewares,
+    ILogger logger) : IWorkflowTool
+{
+    private readonly IAgentTool _tool = tool ?? throw new ArgumentNullException(nameof(tool));
+    private readonly IReadOnlyList<IToolCallMiddleware> _toolMiddlewares =
+        toolMiddlewares ?? throw new ArgumentNullException(nameof(toolMiddlewares));
+    private readonly ILogger _logger = logger ?? NullLogger.Instance;
+
+    public string Name => _tool.Name;
+
+    public async Task<WorkflowToolExecutionResult> ExecuteAsync(WorkflowToolExecutionRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var workflowRuntimeContext = new AgentWorkflowRuntimeContext(
+            Normalize(request.RuntimeContext.ParentActorId),
+            Normalize(request.RuntimeContext.ParentRunId),
+            Normalize(request.RuntimeContext.ParentStepId),
+            Normalize(request.RuntimeContext.RootRunId),
+            Math.Max(0, request.RuntimeContext.Depth));
+        var credentialContext = WorkflowCallerCredentialToolContextMapper.FromCredential(
+            request.CallerCredential,
+            workflowRuntimeContext);
+        var toolContext = credentialContext with
+        {
+            Request = credentialContext.Request with
             {
-                Request = credentialContext.Request with
-                {
-                    CallId = Normalize(request.CallId),
-                    IdempotencyKey = Normalize(request.IdempotencyKey),
-                },
-                Caller = credentialContext.Caller with
-                {
-                    ScopeId = Normalize(request.ScopeId),
-                },
-                Schedule = new AgentToolScheduleContext(Normalize(request.ScheduleId)),
-            };
-            _logger.LogInformation(
-                "Workflow tool credential context prepared. toolName={ToolName} scopeId={ScopeId} rootRunId={RootRunId} parentRunId={ParentRunId} parentStepId={ParentStepId} hasCallerCredentialBearer={HasCallerCredentialBearer} hasNyxIdAccessToken={HasNyxIdAccessToken} hasNyxIdOrgToken={HasNyxIdOrgToken}",
-                _tool.Name,
-                request.ScopeId ?? string.Empty,
-                request.RuntimeContext.RootRunId ?? string.Empty,
-                request.RuntimeContext.ParentRunId ?? string.Empty,
-                request.RuntimeContext.ParentStepId ?? string.Empty,
-                !string.IsNullOrWhiteSpace(request.CallerCredential?.BearerToken),
-                !string.IsNullOrWhiteSpace(toolContext.Credentials.NyxIdAccessToken),
-                !string.IsNullOrWhiteSpace(toolContext.Credentials.NyxIdOrgToken));
-            using var scope = AgentToolContextScope.Push(toolContext);
-            var toolCallContext = new ToolCallContext
+                CallId = Normalize(request.CallId),
+                IdempotencyKey = Normalize(request.IdempotencyKey),
+            },
+            Caller = credentialContext.Caller with
             {
-                Tool = _tool,
-                ToolName = _tool.Name,
-                ToolCallId = Normalize(request.CallId) ?? string.Empty,
-                ArgumentsJson = request.ArgumentsJson,
-                CancellationToken = ct,
-                ExecutionContext = toolContext,
-                ApprovalGrant = request.ApprovalGrant == null
-                    ? null
-                    : new Aevatar.AI.Abstractions.Middleware.ToolApprovalGrant(
-                        request.ApprovalGrant.ApprovalRequestId,
-                        request.ApprovalGrant.ToolName,
-                        request.ApprovalGrant.ToolCallId),
-            };
+                ScopeId = Normalize(request.ScopeId),
+            },
+            Schedule = new AgentToolScheduleContext(Normalize(request.ScheduleId)),
+        };
+        _logger.LogInformation(
+            "Workflow tool credential context prepared. toolName={ToolName} scopeId={ScopeId} rootRunId={RootRunId} parentRunId={ParentRunId} parentStepId={ParentStepId} hasCallerCredentialBearer={HasCallerCredentialBearer} hasNyxIdAccessToken={HasNyxIdAccessToken} hasNyxIdOrgToken={HasNyxIdOrgToken}",
+            _tool.Name,
+            request.ScopeId ?? string.Empty,
+            request.RuntimeContext.RootRunId ?? string.Empty,
+            request.RuntimeContext.ParentRunId ?? string.Empty,
+            request.RuntimeContext.ParentStepId ?? string.Empty,
+            !string.IsNullOrWhiteSpace(request.CallerCredential?.BearerToken),
+            !string.IsNullOrWhiteSpace(toolContext.Credentials.NyxIdAccessToken),
+            !string.IsNullOrWhiteSpace(toolContext.Credentials.NyxIdOrgToken));
+        using var scope = AgentToolContextScope.Push(toolContext);
+        var toolCallContext = new ToolCallContext
+        {
+            Tool = _tool,
+            ToolName = _tool.Name,
+            ToolCallId = Normalize(request.CallId) ?? string.Empty,
+            ArgumentsJson = request.ArgumentsJson,
+            CancellationToken = ct,
+            ExecutionContext = toolContext,
+            ApprovalGrant = request.ApprovalGrant == null
+                ? null
+                : new Aevatar.AI.Abstractions.Middleware.ToolApprovalGrant(
+                    request.ApprovalGrant.ApprovalRequestId,
+                    request.ApprovalGrant.ToolName,
+                    request.ApprovalGrant.ToolCallId),
+        };
 
-            await MiddlewarePipeline.RunToolCallAsync(_toolMiddlewares, toolCallContext, async () =>
-            {
-                if (toolCallContext.Terminate)
-                    return;
-
-                toolCallContext.Result = await _tool.ExecuteAsync(toolCallContext.ArgumentsJson, ct).ConfigureAwait(false);
-            }).ConfigureAwait(false);
-
-            if (toolCallContext.Terminate &&
-                toolCallContext.TerminationKind == ToolCallTerminationKind.ApprovalPending &&
-                toolCallContext.PendingApproval != null)
-            {
-                return new WorkflowToolExecutionResult(
-                    string.Empty,
-                    PendingApproval: ToWorkflowToolApprovalPendingOutcome(toolCallContext.PendingApproval));
-            }
-
+        await MiddlewarePipeline.RunToolCallAsync(_toolMiddlewares, toolCallContext, async () =>
+        {
             if (toolCallContext.Terminate)
-                throw new InvalidOperationException(FormatMiddlewareTermination(toolCallContext));
+                return;
 
-            var resultJson = toolCallContext.Result
-                             ?? throw new InvalidOperationException(
-                                 $"Tool '{_tool.Name}' returned no result.");
-            return AgentWorkflowToolReceiptOutcomeMapper.Map(
-                ToolCallReceiptFinalizer.Finalize(toolCallContext).Receipt,
-                resultJson);
-        }
+            toolCallContext.Result = await _tool.ExecuteAsync(toolCallContext.ArgumentsJson, ct).ConfigureAwait(false);
+        }).ConfigureAwait(false);
 
-        private static WorkflowToolApprovalPendingOutcome ToWorkflowToolApprovalPendingOutcome(
-            ToolApprovalPendingContext pending) =>
-            new(
-                pending.ApprovalRequestId,
-                pending.ToolName,
-                pending.ToolCallId,
-                pending.ArgumentsJson,
-                pending.ApprovalMode.ToString(),
-                pending.IsReadOnly,
-                pending.IsDestructive);
-
-        private static string? Normalize(string? value) =>
-            string.IsNullOrWhiteSpace(value) ? null : value.Trim();
-
-        private static string FormatMiddlewareTermination(ToolCallContext context)
+        if (toolCallContext.Terminate &&
+            toolCallContext.TerminationKind == ToolCallTerminationKind.ApprovalPending &&
+            toolCallContext.PendingApproval != null)
         {
-            var reason = string.IsNullOrWhiteSpace(context.TerminationReason)
-                ? context.Result
-                : context.TerminationReason;
-            var suffix = string.IsNullOrWhiteSpace(reason)
-                ? string.Empty
-                : $": {reason}";
-            return $"Tool '{context.ToolName}' execution terminated by middleware ({context.TerminationKind}){suffix}";
+            return new WorkflowToolExecutionResult(
+                string.Empty,
+                PendingApproval: ToWorkflowToolApprovalPendingOutcome(toolCallContext.PendingApproval));
         }
 
+        if (toolCallContext.Terminate)
+            throw new InvalidOperationException(FormatMiddlewareTermination(toolCallContext));
+
+        var resultJson = toolCallContext.Result
+                         ?? throw new InvalidOperationException(
+                             $"Tool '{_tool.Name}' returned no result.");
+        return AgentWorkflowToolReceiptOutcomeMapper.Map(
+            ToolCallReceiptFinalizer.Finalize(toolCallContext).Receipt,
+            resultJson);
+    }
+
+    private static WorkflowToolApprovalPendingOutcome ToWorkflowToolApprovalPendingOutcome(
+        ToolApprovalPendingContext pending) =>
+        new(
+            pending.ApprovalRequestId,
+            pending.ToolName,
+            pending.ToolCallId,
+            pending.ArgumentsJson,
+            pending.ApprovalMode.ToString(),
+            pending.IsReadOnly,
+            pending.IsDestructive);
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string FormatMiddlewareTermination(ToolCallContext context)
+    {
+        var reason = string.IsNullOrWhiteSpace(context.TerminationReason)
+            ? context.Result
+            : context.TerminationReason;
+        var suffix = string.IsNullOrWhiteSpace(reason)
+            ? string.Empty
+            : $": {reason}";
+        return $"Tool '{context.ToolName}' execution terminated by middleware ({context.TerminationKind}){suffix}";
     }
 }
 

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -84,6 +84,19 @@ namespace Aevatar.Capabilities.Tests;
 [Collection(ProcessEnvSerialCollection.Name)]
 public sealed class MainnetHostCompositionTests
 {
+    private static readonly System.Type[] StudioLocalToolSourceTypes =
+    [
+        typeof(ProvisionWorkflowScheduleToolSource),
+        typeof(CreateStudioTeamToolSource),
+        typeof(StudioTeamQueryToolSource),
+        typeof(CreateStudioMemberToolSource),
+        typeof(StudioMemberQueryToolSource),
+        typeof(StudioWorkflowQueryToolSource),
+        typeof(StudioScheduleQueryToolSource),
+        typeof(BindStudioMemberWorkflowToolSource),
+        typeof(ScheduleStudioMemberWorkflowToolSource),
+    ];
+
     [Fact]
     public void GAgentServiceAndStudioCapabilities_ShouldOwnTheirCompositionDependencies()
     {
@@ -574,25 +587,21 @@ public sealed class MainnetHostCompositionTests
         registry.GetRegisteredNames().Should().Equal(
             ToolSetNames.LarkSelfNotify,
             ToolSetNames.NyxIdConnectedServices,
+            ToolSetNames.StudioLocal,
             ToolSetNames.WorkspaceDefault);
 
         var workspace = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.WorkspaceDefault });
         workspace.IsSuccess.Should().BeTrue(workspace.Error?.Message);
-        workspace.Sources.Should().Contain(source => source is InvokeGAgentToolSource);
-        workspace.Sources.Should().Contain(source => source is InvokeTeamToolSource);
-        workspace.Sources.Should().Contain(source => source is StartWorkflowToolSource);
-        workspace.Sources.Should().Contain(source => source is ObserveRunToolSource);
-        workspace.Sources.Should().Contain(source => source is ReadWorkflowRunArtifactToolSource);
-        workspace.Sources.Should().Contain(source => source is ProvisionWorkflowScheduleToolSource);
-        workspace.Sources.Should().Contain(source => source is CreateStudioTeamToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioTeamQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is CreateStudioMemberToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioMemberQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioScheduleQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioWorkflowQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is WorkflowCatalogAgentToolSource);
-        workspace.Sources.Should().Contain(source => source is BindStudioMemberWorkflowToolSource);
-        workspace.Sources.Should().Contain(source => source is ScheduleStudioMemberWorkflowToolSource);
+        workspace.Sources.ShouldContainSourceTypes(
+            typeof(InvokeGAgentToolSource),
+            typeof(InvokeTeamToolSource),
+            typeof(StartWorkflowToolSource),
+            typeof(ObserveRunToolSource),
+            typeof(ReadWorkflowRunArtifactToolSource),
+            typeof(WorkflowCatalogAgentToolSource),
+            typeof(SkillsAgentToolSource),
+            typeof(OrnnAgentToolSource));
+        workspace.Sources.ShouldNotContainSourceTypes(StudioLocalToolSourceTypes);
         workspace.Sources.Should().Contain(source => source.GetType().Name == "ResponsesAevatarToolProvider");
         workspace.Sources.Should().Contain(source => source is ChannelInteractiveReplyToolSource);
         workspace.Sources.Should().Contain(source => source is ChannelRegistrationToolSource);
@@ -605,6 +614,8 @@ public sealed class MainnetHostCompositionTests
         workspace.Sources.Should().Contain(source => source is WebAgentToolSource);
         workspace.Sources.Should().Contain(source => source is SkillsAgentToolSource);
         workspace.Sources.Should().Contain(source => source is OrnnAgentToolSource);
+        app.Services.GetServices<IAgentToolSource>()
+            .ShouldNotContainSourceTypes(StudioLocalToolSourceTypes);
         app.Services.GetServices<IAgentToolSource>()
             .Select(static source => source.GetType())
             .Should()
@@ -628,6 +639,7 @@ public sealed class MainnetHostCompositionTests
                 source is ChannelNyxIdConnectedServiceInventoryToolSource)
             .Which.Should()
             .BeSameAs(channelInventorySource);
+        channelToolSources.ShouldNotContainSourceTypes(StudioLocalToolSourceTypes);
         var scheduleQueries = app.Services.GetRequiredService<IStudioMemberAutomationQueryPort>();
         var scheduleMutations = app.Services.GetRequiredService<IStudioMemberWorkflowSchedulePort>();
         scheduleQueries.Should().BeSameAs(scheduleMutations);
@@ -648,8 +660,15 @@ public sealed class MainnetHostCompositionTests
         larkSelfNotify.IsSuccess.Should().BeTrue(larkSelfNotify.Error?.Message);
         larkSelfNotify.Sources.Select(static source => source.GetType()).Should()
             .Equal(workspace.Sources.Select(static source => source.GetType()));
+        larkSelfNotify.Sources.ShouldNotContainSourceTypes(StudioLocalToolSourceTypes);
         larkSelfNotify.Sources.Should().Contain(source => source is LarkAgentToolSource);
         larkSelfNotify.Sources.Should().Contain(source => source is NyxIdAgentToolSource);
+
+        var studioLocal = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.StudioLocal });
+        studioLocal.IsSuccess.Should().BeTrue(studioLocal.Error?.Message);
+        studioLocal.Sources.Select(static source => source.GetType())
+            .Should()
+            .Equal(StudioLocalToolSourceTypes);
 
         var nyxIdConnectedServices = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.NyxIdConnectedServices });
         nyxIdConnectedServices.IsSuccess.Should().BeTrue(nyxIdConnectedServices.Error?.Message);
@@ -1428,5 +1447,26 @@ public sealed class MainnetHostCompositionTests
         {
             Environment.SetEnvironmentVariable(_name, _previous);
         }
+    }
+}
+
+internal static class MainnetHostCompositionToolSourceAssertions
+{
+    public static void ShouldContainSourceTypes(
+        this IEnumerable<IAgentToolSource> sources,
+        params System.Type[] expectedSourceTypes)
+    {
+        var actualSourceTypes = sources.Select(static source => source.GetType()).ToArray();
+        foreach (var expectedSourceType in expectedSourceTypes)
+            actualSourceTypes.Should().Contain(expectedSourceType);
+    }
+
+    public static void ShouldNotContainSourceTypes(
+        this IEnumerable<IAgentToolSource> sources,
+        params System.Type[] deniedSourceTypes)
+    {
+        var actualSourceTypes = sources.Select(static source => source.GetType()).ToArray();
+        foreach (var deniedSourceType in deniedSourceTypes)
+            actualSourceTypes.Should().NotContain(deniedSourceType);
     }
 }

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -97,6 +97,22 @@ public sealed class MainnetHostCompositionTests
         typeof(ScheduleStudioMemberWorkflowToolSource),
     ];
 
+    private static readonly string[] StudioLocalWorkflowToolNames =
+    [
+        "aevatar_provision_workflow_schedule",
+        "aevatar_create_team",
+        "aevatar_list_teams",
+        "aevatar_get_team",
+        "aevatar_create_member",
+        "aevatar_list_members",
+        "aevatar_get_member",
+        "aevatar_list_workflows",
+        "aevatar_list_schedules",
+        "aevatar_get_schedule",
+        "aevatar_bind_member_workflow",
+        "aevatar_schedule_member_workflow",
+    ];
+
     [Fact]
     public void GAgentServiceAndStudioCapabilities_ShouldOwnTheirCompositionDependencies()
     {
@@ -648,13 +664,31 @@ public sealed class MainnetHostCompositionTests
         app.Services.GetServices<Aevatar.Workflow.Application.Abstractions.Runs.IWorkflowConnectedServiceResourceFetchAdapter>()
             .Should()
             .ContainSingle(adapter => adapter.GetType().Name == "LarkMessageResourceFetchAdapter");
+        var workflowToolSources = app.Services.GetServices<Aevatar.Workflow.Core.Modules.IWorkflowToolSource>().ToArray();
         var workflowToolNames = new List<string>();
-        foreach (var source in app.Services.GetServices<Aevatar.Workflow.Core.Modules.IWorkflowToolSource>())
+        foreach (var source in workflowToolSources)
         {
             var tools = await source.GetToolsAsync();
             workflowToolNames.AddRange(tools.Select(static tool => tool.Name));
         }
         workflowToolNames.Should().ContainSingle(name => name == "workflow_connected_service_resource_fetch");
+        workflowToolNames.Should().NotContain(StudioLocalWorkflowToolNames);
+        workflowToolSources.Should().ContainSingle(source => source is VisibleAgentWorkflowToolSource);
+
+        using (AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+               {
+                   ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(StudioLocalWorkflowToolNames),
+               }))
+        {
+            var visibleWorkflowToolNames = new List<string>();
+            foreach (var source in workflowToolSources)
+            {
+                var tools = await source.GetToolsAsync();
+                visibleWorkflowToolNames.AddRange(tools.Select(static tool => tool.Name));
+            }
+
+            visibleWorkflowToolNames.Should().Contain(StudioLocalWorkflowToolNames);
+        }
 
         var larkSelfNotify = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.LarkSelfNotify });
         larkSelfNotify.IsSuccess.Should().BeTrue(larkSelfNotify.Error?.Message);


### PR DESCRIPTION
## Summary
- Move Studio provisioning/member/query/bind/schedule tool sources out of `workspace.default` into explicit `studio.local`.
- Keep Lark/channel/default paths on the sanitized workspace toolset instead of ambient Studio-local `IAgentToolSource` registrations.
- Add composition assertions covering `workspace.default`, `lark.self_notify`, global agent tool sources, channel reply sources, and `studio.local`.

## Test plan
- [x] `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --filter MainnetHostCompositionTests --nologo --verbosity minimal`
- [x] `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter NyxIdChatServiceCollectionExtensionsTests --nologo --verbosity minimal`
- [ ] `bash tools/ci/architecture_guards.sh` incomplete locally: Python failed loading `pyexpat`/`libexpat` in `project_reference_layer_guard.py` after earlier guards passed.

Fixes aevatarAI/aevatar#2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)