### PR TITLE
Fix Lark invocation owner scope

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -143,7 +143,7 @@ public sealed class AevatarInvocationDispatcher
         if (error != null)
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(error), error);
 
-        var scope = ResolveCallerScope();
+        var scope = ResolveChannelAwareInvocationScope();
         if (scope.Error != null)
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
 
@@ -331,7 +331,7 @@ public sealed class AevatarInvocationDispatcher
                 ct);
         }
 
-        var scope = ResolveCallerScope();
+        var scope = ResolveChannelAwareInvocationScope();
         if (scope.Error != null)
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(scope.Error), scope.Error);
 
@@ -1750,6 +1750,33 @@ public sealed class AevatarInvocationDispatcher
             scopeId,
             ownerSubject ?? string.Empty,
             responseId));
+    }
+
+    private CallerScopeResolution ResolveChannelAwareInvocationScope() =>
+        ResolveLarkOwnerInvocationScope() ?? ResolveCallerScope();
+
+    private CallerScopeResolution? ResolveLarkOwnerInvocationScope()
+    {
+        var context = AgentToolRequestContext.Current;
+        if (!IsLarkChannel(context) || Normalize(context?.Caller.OwnerScopeId) is not { } ownerScopeId)
+            return null;
+
+        var baseScope = ResolveCallerScope(requireOwner: false);
+        if (baseScope.Error != null)
+            return baseScope;
+
+        return CallerScopeResolution.Success(baseScope.Value! with
+        {
+            ScopeId = ownerScopeId,
+            OwnerSubject = ownerScopeId,
+        });
+    }
+
+    private static bool IsLarkChannel(AgentToolExecutionContext? context)
+    {
+        var platform = Normalize(context?.Channel.Platform);
+        return string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
     }
 
     private CallerScopeResolution ResolveTeamInvocationScope()

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -369,6 +369,70 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task InvokeGAgent_ShouldResolveActorInOwnerScope_WhenFeishuChannelCarriesOwnerScope()
+    {
+        var harness = new Harness();
+        harness.ActorRegistry.Snapshot = new GAgentActorRegistrySnapshot(
+            "owner-scope-1",
+            [new GAgentActorGroup("RoleGAgent", ["owner-actor-1"])],
+            7,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(
+            callId: "call-gagent-feishu-owner-scope",
+            scopeId: "registration-scope-1",
+            ownerScopeId: "owner-scope-1",
+            channelPlatform: "feishu",
+            channelRegistrationScopeId: "registration-scope-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_id": "owner-actor-1",
+              "payload": { "prompt": "hello" }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ActorRegistry.LastScopeId.Should().Be("owner-scope-1");
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var payload = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        payload.ScopeId.Should().Be("owner-scope-1");
+    }
+
+    [Fact]
+    public async Task InvokeGAgent_ShouldKeepCallerScope_WhenLarkChannelHasNoOwnerScope()
+    {
+        var harness = new Harness();
+        harness.ActorRegistry.Snapshot = new GAgentActorRegistrySnapshot(
+            "registration-scope-1",
+            [new GAgentActorGroup("RoleGAgent", ["registration-actor-1"])],
+            7,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(
+            callId: "call-gagent-lark-no-owner-scope",
+            scopeId: "registration-scope-1",
+            ownerScopeId: null,
+            channelPlatform: "lark",
+            channelRegistrationScopeId: "registration-scope-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_id": "registration-actor-1",
+              "payload": { "prompt": "hello" }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ActorRegistry.LastScopeId.Should().Be("registration-scope-1");
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var payload = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        payload.ScopeId.Should().Be("registration-scope-1");
+    }
+
+    [Fact]
     public async Task InvokeGAgent_ShouldKeepCallerScope_WhenApiChatContextCarriesOwnerScope()
     {
         var harness = new Harness();
@@ -1180,6 +1244,33 @@ public sealed class AevatarInvocationToolSourceTests
         ErrorCodeOrNull(output).Should().BeNull(output);
         harness.WorkflowDispatch.Command.Should().NotBeNull();
         harness.WorkflowDispatch.Command!.ScopeId.Should().Be("owner-scope-1");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_ShouldKeepCallerScope_WhenApiChatContextCarriesOwnerScope()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(
+            callId: "call-workflow-api-registration-scope",
+            scopeId: "registration-scope-1",
+            ownerScopeId: "owner-scope-1",
+            channelPlatform: null,
+            channelRegistrationScopeId: null);
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "wf-main",
+              "inputs": { "prompt": "run workflow" },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.ScopeId.Should().Be("registration-scope-1");
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -337,6 +337,70 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task InvokeGAgent_ShouldResolveActorInOwnerScope_WhenLarkChannelCarriesOwnerScope()
+    {
+        var harness = new Harness();
+        harness.ActorRegistry.Snapshot = new GAgentActorRegistrySnapshot(
+            "owner-scope-1",
+            [new GAgentActorGroup("RoleGAgent", ["owner-actor-1"])],
+            7,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(
+            callId: "call-gagent-lark-owner-scope",
+            scopeId: "registration-scope-1",
+            ownerScopeId: "owner-scope-1",
+            channelPlatform: "lark",
+            channelRegistrationScopeId: "registration-scope-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_id": "owner-actor-1",
+              "payload": { "prompt": "hello" }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ActorRegistry.LastScopeId.Should().Be("owner-scope-1");
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var payload = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        payload.ScopeId.Should().Be("owner-scope-1");
+    }
+
+    [Fact]
+    public async Task InvokeGAgent_ShouldKeepCallerScope_WhenApiChatContextCarriesOwnerScope()
+    {
+        var harness = new Harness();
+        harness.ActorRegistry.Snapshot = new GAgentActorRegistrySnapshot(
+            "registration-scope-1",
+            [new GAgentActorGroup("RoleGAgent", ["registration-actor-1"])],
+            7,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(
+            callId: "call-gagent-api-registration-scope",
+            scopeId: "registration-scope-1",
+            ownerScopeId: "owner-scope-1",
+            channelPlatform: null,
+            channelRegistrationScopeId: null);
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_id": "registration-actor-1",
+              "payload": { "prompt": "hello" }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ActorRegistry.LastScopeId.Should().Be("registration-scope-1");
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var payload = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        payload.ScopeId.Should().Be("registration-scope-1");
+    }
+
+    [Fact]
     public async Task InvokeGAgent_ShouldNotResolveCallerScopeFromExternalMetadata()
     {
         var harness = new Harness();
@@ -1089,6 +1153,33 @@ public sealed class AevatarInvocationToolSourceTests
         result.GetProperty("run_id").GetString().Should().Be("call-workflow");
         result.GetProperty("actor_id").GetString().Should().Be("workflow-actor");
         result.GetProperty("stream_topic").GetString().Should().Be("aevatar://actors/workflow-actor/runs/call-workflow");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_ShouldUseOwnerScope_WhenLarkChannelCarriesOwnerScope()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(
+            callId: "call-workflow-lark-owner-scope",
+            scopeId: "registration-scope-1",
+            ownerScopeId: "owner-scope-1",
+            channelPlatform: "lark",
+            channelRegistrationScopeId: "registration-scope-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "wf-main",
+              "inputs": { "prompt": "run workflow" },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.ScopeId.Should().Be("owner-scope-1");
     }
 
     [Fact]
@@ -2808,6 +2899,8 @@ public sealed class AevatarInvocationToolSourceTests
         string? senderNyxUserId = null,
         string? senderBindingId = "binding-1",
         string? ownerScopeId = null,
+        string? channelPlatform = "telegram",
+        string? channelRegistrationScopeId = "registration-scope-1",
         AgentWorkflowRuntimeContext? workflowRuntime = null,
         string? durableReplyCredentialRef = "secrets://nyx/default-reply",
         long durableReplyCredentialExpiresAtUnixMs = 0,
@@ -2817,9 +2910,9 @@ public sealed class AevatarInvocationToolSourceTests
             new AgentToolCredentials(accessToken, "org-token", "sender-token"),
             new AgentToolCallerContext(scopeId, "owner-1", "response-1", ownerScopeId),
             new AgentToolChannelContext(
-                "telegram",
+                channelPlatform,
                 "sender-1",
-                "registration-scope-1",
+                channelRegistrationScopeId,
                 "message-1",
                 "platform-message-1",
                 null,


### PR DESCRIPTION
## Summary
- Route Lark/Feishu channel GAgent and workflow tool execution through the caller owner scope when `OwnerScopeId` is present.
- Preserve caller/registration scope behavior for non-channel API chat contexts and Lark turns without an owner scope.
- Add regression coverage for Lark/Feishu owner-scope invocation, API chat scope preservation, Lark fallback, and Lark workflow starts.

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo` (97/97)
- [x] `git diff --check -- src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs`
- [ ] `bash tools/ci/test_stability_guards.sh` blocked locally after passing initial checks by Python `pyexpat`/`libexpat` dynamic library load failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)