### PR TITLE
Fix CI build break and projection overwrite test

### DIFF
--- a/apps/aevatar-console-web/tests/setupAfterEnv.ts
+++ b/apps/aevatar-console-web/tests/setupAfterEnv.ts
@@ -1,7 +1,14 @@
 import '@testing-library/jest-dom';
-import { act, cleanup } from '@testing-library/react';
+import { act, cleanup, configure } from '@testing-library/react';
 import { Modal } from 'antd';
 import { cleanupTestQueryClients } from './reactQueryTestUtils';
+
+// The default 1s async budget is too tight for loaded CI runners: a query
+// invalidation round trip that settles in ~450ms locally can exceed 1s there,
+// surfacing as a stale assertion rather than a real defect. A satisfied
+// waitFor still resolves immediately, so this only widens the failure budget
+// and costs passing tests nothing.
+configure({ asyncUtilTimeout: 5000 });
 
 afterEach(() => {
   cleanup();

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionProviderE2EIntegrationTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionProviderE2EIntegrationTests.cs
@@ -40,18 +40,24 @@ public sealed class ProjectionProviderE2EIntegrationTests
         {
             Id = id,
             ActorId = id,
+            StateVersion = 1,
+            LastEventId = $"event-{id}-1",
             Value = "v1",
             UpdatedAtEpochMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 
-        await store.UpsertAsync(readModel);
+        var initialWrite = await store.UpsertAsync(readModel);
+        initialWrite.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
         var fetched = await store.GetAsync(readModel.Id);
         fetched.Should().NotBeNull();
         fetched!.Value.Should().Be("v1");
 
+        readModel.StateVersion = 2;
+        readModel.LastEventId = $"event-{id}-2";
         readModel.Value = "v2";
         readModel.UpdatedAtEpochMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        await store.UpsertAsync(readModel);
+        var overwriteWrite = await store.UpsertAsync(readModel);
+        overwriteWrite.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
 
         var mutated = await store.GetAsync(readModel.Id);
         mutated.Should().NotBeNull();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -356,6 +356,7 @@ public sealed class ConversationReplyGeneratorTests
         };
         IAgentRunStepConversationReplyGenerator generator = new NyxIdConversationReplyGenerator(
             providerFactory,
+            BuiltInPromptFloorProvider,
             larkClient: lark,
             fileIngressPort: fileArtifacts,
             fileArtifactReadPort: fileArtifacts);


### PR DESCRIPTION
## Problem

Four jobs were red on `feature/integrate` (PR #2911), from three independent causes:

| Job | Cause |
| --- | --- |
| `coverage-quality`, `kafka-transport-integration` | Solution build broke: `ConversationReplyGeneratorTests.cs:357` omitted the required `IBuiltInPromptFloorProvider` argument. Introduced by the Lark file-card image test; every other one of the 64 call sites passes it. |
| `projection-provider-e2e` | `ElasticsearchStore_ShouldRoundtripUpsertAndOverwrite` wrote both revisions at `StateVersion = 0`. `ProjectionWriteResultEvaluator` sees equal versions with differing bytes, returns `Conflict`, and skips the write — so the doc stayed `v1`. Failing consistently across every run. |
| `console-web` | `hydrates a pristine draft when exact server identity refreshes from A to B` rode the default 1s testing-library async budget. Instrumented locally: mount+alpha ~430ms, the invalidation roundtrip ~450-490ms, exactly 2 fetches. Correct logic, no race — just no headroom on a loaded runner, which surfaced as `Received: Shared OpenAI alpha`. |

## Solution

- Pass `BuiltInPromptFloorProvider` at the one call site that missed it.
- Advance `StateVersion`/`LastEventId` between the two writes and assert both are `Applied`, so the test exercises the monotonic-overwrite read-model contract instead of contradicting it.
- Raise `asyncUtilTimeout` in the console-web jsdom setup. A satisfied `waitFor` still resolves immediately, so this costs passing tests nothing and only widens the budget before a slow-but-correct update is called a failure. Nothing in the suite depends on fast `waitFor` failure (no `rejects`/`waitForElementToBeRemoved` patterns).

The `console-web` change is at the shared setup rather than the one test because all 26 tests in that file carry no explicit timeout, so they share the same cliff.

## Affected paths

- `test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs`
- `test/Aevatar.CQRS.Projection.Core.Tests/ProjectionProviderE2EIntegrationTests.cs`
- `apps/aevatar-console-web/tests/setupAfterEnv.ts`

## Verification

| Command | Result |
| --- | --- |
| `bash tools/ci/restore_and_build.sh` | pass — 0 errors (the step that was failing) |
| `dotnet test .../Aevatar.GAgents.ChannelRuntime.Tests --filter ConversationReplyGeneratorTests` | 74 passed, 0 failed |
| `bash tools/ci/projection_provider_e2e_smoke.sh` (real Elasticsearch via docker) | 2/2 passed, was 1 failed / 1 passed |
| `pnpm --dir apps/aevatar-console-web test --runInBand` | 133 suites, 1213 tests, all passed |
| `pnpm --dir apps/aevatar-console-web tsc` | pass |
| `bash tools/ci/test_stability_guards.sh` | pass |

Tests only — no production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)