### PR TITLE
Store Lark document attachments before extraction

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -539,12 +539,18 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         {
             if (part.Kind == Aevatar.AI.Abstractions.ChatContentPartKind.Text)
             {
+                if (HasFileRefIdentity(part.FileRef))
+                    part.Text = string.Empty;
                 continue;
             }
 
             part.DataBase64 = string.Empty;
         }
     }
+
+    private static bool HasFileRefIdentity(Aevatar.AI.Abstractions.ChatFileRef? fileRef) =>
+        fileRef is not null &&
+        (!string.IsNullOrWhiteSpace(fileRef.FileId) || !string.IsNullOrWhiteSpace(fileRef.ArtifactId));
 
     private async Task DispatchLlmStepExecutorAsync(NeedsLlmReplyEvent request, AgentRunReplyStepState stepState)
     {

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -948,11 +948,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             return false;
         }
 
-        var fileName = NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name) ?? "attachment.pdf";
-        var extractionHeader = truncated
-            ? $"PDF attachment '{fileName}' extracted text (truncated to first {MaxInlineDocumentTextChars} characters):"
-            : $"PDF attachment '{fileName}' extracted text:";
-        parts.Add(ContentPart.TextPart($"{extractionHeader}\n{extractedText}"));
+        parts.Add(BuildDocumentFileRefPart(fileRef, attachment.Name));
         return true;
     }
 
@@ -1027,11 +1023,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             return false;
         }
 
-        var fileName = NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name) ?? "attachment.txt";
-        var contentHeader = truncated
-            ? $"Text attachment '{fileName}' content (truncated to first {MaxInlineDocumentTextChars} characters):"
-            : $"Text attachment '{fileName}' content:";
-        parts.Add(ContentPart.TextPart($"{contentHeader}\n{fileText}"));
+        parts.Add(BuildDocumentFileRefPart(fileRef, attachment.Name));
         return true;
     }
 
@@ -1146,6 +1138,15 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         }
     }
 
+    private static ContentPart BuildDocumentFileRefPart(FileArtifactRef fileRef, string? fallbackFileName) =>
+        new()
+        {
+            Kind = ContentPartKind.Text,
+            FileRef = ToChatFileRef(fileRef),
+            MediaType = NormalizeOptional(fileRef.MediaType),
+            Name = NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(fallbackFileName),
+        };
+
     private async Task<byte[]?> TryReadLarkFileArtifactBytesAsync(
         FileArtifactRef fileRef,
         int maxBytes,
@@ -1222,6 +1223,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 .ConfigureAwait(false);
             materialized.Add(part.Kind switch
             {
+                ContentPartKind.Text => MaterializeDocumentTextPart(part, descriptor, bytes),
                 ContentPartKind.Image => ContentPart.ImagePart(
                     Convert.ToBase64String(bytes),
                     NormalizeImageMediaType(descriptor.MediaType ?? part.MediaType),
@@ -1239,6 +1241,45 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         }
 
         return materialized;
+    }
+
+    private static ContentPart MaterializeDocumentTextPart(
+        ContentPart part,
+        FileArtifactRef descriptor,
+        byte[] bytes)
+    {
+        var mediaType = NormalizeOptional(descriptor.MediaType) ?? NormalizeOptional(part.MediaType);
+        var fileName = NormalizeOptional(descriptor.FileName) ?? NormalizeOptional(part.Name);
+        string extractedText;
+        bool truncated;
+        string header;
+        if (ResolvePdfMediaType(mediaType, fileName: fileName) is not null)
+        {
+            (extractedText, truncated) = ExtractPdfText(bytes, MaxInlineDocumentTextChars);
+            header = truncated
+                ? $"PDF attachment '{fileName ?? "attachment.pdf"}' extracted text (truncated to first {MaxInlineDocumentTextChars} characters):"
+                : $"PDF attachment '{fileName ?? "attachment.pdf"}' extracted text:";
+        }
+        else if (ResolveTextMediaType(mediaType, fileName: fileName) is not null)
+        {
+            (extractedText, truncated) = ExtractUtf8Text(bytes, MaxInlineDocumentTextChars);
+            header = truncated
+                ? $"Text attachment '{fileName ?? "attachment.txt"}' content (truncated to first {MaxInlineDocumentTextChars} characters):"
+                : $"Text attachment '{fileName ?? "attachment.txt"}' content:";
+        }
+        else
+        {
+            return part;
+        }
+
+        return new ContentPart
+        {
+            Kind = ContentPartKind.Text,
+            Text = $"{header}\n{extractedText}",
+            FileRef = part.FileRef,
+            MediaType = mediaType,
+            Name = fileName,
+        };
     }
 
     private static async Task<byte[]> ReadBoundedAsync(
@@ -1652,10 +1693,23 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             ReasoningContent = message.ReasoningContent ?? string.Empty,
             ToolCallId = message.ToolCallId ?? string.Empty,
         };
-        entry.ContentParts.AddRange((message.ContentParts ?? []).Select(ContentPartProtoMapper.ToProto));
+        entry.ContentParts.AddRange((message.ContentParts ?? []).Select(ToPersistedContentPart));
         entry.ToolCalls.AddRange((message.ToolCalls ?? []).Select(ToConversationToolCallEntry));
         return entry;
     }
+
+    private static Aevatar.AI.Abstractions.ChatContentPart ToPersistedContentPart(ContentPart part)
+    {
+        var persisted = ContentPartProtoMapper.ToProto(part);
+        if (persisted.Kind == Aevatar.AI.Abstractions.ChatContentPartKind.Text &&
+            HasFileRefIdentity(persisted.FileRef))
+            persisted.Text = string.Empty;
+        return persisted;
+    }
+
+    private static bool HasFileRefIdentity(Aevatar.AI.Abstractions.ChatFileRef? fileRef) =>
+        fileRef is not null &&
+        (!string.IsNullOrWhiteSpace(fileRef.FileId) || !string.IsNullOrWhiteSpace(fileRef.ArtifactId));
 
     private static ToolCall ToToolCall(ConversationToolCallEntry entry) =>
         new()

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -894,64 +894,36 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             return false;
         }
 
-        LarkMessageResourceDownloadResult downloaded;
-        try
-        {
-            downloaded = await larkClient.DownloadMessageResourceAsync(
-                    token,
-                    new LarkMessageResourceDownloadRequest(
-                        messageId,
-                        resourceKey,
-                        LarkMessageResourceKind.File),
-                    ct)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to download Lark PDF attachment for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} contentType={ContentType} name={Name}",
+        var fileRef = await TryIngestLarkFileAttachmentAsync(
+                larkClient,
+                token,
                 providerSlug,
                 messageId,
+                attachment,
                 resourceKey,
-                attachment.ContentType,
-                attachment.Name);
+                LarkMessageResourceKind.File,
+                ResolveDownloadedPdfMediaType,
+                MaxInlineDocumentBytes,
+                "PDF",
+                ct)
+            .ConfigureAwait(false);
+        if (fileRef is null)
             return false;
-        }
 
-        var mediaType = ResolveDownloadedPdfMediaType(
-            downloaded.ContentType,
-            attachment.ContentType,
-            downloaded.FileName,
-            attachment.Name);
-        if (!downloaded.Succeeded ||
-            downloaded.Content.Length == 0 ||
-            downloaded.Content.Length > MaxInlineDocumentBytes ||
-            mediaType is null)
-        {
-            _logger.LogWarning(
-                "Lark PDF attachment download was not usable for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} contentType={ContentType} downloadedContentType={DownloadedContentType} name={Name} downloadedName={DownloadedName} status={Status} detail={Detail}",
-                providerSlug,
-                messageId,
-                resourceKey,
-                attachment.ContentType,
-                downloaded.ContentType,
-                attachment.Name,
-                downloaded.FileName,
-                downloaded.HttpStatus,
-                downloaded.Detail);
+        var content = await TryReadLarkFileArtifactBytesAsync(
+                fileRef,
+                MaxInlineDocumentBytes,
+                "PDF",
+                ct)
+            .ConfigureAwait(false);
+        if (content is null)
             return false;
-        }
 
         string extractedText;
         bool truncated;
         try
         {
-            (extractedText, truncated) = ExtractPdfText(downloaded.Content, MaxInlineDocumentTextChars);
+            (extractedText, truncated) = ExtractPdfText(content, MaxInlineDocumentTextChars);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -961,7 +933,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 providerSlug,
                 messageId,
                 resourceKey,
-                NormalizeOptional(downloaded.FileName) ?? NormalizeOptional(attachment.Name));
+                NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name));
             return false;
         }
 
@@ -972,11 +944,11 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 providerSlug,
                 messageId,
                 resourceKey,
-                NormalizeOptional(downloaded.FileName) ?? NormalizeOptional(attachment.Name));
+                NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name));
             return false;
         }
 
-        var fileName = NormalizeOptional(downloaded.FileName) ?? NormalizeOptional(attachment.Name) ?? "attachment.pdf";
+        var fileName = NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name) ?? "attachment.pdf";
         var extractionHeader = truncated
             ? $"PDF attachment '{fileName}' extracted text (truncated to first {MaxInlineDocumentTextChars} characters):"
             : $"PDF attachment '{fileName}' extracted text:";
@@ -1018,6 +990,64 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             return false;
         }
 
+        var fileRef = await TryIngestLarkFileAttachmentAsync(
+                larkClient,
+                token,
+                providerSlug,
+                messageId,
+                attachment,
+                resourceKey,
+                LarkMessageResourceKind.File,
+                ResolveDownloadedTextMediaType,
+                MaxInlineDocumentBytes,
+                "text",
+                ct)
+            .ConfigureAwait(false);
+        if (fileRef is null)
+            return false;
+
+        var content = await TryReadLarkFileArtifactBytesAsync(
+                fileRef,
+                MaxInlineDocumentBytes,
+                "text",
+                ct)
+            .ConfigureAwait(false);
+        if (content is null)
+            return false;
+
+        var (fileText, truncated) = ExtractUtf8Text(content, MaxInlineDocumentTextChars);
+        if (string.IsNullOrWhiteSpace(fileText))
+        {
+            _logger.LogWarning(
+                "Lark text attachment produced no usable text for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} name={Name}",
+                providerSlug,
+                messageId,
+                resourceKey,
+                NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name));
+            return false;
+        }
+
+        var fileName = NormalizeOptional(fileRef.FileName) ?? NormalizeOptional(attachment.Name) ?? "attachment.txt";
+        var contentHeader = truncated
+            ? $"Text attachment '{fileName}' content (truncated to first {MaxInlineDocumentTextChars} characters):"
+            : $"Text attachment '{fileName}' content:";
+        parts.Add(ContentPart.TextPart($"{contentHeader}\n{fileText}"));
+        return true;
+    }
+
+    private async Task<FileArtifactRef?> TryIngestLarkFileAttachmentAsync(
+        ILarkNyxClient larkClient,
+        string token,
+        string? providerSlug,
+        string messageId,
+        AttachmentRef attachment,
+        string resourceKey,
+        LarkMessageResourceKind resourceKind,
+        Func<string?, string?, string?, string?, string?> resolveMediaType,
+        int maxBytes,
+        string attachmentLabel,
+        CancellationToken ct)
+    {
         LarkMessageResourceDownloadResult downloaded;
         try
         {
@@ -1026,7 +1056,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                     new LarkMessageResourceDownloadRequest(
                         messageId,
                         resourceKey,
-                        LarkMessageResourceKind.File),
+                        resourceKind),
                     ct)
                 .ConfigureAwait(false);
         }
@@ -1038,27 +1068,29 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         {
             _logger.LogWarning(
                 ex,
-                "Failed to download Lark text attachment for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} contentType={ContentType} name={Name}",
+                "Failed to download Lark {AttachmentLabel} attachment for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} contentType={ContentType} name={Name}",
+                attachmentLabel,
                 providerSlug,
                 messageId,
                 resourceKey,
                 attachment.ContentType,
                 attachment.Name);
-            return false;
+            return null;
         }
 
-        var mediaType = ResolveDownloadedTextMediaType(
+        var mediaType = resolveMediaType(
             downloaded.ContentType,
             attachment.ContentType,
             downloaded.FileName,
             attachment.Name);
         if (!downloaded.Succeeded ||
             downloaded.Content.Length == 0 ||
-            downloaded.Content.Length > MaxInlineDocumentBytes ||
+            downloaded.Content.Length > maxBytes ||
             mediaType is null)
         {
             _logger.LogWarning(
-                "Lark text attachment download was not usable for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} contentType={ContentType} downloadedContentType={DownloadedContentType} name={Name} downloadedName={DownloadedName} status={Status} detail={Detail}",
+                "Lark {AttachmentLabel} attachment download was not usable for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} contentType={ContentType} downloadedContentType={DownloadedContentType} name={Name} downloadedName={DownloadedName} status={Status} detail={Detail}",
+                attachmentLabel,
                 providerSlug,
                 messageId,
                 resourceKey,
@@ -1068,27 +1100,93 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 downloaded.FileName,
                 downloaded.HttpStatus,
                 downloaded.Detail);
-            return false;
+            return null;
         }
 
-        var (fileText, truncated) = ExtractUtf8Text(downloaded.Content, MaxInlineDocumentTextChars);
-        if (string.IsNullOrWhiteSpace(fileText))
+        if (_fileIngressPort is null)
         {
             _logger.LogWarning(
-                "Lark text attachment produced no usable text for chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} name={Name}",
+                "File ingress port is unavailable for Lark {AttachmentLabel} attachment chat LLM input: provider={ProviderSlug} messageId={MessageId} resourceKey={ResourceKey} resourceKind={ResourceKind}",
+                attachmentLabel,
                 providerSlug,
                 messageId,
                 resourceKey,
-                NormalizeOptional(downloaded.FileName) ?? NormalizeOptional(attachment.Name));
-            return false;
+                resourceKind);
+            return null;
         }
 
-        var fileName = NormalizeOptional(downloaded.FileName) ?? NormalizeOptional(attachment.Name) ?? "attachment.txt";
-        var contentHeader = truncated
-            ? $"Text attachment '{fileName}' content (truncated to first {MaxInlineDocumentTextChars} characters):"
-            : $"Text attachment '{fileName}' content:";
-        parts.Add(ContentPart.TextPart($"{contentHeader}\n{fileText}"));
-        return true;
+        var fileName = NormalizeOptional(downloaded.FileName) ?? NormalizeOptional(attachment.Name);
+        try
+        {
+            var ingressResult = await _fileIngressPort.IngestAsync(
+                    new FileArtifactIngressRequest(
+                        downloaded.Content,
+                        FileArtifactSourceKind.ChatInput,
+                        SourceMessageId: messageId,
+                        SourceResourceKey: resourceKey,
+                        FileName: fileName,
+                        MediaType: mediaType),
+                    ct)
+                .ConfigureAwait(false);
+            return ingressResult.FileRef;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to ingest Lark {AttachmentLabel} attachment for chat LLM input: messageId={MessageId} resourceKey={ResourceKey}",
+                attachmentLabel,
+                messageId,
+                resourceKey);
+            return null;
+        }
+    }
+
+    private async Task<byte[]?> TryReadLarkFileArtifactBytesAsync(
+        FileArtifactRef fileRef,
+        int maxBytes,
+        string attachmentLabel,
+        CancellationToken ct)
+    {
+        if (_fileArtifactReadPort is null)
+        {
+            _logger.LogWarning(
+                "File artifact read port is unavailable for Lark {AttachmentLabel} attachment chat LLM input: artifactId={ArtifactId} fileId={FileId}",
+                attachmentLabel,
+                fileRef.ArtifactId,
+                fileRef.FileId);
+            return null;
+        }
+
+        try
+        {
+            var artifact = await _fileArtifactReadPort.OpenReadAsync(fileRef, ct).ConfigureAwait(false);
+            await using var content = artifact.Content;
+            return await ReadBoundedAsync(
+                    content,
+                    maxBytes,
+                    NormalizeOptional(artifact.FileRef.FileName) ?? NormalizeOptional(fileRef.FileName),
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to read Lark {AttachmentLabel} attachment artifact for chat LLM input: artifactId={ArtifactId} fileId={FileId}",
+                attachmentLabel,
+                fileRef.ArtifactId,
+                fileRef.FileId);
+            return null;
+        }
     }
 
     internal static async Task<IReadOnlyList<ContentPart>> MaterializeFileRefPartsAsync(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -56,6 +56,15 @@ public sealed class AgentRunGAgentTests
                 },
                 new Aevatar.AI.Abstractions.ChatContentPart
                 {
+                    Kind = Aevatar.AI.Abstractions.ChatContentPartKind.Text,
+                    Text = "large extracted document text",
+                    FileRef = new Aevatar.AI.Abstractions.ChatFileRef
+                    {
+                        ArtifactId = "workflow-file://wf-file-document",
+                    },
+                },
+                new Aevatar.AI.Abstractions.ChatContentPart
+                {
                     Kind = Aevatar.AI.Abstractions.ChatContentPartKind.Image,
                     DataBase64 = "large-image-base64",
                     FileRef = new Aevatar.AI.Abstractions.ChatFileRef
@@ -86,10 +95,13 @@ public sealed class AgentRunGAgentTests
         var sanitized = AgentRunGAgent.StripInlineMediaPayloads(stepState);
 
         sanitized.Messages.Single().ContentParts[0].Text.Should().Be("describe");
-        sanitized.Messages.Single().ContentParts[1].DataBase64.Should().BeEmpty();
-        sanitized.Messages.Single().ContentParts[1].FileRef.ArtifactId.Should().Be("workflow-file://wf-file-1");
+        sanitized.Messages.Single().ContentParts[1].Text.Should().BeEmpty();
+        sanitized.Messages.Single().ContentParts[1].FileRef.ArtifactId.Should().Be("workflow-file://wf-file-document");
+        sanitized.Messages.Single().ContentParts[2].DataBase64.Should().BeEmpty();
+        sanitized.Messages.Single().ContentParts[2].FileRef.ArtifactId.Should().Be("workflow-file://wf-file-1");
         sanitized.AppendedHistory.Single().ContentParts.Should().OnlyContain(part => part.DataBase64.Length == 0);
-        stepState.Messages.Single().ContentParts[1].DataBase64.Should().Be("large-image-base64");
+        stepState.Messages.Single().ContentParts[1].Text.Should().Be("large extracted document text");
+        stepState.Messages.Single().ContentParts[2].DataBase64.Should().Be("large-image-base64");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -977,11 +977,17 @@ public sealed class ConversationReplyGeneratorTests
         var pdfBytes = BuildSimplePdf("Invoice total 42.00 USD");
         var lark = new RecordingLarkNyxClient(
             new LarkMessageResourceDownloadResult(true, pdfBytes, "application/pdf", "report.pdf"));
+        var fileArtifacts = new RecordingWorkflowFileArtifactPort();
         var providerFactory = new RecordingProviderFactory
         {
             Capabilities = LLMProviderCapabilities.TextOnly,
         };
-        var generator = new NyxIdConversationReplyGenerator(providerFactory, BuiltInPromptFloorProvider, larkClient: lark);
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            BuiltInPromptFloorProvider,
+            larkClient: lark,
+            fileIngressPort: fileArtifacts,
+            fileArtifactReadPort: fileArtifacts);
         var activity = CreateLarkActivity(
             "msg-file-pdf",
             "read this",
@@ -1021,6 +1027,13 @@ public sealed class ConversationReplyGeneratorTests
             "om_file_pdf",
             "file_key",
             LarkMessageResourceKind.File));
+        var ingress = fileArtifacts.IngressRequests.Should().ContainSingle().Subject;
+        ingress.Content.ToArray().Should().Equal(pdfBytes);
+        ingress.SourceKind.Should().Be(FileArtifactSourceKind.ChatInput);
+        ingress.SourceMessageId.Should().Be("om_file_pdf");
+        ingress.SourceResourceKey.Should().Be("file_key");
+        ingress.FileName.Should().Be("report.pdf");
+        ingress.MediaType.Should().Be("application/pdf");
     }
 
     [Fact]
@@ -1029,11 +1042,17 @@ public sealed class ConversationReplyGeneratorTests
         var pdfBytes = BuildSimplePdf(new string('A', 21_000));
         var lark = new RecordingLarkNyxClient(
             new LarkMessageResourceDownloadResult(true, pdfBytes, "application/pdf", "long-report.pdf"));
+        var fileArtifacts = new RecordingWorkflowFileArtifactPort();
         var providerFactory = new RecordingProviderFactory
         {
             Capabilities = LLMProviderCapabilities.TextOnly,
         };
-        var generator = new NyxIdConversationReplyGenerator(providerFactory, BuiltInPromptFloorProvider, larkClient: lark);
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            BuiltInPromptFloorProvider,
+            larkClient: lark,
+            fileIngressPort: fileArtifacts,
+            fileArtifactReadPort: fileArtifacts);
         var activity = CreateLarkActivity(
             "msg-file-long-pdf",
             "read this",
@@ -1078,11 +1097,17 @@ public sealed class ConversationReplyGeneratorTests
         var fileBytes = Encoding.UTF8.GetBytes(fileContent);
         var lark = new RecordingLarkNyxClient(
             new LarkMessageResourceDownloadResult(true, fileBytes, contentType, fileName));
+        var fileArtifacts = new RecordingWorkflowFileArtifactPort();
         var providerFactory = new RecordingProviderFactory
         {
             Capabilities = LLMProviderCapabilities.TextOnly,
         };
-        var generator = new NyxIdConversationReplyGenerator(providerFactory, BuiltInPromptFloorProvider, larkClient: lark);
+        var generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            BuiltInPromptFloorProvider,
+            larkClient: lark,
+            fileIngressPort: fileArtifacts,
+            fileArtifactReadPort: fileArtifacts);
         var activity = CreateLarkActivity(
             $"msg-file-{fileName}",
             "read this",
@@ -1121,6 +1146,15 @@ public sealed class ConversationReplyGeneratorTests
             $"om_file_{fileName}",
             "file_key",
             LarkMessageResourceKind.File));
+        var ingress = fileArtifacts.IngressRequests.Should().ContainSingle().Subject;
+        ingress.Content.ToArray().Should().Equal(fileBytes);
+        ingress.SourceKind.Should().Be(FileArtifactSourceKind.ChatInput);
+        ingress.SourceMessageId.Should().Be($"om_file_{fileName}");
+        ingress.SourceResourceKey.Should().Be("file_key");
+        ingress.FileName.Should().Be(fileName);
+        ingress.MediaType.Should().Be(fileName.EndsWith(".yaml", StringComparison.Ordinal)
+            ? "application/yaml"
+            : contentType);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -664,6 +664,79 @@ public sealed class ConversationReplyGeneratorTests
     }
 
     [Fact]
+    public async Task BuildStepPlanAsync_WithRecentLarkPdfAttachment_PersistsFileRefWithoutExtractedText()
+    {
+        var pdfBytes = BuildSimplePdf("confidential extracted document text");
+        var lark = new RecordingLarkNyxClient(
+            new LarkMessageResourceDownloadResult(true, pdfBytes, "application/pdf", "recent.pdf"));
+        var fileArtifacts = new RecordingWorkflowFileArtifactPort();
+        var providerFactory = new RecordingProviderFactory
+        {
+            Capabilities = LLMProviderCapabilities.TextOnly,
+        };
+        IAgentRunStepConversationReplyGenerator generator = new NyxIdConversationReplyGenerator(
+            providerFactory,
+            BuiltInPromptFloorProvider,
+            larkClient: lark,
+            fileIngressPort: fileArtifacts,
+            fileArtifactReadPort: fileArtifacts);
+        var recentActivity = CreateLarkActivity(
+            "msg-pdf-recent",
+            "earlier pdf",
+            "om_recent_pdf",
+            token: null);
+        recentActivity.Content.Attachments.Add(new AttachmentRef
+        {
+            AttachmentId = "pdf_recent",
+            Kind = AttachmentKind.File,
+            ContentType = "application/pdf",
+            Name = "recent.pdf",
+            SizeBytes = pdfBytes.Length,
+        });
+        var currentActivity = new ChatActivity
+        {
+            Id = "msg-follow-up-pdf",
+            ChannelId = ChannelId.From("lark"),
+            Conversation = new ConversationReference { CanonicalKey = "lark:scope-a:chat-1" },
+            Content = new MessageContent { Text = "what was in the pdf?" },
+        };
+        var attachmentContext = new ChatAttachmentInputContext(
+            [
+                new RecentConversationAttachmentActivity
+                {
+                    ActivityId = recentActivity.Id,
+                    AcceptedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    Activity = recentActivity.Clone(),
+                },
+            ],
+            "recent-token");
+
+        var plan = await generator.BuildStepPlanAsync(
+            currentActivity,
+            new Dictionary<string, string>(),
+            llmControl: null,
+            toolContext: null,
+            priorHistory: null,
+            attachmentContext,
+            forceDisableTools: false,
+            CancellationToken.None);
+
+        var userMessage = plan.InitialMessages.Last(message => message.Role == "user");
+        var documentPart = userMessage.ContentParts.Should().NotBeNull().And.Subject
+            .Single(part => part.Kind == ContentPartKind.Text && part.FileRef is not null);
+        documentPart.Text.Should().BeNull();
+        documentPart.FileRef!.ArtifactId.Should().Be("workflow-file://wf-file-1");
+        documentPart.FileRef.SourceKind.Should().Be(LlmChatFileSourceKind.ChatInput);
+        documentPart.FileRef.SourceMessageId.Should().Be("om_recent_pdf");
+        documentPart.FileRef.SourceResourceKey.Should().Be("pdf_recent");
+        documentPart.MediaType.Should().Be("application/pdf");
+        documentPart.Name.Should().Be("recent.pdf");
+        userMessage.ContentParts!.Should().NotContain(part =>
+            part.Text != null &&
+            part.Text.Contains("confidential extracted document text", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task BuildStepPlanAsync_WithRecentLarkImageAttachment_ShouldUseAttachmentActivityProviderSlugClient()
     {
         var imageBytes = new byte[] { 3, 4, 5 };
@@ -1002,7 +1075,7 @@ public sealed class ConversationReplyGeneratorTests
             SizeBytes = pdfBytes.Length,
         });
 
-        await generator.GenerateReplyAsync(
+        var result = await generator.GenerateReplyAsync(
             activity,
             new Dictionary<string, string>(),
             streamingSink: null,
@@ -1034,6 +1107,15 @@ public sealed class ConversationReplyGeneratorTests
         ingress.SourceResourceKey.Should().Be("file_key");
         ingress.FileName.Should().Be("report.pdf");
         ingress.MediaType.Should().Be("application/pdf");
+        result.AppendedHistory.Should().NotContain(entry =>
+            entry.ContentParts.Any(part =>
+                part.Text.Contains("Invoice total 42.00 USD", StringComparison.Ordinal)));
+        result.AppendedHistory.SelectMany(entry => entry.ContentParts)
+            .Should().Contain(part =>
+                part.Kind == Aevatar.AI.Abstractions.ChatContentPartKind.Text &&
+                part.Text.Length == 0 &&
+                part.FileRef != null &&
+                part.FileRef.ArtifactId == "workflow-file://wf-file-1");
     }
 
     [Fact]
@@ -1122,7 +1204,7 @@ public sealed class ConversationReplyGeneratorTests
             SizeBytes = fileBytes.Length,
         });
 
-        await generator.GenerateReplyAsync(
+        var result = await generator.GenerateReplyAsync(
             activity,
             new Dictionary<string, string>(),
             streamingSink: null,
@@ -1155,6 +1237,15 @@ public sealed class ConversationReplyGeneratorTests
         ingress.MediaType.Should().Be(fileName.EndsWith(".yaml", StringComparison.Ordinal)
             ? "application/yaml"
             : contentType);
+        result.AppendedHistory.Should().NotContain(entry =>
+            entry.ContentParts.Any(part =>
+                part.Text.Contains(fileContent, StringComparison.Ordinal)));
+        result.AppendedHistory.SelectMany(entry => entry.ContentParts)
+            .Should().Contain(part =>
+                part.Kind == Aevatar.AI.Abstractions.ChatContentPartKind.Text &&
+                part.Text.Length == 0 &&
+                part.FileRef != null &&
+                part.FileRef.ArtifactId == "workflow-file://wf-file-1");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Ingest Lark PDF/text file-card downloads into the workflow file artifact store before extracting inline LLM text.
- Read stored artifacts back through `IFileArtifactReadPort` for PDF/text materialization so document handling uses the same artifact lifecycle as chat media.
- Extend conversation reply generator tests to assert original PDF/text bytes and metadata are stored as `ChatInput` file artifacts.

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~ConversationReplyGeneratorTests"`
- [x] `git diff --check`
- [ ] `bash tools/ci/test_stability_guards.sh` (local Python `pyexpat`/`libexpat` link failure after polling and coverage guards passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)