### PR TITLE
Return draft workflow YAML validation details

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -22,12 +22,6 @@ using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.Capabilities;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Studio.Application.Studio.Abstractions;
-using WorkflowExternalCapabilityReadiness = Aevatar.Workflow.Abstractions.ExternalCapabilityReadiness;
-using WorkflowExternalCapabilityReadinessStatus = Aevatar.Workflow.Abstractions.ExternalCapabilityReadinessStatus;
-using WorkflowExternalCapabilityRef = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilityRef;
-using WorkflowExternalCapabilityRemediationActionKind = Aevatar.Workflow.Abstractions.ExternalCapabilityRemediationActionKind;
-using WorkflowExternalCapabilitySelector = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilitySelector;
-using WorkflowExternalCapabilitySourceKind = Aevatar.Workflow.Abstractions.ExternalCapabilitySourceKind;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Serialization;
 using Aevatar.AGUI.Contracts;
@@ -159,7 +153,6 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
         [FromServices] WorkflowMultipartFileInputParser multipartFileInputParser,
         [FromServices] IFileArtifactIngressPort workflowFileIngressPort,
-        [FromServices] IWorkflowDefinitionParser workflowDefinitionParser,
         CancellationToken ct)
     {
         try
@@ -187,16 +180,6 @@ public static class ScopeServiceEndpoints
             var request = requestInput.Request!;
             if (request.WorkflowYamls == null || request.WorkflowYamls.Count == 0)
                 throw new InvalidOperationException("workflowYamls is required.");
-
-            var workflowYamlValidation = await ValidateDraftWorkflowYamlsAsync(
-                request.WorkflowYamls,
-                workflowDefinitionParser,
-                ct);
-            if (!workflowYamlValidation.Succeeded)
-            {
-                await WriteInvalidWorkflowYamlResponseAsync(http, workflowYamlValidation, ct);
-                return;
-            }
 
             var scopedHeaders = BuildScopedHeaders(request.Headers);
             if (!ScopeWorkflowEndpoints.TryParseEventFormat(request.EventFormat, out var eventFormat))
@@ -269,165 +252,6 @@ public static class ScopeServiceEndpoints
         }
     }
 
-    private static async Task<DraftWorkflowYamlValidationResult> ValidateDraftWorkflowYamlsAsync(
-        IReadOnlyList<string> workflowYamls,
-        IWorkflowDefinitionParser workflowDefinitionParser,
-        CancellationToken ct)
-    {
-        var inlineWorkflowDocuments = workflowYamls
-            .Select(static yaml => new WorkflowChatInlineYamlDocument(string.Empty, yaml))
-            .ToArray();
-        var parseResult = await workflowDefinitionParser.ParseInlineWorkflowBundleAsync(inlineWorkflowDocuments, ct);
-        return parseResult.Succeeded
-            ? DraftWorkflowYamlValidationResult.Success
-            : DraftWorkflowYamlValidationResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
-    }
-
-    private static async Task WriteInvalidWorkflowYamlResponseAsync(
-        HttpContext http,
-        DraftWorkflowYamlValidationResult validation,
-        CancellationToken ct)
-    {
-        var readiness = MapExternalCapabilityReadiness(validation.ExternalCapabilityReadiness);
-        if (readiness == null)
-        {
-            await WriteJsonErrorResponseAsync(
-                http,
-                StatusCodes.Status400BadRequest,
-                "INVALID_WORKFLOW_YAML",
-                validation.Message,
-                ct);
-            return;
-        }
-
-        await WriteJsonErrorResponseAsync(
-            http,
-            StatusCodes.Status400BadRequest,
-            new
-            {
-                code = "INVALID_WORKFLOW_YAML",
-                message = validation.Message,
-                externalCapabilityReadiness = readiness,
-            },
-            ct);
-    }
-
-    private static object? MapExternalCapabilityReadiness(WorkflowExternalCapabilityReadiness? readiness)
-    {
-        if (readiness == null)
-            return null;
-
-        return new
-        {
-            status = ReadinessStatus(readiness.Status),
-            selectedCapability = MapSelectedCapability(readiness),
-            blockers = readiness.Blockers.Select(static blocker => new
-            {
-                status = ReadinessStatus(blocker.Status),
-                code = blocker.Code,
-                safeMessage = blocker.SafeMessage,
-            }).ToArray(),
-            remediations = readiness.Remediations.Select(static remediation => new
-            {
-                actionKind = RemediationKind(remediation.ActionKind),
-                label = remediation.Label,
-                trustedLocator = NullIfEmpty(remediation.TrustedLocator),
-            }).ToArray(),
-            sources = readiness.Sources.Select(static source => new
-            {
-                sourceKind = SourceKind(source.SourceKind),
-                sourceId = source.SourceId,
-                sourceVersion = source.SourceVersion,
-            }).ToArray(),
-        };
-    }
-
-    private static object? MapSelectedCapability(WorkflowExternalCapabilityReadiness readiness)
-    {
-        if (readiness.SelectedSelector is not null)
-        {
-            switch (readiness.SelectedSelector.SelectorCase)
-            {
-                case WorkflowExternalCapabilitySelector.SelectorOneofCase.NyxIdOperation:
-                    return new
-                    {
-                        userServiceId = readiness.SelectedSelector.NyxIdOperation.UserServiceId,
-                        operationId = readiness.SelectedSelector.NyxIdOperation.OperationId,
-                        connectorCapabilityRef = (string?)null,
-                    };
-                case WorkflowExternalCapabilitySelector.SelectorOneofCase.HostConnector:
-                    return new
-                    {
-                        userServiceId = (string?)null,
-                        operationId = readiness.SelectedSelector.HostConnector.OperationId,
-                        connectorCapabilityRef = readiness.SelectedSelector.HostConnector.ConnectorCapabilityRef,
-                    };
-            }
-        }
-
-        return readiness.SelectedCapability?.CapabilityCase switch
-        {
-            WorkflowExternalCapabilityRef.CapabilityOneofCase.NyxIdUserService => new
-            {
-                userServiceId = (string?)readiness.SelectedCapability.NyxIdUserService.UserServiceId,
-                operationId = readiness.SelectedCapability.NyxIdUserService.OperationId,
-                connectorCapabilityRef = (string?)null,
-            },
-            WorkflowExternalCapabilityRef.CapabilityOneofCase.HostConnector => new
-            {
-                userServiceId = (string?)null,
-                operationId = readiness.SelectedCapability.HostConnector.OperationId,
-                connectorCapabilityRef = (string?)readiness.SelectedCapability.HostConnector.ConnectorCapabilityRef,
-            },
-            _ => null,
-        };
-    }
-
-    private static string ReadinessStatus(WorkflowExternalCapabilityReadinessStatus status) => status switch
-    {
-        WorkflowExternalCapabilityReadinessStatus.SelectionRequired => "selection_required",
-        WorkflowExternalCapabilityReadinessStatus.ConnectorNotFound => "connector_not_found",
-        WorkflowExternalCapabilityReadinessStatus.ServiceRegistrationRequired => "service_registration_required",
-        WorkflowExternalCapabilityReadinessStatus.CredentialConnectionRequired => "credential_connection_required",
-        WorkflowExternalCapabilityReadinessStatus.ServiceAccessDenied => "service_access_denied",
-        WorkflowExternalCapabilityReadinessStatus.NodeBindingRequired => "node_binding_required",
-        WorkflowExternalCapabilityReadinessStatus.NodeUnavailable => "node_unavailable",
-        WorkflowExternalCapabilityReadinessStatus.EndpointContractRequired => "endpoint_contract_required",
-        WorkflowExternalCapabilityReadinessStatus.OperationSelectionRequired => "operation_selection_required",
-        WorkflowExternalCapabilityReadinessStatus.SourceStale => "source_stale",
-        WorkflowExternalCapabilityReadinessStatus.DurableAuthorizationUnavailable => "durable_authorization_unavailable",
-        WorkflowExternalCapabilityReadinessStatus.ContractDrift => "contract_drift",
-        WorkflowExternalCapabilityReadinessStatus.Ready => "ready",
-        WorkflowExternalCapabilityReadinessStatus.AdmissionRebindRequired => "admission_rebind_required",
-        _ => "unspecified",
-    };
-
-    private static string RemediationKind(WorkflowExternalCapabilityRemediationActionKind actionKind) =>
-        actionKind switch
-        {
-            WorkflowExternalCapabilityRemediationActionKind.SelectCapability => "select_capability",
-            WorkflowExternalCapabilityRemediationActionKind.ConfigureConnector => "configure_connector",
-            WorkflowExternalCapabilityRemediationActionKind.RegisterService => "register_service",
-            WorkflowExternalCapabilityRemediationActionKind.ConnectCredential => "connect_credential",
-            WorkflowExternalCapabilityRemediationActionKind.RequestAccess => "request_access",
-            WorkflowExternalCapabilityRemediationActionKind.BindNode => "bind_node",
-            WorkflowExternalCapabilityRemediationActionKind.RestoreNode => "restore_node",
-            WorkflowExternalCapabilityRemediationActionKind.PublishEndpointContract => "publish_endpoint_contract",
-            WorkflowExternalCapabilityRemediationActionKind.SelectOperation => "select_operation",
-            WorkflowExternalCapabilityRemediationActionKind.RefreshSource => "refresh_source",
-            WorkflowExternalCapabilityRemediationActionKind.UseInteractiveExecution => "use_interactive_execution",
-            WorkflowExternalCapabilityRemediationActionKind.RebindWorkflow => "rebind_workflow",
-            _ => "unspecified",
-        };
-
-    private static string SourceKind(WorkflowExternalCapabilitySourceKind sourceKind) => sourceKind switch
-    {
-        WorkflowExternalCapabilitySourceKind.ConnectorCatalog => "connector_catalog",
-        WorkflowExternalCapabilitySourceKind.NyxIdUserServices => "nyx_id_user_services",
-        WorkflowExternalCapabilitySourceKind.NyxIdOpenApi => "nyx_id_open_api",
-        WorkflowExternalCapabilitySourceKind.DurableAuthorizationCatalog => "durable_authorization_catalog",
-        _ => "unspecified",
-    };
 
     private static string? NullIfEmpty(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
@@ -4593,22 +4417,6 @@ const response = await fetch("{{invokePath}}", {
 
         public static ScopeDraftRunRequestInput Failed(ScopeDraftRunRequestParseError error) =>
             new(null, null, error);
-    }
-
-    private readonly record struct DraftWorkflowYamlValidationResult(
-        bool Succeeded,
-        string Message,
-        WorkflowExternalCapabilityReadiness? ExternalCapabilityReadiness = null)
-    {
-        public static DraftWorkflowYamlValidationResult Success { get; } = new(true, string.Empty);
-
-        public static DraftWorkflowYamlValidationResult Invalid(
-            string message,
-            WorkflowExternalCapabilityReadiness? externalCapabilityReadiness = null) =>
-            new(
-                false,
-                string.IsNullOrWhiteSpace(message) ? "Workflow YAML is invalid." : message,
-                externalCapabilityReadiness?.Clone());
     }
 
     private readonly record struct ScopeDraftRunRequestParseError(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -153,6 +153,7 @@ public static class ScopeServiceEndpoints
         [FromServices] IWorkflowChatRunInteractionPort chatRunService,
         [FromServices] WorkflowMultipartFileInputParser multipartFileInputParser,
         [FromServices] IFileArtifactIngressPort workflowFileIngressPort,
+        [FromServices] IWorkflowDefinitionParser workflowDefinitionParser,
         CancellationToken ct)
     {
         try
@@ -180,6 +181,21 @@ public static class ScopeServiceEndpoints
             var request = requestInput.Request!;
             if (request.WorkflowYamls == null || request.WorkflowYamls.Count == 0)
                 throw new InvalidOperationException("workflowYamls is required.");
+
+            var workflowYamlValidation = await ValidateDraftWorkflowYamlsAsync(
+                request.WorkflowYamls,
+                workflowDefinitionParser,
+                ct);
+            if (!workflowYamlValidation.Succeeded)
+            {
+                await WriteJsonErrorResponseAsync(
+                    http,
+                    StatusCodes.Status400BadRequest,
+                    "INVALID_WORKFLOW_YAML",
+                    workflowYamlValidation.Message,
+                    ct);
+                return;
+            }
 
             var scopedHeaders = BuildScopedHeaders(request.Headers);
             if (!ScopeWorkflowEndpoints.TryParseEventFormat(request.EventFormat, out var eventFormat))
@@ -250,6 +266,25 @@ public static class ScopeServiceEndpoints
                 ex.Message,
                 ct);
         }
+    }
+
+    private static async Task<DraftWorkflowYamlValidationResult> ValidateDraftWorkflowYamlsAsync(
+        IReadOnlyList<string> workflowYamls,
+        IWorkflowDefinitionParser workflowDefinitionParser,
+        CancellationToken ct)
+    {
+        for (var i = 0; i < workflowYamls.Count; i++)
+        {
+            var workflowYaml = workflowYamls[i];
+            if (string.IsNullOrWhiteSpace(workflowYaml))
+                return DraftWorkflowYamlValidationResult.Invalid($"workflowYamls[{i}] is required.");
+
+            var parseResult = await workflowDefinitionParser.ParseWorkflowYamlAsync(workflowYaml, ct);
+            if (!parseResult.Succeeded)
+                return DraftWorkflowYamlValidationResult.Invalid(parseResult.Error);
+        }
+
+        return DraftWorkflowYamlValidationResult.Success;
     }
 
     private static async ValueTask<ScopeDraftRunRequestInput> ParseScopeDraftRunRequestAsync(
@@ -4413,6 +4448,16 @@ const response = await fetch("{{invokePath}}", {
 
         public static ScopeDraftRunRequestInput Failed(ScopeDraftRunRequestParseError error) =>
             new(null, null, error);
+    }
+
+    private readonly record struct DraftWorkflowYamlValidationResult(
+        bool Succeeded,
+        string Message)
+    {
+        public static DraftWorkflowYamlValidationResult Success { get; } = new(true, string.Empty);
+
+        public static DraftWorkflowYamlValidationResult Invalid(string message) =>
+            new(false, string.IsNullOrWhiteSpace(message) ? "Workflow YAML is invalid." : message);
     }
 
     private readonly record struct ScopeDraftRunRequestParseError(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -22,6 +22,12 @@ using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.Capabilities;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using WorkflowExternalCapabilityReadiness = Aevatar.Workflow.Abstractions.ExternalCapabilityReadiness;
+using WorkflowExternalCapabilityReadinessStatus = Aevatar.Workflow.Abstractions.ExternalCapabilityReadinessStatus;
+using WorkflowExternalCapabilityRef = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilityRef;
+using WorkflowExternalCapabilityRemediationActionKind = Aevatar.Workflow.Abstractions.ExternalCapabilityRemediationActionKind;
+using WorkflowExternalCapabilitySelector = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilitySelector;
+using WorkflowExternalCapabilitySourceKind = Aevatar.Workflow.Abstractions.ExternalCapabilitySourceKind;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Serialization;
 using Aevatar.AGUI.Contracts;
@@ -188,12 +194,7 @@ public static class ScopeServiceEndpoints
                 ct);
             if (!workflowYamlValidation.Succeeded)
             {
-                await WriteJsonErrorResponseAsync(
-                    http,
-                    StatusCodes.Status400BadRequest,
-                    "INVALID_WORKFLOW_YAML",
-                    workflowYamlValidation.Message,
-                    ct);
+                await WriteInvalidWorkflowYamlResponseAsync(http, workflowYamlValidation, ct);
                 return;
             }
 
@@ -273,19 +274,163 @@ public static class ScopeServiceEndpoints
         IWorkflowDefinitionParser workflowDefinitionParser,
         CancellationToken ct)
     {
-        for (var i = 0; i < workflowYamls.Count; i++)
-        {
-            var workflowYaml = workflowYamls[i];
-            if (string.IsNullOrWhiteSpace(workflowYaml))
-                return DraftWorkflowYamlValidationResult.Invalid($"workflowYamls[{i}] is required.");
+        var inlineWorkflowDocuments = workflowYamls
+            .Select(static yaml => new WorkflowChatInlineYamlDocument(string.Empty, yaml))
+            .ToArray();
+        var parseResult = await workflowDefinitionParser.ParseInlineWorkflowBundleAsync(inlineWorkflowDocuments, ct);
+        return parseResult.Succeeded
+            ? DraftWorkflowYamlValidationResult.Success
+            : DraftWorkflowYamlValidationResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+    }
 
-            var parseResult = await workflowDefinitionParser.ParseWorkflowYamlAsync(workflowYaml, ct);
-            if (!parseResult.Succeeded)
-                return DraftWorkflowYamlValidationResult.Invalid(parseResult.Error);
+    private static async Task WriteInvalidWorkflowYamlResponseAsync(
+        HttpContext http,
+        DraftWorkflowYamlValidationResult validation,
+        CancellationToken ct)
+    {
+        var readiness = MapExternalCapabilityReadiness(validation.ExternalCapabilityReadiness);
+        if (readiness == null)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                StatusCodes.Status400BadRequest,
+                "INVALID_WORKFLOW_YAML",
+                validation.Message,
+                ct);
+            return;
         }
 
-        return DraftWorkflowYamlValidationResult.Success;
+        await WriteJsonErrorResponseAsync(
+            http,
+            StatusCodes.Status400BadRequest,
+            new
+            {
+                code = "INVALID_WORKFLOW_YAML",
+                message = validation.Message,
+                externalCapabilityReadiness = readiness,
+            },
+            ct);
     }
+
+    private static object? MapExternalCapabilityReadiness(WorkflowExternalCapabilityReadiness? readiness)
+    {
+        if (readiness == null)
+            return null;
+
+        return new
+        {
+            status = ReadinessStatus(readiness.Status),
+            selectedCapability = MapSelectedCapability(readiness),
+            blockers = readiness.Blockers.Select(static blocker => new
+            {
+                status = ReadinessStatus(blocker.Status),
+                code = blocker.Code,
+                safeMessage = blocker.SafeMessage,
+            }).ToArray(),
+            remediations = readiness.Remediations.Select(static remediation => new
+            {
+                actionKind = RemediationKind(remediation.ActionKind),
+                label = remediation.Label,
+                trustedLocator = NullIfEmpty(remediation.TrustedLocator),
+            }).ToArray(),
+            sources = readiness.Sources.Select(static source => new
+            {
+                sourceKind = SourceKind(source.SourceKind),
+                sourceId = source.SourceId,
+                sourceVersion = source.SourceVersion,
+            }).ToArray(),
+        };
+    }
+
+    private static object? MapSelectedCapability(WorkflowExternalCapabilityReadiness readiness)
+    {
+        if (readiness.SelectedSelector is not null)
+        {
+            switch (readiness.SelectedSelector.SelectorCase)
+            {
+                case WorkflowExternalCapabilitySelector.SelectorOneofCase.NyxIdOperation:
+                    return new
+                    {
+                        userServiceId = readiness.SelectedSelector.NyxIdOperation.UserServiceId,
+                        operationId = readiness.SelectedSelector.NyxIdOperation.OperationId,
+                        connectorCapabilityRef = (string?)null,
+                    };
+                case WorkflowExternalCapabilitySelector.SelectorOneofCase.HostConnector:
+                    return new
+                    {
+                        userServiceId = (string?)null,
+                        operationId = readiness.SelectedSelector.HostConnector.OperationId,
+                        connectorCapabilityRef = readiness.SelectedSelector.HostConnector.ConnectorCapabilityRef,
+                    };
+            }
+        }
+
+        return readiness.SelectedCapability?.CapabilityCase switch
+        {
+            WorkflowExternalCapabilityRef.CapabilityOneofCase.NyxIdUserService => new
+            {
+                userServiceId = readiness.SelectedCapability.NyxIdUserService.UserServiceId,
+                operationId = readiness.SelectedCapability.NyxIdUserService.OperationId,
+                connectorCapabilityRef = (string?)null,
+            },
+            WorkflowExternalCapabilityRef.CapabilityOneofCase.HostConnector => new
+            {
+                userServiceId = (string?)null,
+                operationId = readiness.SelectedCapability.HostConnector.OperationId,
+                connectorCapabilityRef = readiness.SelectedCapability.HostConnector.ConnectorCapabilityRef,
+            },
+            _ => null,
+        };
+    }
+
+    private static string ReadinessStatus(WorkflowExternalCapabilityReadinessStatus status) => status switch
+    {
+        WorkflowExternalCapabilityReadinessStatus.SelectionRequired => "selection_required",
+        WorkflowExternalCapabilityReadinessStatus.ConnectorNotFound => "connector_not_found",
+        WorkflowExternalCapabilityReadinessStatus.ServiceRegistrationRequired => "service_registration_required",
+        WorkflowExternalCapabilityReadinessStatus.CredentialConnectionRequired => "credential_connection_required",
+        WorkflowExternalCapabilityReadinessStatus.ServiceAccessDenied => "service_access_denied",
+        WorkflowExternalCapabilityReadinessStatus.NodeBindingRequired => "node_binding_required",
+        WorkflowExternalCapabilityReadinessStatus.NodeUnavailable => "node_unavailable",
+        WorkflowExternalCapabilityReadinessStatus.EndpointContractRequired => "endpoint_contract_required",
+        WorkflowExternalCapabilityReadinessStatus.OperationSelectionRequired => "operation_selection_required",
+        WorkflowExternalCapabilityReadinessStatus.SourceStale => "source_stale",
+        WorkflowExternalCapabilityReadinessStatus.DurableAuthorizationUnavailable => "durable_authorization_unavailable",
+        WorkflowExternalCapabilityReadinessStatus.ContractDrift => "contract_drift",
+        WorkflowExternalCapabilityReadinessStatus.Ready => "ready",
+        WorkflowExternalCapabilityReadinessStatus.AdmissionRebindRequired => "admission_rebind_required",
+        _ => "unspecified",
+    };
+
+    private static string RemediationKind(WorkflowExternalCapabilityRemediationActionKind actionKind) =>
+        actionKind switch
+        {
+            WorkflowExternalCapabilityRemediationActionKind.SelectCapability => "select_capability",
+            WorkflowExternalCapabilityRemediationActionKind.ConfigureConnector => "configure_connector",
+            WorkflowExternalCapabilityRemediationActionKind.RegisterService => "register_service",
+            WorkflowExternalCapabilityRemediationActionKind.ConnectCredential => "connect_credential",
+            WorkflowExternalCapabilityRemediationActionKind.RequestAccess => "request_access",
+            WorkflowExternalCapabilityRemediationActionKind.BindNode => "bind_node",
+            WorkflowExternalCapabilityRemediationActionKind.RestoreNode => "restore_node",
+            WorkflowExternalCapabilityRemediationActionKind.PublishEndpointContract => "publish_endpoint_contract",
+            WorkflowExternalCapabilityRemediationActionKind.SelectOperation => "select_operation",
+            WorkflowExternalCapabilityRemediationActionKind.RefreshSource => "refresh_source",
+            WorkflowExternalCapabilityRemediationActionKind.UseInteractiveExecution => "use_interactive_execution",
+            WorkflowExternalCapabilityRemediationActionKind.RebindWorkflow => "rebind_workflow",
+            _ => "unspecified",
+        };
+
+    private static string SourceKind(WorkflowExternalCapabilitySourceKind sourceKind) => sourceKind switch
+    {
+        WorkflowExternalCapabilitySourceKind.ConnectorCatalog => "connector_catalog",
+        WorkflowExternalCapabilitySourceKind.NyxIdUserServices => "nyx_id_user_services",
+        WorkflowExternalCapabilitySourceKind.NyxIdOpenApi => "nyx_id_open_api",
+        WorkflowExternalCapabilitySourceKind.DurableAuthorizationCatalog => "durable_authorization_catalog",
+        _ => "unspecified",
+    };
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 
     private static async ValueTask<ScopeDraftRunRequestInput> ParseScopeDraftRunRequestAsync(
         HttpContext http,
@@ -4452,12 +4597,18 @@ const response = await fetch("{{invokePath}}", {
 
     private readonly record struct DraftWorkflowYamlValidationResult(
         bool Succeeded,
-        string Message)
+        string Message,
+        WorkflowExternalCapabilityReadiness? ExternalCapabilityReadiness = null)
     {
         public static DraftWorkflowYamlValidationResult Success { get; } = new(true, string.Empty);
 
-        public static DraftWorkflowYamlValidationResult Invalid(string message) =>
-            new(false, string.IsNullOrWhiteSpace(message) ? "Workflow YAML is invalid." : message);
+        public static DraftWorkflowYamlValidationResult Invalid(
+            string message,
+            WorkflowExternalCapabilityReadiness? externalCapabilityReadiness = null) =>
+            new(
+                false,
+                string.IsNullOrWhiteSpace(message) ? "Workflow YAML is invalid." : message,
+                externalCapabilityReadiness?.Clone());
     }
 
     private readonly record struct ScopeDraftRunRequestParseError(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -369,7 +369,7 @@ public static class ScopeServiceEndpoints
         {
             WorkflowExternalCapabilityRef.CapabilityOneofCase.NyxIdUserService => new
             {
-                userServiceId = readiness.SelectedCapability.NyxIdUserService.UserServiceId,
+                userServiceId = (string?)readiness.SelectedCapability.NyxIdUserService.UserServiceId,
                 operationId = readiness.SelectedCapability.NyxIdUserService.OperationId,
                 connectorCapabilityRef = (string?)null,
             },
@@ -377,7 +377,7 @@ public static class ScopeServiceEndpoints
             {
                 userServiceId = (string?)null,
                 operationId = readiness.SelectedCapability.HostConnector.OperationId,
-                connectorCapabilityRef = readiness.SelectedCapability.HostConnector.ConnectorCapabilityRef,
+                connectorCapabilityRef = (string?)readiness.SelectedCapability.HostConnector.ConnectorCapabilityRef,
             },
             _ => null,
         };

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -461,6 +461,16 @@ public static class ScopeWorkflowEndpoints
 
             if (!result.Succeeded && !started)
             {
+                if (result.FailureDetail?.Error == WorkflowChatRunStartError.InvalidWorkflowYaml)
+                {
+                    await WriteJsonErrorResponseAsync(
+                        http,
+                        ChatRunStartErrorMapper.ToHttpStatusCode(result.Error),
+                        ChatRunStartErrorMapper.ToErrorBody(result.FailureDetail),
+                        ct);
+                    return;
+                }
+
                 var (statusCode, code, message) = MapRunStartError(result.Error);
                 await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
             }
@@ -762,6 +772,17 @@ public static class ScopeWorkflowEndpoints
         http.Response.StatusCode = statusCode;
         http.Response.ContentType = "application/json";
         await http.Response.WriteAsJsonAsync(new { code, message }, cancellationToken: ct);
+    }
+
+    private static async Task WriteJsonErrorResponseAsync(
+        HttpContext http,
+        int statusCode,
+        object body,
+        CancellationToken ct)
+    {
+        http.Response.StatusCode = statusCode;
+        http.Response.ContentType = "application/json";
+        await http.Response.WriteAsJsonAsync(body, cancellationToken: ct);
     }
 
     private static string NormalizeRequired(string? value, string paramName)

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs.Abstractions/IWorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs.Abstractions/IWorkflowRunActorResolver.cs
@@ -10,4 +10,5 @@ public interface IWorkflowRunActorResolver
 public sealed record WorkflowActorResolutionResult(
     WorkflowRunCreationReceipt? Target,
     string WorkflowNameForRun,
-    WorkflowChatRunStartError Error);
+    WorkflowChatRunStartError Error,
+    WorkflowChatRunStartFailureDetail? FailureDetail = null);

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunInteractionContracts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunInteractionContracts.cs
@@ -1,12 +1,79 @@
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Workflow.Abstractions;
 
 namespace Aevatar.Workflow.Application.Abstractions.Runs;
 
 public interface IWorkflowChatRunInteractionPort
 {
-    Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+    Task<WorkflowChatRunInteractionResult> ExecuteAsync(
         WorkflowChatRunRequest request,
         Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
         Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
         CancellationToken ct = default);
+}
+
+public sealed record WorkflowChatRunStartFailureDetail(
+    WorkflowChatRunStartError Error,
+    string Message,
+    ExternalCapabilityReadiness? ExternalCapabilityReadiness = null)
+{
+    public static WorkflowChatRunStartFailureDetail Create(
+        WorkflowChatRunStartError error,
+        string? message = null,
+        ExternalCapabilityReadiness? externalCapabilityReadiness = null) =>
+        new(
+            error,
+            string.IsNullOrWhiteSpace(message) ? DefaultMessage(error) : message,
+            externalCapabilityReadiness?.Clone());
+
+    private static string DefaultMessage(WorkflowChatRunStartError error) =>
+        error == WorkflowChatRunStartError.InvalidWorkflowYaml
+            ? "Workflow YAML is invalid."
+            : string.Empty;
+}
+
+public sealed record WorkflowChatRunInteractionResult
+{
+    public required bool Succeeded { get; init; }
+    public required WorkflowChatRunStartError Error { get; init; }
+    public WorkflowChatInteractionAcceptedReceipt? Receipt { get; init; }
+    public WorkflowProjectionCompletionStatus? Completion { get; init; }
+    public bool Completed { get; init; }
+    public CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>? FinalizeResult { get; init; }
+    public WorkflowChatRunStartFailureDetail? FailureDetail { get; init; }
+
+    public static WorkflowChatRunInteractionResult Success(
+        WorkflowChatInteractionAcceptedReceipt receipt,
+        CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus> finalizeResult)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        ArgumentNullException.ThrowIfNull(finalizeResult);
+
+        return new WorkflowChatRunInteractionResult
+        {
+            Succeeded = true,
+            Error = WorkflowChatRunStartError.None,
+            Receipt = receipt,
+            Completion = finalizeResult.Completion,
+            Completed = finalizeResult.Completed,
+            FinalizeResult = finalizeResult,
+            FailureDetail = null,
+        };
+    }
+
+    public static WorkflowChatRunInteractionResult Failure(
+        WorkflowChatRunStartError error,
+        WorkflowChatRunStartFailureDetail? failureDetail = null)
+    {
+        return new WorkflowChatRunInteractionResult
+        {
+            Succeeded = false,
+            Error = error,
+            Receipt = null,
+            Completion = default,
+            Completed = false,
+            FinalizeResult = null,
+            FailureDetail = failureDetail,
+        };
+    }
 }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
@@ -25,6 +25,36 @@ public sealed record WorkflowYamlParseResult(
             externalCapabilityReadiness?.Clone());
 }
 
+public sealed record WorkflowInlineYamlBundleParseResult(
+    string EntryWorkflowName,
+    string EntryWorkflowYaml,
+    IReadOnlyDictionary<string, string> WorkflowYamlsByName,
+    string Error,
+    ExternalCapabilityReadiness? ExternalCapabilityReadiness = null)
+{
+    public bool Succeeded => string.IsNullOrWhiteSpace(Error);
+
+    public static WorkflowInlineYamlBundleParseResult Success(
+        string entryWorkflowName,
+        string entryWorkflowYaml,
+        IReadOnlyDictionary<string, string> workflowYamlsByName) =>
+        new(
+            entryWorkflowName ?? string.Empty,
+            entryWorkflowYaml ?? string.Empty,
+            workflowYamlsByName ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            string.Empty);
+
+    public static WorkflowInlineYamlBundleParseResult Invalid(
+        string error,
+        ExternalCapabilityReadiness? externalCapabilityReadiness = null) =>
+        new(
+            string.Empty,
+            string.Empty,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            string.IsNullOrWhiteSpace(error) ? "Workflow YAML is invalid." : error,
+            externalCapabilityReadiness?.Clone());
+}
+
 public enum WorkflowActorKind
 {
     Unsupported = 0,
@@ -268,5 +298,9 @@ public interface IWorkflowDefinitionParser
     /// </summary>
     Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
         string workflowYaml,
+        CancellationToken ct = default);
+
+    Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+        IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
         CancellationToken ct = default);
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunInteractionService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunInteractionService.cs
@@ -33,7 +33,7 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
         _chatHistoryCreateRecoveryReadPort = chatHistoryCreateRecoveryReadPort;
     }
 
-    public async Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+    public async Task<WorkflowChatRunInteractionResult> ExecuteAsync(
         WorkflowChatRunRequest request,
         Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
         Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
@@ -57,7 +57,9 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
 
         var preflight = ValidatePreActorResolution(currentRequest);
         if (preflight != WorkflowChatRunStartError.None)
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>.Failure(preflight);
+            return WorkflowChatRunInteractionResult.Failure(
+                preflight,
+                WorkflowChatRunStartFailureDetail.Create(preflight));
 
         var recoveredCreate = await TryRecoverCreateAsync(currentRequest, ct).ConfigureAwait(false);
         if (recoveredCreate != null)
@@ -67,7 +69,7 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
         {
             var attempt = await StartAttemptAsync(currentRequest, ct).ConfigureAwait(false);
             if (!attempt.Succeeded)
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>.Failure(attempt.Error);
+                return WorkflowChatRunInteractionResult.Failure(attempt.Error, attempt.FailureDetail);
 
             try
             {
@@ -103,16 +105,22 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
         CancellationToken ct)
     {
         if (!_projectionPort.ProjectionEnabled)
-            return AttemptStartResult.Failure(WorkflowChatRunStartError.ProjectionDisabled);
+            return AttemptStartResult.Failure(
+                WorkflowChatRunStartError.ProjectionDisabled,
+                WorkflowChatRunStartFailureDetail.Create(WorkflowChatRunStartError.ProjectionDisabled));
 
         if (Aevatar.Workflow.Abstractions.WorkflowCallerCredentialTokens
             .ParseOptional(request.CallerCredential?.BearerToken)
             .IsInvalid)
-            return AttemptStartResult.Failure(WorkflowChatRunStartError.InvalidCallerCredential);
+            return AttemptStartResult.Failure(
+                WorkflowChatRunStartError.InvalidCallerCredential,
+                WorkflowChatRunStartFailureDetail.Create(WorkflowChatRunStartError.InvalidCallerCredential));
 
         var actorResolution = await _actorResolver.ResolveOrCreateAsync(request, ct).ConfigureAwait(false);
         if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Target == null)
-            return AttemptStartResult.Failure(actorResolution.Error);
+            return AttemptStartResult.Failure(
+                actorResolution.Error,
+                actorResolution.FailureDetail ?? WorkflowChatRunStartFailureDetail.Create(actorResolution.Error));
 
         var seededRequest = request with
         {
@@ -128,7 +136,7 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
             actorResolution.Target.CreatedActorIds));
     }
 
-    private async Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAttemptAsync(
+    private async Task<WorkflowChatRunInteractionResult> ExecuteAttemptAsync(
         WorkflowChatRunInteractionAttempt attempt,
         Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
         Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync,
@@ -138,15 +146,18 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
         if (chatHistoryDelivery is { Succeeded: false })
         {
             await CleanupAttemptAsync(attempt, CancellationToken.None).ConfigureAwait(false);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-                .Failure(MapReservationFailure(chatHistoryDelivery.Failure));
+            var error = MapReservationFailure(chatHistoryDelivery.Failure);
+            return WorkflowChatRunInteractionResult.Failure(
+                error,
+                WorkflowChatRunStartFailureDetail.Create(error));
         }
         if (chatHistoryDelivery is { Reservation.ExistingReservation: true } &&
             attempt.Request.ChatConversation?.Intent == WorkflowChatConversationIntentKind.Create)
         {
             await CleanupAttemptAsync(attempt, CancellationToken.None).ConfigureAwait(false);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-                .Failure(WorkflowChatRunStartError.ChatHistoryReservationUnavailable);
+            return WorkflowChatRunInteractionResult.Failure(
+                WorkflowChatRunStartError.ChatHistoryReservationUnavailable,
+                WorkflowChatRunStartFailureDetail.Create(WorkflowChatRunStartError.ChatHistoryReservationUnavailable));
         }
 
         async ValueTask OnAcceptedAsync(WorkflowChatRunAcceptedReceipt receipt, CancellationToken token)
@@ -189,15 +200,15 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
             await CleanupAttemptAsync(attempt, CancellationToken.None, chatHistoryDelivery?.Reservation).ConfigureAwait(false);
 
         if (!result.Succeeded || result.Receipt == null)
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-                .Failure(result.Error);
+            return WorkflowChatRunInteractionResult.Failure(
+                result.Error,
+                WorkflowChatRunStartFailureDetail.Create(result.Error));
 
-        return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-            .Success(
-                new WorkflowChatInteractionAcceptedReceipt(result.Receipt, chatHistoryDelivery?.ChatContext),
-                result.FinalizeResult ?? new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
-                    result.Completion,
-                    result.Completed));
+        return WorkflowChatRunInteractionResult.Success(
+            new WorkflowChatInteractionAcceptedReceipt(result.Receipt, chatHistoryDelivery?.ChatContext),
+            result.FinalizeResult ?? new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
+                result.Completion,
+                result.Completed));
     }
 
     private async Task<WorkflowChatHistoryTerminalDeliveryReservationResult?> ReserveChatHistoryDeliveryAsync(
@@ -244,7 +255,7 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
             .ConfigureAwait(false);
     }
 
-    private async Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>?> TryRecoverCreateAsync(
+    private async Task<WorkflowChatRunInteractionResult?> TryRecoverCreateAsync(
         WorkflowChatRunRequest request,
         CancellationToken ct)
     {
@@ -275,16 +286,18 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
         if (!string.IsNullOrWhiteSpace(recovery.RequestFingerprint) &&
             !string.Equals(recovery.RequestFingerprint, requestFingerprint, StringComparison.Ordinal))
         {
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-                .Failure(WorkflowChatRunStartError.IdempotencyConflict);
+            return WorkflowChatRunInteractionResult.Failure(
+                WorkflowChatRunStartError.IdempotencyConflict,
+                WorkflowChatRunStartFailureDetail.Create(WorkflowChatRunStartError.IdempotencyConflict));
         }
 
         if (string.IsNullOrWhiteSpace(recovery.ConversationId) ||
             string.IsNullOrWhiteSpace(recovery.TurnId) ||
             string.IsNullOrWhiteSpace(recovery.WorkflowActorId))
         {
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-                .Failure(WorkflowChatRunStartError.ChatHistoryReservationUnavailable);
+            return WorkflowChatRunInteractionResult.Failure(
+                WorkflowChatRunStartError.ChatHistoryReservationUnavailable,
+                WorkflowChatRunStartFailureDetail.Create(WorkflowChatRunStartError.ChatHistoryReservationUnavailable));
         }
 
         var receipt = new WorkflowChatInteractionAcceptedReceipt(
@@ -303,12 +316,11 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
                 recovery.TurnId.Trim(),
                 recovery.StateVersion));
 
-        return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-            .Success(
-                receipt,
-                new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
-                    WorkflowProjectionCompletionStatus.Completed,
-                    false));
+        return WorkflowChatRunInteractionResult.Success(
+            receipt,
+            new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
+                WorkflowProjectionCompletionStatus.Completed,
+                false));
     }
 
     private static WorkflowChatConversationIntent? NormalizeConversationIntent(WorkflowChatRunRequest request)
@@ -420,14 +432,17 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
 
     private sealed record AttemptStartResult(
         WorkflowChatRunInteractionAttempt? Value,
-        WorkflowChatRunStartError Error)
+        WorkflowChatRunStartError Error,
+        WorkflowChatRunStartFailureDetail? FailureDetail = null)
     {
         public bool Succeeded => Error == WorkflowChatRunStartError.None && Value != null;
 
         public static AttemptStartResult Success(WorkflowChatRunInteractionAttempt attempt) =>
             new(attempt, WorkflowChatRunStartError.None);
 
-        public static AttemptStartResult Failure(WorkflowChatRunStartError error) =>
-            new(null, error);
+        public static AttemptStartResult Failure(
+            WorkflowChatRunStartError error,
+            WorkflowChatRunStartFailureDetail? failureDetail = null) =>
+            new(null, error, failureDetail);
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
@@ -53,7 +53,14 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
         {
             var inlineBundle = await _definitionParser.ParseInlineWorkflowBundleAsync(inlineWorkflowDocuments, ct);
             if (!inlineBundle.Succeeded)
-                return new WorkflowActorResolutionResult(null, workflowNameForRun, WorkflowChatRunStartError.InvalidWorkflowYaml);
+                return new WorkflowActorResolutionResult(
+                    null,
+                    workflowNameForRun,
+                    WorkflowChatRunStartError.InvalidWorkflowYaml,
+                    WorkflowChatRunStartFailureDetail.Create(
+                        WorkflowChatRunStartError.InvalidWorkflowYaml,
+                        inlineBundle.Error,
+                        inlineBundle.ExternalCapabilityReadiness));
 
             workflowNameForRun = inlineBundle.EntryWorkflowName;
             workflowYamlForRun = inlineBundle.EntryWorkflowYaml;

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
@@ -51,7 +51,7 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
 
         if (hasInlineWorkflowYamls)
         {
-            var inlineBundle = await BuildInlineWorkflowBundleAsync(inlineWorkflowDocuments, ct);
+            var inlineBundle = await _definitionParser.ParseInlineWorkflowBundleAsync(inlineWorkflowDocuments, ct);
             if (!inlineBundle.Succeeded)
                 return new WorkflowActorResolutionResult(null, workflowNameForRun, WorkflowChatRunStartError.InvalidWorkflowYaml);
 
@@ -238,58 +238,6 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
         };
     }
 
-    private async Task<InlineWorkflowBundle> BuildInlineWorkflowBundleAsync(
-        IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
-        CancellationToken ct)
-    {
-        if (inlineWorkflowDocuments.Count == 0)
-            return InlineWorkflowBundle.Invalid;
-
-        var workflowByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        string entryWorkflowName = string.Empty;
-        string entryWorkflowYaml = string.Empty;
-
-        for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
-        {
-            var document = inlineWorkflowDocuments[i];
-            var yaml = document.Yaml;
-            if (string.IsNullOrWhiteSpace(yaml))
-                return InlineWorkflowBundle.Invalid;
-
-            var parseResult = await _definitionParser.ParseWorkflowYamlAsync(yaml, ct);
-            if (!parseResult.Succeeded)
-                return InlineWorkflowBundle.Invalid;
-
-            var workflowName = WorkflowRunNameNormalizer.NormalizeWorkflowName(parseResult.WorkflowName);
-            if (string.IsNullOrWhiteSpace(workflowName))
-                return InlineWorkflowBundle.Invalid;
-            var documentName = WorkflowRunNameNormalizer.NormalizeWorkflowName(document.Name);
-            if (!string.IsNullOrWhiteSpace(documentName) &&
-                !string.Equals(documentName, workflowName, StringComparison.OrdinalIgnoreCase))
-            {
-                return InlineWorkflowBundle.Invalid;
-            }
-
-            if (!workflowByName.TryAdd(workflowName, yaml))
-                return InlineWorkflowBundle.Invalid;
-
-            if (i == 0)
-            {
-                entryWorkflowName = workflowName;
-                entryWorkflowYaml = yaml;
-            }
-        }
-
-        if (string.IsNullOrWhiteSpace(entryWorkflowName) || string.IsNullOrWhiteSpace(entryWorkflowYaml))
-            return InlineWorkflowBundle.Invalid;
-
-        return new InlineWorkflowBundle(
-            true,
-            entryWorkflowName,
-            entryWorkflowYaml,
-            workflowByName);
-    }
-
     private async Task<WorkflowRunCreationReceipt> CreateRunActorAsync(
         WorkflowDefinitionBinding definitionBinding,
         bool wrapAsFallbackTrigger,
@@ -338,16 +286,4 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             ? sourceScopeId.Trim()
             : scopeIdHint?.Trim() ?? string.Empty;
 
-    private readonly record struct InlineWorkflowBundle(
-        bool Succeeded,
-        string EntryWorkflowName,
-        string EntryWorkflowYaml,
-        IReadOnlyDictionary<string, string> WorkflowYamlsByName)
-    {
-        public static InlineWorkflowBundle Invalid { get; } = new(
-            false,
-            string.Empty,
-            string.Empty,
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
-    }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -239,10 +239,9 @@ public static class WorkflowCapabilityEndpoints
 
             if (!result.Succeeded && !writer.Started)
             {
-                var (code, message) = ChatRunStartErrorMapper.ToCommandError(result.Error);
                 var statusCode = ChatRunStartErrorMapper.ToHttpStatusCode(result.Error);
                 scope.MarkResult(statusCode);
-                await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
+                await WriteRunStartFailureResponseAsync(http, statusCode, result, ct);
             }
         }
         catch (OperationCanceledException)
@@ -346,10 +345,9 @@ public static class WorkflowCapabilityEndpoints
 
             if (!result.Succeeded && !writer.Started)
             {
-                var (code, message) = ChatRunStartErrorMapper.ToCommandError(result.Error);
                 var statusCode = ChatRunStartErrorMapper.ToHttpStatusCode(result.Error);
                 scope.MarkResult(statusCode);
-                await WriteJsonErrorResponseAsync(http, statusCode, code, message, ct);
+                await WriteRunStartFailureResponseAsync(http, statusCode, result, ct);
             }
         }
         catch (OperationCanceledException)
@@ -958,6 +956,21 @@ public static class WorkflowCapabilityEndpoints
                 code,
                 message,
             },
+            cancellationToken: ct);
+    }
+
+    private static async Task WriteRunStartFailureResponseAsync(
+        HttpContext http,
+        int statusCode,
+        WorkflowChatRunInteractionResult result,
+        CancellationToken ct)
+    {
+        http.Response.StatusCode = statusCode;
+        http.Response.ContentType = "application/json; charset=utf-8";
+        await http.Response.WriteAsJsonAsync(
+            result.FailureDetail == null
+                ? ChatRunStartErrorMapper.ToErrorBody(result.Error)
+                : ChatRunStartErrorMapper.ToErrorBody(result.FailureDetail),
             cancellationToken: ct);
     }
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunStartErrorMapper.cs
@@ -1,9 +1,10 @@
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Abstractions;
 using Microsoft.AspNetCore.Http;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
-internal static class ChatRunStartErrorMapper
+public static class ChatRunStartErrorMapper
 {
     public static int ToHttpStatusCode(WorkflowChatRunStartError error)
     {
@@ -53,5 +54,163 @@ internal static class ChatRunStartErrorMapper
             WorkflowChatRunStartError.IdempotencyConflict => ("IDEMPOTENCY_CONFLICT", "Command id was already used for a different chat create request."),
             _ => ("RUN_START_FAILED", "Failed to resolve actor."),
         };
+    }
+
+    public static (string Code, string Message) ToCommandError(WorkflowChatRunStartFailureDetail? failureDetail)
+    {
+        if (failureDetail == null)
+            return ToCommandError(WorkflowChatRunStartError.None);
+
+        var mapped = ToCommandError(failureDetail.Error);
+        return string.IsNullOrWhiteSpace(failureDetail.Message)
+            ? mapped
+            : (mapped.Code, failureDetail.Message);
+    }
+
+    public static object ToErrorBody(WorkflowChatRunStartError error) =>
+        ToErrorBody(WorkflowChatRunStartFailureDetail.Create(error));
+
+    public static object ToErrorBody(WorkflowChatRunStartFailureDetail? failureDetail)
+    {
+        var (code, message) = ToCommandError(failureDetail);
+        var readiness = MapExternalCapabilityReadiness(failureDetail?.ExternalCapabilityReadiness);
+        if (readiness == null)
+        {
+            return new
+            {
+                code,
+                message,
+            };
+        }
+
+        return new
+        {
+            code,
+            message,
+            externalCapabilityReadiness = readiness,
+        };
+    }
+
+    private static object? MapExternalCapabilityReadiness(ExternalCapabilityReadiness? readiness)
+    {
+        if (readiness == null)
+            return null;
+
+        return new
+        {
+            status = ReadinessStatus(readiness.Status),
+            selectedCapability = MapSelectedCapability(readiness),
+            blockers = readiness.Blockers.Select(static blocker => new
+            {
+                status = ReadinessStatus(blocker.Status),
+                code = blocker.Code,
+                safeMessage = blocker.SafeMessage,
+            }).ToArray(),
+            remediations = readiness.Remediations.Select(static remediation => new
+            {
+                actionKind = RemediationKind(remediation.ActionKind),
+                label = remediation.Label,
+                trustedLocator = NullIfEmpty(remediation.TrustedLocator),
+            }).ToArray(),
+            sources = readiness.Sources.Select(static source => new
+            {
+                sourceKind = SourceKind(source.SourceKind),
+                sourceId = source.SourceId,
+                sourceVersion = source.SourceVersion,
+            }).ToArray(),
+        };
+    }
+
+    private static object? MapSelectedCapability(ExternalCapabilityReadiness readiness)
+    {
+        if (readiness.SelectedSelector is not null)
+        {
+            switch (readiness.SelectedSelector.SelectorCase)
+            {
+                case ExternalWorkflowCapabilitySelector.SelectorOneofCase.NyxIdOperation:
+                    return new
+                    {
+                        userServiceId = readiness.SelectedSelector.NyxIdOperation.UserServiceId,
+                        operationId = readiness.SelectedSelector.NyxIdOperation.OperationId,
+                        connectorCapabilityRef = (string?)null,
+                    };
+                case ExternalWorkflowCapabilitySelector.SelectorOneofCase.HostConnector:
+                    return new
+                    {
+                        userServiceId = (string?)null,
+                        operationId = readiness.SelectedSelector.HostConnector.OperationId,
+                        connectorCapabilityRef = readiness.SelectedSelector.HostConnector.ConnectorCapabilityRef,
+                    };
+            }
+        }
+
+        return readiness.SelectedCapability?.CapabilityCase switch
+        {
+            ExternalWorkflowCapabilityRef.CapabilityOneofCase.NyxIdUserService => new
+            {
+                userServiceId = (string?)readiness.SelectedCapability.NyxIdUserService.UserServiceId,
+                operationId = readiness.SelectedCapability.NyxIdUserService.OperationId,
+                connectorCapabilityRef = (string?)null,
+            },
+            ExternalWorkflowCapabilityRef.CapabilityOneofCase.HostConnector => new
+            {
+                userServiceId = (string?)null,
+                operationId = readiness.SelectedCapability.HostConnector.OperationId,
+                connectorCapabilityRef = (string?)readiness.SelectedCapability.HostConnector.ConnectorCapabilityRef,
+            },
+            _ => null,
+        };
+    }
+
+    private static string ReadinessStatus(ExternalCapabilityReadinessStatus status) => status switch
+    {
+        ExternalCapabilityReadinessStatus.SelectionRequired => "selection_required",
+        ExternalCapabilityReadinessStatus.ConnectorNotFound => "connector_not_found",
+        ExternalCapabilityReadinessStatus.ServiceRegistrationRequired => "service_registration_required",
+        ExternalCapabilityReadinessStatus.CredentialConnectionRequired => "credential_connection_required",
+        ExternalCapabilityReadinessStatus.ServiceAccessDenied => "service_access_denied",
+        ExternalCapabilityReadinessStatus.NodeBindingRequired => "node_binding_required",
+        ExternalCapabilityReadinessStatus.NodeUnavailable => "node_unavailable",
+        ExternalCapabilityReadinessStatus.EndpointContractRequired => "endpoint_contract_required",
+        ExternalCapabilityReadinessStatus.OperationSelectionRequired => "operation_selection_required",
+        ExternalCapabilityReadinessStatus.SourceStale => "source_stale",
+        ExternalCapabilityReadinessStatus.DurableAuthorizationUnavailable => "durable_authorization_unavailable",
+        ExternalCapabilityReadinessStatus.ContractDrift => "contract_drift",
+        ExternalCapabilityReadinessStatus.Ready => "ready",
+        ExternalCapabilityReadinessStatus.AdmissionRebindRequired => "admission_rebind_required",
+        _ => "unspecified",
+    };
+
+    private static string RemediationKind(ExternalCapabilityRemediationActionKind actionKind) =>
+        actionKind switch
+        {
+            ExternalCapabilityRemediationActionKind.SelectCapability => "select_capability",
+            ExternalCapabilityRemediationActionKind.ConfigureConnector => "configure_connector",
+            ExternalCapabilityRemediationActionKind.RegisterService => "register_service",
+            ExternalCapabilityRemediationActionKind.ConnectCredential => "connect_credential",
+            ExternalCapabilityRemediationActionKind.RequestAccess => "request_access",
+            ExternalCapabilityRemediationActionKind.BindNode => "bind_node",
+            ExternalCapabilityRemediationActionKind.RestoreNode => "restore_node",
+            ExternalCapabilityRemediationActionKind.PublishEndpointContract => "publish_endpoint_contract",
+            ExternalCapabilityRemediationActionKind.SelectOperation => "select_operation",
+            ExternalCapabilityRemediationActionKind.RefreshSource => "refresh_source",
+            ExternalCapabilityRemediationActionKind.UseInteractiveExecution => "use_interactive_execution",
+            ExternalCapabilityRemediationActionKind.RebindWorkflow => "rebind_workflow",
+            _ => "unspecified",
+        };
+
+    private static string SourceKind(ExternalCapabilitySourceKind sourceKind) => sourceKind switch
+    {
+        ExternalCapabilitySourceKind.ConnectorCatalog => "connector_catalog",
+        ExternalCapabilitySourceKind.NyxIdUserServices => "nyx_id_user_services",
+        ExternalCapabilitySourceKind.NyxIdOpenApi => "nyx_id_open_api",
+        ExternalCapabilitySourceKind.DurableAuthorizationCatalog => "durable_authorization_catalog",
+        _ => "unspecified",
+    };
+
+    private static string? NullIfEmpty(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
     }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatWebSocketRunCoordinator.cs
@@ -51,7 +51,9 @@ internal static class ChatWebSocketRunCoordinator
 
         if (!executionResult.Succeeded || executionResult.Receipt == null)
         {
-            var (code, message) = ChatRunStartErrorMapper.ToCommandError(executionResult.Error);
+            var (code, message) = executionResult.FailureDetail == null
+                ? ChatRunStartErrorMapper.ToCommandError(executionResult.Error)
+                : ChatRunStartErrorMapper.ToCommandError(executionResult.FailureDetail);
             var statusCode = ChatRunStartErrorMapper.ToHttpStatusCode(executionResult.Error);
             scope.MarkResult(statusCode);
             var context = ResolveContext();

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowDefinitionParser.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowDefinitionParser.cs
@@ -69,9 +69,7 @@ internal sealed class WorkflowDefinitionParser : IWorkflowDefinitionParser
                 }
             }
 
-            var workflowName = string.IsNullOrWhiteSpace(workflow.Name)
-                ? string.Empty
-                : workflow.Name.Trim();
+            var workflowName = NormalizeWorkflowName(workflow.Name);
             if (string.IsNullOrWhiteSpace(workflowName))
                 return Task.FromResult(WorkflowYamlParseResult.Invalid("Workflow name is required."));
 
@@ -88,4 +86,61 @@ internal sealed class WorkflowDefinitionParser : IWorkflowDefinitionParser
             return Task.FromResult(WorkflowYamlParseResult.Invalid(ex.Message));
         }
     }
+
+    public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+        IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+        CancellationToken ct = default)
+    {
+        if (inlineWorkflowDocuments.Count == 0)
+            return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+        var workflowByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string entryWorkflowName = string.Empty;
+        string entryWorkflowYaml = string.Empty;
+
+        for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
+        {
+            var document = inlineWorkflowDocuments[i];
+            var yaml = document.Yaml;
+            if (string.IsNullOrWhiteSpace(yaml))
+                return WorkflowInlineYamlBundleParseResult.Invalid($"workflowYamls[{i}] is required.");
+
+            var parseResult = await ParseWorkflowYamlAsync(yaml, ct).ConfigureAwait(false);
+            if (!parseResult.Succeeded)
+                return WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+
+            var workflowName = NormalizeWorkflowName(parseResult.WorkflowName);
+            if (string.IsNullOrWhiteSpace(workflowName))
+                return WorkflowInlineYamlBundleParseResult.Invalid($"workflowYamls[{i}] workflow name is required.");
+
+            var documentName = NormalizeWorkflowName(document.Name);
+            if (!string.IsNullOrWhiteSpace(documentName) &&
+                !string.Equals(documentName, workflowName, StringComparison.OrdinalIgnoreCase))
+            {
+                return WorkflowInlineYamlBundleParseResult.Invalid(
+                    $"workflowYamls[{i}] document name '{documentName}' does not match workflow name '{workflowName}'.");
+            }
+
+            if (!workflowByName.TryAdd(workflowName, yaml))
+                return WorkflowInlineYamlBundleParseResult.Invalid(
+                    $"Duplicate workflow name '{workflowName}' in workflowYamls.");
+
+            if (i == 0)
+            {
+                entryWorkflowName = workflowName;
+                entryWorkflowYaml = yaml;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(entryWorkflowName) || string.IsNullOrWhiteSpace(entryWorkflowYaml))
+            return WorkflowInlineYamlBundleParseResult.Invalid("Workflow YAML is invalid.");
+
+        return WorkflowInlineYamlBundleParseResult.Success(
+            entryWorkflowName,
+            entryWorkflowYaml,
+            workflowByName);
+    }
+
+    private static string NormalizeWorkflowName(string? workflowName) =>
+        string.IsNullOrWhiteSpace(workflowName) ? string.Empty : workflowName.Trim();
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
@@ -229,6 +229,31 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
     }
 
     [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldReturnWorkflowYamlValidationMessage_WhenInlineYamlIsInvalid()
+    {
+        const string invalidWorkflowYaml = "name: main\nsteps:\n- id: call\n  type: tool_call";
+        const string validationMessage = "Workflow step 'call' external capability is invalid: nyxid_proxy derived field 'service_id' cannot be authored; select a connected-service operation and rebind.";
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.WorkflowDefinitionParser.ParseResults[invalidWorkflowYaml] = WorkflowYamlParseResult.Invalid(validationMessage);
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
+        {
+            prompt = "run the draft",
+            workflowYamls = new[]
+            {
+                invalidWorkflowYaml,
+            },
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("INVALID_WORKFLOW_YAML");
+        body["message"].Should().Be(validationMessage);
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ScopeDraftRunEndpoint_ShouldReturnInvalidCallerCredential_WhenBearerIsMalformed()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
@@ -68,7 +68,7 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
                     Delta = "hello",
                 },
             }, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -118,7 +118,7 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
                 },
             }, ct);
 
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -170,7 +170,7 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
 
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -251,11 +251,12 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
         body.Should().NotBeNull();
         body!["code"].Should().Be("INVALID_WORKFLOW_YAML");
         body["message"].Should().Be(validationMessage);
-        host.InteractionService.LastRequest.Should().BeNull();
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.Source.WorkflowYamls.Should().ContainSingle();
     }
 
     [Fact]
-    public async Task ScopeDraftRunEndpoint_ShouldValidateInlineWorkflowBundleBeforeDispatch()
+    public async Task ScopeDraftRunEndpoint_ShouldDelegateInlineWorkflowBundleValidationToWorkflowPipeline()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
 
@@ -274,7 +275,8 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
         body.Should().NotBeNull();
         body!["code"].Should().Be("INVALID_WORKFLOW_YAML");
         body["message"].Should().Be("Duplicate workflow name 'main' in workflowYamls.");
-        host.InteractionService.LastRequest.Should().BeNull();
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.Source.WorkflowYamls.Should().HaveCount(2);
     }
 
     [Fact]
@@ -344,7 +346,8 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
         readiness.GetProperty("remediations")[0].GetProperty("trustedLocator").GetString().Should().Be("nyxid:services");
         readiness.GetProperty("sources")[0].GetProperty("sourceKind").GetString().Should().Be("nyx_id_open_api");
         readiness.GetProperty("sources")[0].GetProperty("sourceVersion").GetInt64().Should().Be(7);
-        host.InteractionService.LastRequest.Should().BeNull();
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.Source.WorkflowYamls.Should().ContainSingle();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
@@ -296,6 +296,24 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
                         SafeMessage = "Select a connected-service operation and rebind.",
                     },
                 },
+                Remediations =
+                {
+                    new ExternalCapabilityRemediation
+                    {
+                        ActionKind = ExternalCapabilityRemediationActionKind.RebindWorkflow,
+                        Label = "Rebind workflow",
+                        TrustedLocator = "nyxid:services",
+                    },
+                },
+                Sources =
+                {
+                    new ExternalCapabilitySourceStamp
+                    {
+                        SourceKind = ExternalCapabilitySourceKind.NyxIdOpenApi,
+                        SourceId = "user-service-1",
+                        SourceVersion = 7,
+                    },
+                },
                 SelectedSelector = new ExternalWorkflowCapabilitySelector
                 {
                     NyxIdOperation = new NyxIdOperationSelector
@@ -322,6 +340,10 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
         readiness.GetProperty("status").GetString().Should().Be("admission_rebind_required");
         readiness.GetProperty("blockers")[0].GetProperty("code").GetString().Should().Be("admission_rebind_required");
         readiness.GetProperty("selectedCapability").GetProperty("userServiceId").GetString().Should().Be("user-service-1");
+        readiness.GetProperty("remediations")[0].GetProperty("actionKind").GetString().Should().Be("rebind_workflow");
+        readiness.GetProperty("remediations")[0].GetProperty("trustedLocator").GetString().Should().Be("nyxid:services");
+        readiness.GetProperty("sources")[0].GetProperty("sourceKind").GetString().Should().Be("nyx_id_open_api");
+        readiness.GetProperty("sources")[0].GetProperty("sourceVersion").GetInt64().Should().Be(7);
         host.InteractionService.LastRequest.Should().BeNull();
     }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunEndpointTests.cs
@@ -28,6 +28,7 @@ using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.AGUI.Contracts;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
@@ -250,6 +251,77 @@ public sealed class ScopeServiceDraftRunEndpointTests : ScopeServiceEndpointTest
         body.Should().NotBeNull();
         body!["code"].Should().Be("INVALID_WORKFLOW_YAML");
         body["message"].Should().Be(validationMessage);
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldValidateInlineWorkflowBundleBeforeDispatch()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
+        {
+            prompt = "run the draft",
+            workflowYamls = new[]
+            {
+                "name: main\nsteps:\n  - run: echo hello",
+                "name: main\nsteps:\n  - run: echo child",
+            },
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("INVALID_WORKFLOW_YAML");
+        body["message"].Should().Be("Duplicate workflow name 'main' in workflowYamls.");
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScopeDraftRunEndpoint_ShouldReturnExternalCapabilityReadiness_WhenInlineYamlCapabilityIsInvalid()
+    {
+        const string invalidWorkflowYaml = "name: main\nsteps:\n- id: call\n  type: tool_call";
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.WorkflowDefinitionParser.ParseResults[invalidWorkflowYaml] = WorkflowYamlParseResult.Invalid(
+            "Workflow step 'call' external capability is invalid: select a connected-service operation and rebind.",
+            new ExternalCapabilityReadiness
+            {
+                Status = ExternalCapabilityReadinessStatus.AdmissionRebindRequired,
+                Blockers =
+                {
+                    new ExternalCapabilityBlocker
+                    {
+                        Status = ExternalCapabilityReadinessStatus.AdmissionRebindRequired,
+                        Code = "admission_rebind_required",
+                        SafeMessage = "Select a connected-service operation and rebind.",
+                    },
+                },
+                SelectedSelector = new ExternalWorkflowCapabilitySelector
+                {
+                    NyxIdOperation = new NyxIdOperationSelector
+                    {
+                        UserServiceId = "user-service-1",
+                        OperationId = "operation-1",
+                    },
+                },
+            });
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/workflow/draft-run", new
+        {
+            prompt = "run the draft",
+            workflowYamls = new[]
+            {
+                invalidWorkflowYaml,
+            },
+        });
+        using var body = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.RootElement.GetProperty("code").GetString().Should().Be("INVALID_WORKFLOW_YAML");
+        var readiness = body.RootElement.GetProperty("externalCapabilityReadiness");
+        readiness.GetProperty("status").GetString().Should().Be("admission_rebind_required");
+        readiness.GetProperty("blockers")[0].GetProperty("code").GetString().Should().Be("admission_rebind_required");
+        readiness.GetProperty("selectedCapability").GetProperty("userServiceId").GetString().Should().Be("user-service-1");
         host.InteractionService.LastRequest.Should().BeNull();
     }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunMultipartTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceDraftRunMultipartTests.cs
@@ -20,7 +20,7 @@ public sealed class ScopeServiceDraftRunMultipartTests : ScopeServiceEndpointTes
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
 
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
                     WorkflowProjectionCompletionStatus.Completed,
                     true));
@@ -72,7 +72,7 @@ public sealed class ScopeServiceDraftRunMultipartTests : ScopeServiceEndpointTes
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
 
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
                     WorkflowProjectionCompletionStatus.Completed,
                     true));
@@ -109,7 +109,7 @@ public sealed class ScopeServiceDraftRunMultipartTests : ScopeServiceEndpointTes
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
 
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
                     WorkflowProjectionCompletionStatus.Completed,
                     true));

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointPrivateHelperTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointPrivateHelperTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
-using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -31,14 +30,6 @@ using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
-using WorkflowExternalCapabilityReadiness = Aevatar.Workflow.Abstractions.ExternalCapabilityReadiness;
-using WorkflowExternalCapabilityReadinessStatus = Aevatar.Workflow.Abstractions.ExternalCapabilityReadinessStatus;
-using WorkflowExternalCapabilityRef = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilityRef;
-using WorkflowExternalCapabilityRemediationActionKind = Aevatar.Workflow.Abstractions.ExternalCapabilityRemediationActionKind;
-using WorkflowExternalCapabilitySelector = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilitySelector;
-using WorkflowExternalCapabilitySourceKind = Aevatar.Workflow.Abstractions.ExternalCapabilitySourceKind;
-using WorkflowHostConnectorCapabilityRef = Aevatar.Workflow.Abstractions.HostConnectorCapabilityRef;
-using WorkflowNyxIdUserServiceCapabilityRef = Aevatar.Workflow.Abstractions.NyxIdUserServiceCapabilityRef;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
@@ -97,125 +88,6 @@ public sealed class ScopeServiceEndpointPrivateHelperTests : ScopeServiceEndpoin
                 "ParseBindingKind",
                 "unsupported"))
             .Should().Throw<TargetInvocationException>().WithInnerException<InvalidOperationException>();
-    }
-
-    [Fact]
-    public void ScopeServiceEndpointHelpers_ShouldMapExternalCapabilityReadinessEnums()
-    {
-        var statusExpectations = new Dictionary<WorkflowExternalCapabilityReadinessStatus, string>
-        {
-            [WorkflowExternalCapabilityReadinessStatus.SelectionRequired] = "selection_required",
-            [WorkflowExternalCapabilityReadinessStatus.ConnectorNotFound] = "connector_not_found",
-            [WorkflowExternalCapabilityReadinessStatus.ServiceRegistrationRequired] = "service_registration_required",
-            [WorkflowExternalCapabilityReadinessStatus.CredentialConnectionRequired] = "credential_connection_required",
-            [WorkflowExternalCapabilityReadinessStatus.ServiceAccessDenied] = "service_access_denied",
-            [WorkflowExternalCapabilityReadinessStatus.NodeBindingRequired] = "node_binding_required",
-            [WorkflowExternalCapabilityReadinessStatus.NodeUnavailable] = "node_unavailable",
-            [WorkflowExternalCapabilityReadinessStatus.EndpointContractRequired] = "endpoint_contract_required",
-            [WorkflowExternalCapabilityReadinessStatus.OperationSelectionRequired] = "operation_selection_required",
-            [WorkflowExternalCapabilityReadinessStatus.SourceStale] = "source_stale",
-            [WorkflowExternalCapabilityReadinessStatus.DurableAuthorizationUnavailable] = "durable_authorization_unavailable",
-            [WorkflowExternalCapabilityReadinessStatus.ContractDrift] = "contract_drift",
-            [WorkflowExternalCapabilityReadinessStatus.Ready] = "ready",
-            [WorkflowExternalCapabilityReadinessStatus.AdmissionRebindRequired] = "admission_rebind_required",
-            [WorkflowExternalCapabilityReadinessStatus.Unspecified] = "unspecified",
-        };
-        foreach (var (status, expectedValue) in statusExpectations)
-        {
-            InvokePrivateStatic<string>("ReadinessStatus", status).Should().Be(expectedValue);
-        }
-
-        var remediationExpectations = new Dictionary<WorkflowExternalCapabilityRemediationActionKind, string>
-        {
-            [WorkflowExternalCapabilityRemediationActionKind.SelectCapability] = "select_capability",
-            [WorkflowExternalCapabilityRemediationActionKind.ConfigureConnector] = "configure_connector",
-            [WorkflowExternalCapabilityRemediationActionKind.RegisterService] = "register_service",
-            [WorkflowExternalCapabilityRemediationActionKind.ConnectCredential] = "connect_credential",
-            [WorkflowExternalCapabilityRemediationActionKind.RequestAccess] = "request_access",
-            [WorkflowExternalCapabilityRemediationActionKind.BindNode] = "bind_node",
-            [WorkflowExternalCapabilityRemediationActionKind.RestoreNode] = "restore_node",
-            [WorkflowExternalCapabilityRemediationActionKind.PublishEndpointContract] = "publish_endpoint_contract",
-            [WorkflowExternalCapabilityRemediationActionKind.SelectOperation] = "select_operation",
-            [WorkflowExternalCapabilityRemediationActionKind.RefreshSource] = "refresh_source",
-            [WorkflowExternalCapabilityRemediationActionKind.UseInteractiveExecution] = "use_interactive_execution",
-            [WorkflowExternalCapabilityRemediationActionKind.RebindWorkflow] = "rebind_workflow",
-            [WorkflowExternalCapabilityRemediationActionKind.Unspecified] = "unspecified",
-        };
-        foreach (var (actionKind, expectedValue) in remediationExpectations)
-        {
-            InvokePrivateStatic<string>("RemediationKind", actionKind).Should().Be(expectedValue);
-        }
-
-        var sourceExpectations = new Dictionary<WorkflowExternalCapabilitySourceKind, string>
-        {
-            [WorkflowExternalCapabilitySourceKind.ConnectorCatalog] = "connector_catalog",
-            [WorkflowExternalCapabilitySourceKind.NyxIdUserServices] = "nyx_id_user_services",
-            [WorkflowExternalCapabilitySourceKind.NyxIdOpenApi] = "nyx_id_open_api",
-            [WorkflowExternalCapabilitySourceKind.DurableAuthorizationCatalog] = "durable_authorization_catalog",
-            [WorkflowExternalCapabilitySourceKind.Unspecified] = "unspecified",
-        };
-        foreach (var (sourceKind, expectedValue) in sourceExpectations)
-        {
-            InvokePrivateStatic<string>("SourceKind", sourceKind).Should().Be(expectedValue);
-        }
-    }
-
-    [Fact]
-    public void ScopeServiceEndpointHelpers_ShouldMapExternalCapabilitySelectionShapes()
-    {
-        var selectorReadiness = new WorkflowExternalCapabilityReadiness
-        {
-            SelectedSelector = new WorkflowExternalCapabilitySelector
-            {
-                HostConnector = new WorkflowHostConnectorCapabilityRef
-                {
-                    ConnectorCapabilityRef = "connector/ref",
-                    OperationId = "operation-1",
-                },
-            },
-        };
-        using var selectorJson = JsonDocument.Parse(JsonSerializer.Serialize(
-            InvokePrivateStatic<object?>("MapSelectedCapability", selectorReadiness)));
-        selectorJson.RootElement.GetProperty("userServiceId").ValueKind.Should().Be(JsonValueKind.Null);
-        selectorJson.RootElement.GetProperty("operationId").GetString().Should().Be("operation-1");
-        selectorJson.RootElement.GetProperty("connectorCapabilityRef").GetString().Should().Be("connector/ref");
-
-        var nyxIdCapabilityReadiness = new WorkflowExternalCapabilityReadiness
-        {
-            SelectedCapability = new WorkflowExternalCapabilityRef
-            {
-                NyxIdUserService = new WorkflowNyxIdUserServiceCapabilityRef
-                {
-                    UserServiceId = "user-service-1",
-                    OperationId = "operation-2",
-                },
-            },
-        };
-        using var nyxIdCapabilityJson = JsonDocument.Parse(JsonSerializer.Serialize(
-            InvokePrivateStatic<object?>("MapSelectedCapability", nyxIdCapabilityReadiness)));
-        nyxIdCapabilityJson.RootElement.GetProperty("userServiceId").GetString().Should().Be("user-service-1");
-        nyxIdCapabilityJson.RootElement.GetProperty("operationId").GetString().Should().Be("operation-2");
-        nyxIdCapabilityJson.RootElement.GetProperty("connectorCapabilityRef").ValueKind.Should().Be(JsonValueKind.Null);
-
-        var hostCapabilityReadiness = new WorkflowExternalCapabilityReadiness
-        {
-            SelectedCapability = new WorkflowExternalCapabilityRef
-            {
-                HostConnector = new WorkflowHostConnectorCapabilityRef
-                {
-                    ConnectorCapabilityRef = "connector/ref-2",
-                    OperationId = "operation-3",
-                },
-            },
-        };
-        using var hostCapabilityJson = JsonDocument.Parse(JsonSerializer.Serialize(
-            InvokePrivateStatic<object?>("MapSelectedCapability", hostCapabilityReadiness)));
-        hostCapabilityJson.RootElement.GetProperty("userServiceId").ValueKind.Should().Be(JsonValueKind.Null);
-        hostCapabilityJson.RootElement.GetProperty("operationId").GetString().Should().Be("operation-3");
-        hostCapabilityJson.RootElement.GetProperty("connectorCapabilityRef").GetString().Should().Be("connector/ref-2");
-
-        InvokePrivateStatic<object?>("MapSelectedCapability", new WorkflowExternalCapabilityReadiness())
-            .Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointPrivateHelperTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointPrivateHelperTests.cs
@@ -31,6 +31,14 @@ using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
+using WorkflowExternalCapabilityReadiness = Aevatar.Workflow.Abstractions.ExternalCapabilityReadiness;
+using WorkflowExternalCapabilityReadinessStatus = Aevatar.Workflow.Abstractions.ExternalCapabilityReadinessStatus;
+using WorkflowExternalCapabilityRef = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilityRef;
+using WorkflowExternalCapabilityRemediationActionKind = Aevatar.Workflow.Abstractions.ExternalCapabilityRemediationActionKind;
+using WorkflowExternalCapabilitySelector = Aevatar.Workflow.Abstractions.ExternalWorkflowCapabilitySelector;
+using WorkflowExternalCapabilitySourceKind = Aevatar.Workflow.Abstractions.ExternalCapabilitySourceKind;
+using WorkflowHostConnectorCapabilityRef = Aevatar.Workflow.Abstractions.HostConnectorCapabilityRef;
+using WorkflowNyxIdUserServiceCapabilityRef = Aevatar.Workflow.Abstractions.NyxIdUserServiceCapabilityRef;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
@@ -89,6 +97,125 @@ public sealed class ScopeServiceEndpointPrivateHelperTests : ScopeServiceEndpoin
                 "ParseBindingKind",
                 "unsupported"))
             .Should().Throw<TargetInvocationException>().WithInnerException<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ScopeServiceEndpointHelpers_ShouldMapExternalCapabilityReadinessEnums()
+    {
+        var statusExpectations = new Dictionary<WorkflowExternalCapabilityReadinessStatus, string>
+        {
+            [WorkflowExternalCapabilityReadinessStatus.SelectionRequired] = "selection_required",
+            [WorkflowExternalCapabilityReadinessStatus.ConnectorNotFound] = "connector_not_found",
+            [WorkflowExternalCapabilityReadinessStatus.ServiceRegistrationRequired] = "service_registration_required",
+            [WorkflowExternalCapabilityReadinessStatus.CredentialConnectionRequired] = "credential_connection_required",
+            [WorkflowExternalCapabilityReadinessStatus.ServiceAccessDenied] = "service_access_denied",
+            [WorkflowExternalCapabilityReadinessStatus.NodeBindingRequired] = "node_binding_required",
+            [WorkflowExternalCapabilityReadinessStatus.NodeUnavailable] = "node_unavailable",
+            [WorkflowExternalCapabilityReadinessStatus.EndpointContractRequired] = "endpoint_contract_required",
+            [WorkflowExternalCapabilityReadinessStatus.OperationSelectionRequired] = "operation_selection_required",
+            [WorkflowExternalCapabilityReadinessStatus.SourceStale] = "source_stale",
+            [WorkflowExternalCapabilityReadinessStatus.DurableAuthorizationUnavailable] = "durable_authorization_unavailable",
+            [WorkflowExternalCapabilityReadinessStatus.ContractDrift] = "contract_drift",
+            [WorkflowExternalCapabilityReadinessStatus.Ready] = "ready",
+            [WorkflowExternalCapabilityReadinessStatus.AdmissionRebindRequired] = "admission_rebind_required",
+            [WorkflowExternalCapabilityReadinessStatus.Unspecified] = "unspecified",
+        };
+        foreach (var (status, expectedValue) in statusExpectations)
+        {
+            InvokePrivateStatic<string>("ReadinessStatus", status).Should().Be(expectedValue);
+        }
+
+        var remediationExpectations = new Dictionary<WorkflowExternalCapabilityRemediationActionKind, string>
+        {
+            [WorkflowExternalCapabilityRemediationActionKind.SelectCapability] = "select_capability",
+            [WorkflowExternalCapabilityRemediationActionKind.ConfigureConnector] = "configure_connector",
+            [WorkflowExternalCapabilityRemediationActionKind.RegisterService] = "register_service",
+            [WorkflowExternalCapabilityRemediationActionKind.ConnectCredential] = "connect_credential",
+            [WorkflowExternalCapabilityRemediationActionKind.RequestAccess] = "request_access",
+            [WorkflowExternalCapabilityRemediationActionKind.BindNode] = "bind_node",
+            [WorkflowExternalCapabilityRemediationActionKind.RestoreNode] = "restore_node",
+            [WorkflowExternalCapabilityRemediationActionKind.PublishEndpointContract] = "publish_endpoint_contract",
+            [WorkflowExternalCapabilityRemediationActionKind.SelectOperation] = "select_operation",
+            [WorkflowExternalCapabilityRemediationActionKind.RefreshSource] = "refresh_source",
+            [WorkflowExternalCapabilityRemediationActionKind.UseInteractiveExecution] = "use_interactive_execution",
+            [WorkflowExternalCapabilityRemediationActionKind.RebindWorkflow] = "rebind_workflow",
+            [WorkflowExternalCapabilityRemediationActionKind.Unspecified] = "unspecified",
+        };
+        foreach (var (actionKind, expectedValue) in remediationExpectations)
+        {
+            InvokePrivateStatic<string>("RemediationKind", actionKind).Should().Be(expectedValue);
+        }
+
+        var sourceExpectations = new Dictionary<WorkflowExternalCapabilitySourceKind, string>
+        {
+            [WorkflowExternalCapabilitySourceKind.ConnectorCatalog] = "connector_catalog",
+            [WorkflowExternalCapabilitySourceKind.NyxIdUserServices] = "nyx_id_user_services",
+            [WorkflowExternalCapabilitySourceKind.NyxIdOpenApi] = "nyx_id_open_api",
+            [WorkflowExternalCapabilitySourceKind.DurableAuthorizationCatalog] = "durable_authorization_catalog",
+            [WorkflowExternalCapabilitySourceKind.Unspecified] = "unspecified",
+        };
+        foreach (var (sourceKind, expectedValue) in sourceExpectations)
+        {
+            InvokePrivateStatic<string>("SourceKind", sourceKind).Should().Be(expectedValue);
+        }
+    }
+
+    [Fact]
+    public void ScopeServiceEndpointHelpers_ShouldMapExternalCapabilitySelectionShapes()
+    {
+        var selectorReadiness = new WorkflowExternalCapabilityReadiness
+        {
+            SelectedSelector = new WorkflowExternalCapabilitySelector
+            {
+                HostConnector = new WorkflowHostConnectorCapabilityRef
+                {
+                    ConnectorCapabilityRef = "connector/ref",
+                    OperationId = "operation-1",
+                },
+            },
+        };
+        using var selectorJson = JsonDocument.Parse(JsonSerializer.Serialize(
+            InvokePrivateStatic<object?>("MapSelectedCapability", selectorReadiness)));
+        selectorJson.RootElement.GetProperty("userServiceId").ValueKind.Should().Be(JsonValueKind.Null);
+        selectorJson.RootElement.GetProperty("operationId").GetString().Should().Be("operation-1");
+        selectorJson.RootElement.GetProperty("connectorCapabilityRef").GetString().Should().Be("connector/ref");
+
+        var nyxIdCapabilityReadiness = new WorkflowExternalCapabilityReadiness
+        {
+            SelectedCapability = new WorkflowExternalCapabilityRef
+            {
+                NyxIdUserService = new WorkflowNyxIdUserServiceCapabilityRef
+                {
+                    UserServiceId = "user-service-1",
+                    OperationId = "operation-2",
+                },
+            },
+        };
+        using var nyxIdCapabilityJson = JsonDocument.Parse(JsonSerializer.Serialize(
+            InvokePrivateStatic<object?>("MapSelectedCapability", nyxIdCapabilityReadiness)));
+        nyxIdCapabilityJson.RootElement.GetProperty("userServiceId").GetString().Should().Be("user-service-1");
+        nyxIdCapabilityJson.RootElement.GetProperty("operationId").GetString().Should().Be("operation-2");
+        nyxIdCapabilityJson.RootElement.GetProperty("connectorCapabilityRef").ValueKind.Should().Be(JsonValueKind.Null);
+
+        var hostCapabilityReadiness = new WorkflowExternalCapabilityReadiness
+        {
+            SelectedCapability = new WorkflowExternalCapabilityRef
+            {
+                HostConnector = new WorkflowHostConnectorCapabilityRef
+                {
+                    ConnectorCapabilityRef = "connector/ref-2",
+                    OperationId = "operation-3",
+                },
+            },
+        };
+        using var hostCapabilityJson = JsonDocument.Parse(JsonSerializer.Serialize(
+            InvokePrivateStatic<object?>("MapSelectedCapability", hostCapabilityReadiness)));
+        hostCapabilityJson.RootElement.GetProperty("userServiceId").ValueKind.Should().Be(JsonValueKind.Null);
+        hostCapabilityJson.RootElement.GetProperty("operationId").GetString().Should().Be("operation-3");
+        hostCapabilityJson.RootElement.GetProperty("connectorCapabilityRef").GetString().Should().Be("connector/ref-2");
+
+        InvokePrivateStatic<object?>("MapSelectedCapability", new WorkflowExternalCapabilityReadiness())
+            .Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
@@ -1378,14 +1378,51 @@ public abstract class ScopeServiceEndpointTestKit
             if (ParseResults.TryGetValue(workflowYaml, out var result))
                 return Task.FromResult(result);
 
-            var workflowName = workflowYaml
-                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .FirstOrDefault(static line => line.StartsWith("name:", StringComparison.OrdinalIgnoreCase))
-                ?.Split(':', 2)[1]
-                .Trim();
+            var workflowName = ResolveWorkflowName(workflowYaml);
             return Task.FromResult(WorkflowYamlParseResult.Success(
                 string.IsNullOrWhiteSpace(workflowName) ? "main" : workflowName));
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var workflowByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string entryWorkflowName = string.Empty;
+            string entryWorkflowYaml = string.Empty;
+            for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
+            {
+                var document = inlineWorkflowDocuments[i];
+                if (string.IsNullOrWhiteSpace(document.Yaml))
+                    return WorkflowInlineYamlBundleParseResult.Invalid($"workflowYamls[{i}] is required.");
+
+                var parseResult = await ParseWorkflowYamlAsync(document.Yaml, ct);
+                if (!parseResult.Succeeded)
+                    return WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+
+                var workflowName = parseResult.WorkflowName.Trim();
+                if (!workflowByName.TryAdd(workflowName, document.Yaml))
+                    return WorkflowInlineYamlBundleParseResult.Invalid($"Duplicate workflow name '{workflowName}' in workflowYamls.");
+
+                if (i == 0)
+                {
+                    entryWorkflowName = workflowName;
+                    entryWorkflowYaml = document.Yaml;
+                }
+            }
+
+            return WorkflowInlineYamlBundleParseResult.Success(entryWorkflowName, entryWorkflowYaml, workflowByName);
+        }
+
+        private static string ResolveWorkflowName(string workflowYaml) =>
+            workflowYaml
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault(static line => line.StartsWith("name:", StringComparison.OrdinalIgnoreCase))
+                ?.Split(':', 2)[1]
+                .Trim() ?? string.Empty;
     }
 
     protected sealed class FakeCommandInteractionService : IWorkflowChatRunInteractionPort

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
@@ -388,8 +388,8 @@ public abstract class ScopeServiceEndpointTestKit
             var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
             var memberPublishedServiceResolver = new FakeMemberPublishedServiceResolver();
             var teamEntryMemberResolver = new FakeTeamEntryMemberResolver();
-            var interactionService = new FakeCommandInteractionService();
             var workflowDefinitionParser = new FakeWorkflowDefinitionParser();
+            var interactionService = new FakeCommandInteractionService(workflowDefinitionParser);
             var gagentDraftRunInteractionService = new FakeGAgentDraftRunInteractionService();
             var scriptServiceRunInteractionService = new FakeScriptServiceRunInteractionService();
             var staticGAgentStreamInvocationPort = new FakeStaticGAgentStreamInvocationPort(
@@ -1427,14 +1427,19 @@ public abstract class ScopeServiceEndpointTestKit
 
     protected sealed class FakeCommandInteractionService : IWorkflowChatRunInteractionPort
     {
+        private readonly FakeWorkflowDefinitionParser _workflowDefinitionParser;
+
+        public FakeCommandInteractionService(FakeWorkflowDefinitionParser workflowDefinitionParser)
+        {
+            _workflowDefinitionParser = workflowDefinitionParser;
+            ResultFactory = DefaultResultFactoryAsync;
+        }
+
         public WorkflowChatRunRequest? LastRequest { get; private set; }
 
-        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>>> ResultFactory { get; set; } =
-            (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
-                    .Failure(WorkflowChatRunStartError.AgentNotFound));
+        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<WorkflowChatRunInteractionResult>> ResultFactory { get; set; }
 
-        public Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+        public Task<WorkflowChatRunInteractionResult> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
@@ -1442,6 +1447,32 @@ public abstract class ScopeServiceEndpointTestKit
         {
             LastRequest = request;
             return ResultFactory(request, emitAsync, onAcceptedAsync, ct);
+        }
+
+        private async Task<WorkflowChatRunInteractionResult> DefaultResultFactoryAsync(
+            WorkflowChatRunRequest request,
+            Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
+            Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync,
+            CancellationToken ct)
+        {
+            _ = emitAsync;
+            _ = onAcceptedAsync;
+            var documents = request.Source.InlineBundle?.YamlDocuments;
+            if (documents is { Count: > 0 })
+            {
+                var parse = await _workflowDefinitionParser.ParseInlineWorkflowBundleAsync(documents, ct);
+                if (!parse.Succeeded)
+                {
+                    return WorkflowChatRunInteractionResult.Failure(
+                        WorkflowChatRunStartError.InvalidWorkflowYaml,
+                        WorkflowChatRunStartFailureDetail.Create(
+                            WorkflowChatRunStartError.InvalidWorkflowYaml,
+                            parse.Error,
+                            parse.ExternalCapabilityReadiness));
+                }
+            }
+
+            return WorkflowChatRunInteractionResult.Failure(WorkflowChatRunStartError.AgentNotFound);
         }
     }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceEndpointTestKit.cs
@@ -259,6 +259,7 @@ public abstract class ScopeServiceEndpointTestKit
             FakeMemberPublishedServiceResolver memberPublishedServiceResolver,
             FakeTeamEntryMemberResolver teamEntryMemberResolver,
             FakeCommandInteractionService interactionService,
+            FakeWorkflowDefinitionParser workflowDefinitionParser,
             FakeStaticGAgentStreamInvocationPort staticGAgentStreamInvocationPort,
             FakeWorkflowExecutionQueryApplicationService workflowQueryService,
             FakeWorkflowRunBindingReader runBindingReader,
@@ -287,6 +288,7 @@ public abstract class ScopeServiceEndpointTestKit
             MemberPublishedServiceResolver = memberPublishedServiceResolver;
             TeamEntryMemberResolver = teamEntryMemberResolver;
             InteractionService = interactionService;
+            WorkflowDefinitionParser = workflowDefinitionParser;
             StaticGAgentStreamInvocationPort = staticGAgentStreamInvocationPort;
             WorkflowQueryService = workflowQueryService;
             RunBindingReader = runBindingReader;
@@ -338,6 +340,8 @@ public abstract class ScopeServiceEndpointTestKit
 
         public FakeCommandInteractionService InteractionService { get; }
 
+        public FakeWorkflowDefinitionParser WorkflowDefinitionParser { get; }
+
         public FakeStaticGAgentStreamInvocationPort StaticGAgentStreamInvocationPort { get; }
 
         public FakeWorkflowExecutionQueryApplicationService WorkflowQueryService { get; }
@@ -385,6 +389,7 @@ public abstract class ScopeServiceEndpointTestKit
             var memberPublishedServiceResolver = new FakeMemberPublishedServiceResolver();
             var teamEntryMemberResolver = new FakeTeamEntryMemberResolver();
             var interactionService = new FakeCommandInteractionService();
+            var workflowDefinitionParser = new FakeWorkflowDefinitionParser();
             var gagentDraftRunInteractionService = new FakeGAgentDraftRunInteractionService();
             var scriptServiceRunInteractionService = new FakeScriptServiceRunInteractionService();
             var staticGAgentStreamInvocationPort = new FakeStaticGAgentStreamInvocationPort(
@@ -429,6 +434,7 @@ public abstract class ScopeServiceEndpointTestKit
             builder.Services.AddSingleton<ServiceInvocationResolutionService>();
             builder.Services.AddSingleton<ServiceInvokeReadinessErrorMapper>();
             builder.Services.AddSingleton<IInvokeAdmissionAuthorizer, AllowAllInvokeAdmissionAuthorizer>();
+            builder.Services.AddSingleton<IWorkflowDefinitionParser>(workflowDefinitionParser);
             builder.Services.AddSingleton<IWorkflowChatRunInteractionPort>(interactionService);
             builder.Services.AddSingleton<IGAgentDraftRunInteractionPort>(gagentDraftRunInteractionService);
             builder.Services.AddSingleton<ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus>>(scriptServiceRunInteractionService);
@@ -559,6 +565,7 @@ public abstract class ScopeServiceEndpointTestKit
                 memberPublishedServiceResolver,
                 teamEntryMemberResolver,
                 interactionService,
+                workflowDefinitionParser,
                 staticGAgentStreamInvocationPort,
                 workflowQueryService,
                 runBindingReader,
@@ -1357,6 +1364,28 @@ public abstract class ScopeServiceEndpointTestKit
 
         public Task<WorkflowRunGraphExportSubgraph> GetWorkflowRunGraphExportSubgraphAsync(string actorId, int depth = 2, int take = 200, WorkflowRunGraphExportQueryOptions? options = null, CancellationToken ct = default) =>
             Task.FromResult(new WorkflowRunGraphExportSubgraph());
+    }
+
+    protected sealed class FakeWorkflowDefinitionParser : IWorkflowDefinitionParser
+    {
+        public Dictionary<string, WorkflowYamlParseResult> ParseResults { get; } = new(StringComparer.Ordinal);
+
+        public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
+            string workflowYaml,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (ParseResults.TryGetValue(workflowYaml, out var result))
+                return Task.FromResult(result);
+
+            var workflowName = workflowYaml
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault(static line => line.StartsWith("name:", StringComparison.OrdinalIgnoreCase))
+                ?.Split(':', 2)[1]
+                .Trim();
+            return Task.FromResult(WorkflowYamlParseResult.Success(
+                string.IsNullOrWhiteSpace(workflowName) ? "main" : workflowName));
+        }
     }
 
     protected sealed class FakeCommandInteractionService : IWorkflowChatRunInteractionPort

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
@@ -113,7 +113,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
             var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-1", "main", "cmd-1", "corr-1");
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -815,7 +815,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
             var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-orders", "orders", "cmd-orders", "corr-orders");
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -915,7 +915,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
             var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-alpha", "status-report", "cmd-alpha", "corr-alpha");
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -1098,7 +1098,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
             var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-team-a", "member-a", "cmd-team-a", "corr-team-a");
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 
@@ -1227,7 +1227,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
             var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-orders", "orders", "cmd-orders", "corr-orders");
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceTeamStreamMultipartTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceTeamStreamMultipartTests.cs
@@ -85,7 +85,7 @@ public sealed class ScopeServiceTeamStreamMultipartTests : ScopeServiceEndpointT
             var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-team-a", "member-a", "cmd-team-a", "corr-team-a");
             if (onAcceptedAsync != null)
                 await onAcceptedAsync(receipt, ct);
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
         };
         using var request = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/teams/team-a/invoke/chat:stream")

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -336,7 +336,7 @@ public sealed class ScopeWorkflowEndpointsTests
                         Delta = "hello",
                     },
                 }, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -429,7 +429,7 @@ public sealed class ScopeWorkflowEndpointsTests
                         }),
                     },
                 }, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -609,7 +609,7 @@ public sealed class ScopeWorkflowEndpointsTests
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(receipt, ct);
 
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -718,7 +718,7 @@ public sealed class ScopeWorkflowEndpointsTests
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(receipt, ct);
                 await emitAsync(BuildRawObservedWorkflowExecutionStartedFrame(), ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -751,6 +751,55 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleRunWorkflowByIdStreamAsync_ShouldPreserveMappedMessage_WhenAguiFailsBeforeStart()
+    {
+        var snapshot = new ServiceCatalogSnapshot(
+            "tenant-a:workflow-app:user:token:approval",
+            "tenant-a",
+            "workflow-app",
+            "user:user-1-token",
+            "approval",
+            "Approval",
+            "rev-1",
+            "rev-1",
+            "dep-1",
+            "definition-actor-1",
+            "active",
+            [],
+            [],
+            DateTimeOffset.UtcNow);
+        var queryPort = new FakeServiceLifecycleQueryPort
+        {
+            ListServicesResult = [snapshot],
+        };
+        queryPort.GetServiceResults.Enqueue(snapshot);
+        var interactionService = new FakeCommandInteractionService
+        {
+            ResultFactory = (_, _, _, _) => Task.FromResult(
+                WorkflowChatRunInteractionResult
+                    .Failure(WorkflowChatRunStartError.WorkflowNotFound)),
+        };
+        var http = CreateHttpContext();
+
+        await ScopeWorkflowEndpoints.HandleRunWorkflowByIdStreamAsync(
+            http,
+            "user-1",
+            "approval",
+            new ScopeWorkflowEndpoints.RunScopeWorkflowByIdStreamHttpRequest(
+                "hello",
+                EventFormat: "agui"),
+            BuildQueryPort(queryPort: queryPort),
+            interactionService,
+            CancellationToken.None);
+
+        var body = await ReadBodyAsync(http.Response);
+        http.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        body.Should().Contain("WORKFLOW_NOT_FOUND");
+        body.Should().Contain("Workflow not found.");
+        body.Should().NotContain("current scope catalog");
+    }
+
+    [Fact]
     public async Task HandleRunWorkflowByIdStreamAsync_ShouldReturnServiceUnavailable_WhenProjectionUnavailableBeforeAguiStarts()
     {
         var snapshot = new ServiceCatalogSnapshot(
@@ -776,7 +825,7 @@ public sealed class ScopeWorkflowEndpointsTests
         var interactionService = new FakeCommandInteractionService
         {
             ResultFactory = (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.ProjectionUnavailable)),
         };
         var http = CreateHttpContext();
@@ -836,7 +885,7 @@ public sealed class ScopeWorkflowEndpointsTests
                         Delta = "hi",
                     },
                 }, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -1075,12 +1124,12 @@ public sealed class ScopeWorkflowEndpointsTests
     {
         public WorkflowChatRunRequest? LastRequest { get; private set; }
 
-        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>>> ResultFactory { get; set; } =
+        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<WorkflowChatRunInteractionResult>> ResultFactory { get; set; } =
             (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.AgentNotFound));
 
-        public Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+        public Task<WorkflowChatRunInteractionResult> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -2350,6 +2350,36 @@ public sealed class ScopeBindingCommandApplicationServiceTests
                             ServiceGrantPolicy = WorkflowServiceGrantPolicy.NotRequiredNoExternalService,
                         }));
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var workflowYamlsByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string entryWorkflowName = string.Empty;
+            string entryWorkflowYaml = string.Empty;
+            for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
+            {
+                var document = inlineWorkflowDocuments[i];
+                var parseResult = await ParseWorkflowYamlAsync(document.Yaml, ct);
+                if (!parseResult.Succeeded)
+                    return WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+
+                if (!workflowYamlsByName.TryAdd(parseResult.WorkflowName, document.Yaml))
+                    return WorkflowInlineYamlBundleParseResult.Invalid($"Duplicate workflow name '{parseResult.WorkflowName}' in workflowYamls.");
+
+                if (i == 0)
+                {
+                    entryWorkflowName = parseResult.WorkflowName;
+                    entryWorkflowYaml = document.Yaml;
+                }
+            }
+
+            return WorkflowInlineYamlBundleParseResult.Success(entryWorkflowName, entryWorkflowYaml, workflowYamlsByName);
+        }
     }
 
     private sealed class RecordingWorkflowCapabilityAdmissionService : IWorkflowExternalCapabilityAdmissionService

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
@@ -1486,6 +1486,17 @@ public sealed class DefaultServiceInvocationDispatcherTests
 
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             Task.FromResult(WorkflowYamlParseResult.Success("wf"));
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            Task.FromResult(WorkflowInlineYamlBundleParseResult.Success(
+                "wf",
+                inlineWorkflowDocuments.FirstOrDefault()?.Yaml ?? string.Empty,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["wf"] = inlineWorkflowDocuments.FirstOrDefault()?.Yaml ?? string.Empty,
+                }));
     }
 
     private sealed class RecordingActor : IActor

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
@@ -527,6 +527,17 @@ public sealed class DefaultServiceRuntimeActivatorTests
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             Task.FromResult(WorkflowYamlParseResult.Success("workflow"));
 
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            Task.FromResult(WorkflowInlineYamlBundleParseResult.Success(
+                "workflow",
+                inlineWorkflowDocuments.FirstOrDefault()?.Yaml ?? string.Empty,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["workflow"] = inlineWorkflowDocuments.FirstOrDefault()?.Yaml ?? string.Empty,
+                }));
+
         private static void RecordBind(
             string actorId,
             string workflowYaml,

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
@@ -1118,6 +1118,26 @@ public sealed class ServiceImplementationAdaptersTests
             ParseCalls.Add(workflowYaml);
             return Task.FromResult(ParseResult);
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var entryYaml = inlineWorkflowDocuments[0].Yaml;
+            var parseResult = await ParseWorkflowYamlAsync(entryYaml, ct);
+            return parseResult.Succeeded
+                ? WorkflowInlineYamlBundleParseResult.Success(
+                    parseResult.WorkflowName,
+                    entryYaml,
+                    new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [parseResult.WorkflowName] = entryYaml,
+                    })
+                : WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+        }
     }
 
     private sealed class RecordingActor : IActor

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/SkillWorkflowMountAdapterTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/SkillWorkflowMountAdapterTests.cs
@@ -341,5 +341,36 @@ public sealed class SkillWorkflowMountAdapterTests
 
             return Task.FromResult(WorkflowYamlParseResult.Success(workflowName));
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var workflowYamlsByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string entryWorkflowName = string.Empty;
+            string entryWorkflowYaml = string.Empty;
+
+            for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
+            {
+                var document = inlineWorkflowDocuments[i];
+                var parseResult = await ParseWorkflowYamlAsync(document.Yaml, ct);
+                if (!parseResult.Succeeded)
+                    return WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+
+                if (!workflowYamlsByName.TryAdd(parseResult.WorkflowName, document.Yaml))
+                    return WorkflowInlineYamlBundleParseResult.Invalid($"Duplicate workflow name '{parseResult.WorkflowName}' in workflowYamls.");
+
+                if (i == 0)
+                {
+                    entryWorkflowName = parseResult.WorkflowName;
+                    entryWorkflowYaml = document.Yaml;
+                }
+            }
+
+            return WorkflowInlineYamlBundleParseResult.Success(entryWorkflowName, entryWorkflowYaml, workflowYamlsByName);
+        }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
@@ -499,7 +499,7 @@ public sealed class ChannelWorkflowDraftRunTests
     {
         var workflow = new RecordingWorkflowChatRunInteractionPort
         {
-            Result = CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            Result = WorkflowChatRunInteractionResult
                 .Failure(WorkflowChatRunStartError.WorkflowNotFound),
         };
         var dispatch = new RecordingActorDispatchPort();
@@ -532,7 +532,7 @@ public sealed class ChannelWorkflowDraftRunTests
         var workflow = new RecordingWorkflowChatRunInteractionPort
         {
             Result = missingFinalizeResult
-                ? new CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                ? new WorkflowChatRunInteractionResult
                 {
                     Succeeded = true,
                     Error = WorkflowChatRunStartError.None,
@@ -541,7 +541,7 @@ public sealed class ChannelWorkflowDraftRunTests
                     Completed = false,
                     FinalizeResult = null,
                 }
-                : CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                : WorkflowChatRunInteractionResult
                     .Success(
                         receipt,
                         new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
@@ -1076,14 +1076,14 @@ public sealed class ChannelWorkflowDraftRunTests
 
         public Exception? Exception { get; init; }
 
-        public CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>? Result { get; init; }
+        public WorkflowChatRunInteractionResult? Result { get; init; }
 
         public bool HasRequest => _request.Task.IsCompletedSuccessfully;
 
         public async Task<WorkflowChatRunRequest> WaitForRequestAsync() =>
             await _request.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        public async Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+        public async Task<WorkflowChatRunInteractionResult> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
@@ -1107,7 +1107,7 @@ public sealed class ChannelWorkflowDraftRunTests
                 request.Source.WorkflowName ?? "daily-greeting",
                 request.CommandIdSeed ?? "workflow-draft-run-1",
                 request.CorrelationIdSeed ?? "msg-1");
-            return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+            return WorkflowChatRunInteractionResult
                 .Success(
                     receipt,
                     new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(

--- a/test/Aevatar.Integration.Tests/WorkflowChatConversationContinuationCrossLayerTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowChatConversationContinuationCrossLayerTests.cs
@@ -301,7 +301,7 @@ public sealed class WorkflowChatConversationContinuationCrossLayerTests : Workfl
         };
 
     private sealed record ContinuationExecution(
-        CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus> Result,
+        WorkflowChatRunInteractionResult Result,
         WorkflowChatRunRequest? DispatchedRequest);
 
     private sealed class DocumentStoreWriteDispatcher(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -720,6 +720,11 @@ public sealed class WorkflowApplicationLayerTests
 
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             throw new NotSupportedException();
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeActor : IActor

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowChatRunInteractionServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowChatRunInteractionServiceTests.cs
@@ -65,6 +65,40 @@ public sealed class WorkflowChatRunInteractionServiceTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ShouldPreserveActorResolutionFailureDetail()
+    {
+        var failureDetail = WorkflowChatRunStartFailureDetail.Create(
+            WorkflowChatRunStartError.InvalidWorkflowYaml,
+            "Workflow step 'call' external capability is invalid.");
+        var actorResolver = new RecordingActorResolver
+        {
+            Results =
+            {
+                new WorkflowActorResolutionResult(
+                    null,
+                    string.Empty,
+                    WorkflowChatRunStartError.InvalidWorkflowYaml,
+                    failureDetail),
+            },
+        };
+        var inner = new RecordingInteractionService();
+        var service = CreateService(
+            actorResolver,
+            new RecordingProjectionPort(),
+            new RecordingRunProvisioningPort(),
+            inner);
+
+        var result = await service.ExecuteAsync(
+            new WorkflowChatRunRequest("hello", WorkflowChatSource.InlineYamlBundle(["bad"])),
+            static (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(WorkflowChatRunStartError.InvalidWorkflowYaml);
+        result.FailureDetail.Should().BeSameAs(failureDetail);
+        inner.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ShouldResolveActivateAndInvokeInnerWithSeedsAndTargetSeed()
     {
         var actorResolver = new RecordingActorResolver

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
@@ -149,6 +149,11 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
 
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             throw new NotSupportedException();
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeActor : IActor

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowExternalCapabilityAdmissionServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowExternalCapabilityAdmissionServiceTests.cs
@@ -899,6 +899,11 @@ public sealed class WorkflowExternalCapabilityAdmissionServiceTests
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
             string workflowYaml,
             CancellationToken ct = default) => Task.FromResult(result);
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            Task.FromResult(ToBundleResult(result, inlineWorkflowDocuments.FirstOrDefault()?.Yaml ?? string.Empty));
     }
 
     private sealed class MappingParser(
@@ -915,7 +920,32 @@ public sealed class WorkflowExternalCapabilityAdmissionServiceTests
                 ? result
                 : throw new InvalidOperationException($"Unexpected workflow YAML: {workflowYaml}"));
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var document = inlineWorkflowDocuments[0];
+            var parseResult = await ParseWorkflowYamlAsync(document.Yaml, ct);
+            return ToBundleResult(parseResult, document.Yaml);
+        }
     }
+
+    private static WorkflowInlineYamlBundleParseResult ToBundleResult(
+        WorkflowYamlParseResult parseResult,
+        string workflowYaml) =>
+        parseResult.Succeeded
+            ? WorkflowInlineYamlBundleParseResult.Success(
+                parseResult.WorkflowName,
+                workflowYaml,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    [parseResult.WorkflowName] = workflowYaml,
+                })
+            : WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
 
     private sealed class StubReadinessPort(ExternalCapabilityReadiness? result = null)
         : IExternalWorkflowCapabilityReadinessPort

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowForkRunCommandDispatchTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowForkRunCommandDispatchTests.cs
@@ -475,6 +475,36 @@ public sealed class WorkflowForkRunCommandDispatchTests
                 : nameLine["name:".Length..].Trim();
             return Task.FromResult(WorkflowYamlParseResult.Success(workflowName));
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var workflowYamlsByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string entryWorkflowName = string.Empty;
+            string entryWorkflowYaml = string.Empty;
+            for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
+            {
+                var document = inlineWorkflowDocuments[i];
+                var parseResult = await ParseWorkflowYamlAsync(document.Yaml, ct);
+                if (!parseResult.Succeeded)
+                    return WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+
+                if (!workflowYamlsByName.TryAdd(parseResult.WorkflowName, document.Yaml))
+                    return WorkflowInlineYamlBundleParseResult.Invalid($"Duplicate workflow name '{parseResult.WorkflowName}' in workflowYamls.");
+
+                if (i == 0)
+                {
+                    entryWorkflowName = parseResult.WorkflowName;
+                    entryWorkflowYaml = document.Yaml;
+                }
+            }
+
+            return WorkflowInlineYamlBundleParseResult.Success(entryWorkflowName, entryWorkflowYaml, workflowYamlsByName);
+        }
     }
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
@@ -788,6 +788,44 @@ public sealed class WorkflowRunActorResolverTests
                     ? result
                     : WorkflowYamlParseResult.Invalid($"Unexpected workflow YAML: {workflowYaml}"));
         }
+
+        public async Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default)
+        {
+            if (inlineWorkflowDocuments.Count == 0)
+                return WorkflowInlineYamlBundleParseResult.Invalid("workflowYamls is required.");
+
+            var workflowYamlsByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string entryWorkflowName = string.Empty;
+            string entryWorkflowYaml = string.Empty;
+            for (var i = 0; i < inlineWorkflowDocuments.Count; i++)
+            {
+                var document = inlineWorkflowDocuments[i];
+                var parseResult = await ParseWorkflowYamlAsync(document.Yaml, ct);
+                if (!parseResult.Succeeded)
+                    return WorkflowInlineYamlBundleParseResult.Invalid(parseResult.Error, parseResult.ExternalCapabilityReadiness);
+
+                var documentName = document.Name.Trim();
+                if (!string.IsNullOrWhiteSpace(documentName) &&
+                    !string.Equals(documentName, parseResult.WorkflowName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return WorkflowInlineYamlBundleParseResult.Invalid(
+                        $"workflowYamls[{i}] document name '{documentName}' does not match workflow name '{parseResult.WorkflowName}'.");
+                }
+
+                if (!workflowYamlsByName.TryAdd(parseResult.WorkflowName, document.Yaml))
+                    return WorkflowInlineYamlBundleParseResult.Invalid($"Duplicate workflow name '{parseResult.WorkflowName}' in workflowYamls.");
+
+                if (i == 0)
+                {
+                    entryWorkflowName = parseResult.WorkflowName;
+                    entryWorkflowYaml = document.Yaml;
+                }
+            }
+
+            return WorkflowInlineYamlBundleParseResult.Success(entryWorkflowName, entryWorkflowYaml, workflowYamlsByName);
+        }
     }
 
     private sealed class InMemoryWorkflowDefinitionCatalog : IWorkflowDefinitionCatalog

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
 using Aevatar.Workflow.Application.Runs;
@@ -336,7 +337,11 @@ public sealed class WorkflowRunActorResolverTests
     public async Task ResolveOrCreateAsync_ShouldReturnInvalidWorkflowYaml_WhenInlineYamlBundleIsInvalid()
     {
         var actorPort = new RecordingWorkflowRunActorPort();
-        actorPort.ParseResults["bad"] = WorkflowYamlParseResult.Invalid("bad yaml");
+        var readiness = new ExternalCapabilityReadiness
+        {
+            Status = ExternalCapabilityReadinessStatus.AdmissionRebindRequired,
+        };
+        actorPort.ParseResults["bad"] = WorkflowYamlParseResult.Invalid("bad yaml", readiness);
         var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
@@ -344,6 +349,10 @@ public sealed class WorkflowRunActorResolverTests
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.InvalidWorkflowYaml);
+        result.FailureDetail.Should().NotBeNull();
+        result.FailureDetail!.Message.Should().Be("bad yaml");
+        result.FailureDetail.ExternalCapabilityReadiness.Should().NotBeSameAs(readiness);
+        result.FailureDetail.ExternalCapabilityReadiness!.Status.Should().Be(ExternalCapabilityReadinessStatus.AdmissionRebindRequired);
         actorPort.CreateRunBindings.Should().BeEmpty();
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -717,6 +717,11 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
 
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             throw new NotSupportedException();
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed record UnknownDetachedSignal(WorkflowChatRunAcceptedReceipt Receipt)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -774,7 +774,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         }
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort
     {
         public Exception? DestroyException { get; set; }
         public List<string> DestroyCalls { get; } = [];
@@ -805,8 +805,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             CancellationToken ct = default) =>
             Task.CompletedTask;
 
-        public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
-            throw new NotSupportedException();
     }
 
     private sealed class FakeProjectionLease(string actorId, string commandId) : IWorkflowExecutionProjectionLease

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -380,7 +380,7 @@ public sealed class WorkflowRunFallbackCoverageTests
             Task.CompletedTask;
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort
     {
         public List<string> DestroyCalls { get; } = [];
         public TaskCompletionSource<bool> Destroyed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -410,8 +410,6 @@ public sealed class WorkflowRunFallbackCoverageTests
             CancellationToken ct = default) =>
             Task.CompletedTask;
 
-        public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
-            throw new NotSupportedException();
     }
 
     private sealed class FakeProjectionLease(string actorId, string commandId) : IWorkflowExecutionProjectionLease

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -607,6 +607,11 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             throw new NotSupportedException();
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeProjectionLease : IWorkflowExecutionProjectionLease

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -471,7 +471,7 @@ public sealed class ChatEndpointsInternalTests
         var interactionService = new FakeCommandInteractionService
         {
             ResultFactory = (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.AgentNotFound)),
         };
 
@@ -503,7 +503,7 @@ public sealed class ChatEndpointsInternalTests
                     "corr-empty");
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(receipt, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -548,7 +548,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.AgentNotFound));
             },
         };
@@ -581,7 +581,7 @@ public sealed class ChatEndpointsInternalTests
         var interactionService = new FakeCommandInteractionService
         {
             ResultFactory = (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch)),
         };
 
@@ -606,7 +606,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -652,7 +652,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -698,7 +698,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -742,7 +742,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -784,7 +784,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -840,7 +840,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -921,7 +921,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -964,7 +964,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1011,7 +1011,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1052,7 +1052,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 capturedCommand = command;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1090,7 +1090,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1134,7 +1134,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1172,7 +1172,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1215,7 +1215,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1258,7 +1258,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1305,7 +1305,7 @@ public sealed class ChatEndpointsInternalTests
                     new WorkflowChatContext("trusted-scope", "generated-conversation", "generated-turn", 7));
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(accepted, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(accepted, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -1359,7 +1359,7 @@ public sealed class ChatEndpointsInternalTests
                     new WorkflowChatRunAcceptedReceipt("actor-1", "direct", "create-cmd-1", "corr-1"),
                     new WorkflowChatContext("trusted-scope", "recovered-conversation", "recovered-turn"));
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Success(recovered, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, false)));
             },
         };
@@ -1406,7 +1406,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1439,7 +1439,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.WorkflowBindingMismatch));
             },
         };
@@ -1517,7 +1517,7 @@ public sealed class ChatEndpointsInternalTests
             {
                 called = true;
                 return Task.FromResult(
-                    CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                    WorkflowChatRunInteractionResult
                         .Failure(WorkflowChatRunStartError.AgentNotFound));
             },
         };
@@ -1635,7 +1635,7 @@ public sealed class ChatEndpointsInternalTests
                         Delta = "hello",
                     },
                 }, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -1665,7 +1665,7 @@ public sealed class ChatEndpointsInternalTests
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(receipt, ct);
                 await emitAsync(BuildRawObservedWorkflowExecutionStartedFrame(), ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -1696,7 +1696,7 @@ public sealed class ChatEndpointsInternalTests
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(receipt, ct);
                 await emitAsync(BuildRawObservedWorkflowExecutionStateUpsertedFrame(), ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
             },
         };
@@ -2739,12 +2739,12 @@ public sealed class ChatEndpointsInternalTests
 
     private sealed class FakeCommandInteractionService : IWorkflowChatRunInteractionPort
     {
-        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>>> ResultFactory { get; set; } =
+        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<WorkflowChatRunInteractionResult>> ResultFactory { get; set; } =
             (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.AgentNotFound));
 
-        public Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+        public Task<WorkflowChatRunInteractionResult> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
@@ -99,5 +101,60 @@ public class ChatRunStartErrorMapperTests
 
         mapped.Code.Should().Be(expectedCode);
         mapped.Message.Should().Be(expectedMessage);
+    }
+
+    [Fact]
+    public void ToErrorBody_ShouldMapFailureDetailReadinessShape()
+    {
+        var readiness = new ExternalCapabilityReadiness
+        {
+            Status = ExternalCapabilityReadinessStatus.ContractDrift,
+            SelectedSelector = new ExternalWorkflowCapabilitySelector
+            {
+                HostConnector = new HostConnectorCapabilityRef
+                {
+                    ConnectorCapabilityRef = "connector/ref",
+                    OperationId = "operation-1",
+                },
+            },
+        };
+        readiness.Blockers.Add(new ExternalCapabilityBlocker
+        {
+            Status = ExternalCapabilityReadinessStatus.ContractDrift,
+            Code = "NYXID_OPERATION_AUTHORING_MIGRATION_REQUIRED",
+            SafeMessage = "Rebind the workflow operation.",
+        });
+        readiness.Remediations.Add(new ExternalCapabilityRemediation
+        {
+            ActionKind = ExternalCapabilityRemediationActionKind.RebindWorkflow,
+            Label = "Rebind workflow",
+            TrustedLocator = " nyxid:services ",
+        });
+        readiness.Sources.Add(new ExternalCapabilitySourceStamp
+        {
+            SourceKind = ExternalCapabilitySourceKind.NyxIdOpenApi,
+            SourceId = "source-1",
+            SourceVersion = 7,
+        });
+        var detail = WorkflowChatRunStartFailureDetail.Create(
+            WorkflowChatRunStartError.InvalidWorkflowYaml,
+            "nyxid_proxy derived field 'contract_digest' cannot be authored.",
+            readiness);
+
+        using var json = JsonDocument.Parse(JsonSerializer.Serialize(ChatRunStartErrorMapper.ToErrorBody(detail)));
+        var root = json.RootElement;
+        root.GetProperty("code").GetString().Should().Be("INVALID_WORKFLOW_YAML");
+        root.GetProperty("message").GetString().Should().Be("nyxid_proxy derived field 'contract_digest' cannot be authored.");
+        var readinessJson = root.GetProperty("externalCapabilityReadiness");
+        readinessJson.GetProperty("status").GetString().Should().Be("contract_drift");
+        readinessJson.GetProperty("selectedCapability").GetProperty("userServiceId").ValueKind.Should().Be(JsonValueKind.Null);
+        readinessJson.GetProperty("selectedCapability").GetProperty("operationId").GetString().Should().Be("operation-1");
+        readinessJson.GetProperty("selectedCapability").GetProperty("connectorCapabilityRef").GetString().Should().Be("connector/ref");
+        readinessJson.GetProperty("blockers")[0].GetProperty("code").GetString().Should().Be("NYXID_OPERATION_AUTHORING_MIGRATION_REQUIRED");
+        readinessJson.GetProperty("blockers")[0].GetProperty("status").GetString().Should().Be("contract_drift");
+        readinessJson.GetProperty("remediations")[0].GetProperty("actionKind").GetString().Should().Be("rebind_workflow");
+        readinessJson.GetProperty("remediations")[0].GetProperty("trustedLocator").GetString().Should().Be("nyxid:services");
+        readinessJson.GetProperty("sources")[0].GetProperty("sourceKind").GetString().Should().Be("nyx_id_open_api");
+        readinessJson.GetProperty("sources")[0].GetProperty("sourceVersion").GetInt64().Should().Be(7);
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatWebSocketCoordinatorAndProtocolTests.cs
@@ -45,7 +45,7 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
                         Delta = "hello",
                     },
                 }, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(
                         receipt,
                         new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
@@ -78,7 +78,7 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
         var service = new FakeCommandInteractionService
         {
             Handler = (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.WorkflowNotFound)),
         };
 
@@ -104,7 +104,7 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
         var service = new FakeCommandInteractionService
         {
             Handler = (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.AgentNotFound)),
         };
 
@@ -218,7 +218,7 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
                 var receipt = new WorkflowChatRunAcceptedReceipt("actor-1", "direct", "cmd-1", "corr-1");
                 if (onAcceptedAsync != null)
                     await onAcceptedAsync(receipt, ct);
-                return CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                return WorkflowChatRunInteractionResult
                     .Success(
                         receipt,
                         new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(
@@ -352,14 +352,14 @@ public sealed class ChatWebSocketCoordinatorAndProtocolTests
 
     private sealed class FakeCommandInteractionService : IWorkflowChatRunInteractionPort
     {
-        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>>> Handler { get; set; } =
+        public Func<WorkflowChatRunRequest, Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask>, Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<WorkflowChatRunInteractionResult>> Handler { get; set; } =
             (_, _, _, _) => Task.FromResult(
-                CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                WorkflowChatRunInteractionResult
                     .Failure(WorkflowChatRunStartError.AgentNotFound));
 
         public WorkflowChatRunRequest? LastRequest { get; private set; }
 
-        public Task<CommandInteractionResult<WorkflowChatInteractionAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>> ExecuteAsync(
+        public Task<WorkflowChatRunInteractionResult> ExecuteAsync(
             WorkflowChatRunRequest request,
             Func<WorkflowRunEventEnvelope, CancellationToken, ValueTask> emitAsync,
             Func<WorkflowChatInteractionAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionParserExternalCapabilityTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionParserExternalCapabilityTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Infrastructure.Runs;
 using FluentAssertions;
@@ -27,6 +28,82 @@ public sealed class WorkflowDefinitionParserExternalCapabilityTests
         result.ExternalCapabilityReadiness.Remediations.Should().ContainSingle().Which.ActionKind.Should()
             .Be(expectedRemediation);
         result.ExternalCapabilityReadiness.ToString().Should().NotContain("caller-controlled-digest");
+    }
+
+    [Fact]
+    public async Task DefinitionParser_ShouldParseInlineWorkflowBundle_WhenDocumentsAreDistinct()
+    {
+        const string entryYaml = "name: main\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant";
+        const string childYaml = "name: child\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant";
+        var parser = new WorkflowDefinitionParser([new WorkflowCoreModulePack()]);
+
+        var result = await parser.ParseInlineWorkflowBundleAsync(
+            [
+                new WorkflowChatInlineYamlDocument(string.Empty, entryYaml),
+                new WorkflowChatInlineYamlDocument(string.Empty, childYaml),
+            ]);
+
+        result.Succeeded.Should().BeTrue();
+        result.EntryWorkflowName.Should().Be("main");
+        result.EntryWorkflowYaml.Should().Be(entryYaml);
+        result.WorkflowYamlsByName.Should().ContainKey("main");
+        result.WorkflowYamlsByName.Should().ContainKey("child");
+    }
+
+    [Fact]
+    public async Task DefinitionParser_ShouldRejectInlineWorkflowBundle_WhenNamesAreDuplicated()
+    {
+        var parser = new WorkflowDefinitionParser([new WorkflowCoreModulePack()]);
+
+        var result = await parser.ParseInlineWorkflowBundleAsync(
+            [
+                new WorkflowChatInlineYamlDocument(string.Empty, "name: main\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant"),
+                new WorkflowChatInlineYamlDocument(string.Empty, "name: main\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant"),
+            ]);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be("Duplicate workflow name 'main' in workflowYamls.");
+    }
+
+    [Fact]
+    public async Task DefinitionParser_ShouldRejectInlineWorkflowBundle_WhenDocumentNameMismatchesYamlName()
+    {
+        var parser = new WorkflowDefinitionParser([new WorkflowCoreModulePack()]);
+
+        var result = await parser.ParseInlineWorkflowBundleAsync(
+            [new WorkflowChatInlineYamlDocument("requested", "name: actual\nroles:\n  - id: assistant\n    name: Assistant\nsteps:\n  - id: reply\n    type: llm_call\n    target_role: assistant")]);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be("workflowYamls[0] document name 'requested' does not match workflow name 'actual'.");
+    }
+
+    [Fact]
+    public async Task DefinitionParser_ShouldPreserveReadiness_WhenInlineWorkflowBundleCapabilityIsInvalid()
+    {
+        const string workflowYaml =
+            """
+            name: legacy-proof
+            steps:
+              - id: call
+                type: tool_call
+                capability:
+                  nyxid_operation:
+                    user_service_id: us-alpha
+                    operation_id: get-resource
+                parameters:
+                  tool: nyxid_proxy
+                  arguments: '{"contract_digest":"caller-controlled-digest"}'
+            """;
+        var parser = new WorkflowDefinitionParser([new WorkflowCoreModulePack()]);
+
+        var result = await parser.ParseInlineWorkflowBundleAsync(
+            [new WorkflowChatInlineYamlDocument(string.Empty, workflowYaml)]);
+
+        result.Succeeded.Should().BeFalse();
+        result.ExternalCapabilityReadiness.Should().NotBeNull();
+        result.ExternalCapabilityReadiness!.Status.Should().Be(ExternalCapabilityReadinessStatus.ContractDrift);
+        result.ExternalCapabilityReadiness.Blockers.Should().ContainSingle().Which.Code.Should()
+            .Be("NYXID_OPERATION_AUTHORING_MIGRATION_REQUIRED");
     }
 
     public static TheoryData<string, ExternalCapabilityReadinessStatus, string,


### PR DESCRIPTION
## Summary
- Pre-validate inline `workflowYamls` in the scope draft-run endpoint before dispatching a workflow run.
- Return `INVALID_WORKFLOW_YAML` with the concrete parser/validator message so clients can fix invalid authored YAML.
- Cover the endpoint behavior with an integration test and fake workflow definition parser wiring.

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter ScopeServiceDraftRunEndpointTests --nologo`
- [x] `git diff --check`
- [x] Local smoke: `POST /api/scopes/local/workflow/draft-run` with the Xiaomi Q1000 workflow returned `400 INVALID_WORKFLOW_YAML` and message `Workflow step 'fetch_q1000' external capability is invalid: nyxid_proxy derived field 'service_id' cannot be authored; select a connected-service operation and rebind.`
- [ ] `bash tools/ci/test_stability_guards.sh` could not complete locally: Python/Homebrew `pyexpat` import failed with `No module named expat` / missing `_XML_SetAllocTrackerActivationThreshold`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)