### PR TITLE
Fix Team detail layout on narrow screens

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.css
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.css
@@ -1,0 +1,21 @@
+.team-detail-tabs {
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+}
+
+.team-detail-tabs > button {
+  flex-shrink: 0;
+}
+
+@media (max-width: 420px) {
+  .team-detail-tabs {
+    --team-detail-tab-padding-inline: 12px;
+    --team-detail-tabs-gap: 4px;
+    --team-detail-tabs-padding: 4px;
+    --team-detail-tabs-radius: 12px;
+  }
+
+  .team-detail-tabs > button {
+    min-height: 44px;
+  }
+}

--- a/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
@@ -10,6 +10,7 @@ import {
   AevatarPanel,
 } from "@/shared/ui/aevatarPageShells";
 import { AEVATAR_INTERACTIVE_CHIP_CLASS } from "@/shared/ui/interactionStandards";
+import "./TeamDetailChrome.css";
 
 export type TeamTabOption = {
   readonly label: string;
@@ -164,18 +165,23 @@ export const TeamTabBar: React.FC<TeamTabBarProps> = ({
 
   return (
     <div
+      className="team-detail-tabs"
+      data-responsive-layout="horizontal-scroll"
       role="tablist"
       aria-label={intl.formatMessage({ id: "teams.detail.tabList.label" })}
       style={{
         alignItems: "center",
         background: token.colorBgContainer,
         border: `1px solid ${token.colorBorderSecondary}`,
-        borderRadius: 20,
+        borderRadius: "var(--team-detail-tabs-radius, 20px)",
         boxShadow: token.boxShadowSecondary,
         display: "flex",
-        flexWrap: "wrap",
-        gap: 10,
-        padding: 8,
+        flexWrap: "nowrap",
+        gap: "var(--team-detail-tabs-gap, 10px)",
+        maxWidth: "100%",
+        overflowX: "auto",
+        padding: "var(--team-detail-tabs-padding, 8px)",
+        width: "100%",
       }}
     >
       {tabOptions.map((option) => {
@@ -193,10 +199,13 @@ export const TeamTabBar: React.FC<TeamTabBarProps> = ({
               borderRadius: 999,
               color: active ? token.colorWhite : token.colorTextSecondary,
               cursor: "pointer",
+              flex: "0 0 auto",
               fontSize: 14,
               fontWeight: active ? 700 : 500,
-              padding: "10px 16px",
+              minHeight: 44,
+              padding: "10px var(--team-detail-tab-padding-inline, 16px)",
               transition: "all 160ms ease",
+              whiteSpace: "nowrap",
             }}
             type="button"
           >

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -2449,6 +2449,8 @@ describe("TeamDetailPage", () => {
       ".team-members-table-primary-actions",
     ) as HTMLElement | null;
     expect(memberActions).toBeTruthy();
+    expect(memberActions).toHaveAttribute("data-compact-touch-target", "44");
+    expect(memberActions).toHaveStyle("--team-member-action-touch-target: 44px");
     expect(within(memberActions as HTMLElement).getByLabelText("调用")).toBeTruthy();
     expect(
       within(memberActions as HTMLElement).getByLabelText("发布运行记录"),
@@ -2465,6 +2467,19 @@ describe("TeamDetailPage", () => {
     expect(
       within(memberActions as HTMLElement).getByLabelText("删除成员"),
     ).toBeTruthy();
+
+    const createMemberAction = screen.getByRole("link", {
+      name: "创建工作流成员",
+    });
+    expect(createMemberAction).toHaveClass("team-members-create-action");
+    expect(createMemberAction).toHaveAttribute("data-compact-width", "contained");
+
+    const tabList = screen.getByRole("tablist", { name: "团队详情标签" });
+    expect(tabList).toHaveClass("team-detail-tabs");
+    expect(tabList).toHaveAttribute(
+      "data-responsive-layout",
+      "horizontal-scroll",
+    );
 
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.css
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.css
@@ -24,22 +24,30 @@
 
   .team-members-table-primary-actions {
     justify-content: flex-start !important;
-    width: 100% !important;
+    max-width: 100% !important;
   }
+}
 
-  .team-members-table-invoke-action,
-  .team-members-table-published-runs-action,
-  .team-members-table-automate-action,
-  .team-members-table-studio-action,
-  .team-members-table-entry-action,
-  .team-members-table-delete-action {
-    min-width: 0 !important;
+@container team-members-table (max-width: 420px) {
+  .team-members-table-primary-actions {
+    --team-member-action-size: var(--team-member-action-touch-target);
+    --team-member-actions-display: grid;
+    --team-member-actions-gap: 8px;
+    --team-member-actions-justify: flex-start;
+    --team-member-actions-padding: 6px;
+    --team-member-actions-width: max-content;
+    grid-template-columns: repeat(3, var(--team-member-action-touch-target));
   }
 }
 
 @media (max-width: 420px) {
-  .team-members-table-primary-actions {
-    justify-content: flex-start !important;
+  .team-members-panel-header {
+    --team-members-create-height: auto;
+    --team-members-create-min-height: 44px;
+    --team-members-create-white-space: normal;
+    --team-members-create-width: 100%;
+    --team-members-panel-align: stretch;
+    --team-members-panel-direction: column;
   }
 }
 

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -133,7 +133,7 @@ const rosterRowBaseStyle: React.CSSProperties = {
 
 const memberNameRowStyle: React.CSSProperties = {
   alignItems: "center",
-  display: "flex",
+  display: "var(--team-member-actions-display, flex)",
   gap: 8,
   minWidth: 0,
 };
@@ -170,27 +170,28 @@ const actionCellStyle: React.CSSProperties = {
   width: "100%",
 };
 
-const primaryActionsStyle: React.CSSProperties = {
+const primaryActionsStyle = {
   alignItems: "center",
   borderRadius: 12,
   display: "flex",
   flex: "0 0 auto",
-  gap: 4,
-  justifyContent: "flex-end",
+  gap: "var(--team-member-actions-gap, 4px)",
+  justifyContent: "var(--team-member-actions-justify, flex-end)",
   minWidth: 0,
-  padding: 4,
-  width: "max-content",
-};
+  padding: "var(--team-member-actions-padding, 4px)",
+  width: "var(--team-member-actions-width, max-content)",
+  "--team-member-action-touch-target": "44px",
+} as React.CSSProperties;
 
 const memberActionButtonBaseStyle: React.CSSProperties = {
   border: "none",
   borderRadius: 8,
   boxShadow: "none",
-  height: 32,
+  height: "var(--team-member-action-size, 32px)",
   lineHeight: 1,
-  minWidth: 32,
+  minWidth: "var(--team-member-action-size, 32px)",
   paddingInline: 0,
-  width: 32,
+  width: "var(--team-member-action-size, 32px)",
 };
 
 const memberRosterSkeletonRowKeys = ["primary", "secondary", "tertiary"] as const;
@@ -212,8 +213,10 @@ const SkeletonLine: React.FC<{
 );
 
 const panelHeaderStyle: React.CSSProperties = {
-  alignItems: "center",
+  alignItems: "var(--team-members-panel-align, center)",
   display: "flex",
+  flexDirection:
+    "var(--team-members-panel-direction, row)" as React.CSSProperties["flexDirection"],
   flexWrap: "wrap",
   gap: 12,
   justifyContent: "space-between",
@@ -238,7 +241,11 @@ const panelTitleStyle: React.CSSProperties = {
 
 const panelCreateActionStyle: React.CSSProperties = {
   flex: "0 0 auto",
+  height: "var(--team-members-create-height)",
+  minHeight: "var(--team-members-create-min-height)",
   minWidth: 0,
+  whiteSpace: "var(--team-members-create-white-space, nowrap)",
+  width: "var(--team-members-create-width, auto)",
 };
 
 const EllipsisText: React.FC<{
@@ -366,6 +373,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                   <div className="team-members-table-actions" style={actionCellStyle}>
                     <div
                       className="team-members-table-primary-actions"
+                      data-compact-touch-target="44"
                       style={primaryActionsStyle}
                     >
                       <Skeleton.Button
@@ -428,7 +436,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <AevatarPanel>
-        <div style={panelHeaderStyle}>
+        <div className="team-members-panel-header" style={panelHeaderStyle}>
           <div style={panelTitleGroupStyle}>
             <Typography.Title level={3} style={panelTitleStyle}>
               {intl.formatMessage({ id: "teams.members.title" })}
@@ -444,6 +452,8 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
           </div>
           {createMemberHref ? (
             <Button
+              className="team-members-create-action"
+              data-compact-width="contained"
               href={createMemberHref}
               icon={<PlusOutlined />}
               onClick={handleNavigate(createMemberHref)}
@@ -647,6 +657,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                       <div className="team-members-table-actions" style={actionCellStyle}>
                         <div
                           className="team-members-table-primary-actions"
+                          data-compact-touch-target="44"
                           style={{
                             ...primaryActionsStyle,
                             background: token.colorFillQuaternary,

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
@@ -30,6 +30,13 @@ describe("ConsoleHeaderActions", () => {
   it("renders a login entry when there is no restorable auth session", () => {
     render(React.createElement(ConsoleHeaderActions));
 
+    expect(document.querySelector(".console-header-actions")).toHaveAttribute(
+      "data-responsive-layout",
+      "compact-header-actions",
+    );
+    expect(document.querySelector(".console-header-actions__language-label")).toHaveTextContent(
+      "English",
+    );
     expect(
       screen.getByRole("button", { name: "Switch language" }),
     ).toBeInTheDocument();
@@ -63,6 +70,10 @@ describe("ConsoleHeaderActions", () => {
 
     expect(getLocale()).toBe("zh-CN");
     expect(screen.getByText("Abigail Deng")).toBeInTheDocument();
+    expect(document.querySelector(".console-header-actions__user-name")).toHaveAttribute(
+      "data-compact-label",
+      "hidden",
+    );
   });
 
   it("applies an optional dropdown root class to action menus", async () => {

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
@@ -46,6 +46,47 @@ type ConsoleHeaderActionThemeProps = {
   readonly dropdownRootClassName?: string;
 };
 
+const consoleHeaderActionsCss = `
+.console-header-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  gap: 8px;
+  max-width: 100%;
+  min-width: 0;
+}
+
+@media (max-width: 480px) {
+  .console-header-actions {
+    --console-header-action-flex: 0 0 44px;
+    --console-header-action-height: 44px;
+    --console-header-action-min-width: 44px;
+    --console-header-action-padding-inline: 0;
+    --console-header-action-width: 44px;
+    --console-header-user-padding: 0;
+    gap: 4px;
+  }
+
+  .console-header-actions__language-label,
+  .console-header-actions__login-label,
+  .console-header-actions__user-name,
+  .console-header-actions__user-caret {
+    display: none;
+  }
+}
+`;
+
+const compactActionStyle: React.CSSProperties = {
+  boxSizing: "border-box",
+  flex: "var(--console-header-action-flex, 0 1 auto)",
+  height: "var(--console-header-action-height, 36px)",
+  justifyContent: "center",
+  minWidth: "var(--console-header-action-min-width, auto)",
+  paddingInline: "var(--console-header-action-padding-inline)",
+  width: "var(--console-header-action-width, auto)",
+};
+
 export const ConsoleLanguageSwitch: React.FC<ConsoleHeaderActionThemeProps> = ({
   dropdownRootClassName,
 }) => {
@@ -87,13 +128,18 @@ export const ConsoleLanguageSwitch: React.FC<ConsoleHeaderActionThemeProps> = ({
         className="console-header-actions__language"
         icon={<GlobalOutlined />}
         style={{
+          ...compactActionStyle,
           alignItems: "center",
           display: "inline-flex",
-          height: 36,
         }}
         type="text"
       >
-        {intl.formatMessage({ id: selectedOption.messageId })}
+        <span
+          className="console-header-actions__language-label"
+          data-compact-label="hidden"
+        >
+          {intl.formatMessage({ id: selectedOption.messageId })}
+        </span>
       </Button>
     </Dropdown>
   );
@@ -112,12 +158,15 @@ export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
         onClick={() => {
           history.push(buildLoginRoute(getCurrentReturnTo()));
         }}
+        style={compactActionStyle}
         type="link"
       >
-        {intl.formatMessage({
-          defaultMessage: "Sign in",
-          id: "common.user.signIn",
-        })}
+        <span className="console-header-actions__login-label" data-compact-label="hidden">
+          {intl.formatMessage({
+            defaultMessage: "Sign in",
+            id: "common.user.signIn",
+          })}
+        </span>
       </Button>
     );
   }
@@ -165,6 +214,7 @@ export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
       <span
         className="console-header-actions__user"
         style={{
+          ...compactActionStyle,
           alignItems: "center",
           background: "var(--ant-color-fill-tertiary)",
           border: "1px solid var(--ant-color-border-secondary)",
@@ -172,9 +222,8 @@ export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
           cursor: "pointer",
           display: "inline-flex",
           gap: 8,
-          height: 36,
           maxWidth: 220,
-          padding: "0 10px 0 6px",
+          padding: "var(--console-header-user-padding, 0 10px 0 6px)",
         }}
         title={displayName}
       >
@@ -185,6 +234,7 @@ export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
         />
         <Typography.Text
           className="console-header-actions__user-name"
+          data-compact-label="hidden"
           style={{
             flex: 1,
             color: "var(--ant-color-text)",
@@ -219,12 +269,16 @@ export const ConsoleHeaderActions: React.FC<{
     .join(" ");
 
   return (
-    <div
-      className={rootClassName}
-      data-dropdown-root-class-name={dropdownRootClassName}
-    >
-      <ConsoleLanguageSwitch dropdownRootClassName={dropdownRootClassName} />
-      <ConsoleAuthActions dropdownRootClassName={dropdownRootClassName} />
-    </div>
+    <>
+      <style>{consoleHeaderActionsCss}</style>
+      <div
+        className={rootClassName}
+        data-dropdown-root-class-name={dropdownRootClassName}
+        data-responsive-layout="compact-header-actions"
+      >
+        <ConsoleLanguageSwitch dropdownRootClassName={dropdownRootClassName} />
+        <ConsoleAuthActions dropdownRootClassName={dropdownRootClassName} />
+      </div>
+    </>
   );
 };

--- a/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { Grid } from 'antd';
 import React from 'react';
-import { AevatarContextDrawer } from './aevatarPageShells';
+import { AevatarContextDrawer, AevatarPageShell } from './aevatarPageShells';
 
 describe('AevatarContextDrawer', () => {
   afterEach(() => {
@@ -34,5 +34,32 @@ describe('AevatarContextDrawer', () => {
     expect(
       document.querySelector('.aevatar-context-drawer-right'),
     ).toBeNull();
+  });
+});
+
+describe('AevatarPageShell', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('removes nested inline page padding in viewport mode on compact screens', () => {
+    jest.spyOn(Grid, 'useBreakpoint').mockReturnValue({
+      lg: false,
+      md: false,
+      sm: false,
+      xl: false,
+      xs: true,
+      xxl: false,
+    });
+
+    render(
+      <AevatarPageShell title="Compact Team detail">
+        <div>Team content</div>
+      </AevatarPageShell>,
+    );
+
+    expect(
+      screen.getByText('Team content').parentElement?.parentElement,
+    ).toHaveStyle({ paddingInline: 0 });
   });
 });

--- a/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
@@ -164,6 +164,11 @@ const pageContainerChildrenViewportStyle: React.CSSProperties = {
   minHeight: 0,
 };
 
+const compactPageContainerChildrenViewportStyle: React.CSSProperties = {
+  ...pageContainerChildrenViewportStyle,
+  paddingInline: 0,
+};
+
 const pageContainerChildrenDocumentStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
@@ -250,7 +255,10 @@ const titleNavigationRowStyle: React.CSSProperties = {
   alignItems: 'center',
   display: 'flex',
   gap: 8,
+  maxWidth: '100%',
   minWidth: 0,
+  overflow: 'hidden',
+  width: '100%',
 };
 
 const backButtonStyle: React.CSSProperties = {
@@ -263,7 +271,10 @@ const backButtonStyle: React.CSSProperties = {
 };
 
 const breadcrumbStyle: React.CSSProperties = {
+  flex: '1 1 auto',
+  maxWidth: '100%',
   minWidth: 0,
+  overflow: 'hidden',
 };
 
 const breadcrumbLabelStyle: React.CSSProperties = {
@@ -296,7 +307,11 @@ const breadcrumbCss = `
 }
 
 .aevatar-breadcrumb__item {
+  display: flex;
+  flex: 0 1 auto;
+  max-width: var(--aevatar-breadcrumb-item-max-width, 180px);
   min-width: 0;
+  overflow: hidden;
 }
 
 .aevatar-breadcrumb__item--separator {
@@ -306,6 +321,8 @@ const breadcrumbCss = `
 
 .aevatar-breadcrumb__link {
   color: var(--aevatar-breadcrumb-link-color);
+  display: flex;
+  min-width: 0;
   text-decoration: none;
 }
 
@@ -315,6 +332,23 @@ const breadcrumbCss = `
 
 .aevatar-breadcrumb__current {
   color: var(--aevatar-breadcrumb-current-color);
+  display: flex;
+  min-width: 0;
+}
+
+@media (max-width: 480px) {
+  .aevatar-breadcrumb__list {
+    gap: 4px;
+  }
+
+  .aevatar-breadcrumb__item:not(.aevatar-breadcrumb__item--separator) {
+    max-width: 32vw;
+  }
+
+  .aevatar-breadcrumb__item:not(.aevatar-breadcrumb__item--separator):first-child {
+    flex: 0 0 auto;
+    max-width: 24vw;
+  }
 }
 `;
 
@@ -514,7 +548,7 @@ export const AevatarPageShell: React.FC<AevatarPageShellProps> = ({
   titleHelp,
 }) => {
   const screens = Grid.useBreakpoint();
-  const useCompactDocumentPadding = layoutMode === 'document' && !screens.md;
+  const useCompactPagePadding = !screens.md;
 
   return (
     <AevatarLayoutModeContext.Provider value={layoutMode}>
@@ -527,10 +561,12 @@ export const AevatarPageShell: React.FC<AevatarPageShellProps> = ({
         }
         childrenContentStyle={
           layoutMode === 'document'
-            ? useCompactDocumentPadding
+            ? useCompactPagePadding
               ? compactPageContainerChildrenDocumentStyle
               : pageContainerChildrenDocumentStyle
-            : pageContainerChildrenViewportStyle
+            : useCompactPagePadding
+              ? compactPageContainerChildrenViewportStyle
+              : pageContainerChildrenViewportStyle
         }
         content={content}
         extra={extra}


### PR DESCRIPTION
## Summary

- Make Team detail chrome, breadcrumbs, tabs, member actions, and create-member controls usable at 320-390px widths without dropping actions.
- Preserve desktop behavior while adding compact labels, horizontal tab access, contained actions, and stable 44px member command targets.

## Verification

- `pnpm --dir apps/aevatar-console-web exec jest --selectProjects jsdom --runInBand src/shared/ui/aevatarPageShells.test.tsx src/shared/ui/ConsoleHeaderActions.test.tsx src/pages/teams/detail.test.tsx`: passed (3 suites; 4 focused responsive contracts)
- `pnpm --dir apps/aevatar-console-web exec biome lint src/shared/ui/aevatarPageShells.tsx src/shared/ui/aevatarPageShells.test.tsx src/shared/ui/ConsoleHeaderActions.tsx src/shared/ui/ConsoleHeaderActions.test.tsx src/pages/teams/components/TeamDetailChrome.tsx src/pages/teams/tabs/TeamMembersTab.tsx src/pages/teams/detail.test.tsx`: passed
- `pnpm --dir apps/aevatar-console-web tsc`: passed
- `pnpm --dir apps/aevatar-console-web build`: passed
- `bash tools/ci/test_stability_guards.sh`: passed
- `bash tools/ci/frontend_static_boundary_guard.sh`: passed
- `git diff --check origin/dev...HEAD`: passed

## Risks

- Browser QA was timeboxed after three attempts. The deterministic fixture rendered the app, but screenshot capture waited 30 seconds on external font resources each time; live screenshots at all four target widths were therefore not verified.

Closes #3003