### PR TITLE
Preserve projection delete watermarks

### DIFF
--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs
@@ -179,8 +179,15 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
         {
             return _parser.Parse<TReadModel>(json);
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(
+                ex,
+                "Projection read-model deserialization failed during optimistic write. provider={Provider} readModelType={ReadModelType} result={Result} errorType={ErrorType}",
+                ProviderName,
+                typeof(TReadModel).FullName,
+                "ignored",
+                ex.GetType().Name);
             return null;
         }
     }

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs
@@ -56,7 +56,11 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
             for (var attempt = 1; attempt <= MaxAttempts; attempt++)
             {
                 var existing = await TryGetExistingStateAsync(indexName, keyValue, ct);
-                var result = ProjectionWriteResultEvaluator.Evaluate(existing.ReadModel, readModel);
+                var result = existing.DeleteMarker is null
+                    ? ProjectionWriteResultEvaluator.Evaluate(existing.ReadModel, readModel)
+                    : ElasticsearchProjectionDeleteMarkerPayload.EvaluateUpsertAgainstDeleteMarker(
+                        existing.DeleteMarker,
+                        readModel);
                 if (!result.IsApplied)
                 {
                     LogWriteSkipped(keyValue, startedAtTimestamp, result);
@@ -84,7 +88,11 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
             }
 
             var reconciled = await TryGetExistingStateAsync(indexName, keyValue, ct);
-            var reconciledResult = ProjectionWriteResultEvaluator.Evaluate(reconciled.ReadModel, readModel);
+            var reconciledResult = reconciled.DeleteMarker is null
+                ? ProjectionWriteResultEvaluator.Evaluate(reconciled.ReadModel, readModel)
+                : ElasticsearchProjectionDeleteMarkerPayload.EvaluateUpsertAgainstDeleteMarker(
+                    reconciled.DeleteMarker,
+                    readModel);
             if (!reconciledResult.IsApplied)
             {
                 LogWriteSkipped(keyValue, startedAtTimestamp, reconciledResult);
@@ -128,9 +136,13 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
         var seqNo = TryReadLong(jsonDoc.RootElement, "_seq_no");
         var primaryTerm = TryReadLong(jsonDoc.RootElement, "_primary_term");
         if (!jsonDoc.RootElement.TryGetProperty("_source", out var sourceNode))
-            return new ExistingReadModelState(null, seqNo, primaryTerm);
+            return new ExistingReadModelState(null, null, seqNo, primaryTerm);
 
-        return new ExistingReadModelState(DeserializeOrNull(sourceNode.GetRawText()), seqNo, primaryTerm);
+        var deleteMarker = ElasticsearchProjectionDeleteMarkerPayload.TryParse(sourceNode);
+        if (deleteMarker != null)
+            return new ExistingReadModelState(null, deleteMarker, seqNo, primaryTerm);
+
+        return new ExistingReadModelState(DeserializeOrNull(sourceNode.GetRawText()), null, seqNo, primaryTerm);
     }
 
     private static HttpRequestMessage BuildConditionalUpsertRequest(
@@ -139,7 +151,7 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
         string payload,
         ExistingReadModelState existing)
     {
-        var requestPath = existing.ReadModel == null
+        var requestPath = existing.ReadModel == null && existing.DeleteMarker == null
             ? $"{indexName}/_create/{Uri.EscapeDataString(keyValue)}"
             : $"{indexName}/_doc/{Uri.EscapeDataString(keyValue)}?if_seq_no={existing.SeqNo}&if_primary_term={existing.PrimaryTerm}";
         return new HttpRequestMessage(HttpMethod.Put, requestPath)
@@ -227,9 +239,10 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
 
     internal sealed record ExistingReadModelState(
         TReadModel? ReadModel,
+        ProjectionDocumentDeleteMarker? DeleteMarker,
         long SeqNo,
         long PrimaryTerm)
     {
-        public static ExistingReadModelState Missing { get; } = new(null, -1, -1);
+        public static ExistingReadModelState Missing { get; } = new(null, null, -1, -1);
     }
 }

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDeleteMarkerPayload.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDeleteMarkerPayload.cs
@@ -1,13 +1,19 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 
 internal static class ElasticsearchProjectionDeleteMarkerPayload
 {
     internal const string TombstoneField = "__projection_tombstone";
-    internal const string DeletedAtUtcField = "__projection_deleted_at_utc";
+    private static readonly JsonFormatter Formatter = new(
+        JsonFormatter.Settings.Default
+            .WithFormatDefaultValues(true));
+    private static readonly JsonParser Parser = new(
+        JsonParser.Settings.Default
+            .WithIgnoreUnknownFields(true));
 
     internal static bool IsDeleteMarker(JsonElement source)
     {
@@ -25,45 +31,50 @@ internal static class ElasticsearchProjectionDeleteMarkerPayload
         if (!IsDeleteMarker(source))
             return null;
 
-        var id = ReadString(source, "id");
-        var actorId = ReadString(source, "actor_id");
-        var stateVersion = ReadInt64(source, "state_version");
-        var lastEventId = ReadString(source, "last_event_id");
-        var updatedAt = ReadDateTimeOffset(source, "updated_at_utc_value")
-            ?? ReadDateTimeOffset(source, DeletedAtUtcField)
-            ?? DateTimeOffset.MinValue;
-
-        if (string.IsNullOrWhiteSpace(id) ||
-            string.IsNullOrWhiteSpace(actorId) ||
-            stateVersion <= 0 ||
-            string.IsNullOrWhiteSpace(lastEventId))
+        ProjectionDocumentDeleteMarkerRecord record;
+        try
+        {
+            record = Parser.Parse<ProjectionDocumentDeleteMarkerRecord>(source.GetRawText());
+        }
+        catch (InvalidProtocolBufferException)
         {
             return null;
         }
 
+        if (string.IsNullOrWhiteSpace(record.Id) ||
+            string.IsNullOrWhiteSpace(record.ActorId) ||
+            record.StateVersion <= 0 ||
+            string.IsNullOrWhiteSpace(record.LastEventId))
+        {
+            return null;
+        }
+
+        var updatedAt = record.UpdatedAtUtcValue?.ToDateTimeOffset()
+            ?? record.DeletedAtUtcValue?.ToDateTimeOffset()
+            ?? DateTimeOffset.MinValue;
         return new ProjectionDocumentDeleteMarker(
-            id.Trim(),
-            actorId.Trim(),
-            stateVersion,
-            lastEventId.Trim(),
+            record.Id.Trim(),
+            record.ActorId.Trim(),
+            record.StateVersion,
+            record.LastEventId.Trim(),
             updatedAt);
     }
 
     internal static string Serialize(ProjectionDocumentDeleteMarker marker, string keyValue)
     {
         var normalized = Normalize(marker);
-        var payload = new JsonObject
+        var record = new ProjectionDocumentDeleteMarkerRecord
         {
-            [TombstoneField] = true,
-            ["id"] = normalized.Id,
-            ["actor_id"] = normalized.ActorId,
-            ["state_version"] = normalized.StateVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            ["last_event_id"] = normalized.LastEventId,
-            ["updated_at_utc_value"] = normalized.UpdatedAt.UtcDateTime.ToString("O"),
-            [DeletedAtUtcField] = normalized.UpdatedAt.UtcDateTime.ToString("O"),
-            [ElasticsearchProjectionDocumentStorePayloadSupport.StableSortDocumentIdField] = keyValue,
+            ProjectionTombstone = true,
+            Id = normalized.Id,
+            ActorId = normalized.ActorId,
+            StateVersion = normalized.StateVersion,
+            LastEventId = normalized.LastEventId,
+            UpdatedAtUtcValue = Timestamp.FromDateTimeOffset(normalized.UpdatedAt),
+            DeletedAtUtcValue = Timestamp.FromDateTimeOffset(normalized.UpdatedAt),
+            ProjectionDocumentId = keyValue,
         };
-        return payload.ToJsonString();
+        return Formatter.Format(record);
     }
 
     internal static ProjectionDocumentDeleteMarker Normalize(ProjectionDocumentDeleteMarker marker)
@@ -100,35 +111,5 @@ internal static class ElasticsearchProjectionDeleteMarkerPayload
         }
 
         return ProjectionWriteResult.Applied();
-    }
-
-    private static string ReadString(JsonElement source, string propertyName)
-    {
-        return source.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
-            ? value.GetString() ?? string.Empty
-            : string.Empty;
-    }
-
-    private static long ReadInt64(JsonElement source, string propertyName)
-    {
-        if (!source.TryGetProperty(propertyName, out var value))
-            return 0;
-
-        return value.ValueKind switch
-        {
-            JsonValueKind.Number when value.TryGetInt64(out var number) => number,
-            JsonValueKind.String when long.TryParse(value.GetString(), out var parsed) => parsed,
-            _ => 0,
-        };
-    }
-
-    private static DateTimeOffset? ReadDateTimeOffset(JsonElement source, string propertyName)
-    {
-        if (!source.TryGetProperty(propertyName, out var value) || value.ValueKind != JsonValueKind.String)
-            return null;
-
-        return DateTimeOffset.TryParse(value.GetString(), out var parsed)
-            ? parsed
-            : null;
     }
 }

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDeleteMarkerPayload.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDeleteMarkerPayload.cs
@@ -8,6 +8,7 @@ namespace Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 internal static class ElasticsearchProjectionDeleteMarkerPayload
 {
     internal const string TombstoneField = "__projection_tombstone";
+    internal const string DeletedAtUtcField = "__projection_deleted_at_utc";
     private static readonly JsonFormatter Formatter = new(
         JsonFormatter.Settings.Default
             .WithFormatDefaultValues(true));

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDeleteMarkerPayload.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDeleteMarkerPayload.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+
+namespace Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
+
+internal static class ElasticsearchProjectionDeleteMarkerPayload
+{
+    internal const string TombstoneField = "__projection_tombstone";
+    internal const string DeletedAtUtcField = "__projection_deleted_at_utc";
+
+    internal static bool IsDeleteMarker(JsonElement source)
+    {
+        if (!source.TryGetProperty(TombstoneField, out var marker))
+            return false;
+
+        return marker.ValueKind == JsonValueKind.True ||
+               marker.ValueKind == JsonValueKind.String &&
+               bool.TryParse(marker.GetString(), out var parsed) &&
+               parsed;
+    }
+
+    internal static ProjectionDocumentDeleteMarker? TryParse(JsonElement source)
+    {
+        if (!IsDeleteMarker(source))
+            return null;
+
+        var id = ReadString(source, "id");
+        var actorId = ReadString(source, "actor_id");
+        var stateVersion = ReadInt64(source, "state_version");
+        var lastEventId = ReadString(source, "last_event_id");
+        var updatedAt = ReadDateTimeOffset(source, "updated_at_utc_value")
+            ?? ReadDateTimeOffset(source, DeletedAtUtcField)
+            ?? DateTimeOffset.MinValue;
+
+        if (string.IsNullOrWhiteSpace(id) ||
+            string.IsNullOrWhiteSpace(actorId) ||
+            stateVersion <= 0 ||
+            string.IsNullOrWhiteSpace(lastEventId))
+        {
+            return null;
+        }
+
+        return new ProjectionDocumentDeleteMarker(
+            id.Trim(),
+            actorId.Trim(),
+            stateVersion,
+            lastEventId.Trim(),
+            updatedAt);
+    }
+
+    internal static string Serialize(ProjectionDocumentDeleteMarker marker, string keyValue)
+    {
+        var normalized = Normalize(marker);
+        var payload = new JsonObject
+        {
+            [TombstoneField] = true,
+            ["id"] = normalized.Id,
+            ["actor_id"] = normalized.ActorId,
+            ["state_version"] = normalized.StateVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            ["last_event_id"] = normalized.LastEventId,
+            ["updated_at_utc_value"] = normalized.UpdatedAt.UtcDateTime.ToString("O"),
+            [DeletedAtUtcField] = normalized.UpdatedAt.UtcDateTime.ToString("O"),
+            [ElasticsearchProjectionDocumentStorePayloadSupport.StableSortDocumentIdField] = keyValue,
+        };
+        return payload.ToJsonString();
+    }
+
+    internal static ProjectionDocumentDeleteMarker Normalize(ProjectionDocumentDeleteMarker marker)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+        var normalized = marker with
+        {
+            Id = marker.Id?.Trim() ?? string.Empty,
+            ActorId = marker.ActorId?.Trim() ?? string.Empty,
+            LastEventId = marker.LastEventId?.Trim() ?? string.Empty,
+        };
+        _ = ProjectionWriteResultEvaluator.Evaluate(null, normalized);
+        if (normalized.StateVersion <= 0)
+            throw new InvalidOperationException("Projection delete marker state version must be positive.");
+
+        return normalized;
+    }
+
+    internal static ProjectionWriteResult EvaluateUpsertAgainstDeleteMarker(
+        ProjectionDocumentDeleteMarker existing,
+        IProjectionReadModel incoming)
+    {
+        if (!string.Equals(existing.ActorId, incoming.ActorId, StringComparison.Ordinal))
+            return ProjectionWriteResult.Conflict();
+
+        if (incoming.StateVersion < existing.StateVersion)
+            return ProjectionWriteResult.Stale();
+
+        if (incoming.StateVersion == existing.StateVersion)
+        {
+            return string.Equals(existing.LastEventId, incoming.LastEventId, StringComparison.Ordinal)
+                ? ProjectionWriteResult.Duplicate()
+                : ProjectionWriteResult.Conflict();
+        }
+
+        return ProjectionWriteResult.Applied();
+    }
+
+    private static string ReadString(JsonElement source, string propertyName)
+    {
+        return source.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
+    }
+
+    private static long ReadInt64(JsonElement source, string propertyName)
+    {
+        if (!source.TryGetProperty(propertyName, out var value))
+            return 0;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetInt64(out var number) => number,
+            JsonValueKind.String when long.TryParse(value.GetString(), out var parsed) => parsed,
+            _ => 0,
+        };
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffset(JsonElement source, string propertyName)
+    {
+        if (!source.TryGetProperty(propertyName, out var value) || value.ValueKind != JsonValueKind.String)
+            return null;
+
+        return DateTimeOffset.TryParse(value.GetString(), out var parsed)
+            ? parsed
+            : null;
+    }
+}

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStore.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStore.cs
@@ -178,6 +178,78 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
         }
     }
 
+    public async Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default)
+    {
+        marker = ElasticsearchProjectionDeleteMarkerPayload.Normalize(marker);
+        ct.ThrowIfCancellationRequested();
+        ThrowIfDynamicReadModelWritesUnsupportedForDelete();
+
+        await _indexManager.EnsureIndexAsync(_indexName, _indexMetadata, ct);
+        var startedAtTimestamp = Stopwatch.GetTimestamp();
+        try
+        {
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                var existing = await TryGetExistingProjectionStateAsync(_indexName, marker.Id, ct);
+                var result = EvaluateDeleteMarker(existing, marker);
+                if (!result.IsApplied)
+                {
+                    LogVersionedDeleteSkipped(marker, startedAtTimestamp, result);
+                    return result;
+                }
+
+                var payload = ElasticsearchProjectionDeleteMarkerPayload.Serialize(marker, marker.Id);
+                using var request = BuildConditionalTombstoneRequest(_indexName, marker.Id, payload, existing);
+                using var response = await _httpClient.SendAsync(request, ct);
+                if (response.IsSuccessStatusCode)
+                {
+                    LogVersionedDeleteCompleted(marker, startedAtTimestamp);
+                    return ProjectionWriteResult.Applied();
+                }
+
+                if (response.StatusCode != HttpStatusCode.Conflict)
+                    await ElasticsearchProjectionDocumentStoreHttpSupport.EnsureSuccessAsync(response, "versioned delete", ct);
+
+                _logger.LogInformation(
+                    "Projection read-model delete hit optimistic concurrency conflict and will re-evaluate. provider={Provider} readModelType={ReadModelType} key={Key} attempt={Attempt}/{MaxAttempts}",
+                    ProviderName,
+                    typeof(TReadModel).FullName,
+                    marker.Id,
+                    attempt,
+                    3);
+            }
+
+            var reconciled = await TryGetExistingProjectionStateAsync(_indexName, marker.Id, ct);
+            var reconciledResult = EvaluateDeleteMarker(reconciled, marker);
+            if (!reconciledResult.IsApplied)
+            {
+                LogVersionedDeleteSkipped(marker, startedAtTimestamp, reconciledResult);
+                return reconciledResult;
+            }
+
+            throw new InvalidOperationException(
+                $"Elasticsearch optimistic concurrency delete could not be reconciled for read-model '{typeof(TReadModel).FullName}' key '{marker.Id}'.");
+        }
+        catch (Exception ex)
+        {
+            var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
+            _logger.LogError(
+                ex,
+                "Projection read-model versioned delete failed. provider={Provider} readModelType={ReadModelType} key={Key} stateVersion={StateVersion} lastEventId={LastEventId} elapsedMs={ElapsedMs} result={Result} errorType={ErrorType}",
+                ProviderName,
+                typeof(TReadModel).FullName,
+                marker.Id,
+                marker.StateVersion,
+                marker.LastEventId,
+                elapsedMs,
+                "failed",
+                ex.GetType().Name);
+            throw;
+        }
+    }
+
     public async Task<TReadModel?> GetAsync(TKey key, CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
@@ -709,6 +781,10 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
     {
         try
         {
+            using var document = JsonDocument.Parse(json);
+            if (ElasticsearchProjectionDeleteMarkerPayload.IsDeleteMarker(document.RootElement))
+                return null;
+
             return _parser.Parse<TReadModel>(json);
         }
         catch (Exception ex)
@@ -822,6 +898,121 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
             "Dynamically indexed read models must delete via provider-native index-scoped operations.");
     }
 
+    private async Task<ExistingProjectionState> TryGetExistingProjectionStateAsync(
+        string indexName,
+        string keyValue,
+        CancellationToken ct)
+    {
+        using var response = await _httpClient.GetAsync($"{indexName}/_doc/{Uri.EscapeDataString(keyValue)}", ct);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            var notFoundPayload = await response.Content.ReadAsStringAsync(ct);
+            if (ElasticsearchProjectionDocumentStoreHttpSupport.IsIndexNotFoundPayload(notFoundPayload))
+            {
+                if (_autoCreateIndex || _missingIndexBehavior == ElasticsearchMissingIndexBehavior.Throw)
+                    throw new InvalidOperationException(
+                        $"Elasticsearch index '{indexName}' was not found during 'get' for read-model '{typeof(TReadModel).FullName}'.");
+
+                return ExistingProjectionState.Missing;
+            }
+
+            return ExistingProjectionState.Missing;
+        }
+
+        await ElasticsearchProjectionDocumentStoreHttpSupport.EnsureSuccessAsync(response, "get", ct);
+        var successfulPayload = await response.Content.ReadAsStringAsync(ct);
+        using var jsonDoc = JsonDocument.Parse(successfulPayload);
+        var seqNo = TryReadLong(jsonDoc.RootElement, "_seq_no");
+        var primaryTerm = TryReadLong(jsonDoc.RootElement, "_primary_term");
+        if (!jsonDoc.RootElement.TryGetProperty("_source", out var sourceNode))
+            return new ExistingProjectionState(null, null, seqNo, primaryTerm);
+
+        var deleteMarker = ElasticsearchProjectionDeleteMarkerPayload.TryParse(sourceNode);
+        if (deleteMarker != null)
+            return new ExistingProjectionState(null, deleteMarker, seqNo, primaryTerm);
+
+        return new ExistingProjectionState(DeserializeOrNull(sourceNode.GetRawText()), null, seqNo, primaryTerm);
+    }
+
+    private static ProjectionWriteResult EvaluateDeleteMarker(
+        ExistingProjectionState existing,
+        ProjectionDocumentDeleteMarker marker)
+    {
+        if (existing.ReadModel != null)
+            return ProjectionWriteResultEvaluator.Evaluate(existing.ReadModel, marker);
+
+        if (existing.DeleteMarker == null)
+            return ProjectionWriteResult.Applied();
+
+        var result = ElasticsearchProjectionDeleteMarkerPayload.EvaluateUpsertAgainstDeleteMarker(
+            existing.DeleteMarker,
+            marker);
+        return result.Disposition == ProjectionWriteDisposition.Duplicate
+            ? ProjectionWriteResult.Duplicate()
+            : result;
+    }
+
+    private static HttpRequestMessage BuildConditionalTombstoneRequest(
+        string indexName,
+        string keyValue,
+        string payload,
+        ExistingProjectionState existing)
+    {
+        var requestPath = existing.ReadModel == null && existing.DeleteMarker == null
+            ? $"{indexName}/_create/{Uri.EscapeDataString(keyValue)}"
+            : $"{indexName}/_doc/{Uri.EscapeDataString(keyValue)}?if_seq_no={existing.SeqNo}&if_primary_term={existing.PrimaryTerm}";
+        return new HttpRequestMessage(HttpMethod.Put, requestPath)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private static long TryReadLong(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var property))
+            return -1;
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.Number when property.TryGetInt64(out var number) => number,
+            JsonValueKind.String when long.TryParse(property.GetString(), out var parsed) => parsed,
+            _ => -1,
+        };
+    }
+
+    private void LogVersionedDeleteCompleted(
+        ProjectionDocumentDeleteMarker marker,
+        long startedAtTimestamp)
+    {
+        var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
+        _logger.LogInformation(
+            "Projection read-model versioned delete completed. provider={Provider} readModelType={ReadModelType} key={Key} stateVersion={StateVersion} lastEventId={LastEventId} elapsedMs={ElapsedMs} result={Result}",
+            ProviderName,
+            typeof(TReadModel).FullName,
+            marker.Id,
+            marker.StateVersion,
+            marker.LastEventId,
+            elapsedMs,
+            ProjectionWriteDisposition.Applied);
+    }
+
+    private void LogVersionedDeleteSkipped(
+        ProjectionDocumentDeleteMarker marker,
+        long startedAtTimestamp,
+        ProjectionWriteResult result)
+    {
+        var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
+        _logger.LogInformation(
+            "Projection read-model versioned delete skipped. provider={Provider} readModelType={ReadModelType} key={Key} stateVersion={StateVersion} lastEventId={LastEventId} elapsedMs={ElapsedMs} result={Result}",
+            ProviderName,
+            typeof(TReadModel).FullName,
+            marker.Id,
+            marker.StateVersion,
+            marker.LastEventId,
+            elapsedMs,
+            result.Disposition);
+    }
+
     private static TypeRegistry BuildDefaultTypeRegistry()
     {
         var descriptors = new List<MessageDescriptor>();
@@ -868,4 +1059,13 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
     }
 
     private sealed record ResolvedIndexTarget(string IndexName, DocumentIndexMetadata Metadata);
+
+    private sealed record ExistingProjectionState(
+        TReadModel? ReadModel,
+        ProjectionDocumentDeleteMarker? DeleteMarker,
+        long SeqNo,
+        long PrimaryTerm)
+    {
+        public static ExistingProjectionState Missing { get; } = new(null, null, -1, -1);
+    }
 }

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStoreMetadataSupport.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStoreMetadataSupport.cs
@@ -171,6 +171,19 @@ internal static class ElasticsearchProjectionDocumentStoreMetadataSupport
                 CreateStableSortFieldMapping();
         }
 
+        normalizedProperties.TryAdd(
+            ElasticsearchProjectionDeleteMarkerPayload.TombstoneField,
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = "boolean",
+            });
+        normalizedProperties.TryAdd(
+            ElasticsearchProjectionDeleteMarkerPayload.DeletedAtUtcField,
+            new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["type"] = "date",
+            });
+
         mappings["properties"] = normalizedProperties;
     }
 

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStorePayloadSupport.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStorePayloadSupport.cs
@@ -106,15 +106,27 @@ internal static class ElasticsearchProjectionDocumentStorePayloadSupport
         Func<string, string> fieldPathResolver,
         Func<ProjectionDocumentFilter, string, string> exactMatchFieldPathResolver)
     {
+        var tombstoneExclusion = new Dictionary<string, object?>
+        {
+            ["term"] = new Dictionary<string, object?>
+            {
+                [ElasticsearchProjectionDeleteMarkerPayload.TombstoneField] = true,
+            },
+        };
+
         if (query.Filters.Count == 0 && query.AnyOfFilters.Count == 0)
         {
             return new Dictionary<string, object?>
             {
-                ["match_all"] = new Dictionary<string, object?>(),
+                ["bool"] = new Dictionary<string, object?>
+                {
+                    ["must_not"] = new object[] { tombstoneExclusion },
+                },
             };
         }
 
         var booleanQuery = new Dictionary<string, object?>();
+        booleanQuery["must_not"] = new object[] { tombstoneExclusion };
         if (query.Filters.Count > 0)
         {
             booleanQuery["filter"] = query.Filters

--- a/src/Aevatar.CQRS.Projection.Providers.InMemory/Stores/InMemoryProjectionDocumentStore.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.InMemory/Stores/InMemoryProjectionDocumentStore.cs
@@ -16,6 +16,7 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
     private const string ProviderName = "InMemory";
     private readonly object _gate = new();
     private readonly Dictionary<string, TReadModel> _itemsByKey = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, ProjectionDocumentDeleteMarker> _deleteMarkersByKey = new(StringComparer.Ordinal);
     private readonly Func<TReadModel, TKey> _keySelector;
     private readonly Func<TKey, string> _keyFormatter;
     private readonly Func<TReadModel, object?>? _defaultSortSelector;
@@ -51,9 +52,24 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
             lock (_gate)
             {
                 _itemsByKey.TryGetValue(key, out var existing);
-                result = ProjectionWriteResultEvaluator.Evaluate(existing, readModel);
+                if (existing != null)
+                {
+                    result = ProjectionWriteResultEvaluator.Evaluate(existing, readModel);
+                }
+                else if (_deleteMarkersByKey.TryGetValue(key, out var marker))
+                {
+                    result = EvaluateUpsertAgainstDeleteMarker(marker, readModel);
+                }
+                else
+                {
+                    result = ProjectionWriteResult.Applied();
+                }
+
                 if (result.IsApplied)
+                {
                     _itemsByKey[key] = Clone(readModel);
+                    _deleteMarkersByKey.Remove(key);
+                }
             }
 
             var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
@@ -117,6 +133,73 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
                 ProviderName,
                 typeof(TReadModel).FullName,
                 trimmedId,
+                elapsedMs,
+                "failed",
+                ex.GetType().Name);
+            throw;
+        }
+    }
+
+    public Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+        ct.ThrowIfCancellationRequested();
+
+        marker = NormalizeDeleteMarker(marker);
+        var key = marker.Id;
+        var startedAt = DateTimeOffset.UtcNow;
+        try
+        {
+            ProjectionWriteResult result;
+            lock (_gate)
+            {
+                if (_itemsByKey.TryGetValue(key, out var existing))
+                {
+                    result = ProjectionWriteResultEvaluator.Evaluate(existing, marker);
+                    if (result.IsApplied)
+                    {
+                        _itemsByKey.Remove(key);
+                        _deleteMarkersByKey[key] = marker;
+                    }
+                }
+                else if (_deleteMarkersByKey.TryGetValue(key, out var existingMarker))
+                {
+                    result = EvaluateDeleteMarker(existingMarker, marker);
+                    if (result.IsApplied)
+                        _deleteMarkersByKey[key] = marker;
+                }
+                else
+                {
+                    result = ProjectionWriteResult.Applied();
+                    _deleteMarkersByKey[key] = marker;
+                }
+            }
+
+            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+            _logger.LogInformation(
+                "Projection read-model versioned delete completed. provider={Provider} readModelType={ReadModelType} key={Key} stateVersion={StateVersion} lastEventId={LastEventId} elapsedMs={ElapsedMs} result={Result}",
+                ProviderName,
+                typeof(TReadModel).FullName,
+                key,
+                marker.StateVersion,
+                marker.LastEventId,
+                elapsedMs,
+                result.Disposition);
+            return Task.FromResult(result);
+        }
+        catch (Exception ex)
+        {
+            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+            _logger.LogError(
+                ex,
+                "Projection read-model versioned delete failed. provider={Provider} readModelType={ReadModelType} key={Key} stateVersion={StateVersion} lastEventId={LastEventId} elapsedMs={ElapsedMs} result={Result} errorType={ErrorType}",
+                ProviderName,
+                typeof(TReadModel).FullName,
+                key,
+                marker.StateVersion,
+                marker.LastEventId,
                 elapsedMs,
                 "failed",
                 ex.GetType().Name);
@@ -198,6 +281,52 @@ public sealed class InMemoryProjectionDocumentStore<TReadModel, TKey>
     }
 
     private string FormatKey(TKey key) => _keyFormatter(key)?.Trim() ?? "";
+
+    private static ProjectionDocumentDeleteMarker NormalizeDeleteMarker(ProjectionDocumentDeleteMarker marker)
+    {
+        var normalized = marker with
+        {
+            Id = marker.Id?.Trim() ?? string.Empty,
+            ActorId = marker.ActorId?.Trim() ?? string.Empty,
+            LastEventId = marker.LastEventId?.Trim() ?? string.Empty,
+        };
+
+        _ = ProjectionWriteResultEvaluator.Evaluate(null, normalized);
+        if (normalized.StateVersion <= 0)
+            throw new InvalidOperationException("Projection delete marker state version must be positive.");
+
+        return normalized;
+    }
+
+    private static ProjectionWriteResult EvaluateUpsertAgainstDeleteMarker(
+        ProjectionDocumentDeleteMarker existing,
+        IProjectionReadModel incoming)
+    {
+        if (!string.Equals(existing.ActorId, incoming.ActorId, StringComparison.Ordinal))
+            return ProjectionWriteResult.Conflict();
+
+        if (incoming.StateVersion < existing.StateVersion)
+            return ProjectionWriteResult.Stale();
+
+        if (incoming.StateVersion == existing.StateVersion)
+        {
+            return string.Equals(existing.LastEventId, incoming.LastEventId, StringComparison.Ordinal)
+                ? ProjectionWriteResult.Duplicate()
+                : ProjectionWriteResult.Conflict();
+        }
+
+        return ProjectionWriteResult.Applied();
+    }
+
+    private static ProjectionWriteResult EvaluateDeleteMarker(
+        ProjectionDocumentDeleteMarker existing,
+        ProjectionDocumentDeleteMarker incoming)
+    {
+        var evaluated = EvaluateUpsertAgainstDeleteMarker(existing, incoming);
+        return evaluated.Disposition == ProjectionWriteDisposition.Duplicate
+            ? ProjectionWriteResult.Duplicate()
+            : evaluated;
+    }
 
     private int CompareReadModels(
         TReadModel left,

--- a/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteDispatcher.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteDispatcher.cs
@@ -6,4 +6,9 @@ public interface IProjectionWriteDispatcher<in TReadModel>
     Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default);
 
     Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default);
+
+    Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default) =>
+        DeleteAsync(marker.Id, ct);
 }

--- a/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteDispatcher.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteDispatcher.cs
@@ -10,5 +10,6 @@ public interface IProjectionWriteDispatcher<in TReadModel>
     Task<ProjectionWriteResult> DeleteAsync(
         ProjectionDocumentDeleteMarker marker,
         CancellationToken ct = default) =>
-        DeleteAsync(marker.Id, ct);
+        throw new NotSupportedException(
+            $"Projection write dispatcher '{GetType().FullName}' does not support versioned read-model deletes.");
 }

--- a/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteSink.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteSink.cs
@@ -16,5 +16,6 @@ public interface IProjectionWriteSink<in TReadModel>
     Task<ProjectionWriteResult> DeleteAsync(
         ProjectionDocumentDeleteMarker marker,
         CancellationToken ct = default) =>
-        DeleteAsync(marker.Id, ct);
+        throw new NotSupportedException(
+            $"Projection write sink '{GetType().FullName}' does not support versioned read-model deletes.");
 }

--- a/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteSink.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime.Abstractions/Abstractions/Stores/IProjectionWriteSink.cs
@@ -12,4 +12,9 @@ public interface IProjectionWriteSink<in TReadModel>
     Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default);
 
     Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default);
+
+    Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default) =>
+        DeleteAsync(marker.Id, ct);
 }

--- a/src/Aevatar.CQRS.Projection.Runtime/Runtime/ObservedProjectionWriteDispatcher.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime/Runtime/ObservedProjectionWriteDispatcher.cs
@@ -57,4 +57,29 @@ public sealed class ObservedProjectionWriteDispatcher<TReadModel>
             throw;
         }
     }
+
+    public async Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker.Id);
+        ct.ThrowIfCancellationRequested();
+
+        using var activity = AevatarActivitySource.StartReadmodelDelete(
+            typeof(TReadModel).Name,
+            marker.Id);
+
+        try
+        {
+            var result = await _inner.DeleteAsync(marker, ct);
+            AevatarActivitySource.SafeSetStatus(activity, ActivityStatusCode.Ok);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            AevatarActivitySource.SafeSetStatus(activity, ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
 }

--- a/src/Aevatar.CQRS.Projection.Runtime/Runtime/ProjectionDocumentStoreBinding.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime/Runtime/ProjectionDocumentStoreBinding.cs
@@ -34,4 +34,14 @@ public sealed class ProjectionDocumentStoreBinding<TReadModel>
 
         return _writer.DeleteAsync(id, ct);
     }
+
+    public Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default)
+    {
+        if (_writer is null)
+            return Task.FromResult(ProjectionWriteResult.Applied());
+
+        return _writer.DeleteAsync(marker, ct);
+    }
 }

--- a/src/Aevatar.CQRS.Projection.Runtime/Runtime/ProjectionStoreDispatcher.cs
+++ b/src/Aevatar.CQRS.Projection.Runtime/Runtime/ProjectionStoreDispatcher.cs
@@ -68,4 +68,14 @@ public sealed class ProjectionStoreDispatcher<TReadModel>
         ct.ThrowIfCancellationRequested();
         return _binding.DeleteAsync(id, ct);
     }
+
+    public Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(marker);
+        ArgumentException.ThrowIfNullOrWhiteSpace(marker.Id);
+        ct.ThrowIfCancellationRequested();
+        return _binding.DeleteAsync(marker, ct);
+    }
 }

--- a/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/IProjectionDocumentWriter.cs
+++ b/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/IProjectionDocumentWriter.cs
@@ -10,5 +10,6 @@ public interface IProjectionDocumentWriter<in TReadModel>
     Task<ProjectionWriteResult> DeleteAsync(
         ProjectionDocumentDeleteMarker marker,
         CancellationToken ct = default) =>
-        DeleteAsync(marker.Id, ct);
+        throw new NotSupportedException(
+            $"Projection writer '{GetType().FullName}' does not support versioned read-model deletes.");
 }

--- a/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/IProjectionDocumentWriter.cs
+++ b/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/IProjectionDocumentWriter.cs
@@ -6,4 +6,9 @@ public interface IProjectionDocumentWriter<in TReadModel>
     Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default);
 
     Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default);
+
+    Task<ProjectionWriteResult> DeleteAsync(
+        ProjectionDocumentDeleteMarker marker,
+        CancellationToken ct = default) =>
+        DeleteAsync(marker.Id, ct);
 }

--- a/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/ProjectionDocumentDeleteMarker.cs
+++ b/src/Aevatar.CQRS.Projection.Stores.Abstractions/Abstractions/ReadModels/ProjectionDocumentDeleteMarker.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.CQRS.Projection.Stores.Abstractions;
+
+public sealed record ProjectionDocumentDeleteMarker(
+    string Id,
+    string ActorId,
+    long StateVersion,
+    string LastEventId,
+    DateTimeOffset UpdatedAt) : IProjectionReadModel;

--- a/src/Aevatar.CQRS.Projection.Stores.Abstractions/Aevatar.CQRS.Projection.Stores.Abstractions.csproj
+++ b/src/Aevatar.CQRS.Projection.Stores.Abstractions/Aevatar.CQRS.Projection.Stores.Abstractions.csproj
@@ -8,5 +8,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="projection_document_delete_marker.proto" GrpcServices="None" />
   </ItemGroup>
 </Project>

--- a/src/Aevatar.CQRS.Projection.Stores.Abstractions/projection_document_delete_marker.proto
+++ b/src/Aevatar.CQRS.Projection.Stores.Abstractions/projection_document_delete_marker.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option csharp_namespace = "Aevatar.CQRS.Projection.Stores.Abstractions";
+
+import "google/protobuf/timestamp.proto";
+
+message ProjectionDocumentDeleteMarkerRecord {
+  bool projection_tombstone = 1 [json_name = "__projection_tombstone"];
+  string id = 2 [json_name = "id"];
+  string actor_id = 3 [json_name = "actor_id"];
+  int64 state_version = 4 [json_name = "state_version"];
+  string last_event_id = 5 [json_name = "last_event_id"];
+  google.protobuf.Timestamp updated_at_utc_value = 6 [json_name = "updated_at_utc_value"];
+  google.protobuf.Timestamp deleted_at_utc_value = 7 [json_name = "__projection_deleted_at_utc"];
+  string projection_document_id = 8 [json_name = "ProjectionDocumentId"];
+}

--- a/src/Aevatar.Studio.Projection/Projectors/StudioMemberCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioMemberCurrentStateProjector.cs
@@ -1,6 +1,7 @@
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Abstractions.Orchestration;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.StudioMember;
 using Aevatar.Studio.Projection.Mapping;
@@ -54,7 +55,14 @@ public sealed class StudioMemberCurrentStateProjector
 
         if (state.Deleted)
         {
-            await _writeDispatcher.DeleteAsync(context.RootActorId, ct);
+            await _writeDispatcher.DeleteAsync(
+                new ProjectionDocumentDeleteMarker(
+                    context.RootActorId,
+                    context.RootActorId,
+                    stateEvent.Version,
+                    stateEvent.EventId ?? string.Empty,
+                    updatedAt),
+                ct);
             return;
         }
 

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
@@ -1174,6 +1174,56 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
     }
 
     [Fact]
+    public async Task UpsertAsync_WhenDelayedWriteFollowsVersionedDelete_ShouldRemainTombstoned()
+    {
+        var handler = new ScriptedHttpMessageHandler();
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"_seq_no":7,"_primary_term":3,"_source":{"id":"actor-tombstone","actor_id":"actor-tombstone","state_version":"7","last_event_id":"evt-7","updated_at_utc_value":"2026-07-29T00:00:07Z","value":"live"}}"""));
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"result":"updated"}"""));
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"_seq_no":8,"_primary_term":3,"_source":{"__projection_tombstone":true,"id":"actor-tombstone","actor_id":"actor-tombstone","state_version":"8","last_event_id":"evt-8-delete","updated_at_utc_value":"2026-07-29T00:00:08Z","__projection_deleted_at_utc":"2026-07-29T00:00:08Z","ProjectionDocumentId":"actor-tombstone"}}"""));
+
+        using var store = CreateStore(
+            new ElasticsearchProjectionDocumentStoreOptions
+            {
+                AutoCreateIndex = false,
+            },
+            handler);
+
+        var deleted = await store.DeleteAsync(new ProjectionDocumentDeleteMarker(
+            "actor-tombstone",
+            "actor-tombstone",
+            8,
+            "evt-8-delete",
+            DateTimeOffset.Parse("2026-07-29T00:00:08Z")));
+        var delayed = await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "actor-tombstone",
+            ActorId = "actor-tombstone",
+            StateVersion = 7,
+            LastEventId = "evt-7",
+            UpdatedAt = DateTimeOffset.Parse("2026-07-29T00:00:07Z"),
+            Value = "delayed",
+        });
+
+        deleted.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
+        delayed.Disposition.Should().Be(ProjectionWriteDisposition.Stale);
+        handler.CapturedRequests.Should().HaveCount(3);
+        handler.CapturedRequests[1].Method.Should().Be("PUT");
+        handler.CapturedRequests[1].PathAndQuery.Should().Contain("if_seq_no=7");
+        handler.CapturedRequests[1].Body.Should().Contain("\"__projection_tombstone\":true");
+        handler.CapturedRequests[1].Body.Should().Contain("\"state_version\":\"8\"");
+        handler.CapturedRequests[1].Body.Should().Contain("\"last_event_id\":\"evt-8-delete\"");
+        handler.CapturedRequests.Should().ContainSingle(r =>
+            r.Method == "PUT" &&
+            r.Body.Contains("\"__projection_tombstone\":true", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task UpsertAsync_WhenReadModelUsesDynamicIndexScope_ShouldTargetScopeSpecificIndices()
     {
         var handler = new ScriptedHttpMessageHandler();
@@ -1414,6 +1464,37 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
 
         // 2xx with unparseable body: treat as Applied (conservative default vs dropping the delete).
         result.IsApplied.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetAndQueryAsync_ShouldHideProviderOwnedTombstones()
+    {
+        var getHandler = new ScriptedHttpMessageHandler();
+        getHandler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"_seq_no":8,"_primary_term":3,"_source":{"__projection_tombstone":true,"id":"actor-tombstone","actor_id":"actor-tombstone","state_version":"8","last_event_id":"evt-8-delete","updated_at_utc_value":"2026-07-29T00:00:08Z","__projection_deleted_at_utc":"2026-07-29T00:00:08Z","ProjectionDocumentId":"actor-tombstone"}}"""));
+        using var getStore = CreateStore(
+            new ElasticsearchProjectionDocumentStoreOptions { AutoCreateIndex = false },
+            getHandler);
+
+        var hidden = await getStore.GetAsync("actor-tombstone");
+
+        hidden.Should().BeNull();
+
+        var queryHandler = new ScriptedHttpMessageHandler();
+        queryHandler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"hits":{"hits":[{"_source":{"__projection_tombstone":true,"id":"actor-tombstone","actor_id":"actor-tombstone","state_version":"8","last_event_id":"evt-8-delete","updated_at_utc_value":"2026-07-29T00:00:08Z"}}]}}"""));
+        using var queryStore = CreateStore(
+            new ElasticsearchProjectionDocumentStoreOptions { AutoCreateIndex = false },
+            queryHandler);
+
+        var query = await queryStore.QueryAsync(new ProjectionDocumentQuery { Take = 10 });
+
+        query.Items.Should().BeEmpty();
+        queryHandler.CapturedRequests.Should().ContainSingle()
+            .Which.Body.Should().Contain("\"must_not\"");
+        queryHandler.CapturedRequests[0].Body.Should().Contain("\"__projection_tombstone\":true");
     }
 
     [Fact]

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
@@ -1215,12 +1215,14 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
         handler.CapturedRequests.Should().HaveCount(3);
         handler.CapturedRequests[1].Method.Should().Be("PUT");
         handler.CapturedRequests[1].PathAndQuery.Should().Contain("if_seq_no=7");
-        handler.CapturedRequests[1].Body.Should().Contain("\"__projection_tombstone\":true");
-        handler.CapturedRequests[1].Body.Should().Contain("\"state_version\":\"8\"");
-        handler.CapturedRequests[1].Body.Should().Contain("\"last_event_id\":\"evt-8-delete\"");
-        handler.CapturedRequests.Should().ContainSingle(r =>
-            r.Method == "PUT" &&
-            r.Body.Contains("\"__projection_tombstone\":true", StringComparison.Ordinal));
+        var tombstonePayload = ParseJson(handler.CapturedRequests[1].Body);
+        tombstonePayload.GetProperty("__projection_tombstone").GetBoolean().Should().BeTrue();
+        tombstonePayload.GetProperty("state_version").GetString().Should().Be("8");
+        tombstonePayload.GetProperty("last_event_id").GetString().Should().Be("evt-8-delete");
+        var tombstoneRequests = handler.CapturedRequests
+            .Where(r => r.Method == "PUT" && HasTombstonePayload(r.Body))
+            .ToList();
+        tombstoneRequests.Should().ContainSingle();
     }
 
     [Fact]
@@ -2127,6 +2129,13 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
     {
         using var document = System.Text.Json.JsonDocument.Parse(json);
         return document.RootElement.Clone();
+    }
+
+    private static bool HasTombstonePayload(string json)
+    {
+        var payload = ParseJson(json);
+        return payload.TryGetProperty("__projection_tombstone", out var tombstone) &&
+               tombstone.ValueKind == JsonValueKind.True;
     }
 
     private static IReadOnlyDictionary<string, JsonElement> GetProperties(JsonElement indexPayload)

--- a/test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/InMemoryProjectionDocumentStoreBehaviorTests.cs
@@ -215,6 +215,44 @@ public sealed class InMemoryProjectionDocumentStoreBehaviorTests
     }
 
     [Fact]
+    public async Task DeleteAsync_WithAuthoritativeMarker_ShouldRejectDelayedOlderUpsert()
+    {
+        var store = new InMemoryProjectionDocumentStore<TestStoreReadModel, string>(
+            keySelector: model => model.Id);
+        await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "actor-tombstone",
+            ActorId = "actor-tombstone",
+            StateVersion = 7,
+            LastEventId = "evt-7",
+            UpdatedAt = DateTimeOffset.Parse("2026-07-29T00:00:07Z"),
+            Value = "live",
+        });
+
+        var delete = await store.DeleteAsync(new ProjectionDocumentDeleteMarker(
+            "actor-tombstone",
+            "actor-tombstone",
+            8,
+            "evt-8-delete",
+            DateTimeOffset.Parse("2026-07-29T00:00:08Z")));
+        var delayed = await store.UpsertAsync(new TestStoreReadModel
+        {
+            Id = "actor-tombstone",
+            ActorId = "actor-tombstone",
+            StateVersion = 7,
+            LastEventId = "evt-7",
+            UpdatedAt = DateTimeOffset.Parse("2026-07-29T00:00:07Z"),
+            Value = "delayed",
+        });
+
+        delete.Disposition.Should().Be(ProjectionWriteDisposition.Applied);
+        delayed.Disposition.Should().Be(ProjectionWriteDisposition.Stale);
+        (await store.GetAsync("actor-tombstone")).Should().BeNull();
+        var query = await store.QueryAsync(new ProjectionDocumentQuery { Take = 10 });
+        query.Items.Should().NotContain(x => x.Id == "actor-tombstone");
+    }
+
+    [Fact]
     public async Task UpsertAsync_WhenIncomingAuthoritativeVersionSkipsAhead_ShouldApply()
     {
         var store = new InMemoryProjectionDocumentStore<TestStoreReadModel, string>(

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionStoreDispatcherTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionStoreDispatcherTests.cs
@@ -128,6 +128,36 @@ public class ProjectionStoreDispatcherTests
     }
 
     [Fact]
+    public async Task DeleteAsync_WithMarker_ShouldDelegateMarkerToSingleBinding()
+    {
+        var binding = new RecordingBinding("document");
+        var dispatcher = new ProjectionStoreDispatcher<TestReadModel>([binding]);
+        var marker = NewDeleteMarker();
+
+        await dispatcher.DeleteAsync(marker);
+
+        binding.DeleteCount.Should().Be(1);
+        binding.LastDeletedId.Should().Be(marker.Id);
+        binding.LastDeleteMarker.Should().BeSameAs(marker);
+    }
+
+    [Fact]
+    public async Task ObservedProjectionWriteDispatcher_DeleteAsync_WithMarker_ShouldForwardMarkerThroughStoreBindingToWriter()
+    {
+        var writer = new RecordingDocumentWriter();
+        var binding = new ProjectionDocumentStoreBinding<TestReadModel>(writer);
+        var inner = new ProjectionStoreDispatcher<TestReadModel>([binding]);
+        var dispatcher = new ObservedProjectionWriteDispatcher<TestReadModel>(inner);
+        var marker = NewDeleteMarker();
+
+        var result = await dispatcher.DeleteAsync(marker);
+
+        result.IsApplied.Should().BeTrue();
+        writer.Deletes.Should().BeEmpty();
+        writer.DeleteMarkers.Should().ContainSingle().Which.Should().BeSameAs(marker);
+    }
+
+    [Fact]
     public async Task ObservedProjectionWriteDispatcher_ShouldEmitUpsertAndDeleteActivities()
     {
         var stopped = new ConcurrentQueue<Activity>();
@@ -266,6 +296,20 @@ public class ProjectionStoreDispatcherTests
     }
 
     [Fact]
+    public async Task ProjectionDocumentBinding_DeleteAsync_WithMarker_ShouldForwardMarkerToWriter()
+    {
+        var writer = new RecordingDocumentWriter();
+        var binding = new ProjectionDocumentStoreBinding<TestReadModel>(writer);
+        var marker = NewDeleteMarker();
+
+        var result = await binding.DeleteAsync(marker);
+
+        result.IsApplied.Should().BeTrue();
+        writer.Deletes.Should().BeEmpty();
+        writer.DeleteMarkers.Should().ContainSingle().Which.Should().BeSameAs(marker);
+    }
+
+    [Fact]
     public async Task ProjectionDocumentBinding_DeleteAsync_WhenWriterMissing_ShouldNoOpAsApplied()
     {
         var binding = new ProjectionDocumentStoreBinding<TestReadModel>();
@@ -302,6 +346,13 @@ public class ProjectionStoreDispatcherTests
         public string Value { get; set; } = "";
     }
 
+    private static ProjectionDocumentDeleteMarker NewDeleteMarker() => new(
+        "id-to-delete",
+        "actor-1",
+        42,
+        "event-42",
+        new DateTimeOffset(2026, 7, 29, 1, 2, 3, TimeSpan.Zero));
+
     private sealed class RecordingBinding : IProjectionWriteSink<TestReadModel>
     {
         public RecordingBinding(string name)
@@ -323,6 +374,8 @@ public class ProjectionStoreDispatcherTests
 
         public string LastDeletedId { get; private set; } = "";
 
+        public ProjectionDocumentDeleteMarker? LastDeleteMarker { get; private set; }
+
         public Task<ProjectionWriteResult> UpsertAsync(TestReadModel readModel, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
@@ -338,6 +391,17 @@ public class ProjectionStoreDispatcherTests
             LastDeletedId = id;
             return Task.FromResult(ProjectionWriteResult.Applied());
         }
+
+        public Task<ProjectionWriteResult> DeleteAsync(
+            ProjectionDocumentDeleteMarker marker,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            DeleteCount++;
+            LastDeletedId = marker.Id;
+            LastDeleteMarker = marker;
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
     }
 
     private sealed class RecordingDocumentWriter : IProjectionDocumentWriter<TestReadModel>
@@ -345,6 +409,8 @@ public class ProjectionStoreDispatcherTests
         public List<TestReadModel> Upserts { get; } = [];
 
         public List<string> Deletes { get; } = [];
+
+        public List<ProjectionDocumentDeleteMarker> DeleteMarkers { get; } = [];
 
         public Task<ProjectionWriteResult> UpsertAsync(TestReadModel readModel, CancellationToken ct = default)
         {
@@ -357,6 +423,15 @@ public class ProjectionStoreDispatcherTests
         {
             ct.ThrowIfCancellationRequested();
             Deletes.Add(id);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(
+            ProjectionDocumentDeleteMarker marker,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            DeleteMarkers.Add(marker);
             return Task.FromResult(ProjectionWriteResult.Applied());
         }
     }

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionStoreDispatcherTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionStoreDispatcherTests.cs
@@ -158,6 +158,20 @@ public class ProjectionStoreDispatcherTests
     }
 
     [Fact]
+    public async Task DeleteAsync_WithMarker_WhenSinkDoesNotSupportMarkers_ShouldFailClosed()
+    {
+        var binding = new IdOnlyBinding("document");
+        var dispatcher = new ProjectionStoreDispatcher<TestReadModel>([binding]);
+        var marker = NewDeleteMarker();
+
+        Func<Task> act = () => dispatcher.DeleteAsync(marker);
+
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*versioned read-model deletes*");
+        binding.Deletes.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ObservedProjectionWriteDispatcher_ShouldEmitUpsertAndDeleteActivities()
     {
         var stopped = new ConcurrentQueue<Activity>();
@@ -310,6 +324,20 @@ public class ProjectionStoreDispatcherTests
     }
 
     [Fact]
+    public async Task ProjectionDocumentBinding_DeleteAsync_WithMarker_WhenWriterDoesNotSupportMarkers_ShouldFailClosed()
+    {
+        var writer = new IdOnlyDocumentWriter();
+        var binding = new ProjectionDocumentStoreBinding<TestReadModel>(writer);
+        var marker = NewDeleteMarker();
+
+        Func<Task> act = () => binding.DeleteAsync(marker);
+
+        await act.Should().ThrowAsync<NotSupportedException>()
+            .WithMessage("*versioned read-model deletes*");
+        writer.Deletes.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ProjectionDocumentBinding_DeleteAsync_WhenWriterMissing_ShouldNoOpAsApplied()
     {
         var binding = new ProjectionDocumentStoreBinding<TestReadModel>();
@@ -352,6 +380,30 @@ public class ProjectionStoreDispatcherTests
         42,
         "event-42",
         new DateTimeOffset(2026, 7, 29, 1, 2, 3, TimeSpan.Zero));
+
+    private sealed class IdOnlyBinding(string sinkName) : IProjectionWriteSink<TestReadModel>
+    {
+        public string SinkName { get; } = sinkName;
+
+        public bool IsEnabled => true;
+
+        public string DisabledReason => "enabled";
+
+        public List<string> Deletes { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(TestReadModel readModel, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Deletes.Add(id);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+    }
 
     private sealed class RecordingBinding : IProjectionWriteSink<TestReadModel>
     {
@@ -400,6 +452,24 @@ public class ProjectionStoreDispatcherTests
             DeleteCount++;
             LastDeletedId = marker.Id;
             LastDeleteMarker = marker;
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+    }
+
+    private sealed class IdOnlyDocumentWriter : IProjectionDocumentWriter<TestReadModel>
+    {
+        public List<string> Deletes { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(TestReadModel readModel, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Deletes.Add(id);
             return Task.FromResult(ProjectionWriteResult.Applied());
         }
     }

--- a/test/Aevatar.Studio.Tests/StudioMemberCurrentStateProjectorTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberCurrentStateProjectorTests.cs
@@ -217,10 +217,18 @@ public sealed class StudioMemberCurrentStateProjectorTests
                 },
                 state,
                 6,
-                "evt-deleted"));
+                "evt-deleted",
+                DateTimeOffset.Parse("2026-07-09T06:40:00Z")));
 
         dispatcher.Upserts.Should().BeEmpty();
         dispatcher.Deletes.Should().ContainSingle().Which.Should().Be(RootActorId);
+        dispatcher.DeleteMarkers.Should().ContainSingle().Which.Should().Be(
+            new ProjectionDocumentDeleteMarker(
+                RootActorId,
+                RootActorId,
+                6,
+                "evt-deleted",
+                DateTimeOffset.Parse("2026-07-09T06:40:00Z")));
     }
 
     [Fact]
@@ -284,12 +292,14 @@ public sealed class StudioMemberCurrentStateProjectorTests
         IMessage payload,
         StudioMemberState state,
         long version,
-        string eventId)
+        string eventId,
+        DateTimeOffset? timestamp = null)
     {
+        var timestampValue = timestamp ?? DateTimeOffset.UtcNow;
         return new EventEnvelope
         {
             Id = eventId,
-            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Timestamp = Timestamp.FromDateTimeOffset(timestampValue),
             Route = EnvelopeRouteSemantics.CreateObserverPublication(RootActorId),
             Payload = Any.Pack(new CommittedStateEventPublished
             {
@@ -298,7 +308,7 @@ public sealed class StudioMemberCurrentStateProjectorTests
                     EventId = eventId,
                     Version = version,
                     EventData = Any.Pack(payload),
-                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    Timestamp = Timestamp.FromDateTimeOffset(timestampValue),
                 },
                 StateRoot = Any.Pack(state),
             }),
@@ -310,6 +320,7 @@ public sealed class StudioMemberCurrentStateProjectorTests
     {
         public List<TReadModel> Upserts { get; } = [];
         public List<string> Deletes { get; } = [];
+        public List<ProjectionDocumentDeleteMarker> DeleteMarkers { get; } = [];
 
         public Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default)
         {
@@ -322,6 +333,16 @@ public sealed class StudioMemberCurrentStateProjectorTests
         {
             ct.ThrowIfCancellationRequested();
             Deletes.Add(id);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(
+            ProjectionDocumentDeleteMarker marker,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Deletes.Add(marker.Id);
+            DeleteMarkers.Add(marker);
             return Task.FromResult(ProjectionWriteResult.Applied());
         }
     }

--- a/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberEndpointsTests.cs
@@ -1,9 +1,14 @@
 using System.Reflection;
 using System.Security.Claims;
 using System.Text.Json;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.StudioMember;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Hosting.Endpoints;
+using Aevatar.Studio.Projection.QueryPorts;
+using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.ExternalCapabilities;
 using FluentAssertions;
@@ -397,6 +402,68 @@ public sealed class StudioMemberEndpointsTests
 
         service.DeleteInvoked.Should().BeFalse();
         AssertIsJsonStatus(result, expectedStatus: StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task DeleteAccepted_WhenCommittedDeleteIsProjected_ShouldMakeDetail404AndRosterEmpty()
+    {
+        var actorId = StudioMemberConventions.BuildActorId(ScopeId, "m-alpha");
+        var store = new InMemoryProjectionDocumentStore<StudioMemberCurrentStateDocument, string>(
+            keySelector: model => model.Id);
+        await store.UpsertAsync(new StudioMemberCurrentStateDocument
+        {
+            Id = actorId,
+            ActorId = actorId,
+            StateVersion = 7,
+            LastEventId = "evt-7",
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-29T00:00:07Z")),
+            MemberId = "m-alpha",
+            ScopeId = ScopeId,
+            DisplayName = "Alpha",
+            ImplementationKind = MemberImplementationKindNames.Workflow,
+            LifecycleStage = MemberLifecycleStageNames.BindReady,
+            PublishedServiceId = "svc-alpha",
+            CreatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-07-28T00:00:00Z")),
+        });
+        var service = new ProjectionBackedMemberService(new ProjectionStudioMemberQueryPort(store));
+
+        var acceptedResult = await InvokeHandle<IResult>(
+            "HandleDeleteAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            "m-alpha",
+            service,
+            CancellationToken.None);
+
+        var accepted = acceptedResult.Should().BeOfType<Accepted<StudioMemberCommandResponse>>().Subject;
+        accepted.Value!.Status.Should().Be(StudioMemberCommandStatusNames.DeleteAccepted);
+
+        await store.DeleteAsync(new ProjectionDocumentDeleteMarker(
+            actorId,
+            actorId,
+            8,
+            "evt-8-delete",
+            DateTimeOffset.Parse("2026-07-29T00:00:08Z")));
+
+        var getResult = await InvokeHandle<IResult>(
+            "HandleGetAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            "m-alpha",
+            service,
+            CancellationToken.None);
+        var listResult = await InvokeHandle<IResult>(
+            "HandleListAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            service,
+            (int?)null,
+            (string?)null,
+            CancellationToken.None);
+
+        AssertNotFoundResult(getResult, "STUDIO_MEMBER_NOT_FOUND");
+        listResult.Should().BeOfType<Ok<StudioMemberRosterResponse>>()
+            .Which.Value!.Members.Should().BeEmpty();
     }
 
     [Fact]
@@ -1193,6 +1260,87 @@ public sealed class StudioMemberEndpointsTests
                 memberId,
                 DateTimeOffset.UtcNow));
         }
+    }
+
+    private sealed class ProjectionBackedMemberService(
+        ProjectionStudioMemberQueryPort queryPort) : IStudioMemberService
+    {
+        public Task<StudioMemberSummaryResponse> CreateAsync(
+            string scopeId,
+            CreateStudioMemberRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not create members.");
+
+        public Task<StudioMemberRosterResponse> ListAsync(
+            string scopeId,
+            StudioMemberRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            queryPort.ListAsync(scopeId, page, ct);
+
+        public async Task<StudioMemberDetailResponse> GetAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            await queryPort.GetAsync(scopeId, memberId, ct)
+            ?? throw new StudioMemberNotFoundException(scopeId, memberId);
+
+        public Task<StudioMemberBindingAcceptedResponse> BindAsync(
+            string scopeId,
+            string memberId,
+            UpdateStudioMemberBindingRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not bind members.");
+
+        public Task<StudioMemberBindingViewResponse> GetBindingAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not read bindings.");
+
+        public Task<StudioMemberBindingRunStatusResponse> GetBindingRunAsync(
+            string scopeId,
+            string memberId,
+            string bindingRunId,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not read binding runs.");
+
+        public Task<StudioMemberEndpointContractResponse?> GetEndpointContractAsync(
+            string scopeId,
+            string memberId,
+            string endpointId,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not read endpoint contracts.");
+
+        public Task<StudioMemberBindingActivationResponse> ActivateBindingRevisionAsync(
+            string scopeId,
+            string memberId,
+            string revisionId,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not activate revisions.");
+
+        public Task<StudioMemberBindingRevisionActionResponse> RetireBindingRevisionAsync(
+            string scopeId,
+            string memberId,
+            string revisionId,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not retire revisions.");
+
+        public Task<StudioMemberCommandResponse> UpdateAsync(
+            string scopeId,
+            string memberId,
+            UpdateStudioMemberRequest request,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("delete projection regression must not update members.");
+
+        public Task<StudioMemberCommandResponse> DeleteAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            Task.FromResult(new StudioMemberCommandResponse(
+                StudioMemberCommandStatusNames.DeleteAccepted,
+                scopeId,
+                memberId,
+                DateTimeOffset.Parse("2026-07-29T00:00:08Z")));
     }
 
     private sealed class TestHostEnvironment : IHostEnvironment

--- a/tools/ci/guards/catch_exception_observability_baseline.tsv
+++ b/tools/ci/guards/catch_exception_observability_baseline.tsv
@@ -18,7 +18,6 @@ src/Aevatar.AI.ToolProviders.ServiceInvoke/Tools/ListServicesTool.cs	157	empty b
 src/Aevatar.AI.ToolProviders.Skills/SkillScriptExtractor.cs	119	empty broad catch block
 src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs	47	empty broad catch block
 src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs	59	empty broad catch block
-src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs	170	broad catch returns null without visible failure signal
 src/Aevatar.Foundation.Abstractions/Observability/AevatarActivitySource.cs	248	empty broad catch block
 src/Aevatar.Foundation.Abstractions/Observability/AevatarActivitySource.cs	263	empty broad catch block
 src/Aevatar.Foundation.Abstractions/Observability/AevatarActivitySource.cs	275	broad catch returns null without visible failure signal


### PR DESCRIPTION
## Summary
- Fix aevatarAI/aevatar#3022 by replacing Studio member current-state hard delete with a version-aware projection delete marker.
- Preserve provider-owned delete watermarks in InMemory and Elasticsearch projection stores so delayed older upserts cannot resurrect deleted read models.
- Model the persisted Elasticsearch tombstone payload with a Protobuf contract and generated JSON parsing/formatting.
- Add regression coverage for stale-upsert rejection, dispatcher marker forwarding/fail-closed behavior, Studio member delete projection, and member detail/roster convergence.

## PR comments
- Addressed Codex P1 feedback about hand-built durable tombstone JSON by adding `projection_document_delete_marker.proto` and using `ProjectionDocumentDeleteMarkerRecord` for ES tombstone persistence/parsing.

## Verification
- PASS `git diff --check`
- PASS `bash tools/ci/projection_state_version_guard.sh`
- PASS `bash tools/ci/projection_state_mirror_current_state_guard.sh`
- PASS `bash tools/ci/query_projection_priming_guard.sh`
- PASS `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin bash tools/ci/test_stability_guards.sh`
- BLOCKED locally: `dotnet build src/Aevatar.CQRS.Projection.Stores.Abstractions/Aevatar.CQRS.Projection.Stores.Abstractions.csproj --nologo --no-restore` failed with `NU1301` because `api.nuget.org` could not be resolved in this environment.
- BLOCKED locally: `dotnet test test/Aevatar.CQRS.Projection.Core.Tests/Aevatar.CQRS.Projection.Core.Tests.csproj --nologo --no-restore --filter "ProjectionStoreDispatcherTests|ElasticsearchProjectionDocumentStoreBehaviorTests|InMemoryProjectionDocumentStoreBehaviorTests"` failed with the same `NU1301` DNS issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)