### PR TITLE
Avoid empty schedule catalog refresh

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
@@ -823,6 +823,14 @@ public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSche
         long observedCatalogStateVersion,
         CancellationToken ct)
     {
+        var requiredServices = ResolveCatalogRefreshRequiredServices(authorizationRequest, resolvedRequiredServices);
+        if (resolvedRequiredServices is { Count: 0 } && requiredServices.Count == 0)
+        {
+            return CatalogRefreshRecoveryResult.Failed(
+                failureCode,
+                $"nyxid_catalog_refresh_required_services_unavailable:{detail}");
+        }
+
         string bearerToken;
         try
         {
@@ -848,7 +856,7 @@ public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSche
             refresh = await _catalogRefreshPort.RefreshAsync(
                 authorizationRequest.Owner,
                 bearerToken,
-                ResolveCatalogRefreshRequiredServices(authorizationRequest, resolvedRequiredServices),
+                requiredServices,
                 ct);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)

--- a/test/Aevatar.Studio.Tests/StudioMemberWorkflowSchedulePortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberWorkflowSchedulePortTests.cs
@@ -410,6 +410,37 @@ public sealed class StudioMemberWorkflowSchedulePortTests
     }
 
     [Fact]
+    public async Task PreflightForWriteAsync_WhenCatalogSnapshotUnavailableWithoutRequiredServices_ShouldNotRefresh()
+    {
+        var planner = new RecordingAuthorizationPlanner();
+        planner.Results.Enqueue(ScheduledInvocationAuthorizationPlanResult.Failed(
+            ScheduledInvocationAuthorizationFailureCode.SnapshotNotFound,
+            "nyxid_catalog_snapshot_not_found",
+            requiredNyxIdServices: []));
+        planner.Results.Enqueue(RecordingAuthorizationPlanner.SuccessResult());
+        var refresh = new RecordingCatalogRefreshPort();
+        var tokenProvider = new RecordingWorkflowCallerAccessTokenProvider();
+        var request = Request("scope-1", "member-1") with
+        {
+            ProvisioningBearerToken = null,
+        };
+        var port = NewPort(
+            new RecordingScheduleService(),
+            planner: planner,
+            catalogRefresh: refresh,
+            callerAccessTokenProvider: tokenProvider);
+
+        var result = await port.PreflightForWriteAsync(request);
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(ScheduledInvocationAuthorizationFailureCode.SnapshotNotFound);
+        result.Detail.Should().Be("nyxid_catalog_refresh_required_services_unavailable:nyxid_catalog_snapshot_not_found");
+        planner.Requests.Should().ContainSingle();
+        refresh.RefreshCallCount.Should().Be(0);
+        tokenProvider.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task PreflightForWriteAsync_WhenRetryReturnsNonCatalogFailureWithoutCatalogObservation_ShouldReturnPlannerFailure()
     {
         var planner = new RecordingAuthorizationPlanner();


### PR DESCRIPTION
## Summary
- Stop Studio schedule recovery from calling targeted NyxID catalog refresh when the planner explicitly resolved an empty required-service set.
- Add a regression test covering empty required services so the failure remains local and does not surface as missing exact service identity.

## Test plan
- [x] dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~StudioMemberWorkflowSchedulePortTests -v minimal
- [x] PATH=\"/usr/bin:$PATH\" bash tools/ci/test_stability_guards.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)