### PR TITLE
Authorize no-service schedules without owner catalog

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/Authoring/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Scheduled/Authoring/ScheduledAgentApiKeyIssuer.cs
@@ -183,11 +183,13 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
             .Distinct(StringComparer.Ordinal)
             .Order(StringComparer.Ordinal)
             .ToArray();
+        var serviceCatalogRequired = serviceIds.Length > 0 ||
+                                     policy.ServiceGrantRequirement == AuthorizationGrantRequirement.Required;
         if (!IsCanonicalIdSequence(serviceIds) ||
             plan.NyxIdServiceGrants.Any(static grant => !IsValidServiceGrant(grant)) ||
-            plan.CatalogAuthority == null ||
-            !IsNormalized(plan.CatalogAuthority.ContractVersion) ||
-            !IsNormalized(plan.CatalogAuthority.PolicyVersion) ||
+            serviceCatalogRequired && (plan.CatalogAuthority == null ||
+                !IsNormalized(plan.CatalogAuthority.ContractVersion) ||
+                !IsNormalized(plan.CatalogAuthority.PolicyVersion)) ||
             serviceIds.Length == 0 && policy.ServiceGrantRequirement == AuthorizationGrantRequirement.Required ||
             nodeIds.Length == 0 && policy.NodeGrantRequirement == AuthorizationGrantRequirement.Required)
         {
@@ -449,8 +451,7 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
         IReadOnlyList<string> nodeIds)
     {
         if (!string.Equals(scopePlan.Authority, NyxIdAuthorizationAuthorities.NyxId, StringComparison.Ordinal) ||
-            !string.Equals(scopePlan.ContractVersion, plan.CatalogAuthority.ContractVersion, StringComparison.Ordinal) ||
-            !string.Equals(scopePlan.PolicyVersion, plan.CatalogAuthority.PolicyVersion, StringComparison.Ordinal) ||
+            !MatchesScopePlanVersions(scopePlan, plan.CatalogAuthority) ||
             !MatchesPrincipal(scopePlan.IntendedKeyOwner, ownerKind, ownerSubject) ||
             !MatchesPrincipal(scopePlan.AuthenticatedActor, plan.AuthenticatedActor) ||
             scopePlan.Freshness.Mode != NyxIdScopePlanFreshnessMode.MutationRevalidatedSnapshot ||
@@ -482,6 +483,21 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
 
         return true;
     }
+
+    private static bool MatchesScopePlanVersions(
+        NyxIdApiKeyScopePlan scopePlan,
+        NyxIdCatalogAuthorityStamp? catalogAuthority) =>
+        catalogAuthority is null
+            ? string.Equals(
+                  scopePlan.ContractVersion,
+                  NyxIdApiAccessResponseParser.ScopePlanContractVersion,
+                  StringComparison.Ordinal) &&
+              string.Equals(
+                  scopePlan.PolicyVersion,
+                  NyxIdApiAccessResponseParser.ScopePlanPolicyVersion,
+                  StringComparison.Ordinal)
+            : string.Equals(scopePlan.ContractVersion, catalogAuthority.ContractVersion, StringComparison.Ordinal) &&
+              string.Equals(scopePlan.PolicyVersion, catalogAuthority.PolicyVersion, StringComparison.Ordinal);
 
     private static bool MatchesPrincipal(
         NyxIdScopePlanPrincipal principal,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberWorkflowSchedulePort.cs
@@ -1211,8 +1211,9 @@ public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSche
         ArgumentNullException.ThrowIfNull(plan);
         var policy = plan.CredentialPolicy
             ?? throw new InvalidOperationException("scheduled_authorization_policy_missing");
-        var catalog = plan.CatalogAuthority
-            ?? throw new InvalidOperationException("scheduled_authorization_catalog_authority_missing");
+        var catalog = plan.CatalogAuthority;
+        if (catalog is null && policy.ServiceGrantRequirement != AuthorizationGrantRequirement.NotRequired)
+            throw new InvalidOperationException("scheduled_authorization_catalog_authority_missing");
         var disclosure = plan.Disclosures.ToHashSet();
         var grants = plan.NyxIdServiceGrants.Select(static grant =>
             new ScheduledInvocationAuthorizationServiceGrant(
@@ -1242,13 +1243,13 @@ public sealed class StudioMemberWorkflowSchedulePort : IStudioMemberWorkflowSche
                 SourceVersion(plan, AuthorizationSourceKind.WorkflowRevision),
                 SourceVersion(plan, AuthorizationSourceKind.ConnectorCatalog),
                 SourceVersion(plan, AuthorizationSourceKind.OwnerLlmRoute),
-                catalog.ActorStateVersion,
-                catalog.ObservedAt.ToDateTimeOffset(),
-                catalog.FreshUntil.ToDateTimeOffset(),
-                catalog.ContentDigest,
-                catalog.ContractVersion,
-                catalog.PolicyVersion,
-                catalog.EvaluatedAt.ToDateTimeOffset()),
+                catalog?.ActorStateVersion ?? 0,
+                catalog?.ObservedAt?.ToDateTimeOffset() ?? default,
+                catalog?.FreshUntil?.ToDateTimeOffset() ?? default,
+                catalog?.ContentDigest ?? string.Empty,
+                catalog?.ContractVersion ?? string.Empty,
+                catalog?.PolicyVersion ?? string.Empty,
+                catalog?.EvaluatedAt?.ToDateTimeOffset() ?? default),
             plan.OwnerLlmSelection?.Clone());
     }
 

--- a/src/platform/Aevatar.GAgentService.Application/Schedules/Authorization/ScheduledInvocationAuthorizationPlanner.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Schedules/Authorization/ScheduledInvocationAuthorizationPlanner.cs
@@ -47,6 +47,16 @@ public sealed class ScheduledInvocationAuthorizationPlanner : IScheduledInvocati
         var evidence = await ResolveTargetEvidenceAsync(request, ct);
         if (evidence.Failure != null)
             return evidence.Failure;
+        if (CanAuthorizeWithoutServiceCatalog(evidence))
+        {
+            var plan = BuildPlan(
+                request,
+                authenticatedActor,
+                evidence,
+                [],
+                catalogAuthority: null);
+            return ScheduledInvocationAuthorizationPlanResult.Succeeded(plan);
+        }
 
         var snapshot = await _catalogQueryPort.GetAsync(request.Owner, ct);
         if (snapshot == null)
@@ -117,39 +127,63 @@ public sealed class ScheduledInvocationAuthorizationPlanner : IScheduledInvocati
             };
         }
 
+        var catalogAuthority = new NyxIdCatalogAuthorityStamp
+        {
+            ActorStateVersion = snapshot.StateVersion,
+            ObservedAt = Timestamp.FromDateTimeOffset(snapshot.ObservedAtUtc),
+            FreshUntil = Timestamp.FromDateTimeOffset(snapshot.FreshUntilUtc),
+            ContentDigest = snapshot.ContentDigest,
+            ContractVersion = snapshot.ContractVersion,
+            PolicyVersion = snapshot.PolicyVersion,
+            EvaluatedAt = Timestamp.FromDateTimeOffset(snapshot.EvaluatedAtUtc),
+        };
+        return ScheduledInvocationAuthorizationPlanResult.Succeeded(BuildPlan(
+            request,
+            authenticatedActor,
+            evidence,
+            grants.ServiceGrants,
+            catalogAuthority));
+    }
+
+    public static string ComputeDigest(ScheduledInvocationAuthorizationPlan plan)
+        => ScheduledInvocationAuthorizationPlanIntegrity.ComputeDigest(plan);
+
+    private static bool CanAuthorizeWithoutServiceCatalog(TargetEvidenceResolution evidence) =>
+        evidence.RequiredServices.Count == 0 &&
+        evidence.ServiceGrantRequirement == AuthorizationGrantRequirement.NotRequired;
+
+    private static ScheduledInvocationAuthorizationPlan BuildPlan(
+        ScheduledInvocationAuthorizationRequest request,
+        AuthorizationOwnerIdentity authenticatedActor,
+        TargetEvidenceResolution evidence,
+        IReadOnlyList<NyxIdServiceGrant> serviceGrants,
+        NyxIdCatalogAuthorityStamp? catalogAuthority)
+    {
         var plan = new ScheduledInvocationAuthorizationPlan
         {
             SchemaVersion = SchemaVersion,
             InvocationTarget = request.InvocationTarget.Clone(),
             Owner = request.Owner.Clone(),
-            AuthenticatedActor = authenticatedActor,
+            AuthenticatedActor = authenticatedActor.Clone(),
             CredentialPolicy = new ScheduledInvocationCredentialPolicy
             {
                 AllowAllServices = false,
                 AllowAllNodes = false,
                 ServiceGrantRequirement = evidence.ServiceGrantRequirement,
-                NodeGrantRequirement = grants.ServiceGrants.Any(static grant =>
+                NodeGrantRequirement = serviceGrants.Any(static grant =>
                     grant.NodeGrantRequirement == AuthorizationGrantRequirement.Required)
                         ? AuthorizationGrantRequirement.Required
                         : AuthorizationGrantRequirement.NotRequired,
                 ExpiresAt = Timestamp.FromDateTimeOffset(request.ExpiresAtUtc),
                 PolicyVersion = PolicyVersion,
             },
-            CatalogAuthority = new NyxIdCatalogAuthorityStamp
-            {
-                ActorStateVersion = snapshot.StateVersion,
-                ObservedAt = Timestamp.FromDateTimeOffset(snapshot.ObservedAtUtc),
-                FreshUntil = Timestamp.FromDateTimeOffset(snapshot.FreshUntilUtc),
-                ContentDigest = snapshot.ContentDigest,
-                ContractVersion = snapshot.ContractVersion,
-                PolicyVersion = snapshot.PolicyVersion,
-                EvaluatedAt = Timestamp.FromDateTimeOffset(snapshot.EvaluatedAtUtc),
-            },
         };
+        if (catalogAuthority is not null)
+            plan.CatalogAuthority = catalogAuthority.Clone();
         plan.CredentialPolicy.Scopes.Add(NyxIdCredentialScope.Read);
         plan.CredentialPolicy.Scopes.Add(NyxIdCredentialScope.Proxy);
-        plan.NyxIdServiceGrants.Add(grants.ServiceGrants);
-        plan.SourceStamps.Add(evidence.SourceStamps);
+        plan.NyxIdServiceGrants.Add(serviceGrants.Select(static grant => grant.Clone()));
+        plan.SourceStamps.Add(evidence.SourceStamps.Select(static stamp => stamp.Clone()));
         plan.Disclosures.Add(new[]
         {
             ScheduledInvocationDisclosure.DedicatedCredential,
@@ -162,11 +196,8 @@ public sealed class ScheduledInvocationAuthorizationPlanner : IScheduledInvocati
         if (evidence.OwnerLLMSelection is not null)
             plan.OwnerLlmSelection = evidence.OwnerLLMSelection.Clone();
         plan.PermissionDigest = ComputeDigest(plan);
-        return ScheduledInvocationAuthorizationPlanResult.Succeeded(plan);
+        return plan;
     }
-
-    public static string ComputeDigest(ScheduledInvocationAuthorizationPlan plan)
-        => ScheduledInvocationAuthorizationPlanIntegrity.ComputeDigest(plan);
 
     private async Task<TargetEvidenceResolution> ResolveTargetEvidenceAsync(
         ScheduledInvocationAuthorizationRequest request,

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Schedules/ScheduledServiceInvocationDispatchPort.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Schedules/ScheduledServiceInvocationDispatchPort.cs
@@ -93,7 +93,7 @@ public sealed class ScheduledServiceInvocationDispatchPort : IScheduledServiceIn
 
         if (fact == null ||
             IsCoreAuthorizationFactInvalid(fact, _timeProvider.GetUtcNow()) ||
-            IsCatalogAuthorityInvalid(fact.Authority) ||
+            RequiresCatalogAuthority(fact) && IsCatalogAuthorityInvalid(fact.Authority) ||
             AreServiceGrantsInvalid(fact) ||
             IsDisclosureInvalid(fact.Disclosure))
         {
@@ -128,6 +128,9 @@ public sealed class ScheduledServiceInvocationDispatchPort : IScheduledServiceIn
         string.IsNullOrWhiteSpace(authority.CatalogContractVersion) ||
         string.IsNullOrWhiteSpace(authority.CatalogPolicyVersion) ||
         authority.CatalogEvaluatedAt == default;
+
+    private static bool RequiresCatalogAuthority(ScheduledInvocationAuthorizationFact fact) =>
+        !fact.ServiceGrantsNotRequired || fact.ServiceGrants.Count > 0;
 
     private static bool AreServiceGrantsInvalid(ScheduledInvocationAuthorizationFact fact) =>
         fact.ServiceGrants.Count == 0 && !fact.ServiceGrantsNotRequired ||

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchServiceInvocationTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchServiceInvocationTests.cs
@@ -350,6 +350,52 @@ public sealed class ScheduledDispatchServiceInvocationTests
     }
 
     [Fact]
+    public async Task ScheduledServiceInvocationDispatchPort_WithNoServiceGrants_ShouldNotRequireCatalogAuthority()
+    {
+        var now = new DateTimeOffset(2026, 7, 15, 8, 0, 0, TimeSpan.Zero);
+        var invocationPort = new RecordingServiceInvocationPort();
+        var port = new ScheduledServiceInvocationDispatchPort(
+            invocationPort,
+            new RecordingScheduledServiceInvocationCredentialExchangePort(),
+            secretVault: null,
+            timeProvider: new FixedTimeProvider(now));
+        var dispatch = new ScheduledServiceInvocationDispatchRequest(
+            new ServiceInvocationRequest
+            {
+                CommandId = "cmd-no-service-grants",
+                CorrelationId = "corr-no-service-grants",
+                Identity = new ServiceIdentity { ServiceId = "svc-alpha" },
+                EndpointId = "chat",
+                Payload = Any.Pack(new ChatRequestEvent { Prompt = "run" }),
+            },
+            CreateScheduledAgentKeyAuth(now.AddHours(1)),
+            ProjectNyxIdAccessTokenToWorkflowCallerCredential: true,
+            ScheduleId: "schedule-no-service-grants",
+            AuthorizationFact: CreateAuthorizationFactDispatch(now).AuthorizationFact! with
+            {
+                ServiceGrants = [],
+                ServiceGrantsNotRequired = true,
+                Authority = new ScheduledInvocationAuthorizationAuthority(
+                    11,
+                    12,
+                    13,
+                    0,
+                    0,
+                    default,
+                    default,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty,
+                    default),
+                OwnerLLMSelection = null,
+            });
+
+        await port.DispatchAsync(dispatch);
+
+        invocationPort.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task ScheduledServiceInvocationDispatchPort_WithExpiredCatalogFreshness_ShouldUseCommittedFact()
     {
         var now = new DateTimeOffset(2026, 7, 15, 8, 0, 0, TimeSpan.Zero);

--- a/test/Aevatar.GAgentService.Tests/Authorization/ScheduledInvocationAuthorizationPlannerTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Authorization/ScheduledInvocationAuthorizationPlannerTests.cs
@@ -21,6 +21,26 @@ public sealed class ScheduledInvocationAuthorizationPlannerTests
     }
 
     [Fact]
+    public async Task PlanAsync_WhenNoServiceGrantsRequired_ShouldNotReadCatalog()
+    {
+        var catalog = new MutableCatalogQueryPort(Snapshot() with { Invalidated = true });
+        var planner = NewPlanner(catalog);
+        var request = Request(Array.Empty<string>()) with
+        {
+            ServiceGrantRequirement = AuthorizationGrantRequirement.NotRequired,
+        };
+
+        var result = await planner.PlanAsync(request);
+
+        result.Success.Should().BeTrue();
+        result.Plan!.CatalogAuthority.Should().BeNull();
+        result.Plan.NyxIdServiceGrants.Should().BeEmpty();
+        result.Plan.CredentialPolicy.ServiceGrantRequirement.Should()
+            .Be(AuthorizationGrantRequirement.NotRequired);
+        catalog.QueryCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task PlanAsync_ShouldCanonicalizeServiceAndNodePermissionSets()
     {
         var catalog = new MutableCatalogQueryPort(Snapshot(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentApiKeyIssuerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentApiKeyIssuerTests.cs
@@ -70,6 +70,48 @@ public sealed class ScheduledAgentApiKeyIssuerTests
     }
 
     [Fact]
+    public async Task IssueAsync_WhenNoServiceGrantsRequired_CreatesEmptyAllowlistKey()
+    {
+        var handler = new RoutingJsonHandler(
+            EmptyScopePlanJson(),
+            """{"id":"key-empty","full_key":"secret"}""");
+        var issuer = CreateIssuer(handler);
+        var plan = ValidPlan();
+        plan.NyxIdServiceGrants.Clear();
+        plan.CatalogAuthority = null;
+        plan.CredentialPolicy.ServiceGrantRequirement = AuthorizationGrantRequirement.NotRequired;
+        plan.CredentialPolicy.NodeGrantRequirement = AuthorizationGrantRequirement.NotRequired;
+        plan.PermissionDigest = ScheduledInvocationAuthorizationPlanIntegrity.ComputeDigest(plan);
+
+        var result = await issuer.IssueAsync(
+            "session-token",
+            new ValidatedScheduledInvocationAuthorizationPlan(plan),
+            "scheduled-empty-key",
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ApiKeyId.Should().Be("key-empty");
+        handler.Requests.Should().Equal(
+            "/api/v1/api-keys/scope-plan",
+            "/api/v1/api-keys");
+        using var scopeRequest = System.Text.Json.JsonDocument.Parse(handler.RequestBodies[0]);
+        scopeRequest.RootElement.GetProperty("selected_service_ids")
+            .EnumerateArray()
+            .Should().BeEmpty();
+
+        using var createRequest = System.Text.Json.JsonDocument.Parse(handler.RequestBodies[1]);
+        createRequest.RootElement.GetProperty("allowed_service_ids")
+            .EnumerateArray()
+            .Should().BeEmpty();
+        createRequest.RootElement.GetProperty("allowed_node_ids")
+            .EnumerateArray()
+            .Should().BeEmpty();
+        createRequest.RootElement.GetProperty("allow_all_services").GetBoolean().Should().BeFalse();
+        createRequest.RootElement.GetProperty("allow_all_nodes").GetBoolean().Should().BeFalse();
+        createRequest.RootElement.GetProperty("scope_plan_digest").GetString().Should().Be(TargetedScopePlanDigest);
+    }
+
+    [Fact]
     public async Task IssueAsync_ForOrganizationOwner_ShouldMapExactTargetOrganization()
     {
         var handler = new RoutingJsonHandler(
@@ -639,6 +681,32 @@ public sealed class ScheduledAgentApiKeyIssuerTests
           ],
           "allowed_service_ids": ["us-alpha", "us-beta"],
           "allowed_node_ids": ["node-a", "node-shared"],
+          "evaluated_at": "2026-07-16T00:00:01Z",
+          "normalized_grant_digest": "{{TargetedScopePlanDigest}}",
+          "freshness": {
+            "mode": "mutation_revalidated_snapshot",
+            "precondition_field": "scope_plan_digest",
+            "post_creation_drift": "fail_closed"
+          },
+          "completeness": {
+            "list_complete": true,
+            "no_duplicates": true,
+            "route_candidate_basis": "active_configured_routes",
+            "transient_node_state_excluded": true
+          }
+        }
+        """;
+
+    private static string EmptyScopePlanJson() => $$"""
+        {
+          "authority": "nyxid",
+          "contract_version": "1",
+          "policy_version": "api-key-scope-v1",
+          "authenticated_actor": { "id": "owner-alpha", "type": "personal" },
+          "intended_key_owner": { "id": "owner-alpha", "type": "personal" },
+          "services": [],
+          "allowed_service_ids": [],
+          "allowed_node_ids": [],
           "evaluated_at": "2026-07-16T00:00:01Z",
           "normalized_grant_digest": "{{TargetedScopePlanDigest}}",
           "freshness": {


### PR DESCRIPTION
## Summary
- Treat schedules with no required NyxID services and `ServiceGrantRequirement.NotRequired` as catalog-independent during authorization planning.
- Allow the committed authorization fact, dispatch validation, and scheduled-agent API key issuance path to carry a no-service plan without catalog authority.
- Keep service-grant schedules fail-closed on catalog authority and add focused regression coverage across planner, Studio schedule port, dispatch, and key issuance.

## Test plan
- [x] dotnet build aevatar.slnx --nologo --no-restore
- [x] dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~ScheduledInvocationAuthorizationPlannerTests|FullyQualifiedName~ScheduledDispatchServiceInvocationTests" -v minimal
- [x] dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~ScheduledAgentApiKeyIssuerTests -v minimal
- [x] dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~StudioMemberWorkflowSchedulePortTests -v minimal
- [x] PATH="/usr/bin:$PATH" bash tools/ci/test_stability_guards.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)