### PR TITLE
Expose schedule authorization mismatch details

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/Authoring/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Scheduled/Authoring/ScheduledAgentApiKeyIssuer.cs
@@ -226,15 +226,27 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
         }
 
         var scopePlan = scopePlanResult.Value!;
-        if (!MatchesAuthorizationPlan(
+        if (!TryResolveAuthorizationPlanMismatch(
                 scopePlan,
                 plan,
                 ownerKind,
                 ownerSubject,
                 serviceIds,
-                nodeIds))
+                nodeIds,
+                out var mismatchReason))
         {
-            return ScheduledAgentApiKeyIssueResult.Failed("authorization_plan_changed");
+            if (_logger != null)
+            {
+                _logger.Log(
+                    LogLevel.Warning,
+                    new EventId(),
+                    $"NyxID scheduled API key scope-plan no longer matches the validated authorization plan. reason={mismatchReason} planned_service_count={plan.NyxIdServiceGrants.Count()} current_service_count={scopePlan.Services.Count()} planned_node_count={nodeIds.Count()} current_node_count={scopePlan.AllowedNodeIds.Count()}",
+                    null,
+                    static (state, _) => state);
+            }
+            return ScheduledAgentApiKeyIssueResult.Failed(
+                "authorization_plan_changed",
+                $"authorization_plan_changed:{mismatchReason}");
         }
 
         var response = await client.CreateApiKeyAsync(
@@ -442,30 +454,71 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
         }
     }
 
-    private static bool MatchesAuthorizationPlan(
+    private static bool TryResolveAuthorizationPlanMismatch(
         NyxIdApiKeyScopePlan scopePlan,
         ScheduledInvocationAuthorizationPlan plan,
         AuthorizationOwnerKind ownerKind,
         string ownerSubject,
         IReadOnlyList<string> serviceIds,
-        IReadOnlyList<string> nodeIds)
+        IReadOnlyList<string> nodeIds,
+        out string mismatchReason)
     {
-        if (!string.Equals(scopePlan.Authority, NyxIdAuthorizationAuthorities.NyxId, StringComparison.Ordinal) ||
-            !MatchesScopePlanVersions(scopePlan, plan.CatalogAuthority) ||
-            !MatchesPrincipal(scopePlan.IntendedKeyOwner, ownerKind, ownerSubject) ||
-            !MatchesPrincipal(scopePlan.AuthenticatedActor, plan.AuthenticatedActor) ||
-            scopePlan.Freshness.Mode != NyxIdScopePlanFreshnessMode.MutationRevalidatedSnapshot ||
-            !string.Equals(scopePlan.Freshness.PreconditionField, "scope_plan_digest", StringComparison.Ordinal) ||
-            scopePlan.Freshness.PostCreationDrift != NyxIdScopePlanPostCreationDrift.FailClosed ||
-            !scopePlan.Completeness.ListComplete ||
-            !scopePlan.Completeness.NoDuplicates ||
-            scopePlan.Completeness.RouteCandidateBasis !=
-            NyxIdScopePlanRouteCandidateBasis.ActiveConfiguredRoutes ||
-            !scopePlan.Completeness.TransientNodeStateExcluded ||
-            !scopePlan.AllowedServiceIds.SequenceEqual(serviceIds, StringComparer.Ordinal) ||
-            !scopePlan.AllowedNodeIds.SequenceEqual(nodeIds, StringComparer.Ordinal) ||
-            scopePlan.Services.Count != plan.NyxIdServiceGrants.Count)
+        if (!string.Equals(scopePlan.Authority, NyxIdAuthorizationAuthorities.NyxId, StringComparison.Ordinal))
         {
+            mismatchReason = "scope_plan_authority_mismatch";
+            return false;
+        }
+
+        if (!MatchesScopePlanVersions(scopePlan, plan.CatalogAuthority))
+        {
+            mismatchReason = "scope_plan_versions_mismatch";
+            return false;
+        }
+
+        if (!MatchesPrincipal(scopePlan.IntendedKeyOwner, ownerKind, ownerSubject))
+        {
+            mismatchReason = "intended_key_owner_mismatch";
+            return false;
+        }
+
+        if (!MatchesPrincipal(scopePlan.AuthenticatedActor, plan.AuthenticatedActor))
+        {
+            mismatchReason = "authenticated_actor_mismatch";
+            return false;
+        }
+
+        if (scopePlan.Freshness.Mode != NyxIdScopePlanFreshnessMode.MutationRevalidatedSnapshot ||
+            !string.Equals(scopePlan.Freshness.PreconditionField, "scope_plan_digest", StringComparison.Ordinal) ||
+            scopePlan.Freshness.PostCreationDrift != NyxIdScopePlanPostCreationDrift.FailClosed)
+        {
+            mismatchReason = "scope_plan_freshness_mismatch";
+            return false;
+        }
+
+        if (!scopePlan.Completeness.ListComplete ||
+            !scopePlan.Completeness.NoDuplicates ||
+            scopePlan.Completeness.RouteCandidateBasis != NyxIdScopePlanRouteCandidateBasis.ActiveConfiguredRoutes ||
+            !scopePlan.Completeness.TransientNodeStateExcluded)
+        {
+            mismatchReason = "scope_plan_completeness_mismatch";
+            return false;
+        }
+
+        if (!scopePlan.AllowedServiceIds.SequenceEqual(serviceIds, StringComparer.Ordinal))
+        {
+            mismatchReason = "allowed_service_ids_mismatch";
+            return false;
+        }
+
+        if (!scopePlan.AllowedNodeIds.SequenceEqual(nodeIds, StringComparer.Ordinal))
+        {
+            mismatchReason = "allowed_node_ids_mismatch";
+            return false;
+        }
+
+        if (scopePlan.Services.Count != plan.NyxIdServiceGrants.Count)
+        {
+            mismatchReason = "service_grant_count_mismatch";
             return false;
         }
 
@@ -473,14 +526,26 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
         {
             var plannedGrant = plan.NyxIdServiceGrants[index];
             var currentGrant = scopePlan.Services[index];
-            if (!string.Equals(currentGrant.UserServiceId, plannedGrant.UserServiceId, StringComparison.Ordinal) ||
-                !MatchesPrincipal(currentGrant.ResourceOwner, plannedGrant.ResourceOwner) ||
-                !MatchesNodeGrant(currentGrant.NodeGrant, plannedGrant))
+            if (!string.Equals(currentGrant.UserServiceId, plannedGrant.UserServiceId, StringComparison.Ordinal))
             {
+                mismatchReason = "service_grant_identity_mismatch";
+                return false;
+            }
+
+            if (!MatchesPrincipal(currentGrant.ResourceOwner, plannedGrant.ResourceOwner))
+            {
+                mismatchReason = "service_grant_resource_owner_mismatch";
+                return false;
+            }
+
+            if (!MatchesNodeGrant(currentGrant.NodeGrant, plannedGrant))
+            {
+                mismatchReason = "service_grant_node_mismatch";
                 return false;
             }
         }
 
+        mismatchReason = string.Empty;
         return true;
     }
 

--- a/agents/Aevatar.GAgents.Scheduled/Authoring/ScheduledAgentApiKeyIssuer.cs
+++ b/agents/Aevatar.GAgents.Scheduled/Authoring/ScheduledAgentApiKeyIssuer.cs
@@ -240,13 +240,13 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
                 _logger.Log(
                     LogLevel.Warning,
                     new EventId(),
-                    $"NyxID scheduled API key scope-plan no longer matches the validated authorization plan. reason={mismatchReason} planned_service_count={plan.NyxIdServiceGrants.Count()} current_service_count={scopePlan.Services.Count()} planned_node_count={nodeIds.Count()} current_node_count={scopePlan.AllowedNodeIds.Count()}",
+                    $"NyxID scheduled API key scope-plan no longer matches the validated authorization plan. reason={ScheduledAuthorizationPlanMismatchReasons.ToWireValue(mismatchReason)} planned_service_count={plan.NyxIdServiceGrants.Count()} current_service_count={scopePlan.Services.Count()} planned_node_count={nodeIds.Count()} current_node_count={scopePlan.AllowedNodeIds.Count()}",
                     null,
                     static (state, _) => state);
             }
             return ScheduledAgentApiKeyIssueResult.Failed(
                 "authorization_plan_changed",
-                $"authorization_plan_changed:{mismatchReason}");
+                authorizationPlanMismatchReason: mismatchReason);
         }
 
         var response = await client.CreateApiKeyAsync(
@@ -461,29 +461,29 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
         string ownerSubject,
         IReadOnlyList<string> serviceIds,
         IReadOnlyList<string> nodeIds,
-        out string mismatchReason)
+        out ScheduledAuthorizationPlanMismatchReason mismatchReason)
     {
         if (!string.Equals(scopePlan.Authority, NyxIdAuthorizationAuthorities.NyxId, StringComparison.Ordinal))
         {
-            mismatchReason = "scope_plan_authority_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.ScopePlanAuthorityMismatch;
             return false;
         }
 
         if (!MatchesScopePlanVersions(scopePlan, plan.CatalogAuthority))
         {
-            mismatchReason = "scope_plan_versions_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.ScopePlanVersionsMismatch;
             return false;
         }
 
         if (!MatchesPrincipal(scopePlan.IntendedKeyOwner, ownerKind, ownerSubject))
         {
-            mismatchReason = "intended_key_owner_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.IntendedKeyOwnerMismatch;
             return false;
         }
 
         if (!MatchesPrincipal(scopePlan.AuthenticatedActor, plan.AuthenticatedActor))
         {
-            mismatchReason = "authenticated_actor_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.AuthenticatedActorMismatch;
             return false;
         }
 
@@ -491,7 +491,7 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
             !string.Equals(scopePlan.Freshness.PreconditionField, "scope_plan_digest", StringComparison.Ordinal) ||
             scopePlan.Freshness.PostCreationDrift != NyxIdScopePlanPostCreationDrift.FailClosed)
         {
-            mismatchReason = "scope_plan_freshness_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.ScopePlanFreshnessMismatch;
             return false;
         }
 
@@ -500,25 +500,25 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
             scopePlan.Completeness.RouteCandidateBasis != NyxIdScopePlanRouteCandidateBasis.ActiveConfiguredRoutes ||
             !scopePlan.Completeness.TransientNodeStateExcluded)
         {
-            mismatchReason = "scope_plan_completeness_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.ScopePlanCompletenessMismatch;
             return false;
         }
 
         if (!scopePlan.AllowedServiceIds.SequenceEqual(serviceIds, StringComparer.Ordinal))
         {
-            mismatchReason = "allowed_service_ids_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.AllowedServiceIdsMismatch;
             return false;
         }
 
         if (!scopePlan.AllowedNodeIds.SequenceEqual(nodeIds, StringComparer.Ordinal))
         {
-            mismatchReason = "allowed_node_ids_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch;
             return false;
         }
 
         if (scopePlan.Services.Count != plan.NyxIdServiceGrants.Count)
         {
-            mismatchReason = "service_grant_count_mismatch";
+            mismatchReason = ScheduledAuthorizationPlanMismatchReason.ServiceGrantCountMismatch;
             return false;
         }
 
@@ -528,24 +528,24 @@ internal sealed class ScheduledAgentApiKeyIssuer : IScheduledAgentApiKeyIssuer
             var currentGrant = scopePlan.Services[index];
             if (!string.Equals(currentGrant.UserServiceId, plannedGrant.UserServiceId, StringComparison.Ordinal))
             {
-                mismatchReason = "service_grant_identity_mismatch";
+                mismatchReason = ScheduledAuthorizationPlanMismatchReason.ServiceGrantIdentityMismatch;
                 return false;
             }
 
             if (!MatchesPrincipal(currentGrant.ResourceOwner, plannedGrant.ResourceOwner))
             {
-                mismatchReason = "service_grant_resource_owner_mismatch";
+                mismatchReason = ScheduledAuthorizationPlanMismatchReason.ServiceGrantResourceOwnerMismatch;
                 return false;
             }
 
             if (!MatchesNodeGrant(currentGrant.NodeGrant, plannedGrant))
             {
-                mismatchReason = "service_grant_node_mismatch";
+                mismatchReason = ScheduledAuthorizationPlanMismatchReason.ServiceGrantNodeMismatch;
                 return false;
             }
         }
 
-        mismatchReason = string.Empty;
+        mismatchReason = ScheduledAuthorizationPlanMismatchReason.Unspecified;
         return true;
     }
 

--- a/agents/Aevatar.GAgents.Scheduled/ScheduledAgentApiKeyIssueResult.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ScheduledAgentApiKeyIssueResult.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
 
 namespace Aevatar.GAgents.Scheduled;
 
@@ -20,7 +21,8 @@ public sealed class ScheduledAgentApiKeyIssueResult
         int? httpStatus,
         string? serviceSlug,
         string? skillRef,
-        long keyExpiresAtUnixMs)
+        long keyExpiresAtUnixMs,
+        ScheduledAuthorizationPlanMismatchReason authorizationPlanMismatchReason)
     {
         Success = success;
         ApiKeyId = apiKeyId;
@@ -32,6 +34,7 @@ public sealed class ScheduledAgentApiKeyIssueResult
         ServiceSlug = serviceSlug;
         SkillRef = skillRef;
         KeyExpiresAtUnixMs = keyExpiresAtUnixMs;
+        AuthorizationPlanMismatchReason = authorizationPlanMismatchReason;
     }
 
     private readonly ScheduledAgentOpaqueSecret? _secret;
@@ -45,12 +48,24 @@ public sealed class ScheduledAgentApiKeyIssueResult
     public string? ServiceSlug { get; }
     public string? SkillRef { get; }
     public long KeyExpiresAtUnixMs { get; }
+    public ScheduledAuthorizationPlanMismatchReason AuthorizationPlanMismatchReason { get; }
 
     public static ScheduledAgentApiKeyIssueResult Succeeded(
         string apiKeyId,
         string fullKey,
         long keyExpiresAtUnixMs = 0) =>
-        new(true, apiKeyId, new ScheduledAgentOpaqueSecret(fullKey), null, null, null, null, null, null, keyExpiresAtUnixMs);
+        new(
+            true,
+            apiKeyId,
+            new ScheduledAgentOpaqueSecret(fullKey),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            keyExpiresAtUnixMs,
+            ScheduledAuthorizationPlanMismatchReason.Unspecified);
 
     public static ScheduledAgentApiKeyIssueResult Failed(
         string error,
@@ -58,8 +73,21 @@ public sealed class ScheduledAgentApiKeyIssueResult
         string? hint = null,
         int? httpStatus = null,
         string? serviceSlug = null,
-        string? skillRef = null) =>
-        new(false, null, null, error, detail, hint, httpStatus, serviceSlug, skillRef, 0);
+        string? skillRef = null,
+        ScheduledAuthorizationPlanMismatchReason authorizationPlanMismatchReason =
+            ScheduledAuthorizationPlanMismatchReason.Unspecified) =>
+        new(
+            false,
+            null,
+            null,
+            error,
+            detail,
+            hint,
+            httpStatus,
+            serviceSlug,
+            skillRef,
+            0,
+            authorizationPlanMismatchReason);
 
     public static ScheduledAgentApiKeyIssueResult FailedAfterIssue(
         string apiKeyId,
@@ -68,8 +96,21 @@ public sealed class ScheduledAgentApiKeyIssueResult
         string? hint = null,
         int? httpStatus = null,
         string? serviceSlug = null,
-        string? skillRef = null) =>
-        new(false, apiKeyId, null, error, detail, hint, httpStatus, serviceSlug, skillRef, 0);
+        string? skillRef = null,
+        ScheduledAuthorizationPlanMismatchReason authorizationPlanMismatchReason =
+            ScheduledAuthorizationPlanMismatchReason.Unspecified) =>
+        new(
+            false,
+            apiKeyId,
+            null,
+            error,
+            detail,
+            hint,
+            httpStatus,
+            serviceSlug,
+            skillRef,
+            0,
+            authorizationPlanMismatchReason);
 
     public Task<Aevatar.Foundation.Abstractions.Credentials.StoreSecretResult> StoreSecretAsync(
         Aevatar.Foundation.Abstractions.Credentials.ISecretVault secretVault,
@@ -91,6 +132,8 @@ public sealed class ScheduledAgentApiKeyIssueResult
             http_status = HttpStatus,
             service_slug = ServiceSlug,
             skill_ref = SkillRef,
+            authorization_plan_mismatch_reason = ScheduledAuthorizationPlanMismatchReasons.ToWireValue(
+                AuthorizationPlanMismatchReason),
         }, ErrorJsonOptions);
 
     public override string ToString() =>

--- a/agents/Aevatar.GAgents.Scheduled/StudioScheduledCredentialMaterializer.cs
+++ b/agents/Aevatar.GAgents.Scheduled/StudioScheduledCredentialMaterializer.cs
@@ -100,11 +100,29 @@ public sealed class StudioScheduledCredentialMaterializer : IStudioScheduledCred
                     issued.ApiKeyId,
                     effectLocator,
                     issueFailure);
+                if (string.Equals(issued.Error, "authorization_plan_changed", StringComparison.Ordinal) &&
+                    issued.AuthorizationPlanMismatchReason != ScheduledAuthorizationPlanMismatchReason.Unspecified)
+                {
+                    throw new StudioMemberAutomationPlanConflictException(
+                        "authorization_plan_changed",
+                        "authorization_plan_changed",
+                        issued.AuthorizationPlanMismatchReason);
+                }
+
                 throw new StudioScheduledCredentialMaterializationException(
                     issueFailure.Message,
                     effectsCleaned: true,
                     issueFailure);
             }
+            if (string.Equals(issued.Error, "authorization_plan_changed", StringComparison.Ordinal) &&
+                issued.AuthorizationPlanMismatchReason != ScheduledAuthorizationPlanMismatchReason.Unspecified)
+            {
+                throw new StudioMemberAutomationPlanConflictException(
+                    "authorization_plan_changed",
+                    "authorization_plan_changed",
+                    issued.AuthorizationPlanMismatchReason);
+            }
+
             throw new InvalidOperationException(issued.Error ?? "scheduled_credential_materialization_failed");
         }
 

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -206,7 +206,8 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
         {
             return ErrorJson(
                 ToPlanConflictCode(ex.Code),
-                ToPlanConflictMessage(ex.Code));
+                ToPlanConflictMessage(ex.Code),
+                ScheduledAuthorizationPlanMismatchReasons.ToWireValue(ex.AuthorizationPlanMismatchReason));
         }
         catch (Exception ex)
         {
@@ -230,9 +231,12 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
         _ => "The schedule request conflicts with the current authorization state.",
     };
 
-    private static string ErrorJson(string code, string message) =>
+    private static string ErrorJson(
+        string code,
+        string message,
+        string? authorizationPlanMismatchReason = null) =>
         JsonSerializer.Serialize(new ScheduleStudioMemberWorkflowErrorJson(
-            new ScheduleStudioMemberWorkflowErrorBody(code, message)),
+            new ScheduleStudioMemberWorkflowErrorBody(code, message, authorizationPlanMismatchReason)),
             s_jsonOptions);
 
     private static string? Normalize(string? value) =>
@@ -314,7 +318,10 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
 
     private sealed record ScheduleStudioMemberWorkflowErrorJson(ScheduleStudioMemberWorkflowErrorBody Error);
 
-    private sealed record ScheduleStudioMemberWorkflowErrorBody(string Code, string Message);
+    private sealed record ScheduleStudioMemberWorkflowErrorBody(
+        string Code,
+        string Message,
+        string? AuthorizationPlanMismatchReason = null);
 }
 
 internal static class StudioMemberWorkflowScheduleAuthorizationResolver

--- a/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowScheduleContracts.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Provisioning/StudioMemberWorkflowScheduleContracts.cs
@@ -181,13 +181,20 @@ public sealed class StudioMemberAutomationNotFoundException : Exception
 
 public sealed class StudioMemberAutomationPlanConflictException : Exception
 {
-    public StudioMemberAutomationPlanConflictException(string code, string message)
+    public StudioMemberAutomationPlanConflictException(
+        string code,
+        string message,
+        ScheduledAuthorizationPlanMismatchReason authorizationPlanMismatchReason =
+            ScheduledAuthorizationPlanMismatchReason.Unspecified)
         : base(message)
     {
         Code = string.IsNullOrWhiteSpace(code) ? "authorization_plan_changed" : code.Trim();
+        AuthorizationPlanMismatchReason = authorizationPlanMismatchReason;
     }
 
     public string Code { get; }
+
+    public ScheduledAuthorizationPlanMismatchReason AuthorizationPlanMismatchReason { get; }
 }
 
 public sealed class StudioMemberAutomationProjectionPendingException : Exception

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioMemberAutomationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioMemberAutomationEndpoints.cs
@@ -497,12 +497,12 @@ internal static class StudioMemberAutomationEndpoints
                 },
                 statusCode: StatusCodes.Status503ServiceUnavailable),
             StudioMemberAutomationPlanConflictException conflict => Results.Json(
-                new
-                {
-                    code = ToPlanConflictCode(conflict.Code),
-                    message = ToPlanConflictMessage(conflict.Code),
-                    preflightLocator = BuildPreflightLocator(scopeId, teamId, memberId),
-                },
+                new StudioMemberAutomationConflictResponse(
+                    ToPlanConflictCode(conflict.Code),
+                    ToPlanConflictMessage(conflict.Code),
+                    BuildPreflightLocator(scopeId, teamId, memberId),
+                    ScheduledAuthorizationPlanMismatchReasons.ToWireValue(
+                        conflict.AuthorizationPlanMismatchReason)),
                 statusCode: StatusCodes.Status409Conflict),
             ScheduledDispatchConflictException => Results.Conflict(
                 new { code = "TEAM_AUTOMATION_CONFLICT", message = exception.Message }),
@@ -540,6 +540,13 @@ internal static class StudioMemberAutomationEndpoints
     private static string BuildPreflightLocator(string scopeId, string teamId, string memberId) =>
         $"/api/scopes/{Uri.EscapeDataString(scopeId.Trim())}/teams/{Uri.EscapeDataString(teamId.Trim())}" +
         $"/members/{Uri.EscapeDataString(memberId.Trim())}/automations/preflight";
+
+    private sealed record StudioMemberAutomationConflictResponse(
+        string code,
+        string message,
+        string preflightLocator,
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? authorizationPlanMismatchReason);
 }
 
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]

--- a/src/platform/Aevatar.GAgentService.Abstractions/Schedules/Authorization/ScheduledInvocationAuthorizationContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Schedules/Authorization/ScheduledInvocationAuthorizationContracts.cs
@@ -174,6 +174,43 @@ public sealed record NyxIdAuthorizationCatalogSnapshot(
     DateTimeOffset? CleanedAtUtc = null,
     string CleanupReason = "");
 
+public enum ScheduledAuthorizationPlanMismatchReason
+{
+    Unspecified = 0,
+    ScopePlanAuthorityMismatch = 1,
+    ScopePlanVersionsMismatch = 2,
+    IntendedKeyOwnerMismatch = 3,
+    AuthenticatedActorMismatch = 4,
+    ScopePlanFreshnessMismatch = 5,
+    ScopePlanCompletenessMismatch = 6,
+    AllowedServiceIdsMismatch = 7,
+    AllowedNodeIdsMismatch = 8,
+    ServiceGrantCountMismatch = 9,
+    ServiceGrantIdentityMismatch = 10,
+    ServiceGrantResourceOwnerMismatch = 11,
+    ServiceGrantNodeMismatch = 12,
+}
+
+public static class ScheduledAuthorizationPlanMismatchReasons
+{
+    public static string? ToWireValue(ScheduledAuthorizationPlanMismatchReason reason) => reason switch
+    {
+        ScheduledAuthorizationPlanMismatchReason.ScopePlanAuthorityMismatch => "scope_plan_authority_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ScopePlanVersionsMismatch => "scope_plan_versions_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.IntendedKeyOwnerMismatch => "intended_key_owner_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.AuthenticatedActorMismatch => "authenticated_actor_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ScopePlanFreshnessMismatch => "scope_plan_freshness_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ScopePlanCompletenessMismatch => "scope_plan_completeness_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.AllowedServiceIdsMismatch => "allowed_service_ids_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch => "allowed_node_ids_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ServiceGrantCountMismatch => "service_grant_count_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ServiceGrantIdentityMismatch => "service_grant_identity_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ServiceGrantResourceOwnerMismatch => "service_grant_resource_owner_mismatch",
+        ScheduledAuthorizationPlanMismatchReason.ServiceGrantNodeMismatch => "service_grant_node_mismatch",
+        _ => null,
+    };
+}
+
 public enum NyxIdAuthorizationCatalogVisibilityStatus
 {
     Unspecified = 0,

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -1325,6 +1325,38 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
+    public async Task ScheduleMemberWorkflow_WhenAuthorizationPlanMismatchDuringCreate_ShouldReturnSanitizedReason()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort
+        {
+            CreateException = new StudioMemberAutomationPlanConflictException(
+                "authorization_plan_changed",
+                "private authorization planner detail owner-alpha node-a",
+                ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch),
+        };
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "member-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("authorization_plan_changed");
+        ErrorMessage(output).Should().Be("The authorization plan changed. Run schedule preflight again before retrying.");
+        ErrorAuthorizationPlanMismatchReason(output).Should().Be("allowed_node_ids_mismatch");
+        output.Should()
+            .NotContain("private authorization planner detail")
+            .And.NotContain("owner-alpha")
+            .And.NotContain("node-a");
+        schedulePort.WritePreflightRequests.Should().ContainSingle();
+        schedulePort.CreateCallCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task ScheduleMemberWorkflow_WhenScopeMissing_ShouldReturnStructuredErrorAndNotCallPort()
     {
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
@@ -1826,6 +1858,15 @@ public sealed class ProvisionWorkflowScheduleToolTests
         return document.RootElement.TryGetProperty("error", out var error)
             && error.TryGetProperty("message", out var message)
             ? message.GetString()
+            : null;
+    }
+
+    private static string? ErrorAuthorizationPlanMismatchReason(string output)
+    {
+        using var document = JsonDocument.Parse(output);
+        return document.RootElement.TryGetProperty("error", out var error)
+            && error.TryGetProperty("authorization_plan_mismatch_reason", out var reason)
+            ? reason.GetString()
             : null;
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentApiKeyIssuerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentApiKeyIssuerTests.cs
@@ -161,8 +161,13 @@ public sealed class ScheduledAgentApiKeyIssuerTests
 
         result.Success.Should().BeFalse();
         result.Error.Should().Be("authorization_plan_changed");
-        result.Detail.Should().Be("authorization_plan_changed:authenticated_actor_mismatch");
-        result.ToErrorJson().Should().NotContain("admin-alpha").And.NotContain("admin-other");
+        result.Detail.Should().BeNull();
+        result.AuthorizationPlanMismatchReason.Should()
+            .Be(ScheduledAuthorizationPlanMismatchReason.AuthenticatedActorMismatch);
+        result.ToErrorJson().Should()
+            .Contain("authenticated_actor_mismatch")
+            .And.NotContain("admin-alpha")
+            .And.NotContain("admin-other");
         handler.Requests.Should().ContainSingle().Which.Should().Be("/api/v1/api-keys/scope-plan");
     }
 
@@ -187,21 +192,25 @@ public sealed class ScheduledAgentApiKeyIssuerTests
 
         result.Success.Should().BeFalse();
         result.Error.Should().Be("authorization_plan_changed");
-        result.Detail.Should().Be("authorization_plan_changed:allowed_node_ids_mismatch");
-        result.ToErrorJson().Should().NotContain("node-other");
+        result.Detail.Should().BeNull();
+        result.AuthorizationPlanMismatchReason.Should()
+            .Be(ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch);
+        result.ToErrorJson().Should()
+            .Contain("allowed_node_ids_mismatch")
+            .And.NotContain("node-other");
         handler.Requests.Should().ContainSingle().Which.Should().Be("/api/v1/api-keys/scope-plan");
     }
 
     [Theory]
-    [InlineData("contract_version", "scope_plan_versions_mismatch")]
-    [InlineData("policy_version", "scope_plan_versions_mismatch")]
-    [InlineData("principal", "intended_key_owner_mismatch")]
-    [InlineData("service_identity", "allowed_service_ids_mismatch")]
-    [InlineData("resource_owner", "service_grant_resource_owner_mismatch")]
-    [InlineData("node_requirement", "allowed_node_ids_mismatch")]
+    [InlineData("contract_version", ScheduledAuthorizationPlanMismatchReason.ScopePlanVersionsMismatch)]
+    [InlineData("policy_version", ScheduledAuthorizationPlanMismatchReason.ScopePlanVersionsMismatch)]
+    [InlineData("principal", ScheduledAuthorizationPlanMismatchReason.IntendedKeyOwnerMismatch)]
+    [InlineData("service_identity", ScheduledAuthorizationPlanMismatchReason.AllowedServiceIdsMismatch)]
+    [InlineData("resource_owner", ScheduledAuthorizationPlanMismatchReason.ServiceGrantResourceOwnerMismatch)]
+    [InlineData("node_requirement", ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch)]
     public async Task IssueAsync_WhenCurrentScopeFactDiffersFromValidatedPlan_FailsBeforeCreate(
         string mismatch,
-        string expectedReason)
+        ScheduledAuthorizationPlanMismatchReason expectedReason)
     {
         var plan = ValidPlan();
         var scopePlanJson = PersonalScopePlanJson();
@@ -256,9 +265,11 @@ public sealed class ScheduledAgentApiKeyIssuerTests
 
         result.Success.Should().BeFalse();
         result.Error.Should().Be("authorization_plan_changed");
-        result.Detail.Should().Be($"authorization_plan_changed:{expectedReason}");
+        result.Detail.Should().BeNull();
+        result.AuthorizationPlanMismatchReason.Should().Be(expectedReason);
         result.ToErrorJson().Should()
-            .NotContain("owner-alpha")
+            .Contain(ScheduledAuthorizationPlanMismatchReasons.ToWireValue(expectedReason))
+            .And.NotContain("owner-alpha")
             .And.NotContain("owner-other")
             .And.NotContain("us-other")
             .And.NotContain("resource-other")

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentApiKeyIssuerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ScheduledAgentApiKeyIssuerTests.cs
@@ -161,6 +161,8 @@ public sealed class ScheduledAgentApiKeyIssuerTests
 
         result.Success.Should().BeFalse();
         result.Error.Should().Be("authorization_plan_changed");
+        result.Detail.Should().Be("authorization_plan_changed:authenticated_actor_mismatch");
+        result.ToErrorJson().Should().NotContain("admin-alpha").And.NotContain("admin-other");
         handler.Requests.Should().ContainSingle().Which.Should().Be("/api/v1/api-keys/scope-plan");
     }
 
@@ -185,18 +187,21 @@ public sealed class ScheduledAgentApiKeyIssuerTests
 
         result.Success.Should().BeFalse();
         result.Error.Should().Be("authorization_plan_changed");
+        result.Detail.Should().Be("authorization_plan_changed:allowed_node_ids_mismatch");
+        result.ToErrorJson().Should().NotContain("node-other");
         handler.Requests.Should().ContainSingle().Which.Should().Be("/api/v1/api-keys/scope-plan");
     }
 
     [Theory]
-    [InlineData("contract_version")]
-    [InlineData("policy_version")]
-    [InlineData("principal")]
-    [InlineData("service_identity")]
-    [InlineData("resource_owner")]
-    [InlineData("node_requirement")]
+    [InlineData("contract_version", "scope_plan_versions_mismatch")]
+    [InlineData("policy_version", "scope_plan_versions_mismatch")]
+    [InlineData("principal", "intended_key_owner_mismatch")]
+    [InlineData("service_identity", "allowed_service_ids_mismatch")]
+    [InlineData("resource_owner", "service_grant_resource_owner_mismatch")]
+    [InlineData("node_requirement", "allowed_node_ids_mismatch")]
     public async Task IssueAsync_WhenCurrentScopeFactDiffersFromValidatedPlan_FailsBeforeCreate(
-        string mismatch)
+        string mismatch,
+        string expectedReason)
     {
         var plan = ValidPlan();
         var scopePlanJson = PersonalScopePlanJson();
@@ -251,6 +256,13 @@ public sealed class ScheduledAgentApiKeyIssuerTests
 
         result.Success.Should().BeFalse();
         result.Error.Should().Be("authorization_plan_changed");
+        result.Detail.Should().Be($"authorization_plan_changed:{expectedReason}");
+        result.ToErrorJson().Should()
+            .NotContain("owner-alpha")
+            .And.NotContain("owner-other")
+            .And.NotContain("us-other")
+            .And.NotContain("resource-other")
+            .And.NotContain("node-a");
         handler.Requests.Should().ContainSingle().Which.Should().Be("/api/v1/api-keys/scope-plan");
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/StudioScheduledCredentialMaterializerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/StudioScheduledCredentialMaterializerTests.cs
@@ -86,6 +86,65 @@ public sealed class StudioScheduledCredentialMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_WhenAuthorizationPlanMismatch_ShouldPropagateTypedConflict()
+    {
+        var issuer = new RecordingIssuer
+        {
+            IssueResult = ScheduledAgentApiKeyIssueResult.Failed(
+                "authorization_plan_changed",
+                authorizationPlanMismatchReason: ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch),
+        };
+        var vault = new RecordingSecretVault();
+
+        var action = () => new StudioScheduledCredentialMaterializer(issuer, vault).MaterializeAsync(
+            "bearer-alpha",
+            Plan(AuthorizationOwnerKind.Personal, "owner-alpha"),
+            "schedule-alpha",
+            "operation-alpha",
+            EffectLocator("schedule-alpha", "operation-alpha"),
+            1,
+            OwnerScope.ForNyxIdNative("owner-alpha"));
+
+        var conflict = await action.Should().ThrowAsync<StudioMemberAutomationPlanConflictException>()
+            .WithMessage("authorization_plan_changed");
+        conflict.Which.Code.Should().Be("authorization_plan_changed");
+        conflict.Which.AuthorizationPlanMismatchReason.Should()
+            .Be(ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch);
+        vault.Stores.Should().BeEmpty();
+        issuer.Revocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MaterializeAsync_WhenAuthorizationPlanMismatchAfterIssue_ShouldCleanupAndPropagateTypedConflict()
+    {
+        var issuer = new RecordingIssuer
+        {
+            IssueResult = ScheduledAgentApiKeyIssueResult.FailedAfterIssue(
+                "api-key-alpha",
+                "authorization_plan_changed",
+                authorizationPlanMismatchReason: ScheduledAuthorizationPlanMismatchReason.AllowedServiceIdsMismatch),
+        };
+        var vault = new RecordingSecretVault();
+
+        var action = () => new StudioScheduledCredentialMaterializer(issuer, vault).MaterializeAsync(
+            "bearer-alpha",
+            Plan(AuthorizationOwnerKind.Personal, "owner-alpha"),
+            "schedule-alpha",
+            "operation-alpha",
+            EffectLocator("schedule-alpha", "operation-alpha"),
+            1,
+            OwnerScope.ForNyxIdNative("owner-alpha"));
+
+        var conflict = await action.Should().ThrowAsync<StudioMemberAutomationPlanConflictException>()
+            .WithMessage("authorization_plan_changed");
+        conflict.Which.AuthorizationPlanMismatchReason.Should()
+            .Be(ScheduledAuthorizationPlanMismatchReason.AllowedServiceIdsMismatch);
+        issuer.Revocations.Should().ContainSingle().Which.Should().Be(("bearer-alpha", "api-key-alpha"));
+        vault.Revocations.Should().ContainSingle().Which.SubjectId.Should().Be("api-key-alpha");
+        vault.Stores.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task MaterializeAsync_WhenVaultFails_ShouldRevokeIssuedKey()
     {
         var issuer = new RecordingIssuer

--- a/test/Aevatar.Studio.Tests/StudioMemberAutomationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberAutomationEndpointsTests.cs
@@ -348,17 +348,28 @@ public sealed class StudioMemberAutomationEndpointsTests
     }
 
     [Theory]
-    [InlineData("authorization_plan_changed", "TEAM_AUTOMATION_AUTHORIZATION_PLAN_CHANGED")]
-    [InlineData("reauthorization_required", "TEAM_AUTOMATION_REAUTHORIZATION_REQUIRED")]
+    [InlineData(
+        "authorization_plan_changed",
+        "TEAM_AUTOMATION_AUTHORIZATION_PLAN_CHANGED",
+        ScheduledAuthorizationPlanMismatchReason.AllowedNodeIdsMismatch,
+        "allowed_node_ids_mismatch")]
+    [InlineData(
+        "reauthorization_required",
+        "TEAM_AUTOMATION_REAUTHORIZATION_REQUIRED",
+        ScheduledAuthorizationPlanMismatchReason.Unspecified,
+        null)]
     public async Task Update_ShouldReturnTypedConflictWithCanonicalPreflightLocator(
         string conflictCode,
-        string expectedWireCode)
+        string expectedWireCode,
+        ScheduledAuthorizationPlanMismatchReason mismatchReason,
+        string? expectedMismatchReason)
     {
         var schedules = new StubSchedules
         {
             Exception = new StudioMemberAutomationPlanConflictException(
                 conflictCode,
-                "sensitive backend detail must not cross the boundary"),
+                "sensitive backend detail must not cross the boundary",
+                mismatchReason),
         };
 
         var result = await StudioMemberAutomationEndpoints.HandleUpdateAsync(
@@ -384,7 +395,13 @@ public sealed class StudioMemberAutomationEndpointsTests
         StringProperty(value, "code").Should().Be(expectedWireCode);
         StringProperty(value, "preflightLocator").Should().Be(
             $"/api/scopes/{ScopeId}/teams/{TeamId}/members/{MemberId}/automations/preflight");
-        JsonSerializer.Serialize(value).Should().NotContain("sensitive backend detail");
+        StringProperty(value, "authorizationPlanMismatchReason").Should().Be(expectedMismatchReason);
+        var serialized = JsonSerializer.Serialize(value, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        serialized.Should().NotContain("sensitive backend detail");
+        if (expectedMismatchReason is null)
+            serialized.Should().NotContain("authorizationPlanMismatchReason");
+        else
+            serialized.Should().Contain(expectedMismatchReason);
         AssertNoCredentialMaterial(value);
         schedules.LastUpdate.Should().NotBeNull();
         schedules.LastUpdate!.ScopeId.Should().Be(ScopeId);


### PR DESCRIPTION
## Summary
- Keep scheduled API key issuance fail-closed on authorization plan drift while returning a sanitized mismatch reason in `Detail`.
- Add warning diagnostics with only mismatch category and grant/node counts.
- Extend issuer tests to assert reason mapping and avoid leaking owner/service/node identities in error JSON.

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~ScheduledAgentApiKeyIssuerTests" --verbosity quiet -clp:ErrorsOnly`
- [ ] `bash tools/ci/test_stability_guards.sh` could not complete locally: Homebrew Python 3.12 `pyexpat` fails to load against system `libexpat`; earlier guard stages reported passed before the Python import crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)