### PR TITLE
Reject transformed Lark scope as schedule owner

### DIFF
--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/Aevatar.AI.ToolProviders.StudioProvisioning.csproj
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/Aevatar.AI.ToolProviders.StudioProvisioning.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 </Project>

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ProvisionWorkflowScheduleToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ProvisionWorkflowScheduleToolSource.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Studio.Application.Provisioning;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
@@ -94,10 +95,14 @@ public sealed class BindStudioMemberWorkflowToolSource : IAgentToolSource
 public sealed class ScheduleStudioMemberWorkflowToolSource : IAgentToolSource
 {
     private readonly IStudioMemberWorkflowSchedulePort? _schedulePort;
+    private readonly ILoggerFactory? _loggerFactory;
 
-    public ScheduleStudioMemberWorkflowToolSource(IStudioMemberWorkflowSchedulePort? schedulePort = null)
+    public ScheduleStudioMemberWorkflowToolSource(
+        IStudioMemberWorkflowSchedulePort? schedulePort = null,
+        ILoggerFactory? loggerFactory = null)
     {
         _schedulePort = schedulePort;
+        _loggerFactory = loggerFactory;
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
@@ -106,6 +111,8 @@ public sealed class ScheduleStudioMemberWorkflowToolSource : IAgentToolSource
         return Task.FromResult<IReadOnlyList<IAgentTool>>(
             _schedulePort is null
                 ? []
-                : [new ScheduleStudioMemberWorkflowTool(_schedulePort)]);
+                : [new ScheduleStudioMemberWorkflowTool(
+                    _schedulePort,
+                    _loggerFactory?.CreateLogger<ScheduleStudioMemberWorkflowTool>())]);
     }
 }

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -5,6 +5,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
 using Aevatar.Studio.Application.Provisioning;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
@@ -20,10 +21,14 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
     };
 
     private readonly IStudioMemberWorkflowSchedulePort _schedulePort;
+    private readonly ILogger<ScheduleStudioMemberWorkflowTool>? _logger;
 
-    public ScheduleStudioMemberWorkflowTool(IStudioMemberWorkflowSchedulePort schedulePort)
+    public ScheduleStudioMemberWorkflowTool(
+        IStudioMemberWorkflowSchedulePort schedulePort,
+        ILogger<ScheduleStudioMemberWorkflowTool>? logger = null)
     {
         _schedulePort = schedulePort ?? throw new ArgumentNullException(nameof(schedulePort));
+        _logger = logger;
     }
 
     public string Name => "aevatar_schedule_member_workflow";
@@ -84,6 +89,7 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
         var authorizationContext = StudioMemberWorkflowScheduleAuthorizationResolver.Resolve();
         if (authorizationContext.Error is { } authorizationError)
         {
+            LogAuthorizationResolutionFailure(authorizationError.Code);
             return ErrorJson(
                 authorizationError.Code,
                 authorizationError.Message);
@@ -231,6 +237,25 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
         _ => "The schedule request conflicts with the current authorization state.",
     };
 
+    private void LogAuthorizationResolutionFailure(string code)
+    {
+        if (_logger is null)
+            return;
+
+        var typedAuthority = AgentToolRequestContext.NyxIdAuthority;
+        _logger.LogWarning(
+            "Studio member workflow schedule authorization resolution failed: code={Code} has_typed_authority={HasTypedAuthority} has_binding_id={HasBindingId} has_sender_nyx_user_id={HasSenderNyxUserId} has_sender_tenant={HasSenderTenant} has_channel_platform={HasChannelPlatform} has_channel_sender_id={HasChannelSenderId} has_owner_subject={HasOwnerSubject} has_owner_scope_id={HasOwnerScopeId}",
+            code,
+            typedAuthority.IsComplete,
+            Normalize(AgentToolRequestContext.SenderBindingId) is not null,
+            Normalize(AgentToolRequestContext.SenderNyxUserId) is not null,
+            Normalize(AgentToolRequestContext.Current?.SenderBinding.SenderTenant) is not null,
+            Normalize(AgentToolRequestContext.ChannelPlatform) is not null,
+            Normalize(AgentToolRequestContext.ChannelSenderId) is not null,
+            Normalize(AgentToolRequestContext.OwnerSubject) is not null,
+            Normalize(AgentToolRequestContext.OwnerScopeId) is not null);
+    }
+
     private static string ErrorJson(
         string code,
         string message,
@@ -329,16 +354,6 @@ internal static class StudioMemberWorkflowScheduleAuthorizationResolver
     public static StudioMemberWorkflowScheduleAuthorizationResolution Resolve()
     {
         var typedAuthority = AgentToolRequestContext.NyxIdAuthority;
-        var ownerSubject = typedAuthority.IsComplete
-            ? Normalize(typedAuthority.ExternalUserId)
-            : Normalize(AgentToolRequestContext.OwnerSubject);
-        if (ownerSubject is null)
-        {
-            return StudioMemberWorkflowScheduleAuthorizationResolution.Failure(
-                "caller_subject_unavailable",
-                "owner subject is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
-        }
-
         var bindingId = Normalize(AgentToolRequestContext.SenderBindingId);
         if (bindingId is null)
         {
@@ -347,6 +362,11 @@ internal static class StudioMemberWorkflowScheduleAuthorizationResolver
                 "A verified NyxID binding is required to authorize a Team schedule.");
         }
 
+        var resolvedSubject = ResolveSubject(typedAuthority);
+        if (resolvedSubject.Error is { } error)
+            return error;
+
+        var subject = resolvedSubject.Subject!;
         var provisioningBearerToken = Normalize(AgentToolRequestContext.NyxIdAccessToken);
         if (provisioningBearerToken is null && !typedAuthority.IsComplete)
         {
@@ -355,40 +375,97 @@ internal static class StudioMemberWorkflowScheduleAuthorizationResolver
                 "A current NyxID credential is required to create the schedule credential.");
         }
 
-        var nyxUserId = typedAuthority.IsComplete
-            ? ownerSubject
-            : Normalize(AgentToolRequestContext.SenderNyxUserId) ?? ownerSubject;
-        var subjectPlatform = typedAuthority.IsComplete
-            ? Normalize(typedAuthority.Platform) ?? NyxIdAuthorizationAuthorities.NyxId
-            : Normalize(AgentToolRequestContext.ChannelPlatform) ?? NyxIdAuthorizationAuthorities.NyxId;
-        var subjectTenant = typedAuthority.IsComplete
-            ? Normalize(typedAuthority.Tenant) ?? string.Empty
-            : Normalize(AgentToolRequestContext.Current?.SenderBinding.SenderTenant) ??
-              Normalize(AgentToolRequestContext.ChannelRegistrationScopeId) ??
-              string.Empty;
-        var subjectExternalUserId = typedAuthority.IsComplete
-            ? ownerSubject
-            : Normalize(AgentToolRequestContext.ChannelSenderId) ?? ownerSubject;
-
         return StudioMemberWorkflowScheduleAuthorizationResolution.Success(
             new StudioMemberWorkflowScheduleAuthorizationContext(
-                OwnerSubject: nyxUserId,
+                OwnerSubject: subject.NyxUserId,
                 AuthenticatedOwner: new AuthenticatedAuthorizationOwnerContext(
                     new AuthorizationOwnerIdentity
                     {
                         Authority = NyxIdAuthorizationAuthorities.NyxId,
                         OwnerKind = AuthorizationOwnerKind.Personal,
-                        OwnerSubject = nyxUserId,
+                        OwnerSubject = subject.NyxUserId,
                     },
-                    subjectPlatform,
-                    subjectTenant,
-                    subjectExternalUserId,
+                    subject.Platform,
+                    subject.Tenant,
+                    subject.ExternalUserId,
                     bindingId),
                 ProvisioningBearerToken: provisioningBearerToken));
     }
 
+    private static StudioMemberWorkflowScheduleSubjectResolution ResolveSubject(
+        AgentToolNyxIdAuthorityContext typedAuthority)
+    {
+        if (typedAuthority.IsComplete)
+        {
+            var nyxUserId = Normalize(typedAuthority.ExternalUserId)!;
+            return StudioMemberWorkflowScheduleSubjectResolution.Success(
+                new StudioMemberWorkflowScheduleSubject(
+                    nyxUserId,
+                    Normalize(typedAuthority.Platform) ?? NyxIdAuthorizationAuthorities.NyxId,
+                    Normalize(typedAuthority.Tenant) ?? string.Empty,
+                    nyxUserId));
+        }
+
+        var senderNyxUserId = Normalize(AgentToolRequestContext.SenderNyxUserId);
+        if (senderNyxUserId is null)
+        {
+            return StudioMemberWorkflowScheduleSubjectResolution.Failure(
+                "caller_subject_unavailable",
+                "A caller NyxID user id is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        var channelPlatform = Normalize(AgentToolRequestContext.ChannelPlatform);
+        if (channelPlatform is null)
+        {
+            return StudioMemberWorkflowScheduleSubjectResolution.Failure(
+                "caller_subject_unavailable",
+                "A channel platform is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        var senderTenant = Normalize(AgentToolRequestContext.Current?.SenderBinding.SenderTenant);
+        if (senderTenant is null)
+        {
+            return StudioMemberWorkflowScheduleSubjectResolution.Failure(
+                "caller_subject_unavailable",
+                "A sender tenant is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        var channelSenderId = Normalize(AgentToolRequestContext.ChannelSenderId);
+        if (channelSenderId is null)
+        {
+            return StudioMemberWorkflowScheduleSubjectResolution.Failure(
+                "caller_subject_unavailable",
+                "A channel sender identity is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        return StudioMemberWorkflowScheduleSubjectResolution.Success(
+            new StudioMemberWorkflowScheduleSubject(
+                senderNyxUserId,
+                channelPlatform,
+                senderTenant,
+                channelSenderId));
+    }
+
     private static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}
+
+internal sealed record StudioMemberWorkflowScheduleSubject(
+    string NyxUserId,
+    string Platform,
+    string Tenant,
+    string ExternalUserId);
+
+internal sealed record StudioMemberWorkflowScheduleSubjectResolution(
+    StudioMemberWorkflowScheduleSubject? Subject,
+    StudioMemberWorkflowScheduleAuthorizationResolution? Error)
+{
+    public static StudioMemberWorkflowScheduleSubjectResolution Success(
+        StudioMemberWorkflowScheduleSubject subject) =>
+        new(subject, null);
+
+    public static StudioMemberWorkflowScheduleSubjectResolution Failure(string code, string message) =>
+        new(null, StudioMemberWorkflowScheduleAuthorizationResolution.Failure(code, message));
 }
 
 internal sealed record StudioMemberWorkflowScheduleAuthorizationResolution(

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -395,15 +395,19 @@ internal static class StudioMemberWorkflowScheduleAuthorizationResolver
     private static StudioMemberWorkflowScheduleSubjectResolution ResolveSubject(
         AgentToolNyxIdAuthorityContext typedAuthority)
     {
-        if (typedAuthority.IsComplete)
+        var typedPlatform = Normalize(typedAuthority.Platform);
+        var typedExternalUserId = Normalize(typedAuthority.ExternalUserId);
+        if (typedAuthority.IsComplete && string.Equals(
+                typedPlatform,
+                NyxIdAuthorizationAuthorities.NyxId,
+                StringComparison.Ordinal))
         {
-            var nyxUserId = Normalize(typedAuthority.ExternalUserId)!;
             return StudioMemberWorkflowScheduleSubjectResolution.Success(
                 new StudioMemberWorkflowScheduleSubject(
-                    nyxUserId,
-                    Normalize(typedAuthority.Platform) ?? NyxIdAuthorizationAuthorities.NyxId,
+                    typedExternalUserId!,
+                    typedPlatform!,
                     Normalize(typedAuthority.Tenant) ?? string.Empty,
-                    nyxUserId));
+                    typedExternalUserId!));
         }
 
         var senderNyxUserId = Normalize(AgentToolRequestContext.SenderNyxUserId);
@@ -412,6 +416,19 @@ internal static class StudioMemberWorkflowScheduleAuthorizationResolver
             return StudioMemberWorkflowScheduleSubjectResolution.Failure(
                 "caller_subject_unavailable",
                 "A caller NyxID user id is required in AgentToolRequestContext so the schedule can re-mint caller NyxID credentials when it fires.");
+        }
+
+        if (typedAuthority.IsComplete)
+        {
+            var typedTenant = Normalize(typedAuthority.Tenant) ??
+                              Normalize(AgentToolRequestContext.Current?.SenderBinding.SenderTenant) ??
+                              string.Empty;
+            return StudioMemberWorkflowScheduleSubjectResolution.Success(
+                new StudioMemberWorkflowScheduleSubject(
+                    senderNyxUserId,
+                    typedPlatform!,
+                    typedTenant,
+                    typedExternalUserId!));
         }
 
         var channelPlatform = Normalize(AgentToolRequestContext.ChannelPlatform);

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -11,6 +11,7 @@ using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning.Tests;
@@ -953,7 +954,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -971,7 +976,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
         schedulePort.LastRequest.ScheduleTimezone.Should().Be("Asia/Shanghai");
         schedulePort.LastRequest.Prompt.Should().Be("run digest");
         schedulePort.LastRequest.DisplayName.Should().Be("Daily digest");
-        schedulePort.LastRequest.CallerSubjectExternalUserId.Should().Be("owner-1");
+        schedulePort.LastRequest.CallerSubjectExternalUserId.Should().Be("nyx-user-alpha");
         schedulePort.LastRequest.OperationId.Should()
             .MatchRegex("^studio-member-workflow-create:[0-9a-f]{64}$");
         schedulePort.LastRequest.IdempotencyKey.Should()
@@ -1006,7 +1011,8 @@ public sealed class ProvisionWorkflowScheduleToolTests
             scopeId: "registration-scope",
             ownerSubject: "owner-1",
             accessToken: "access-token-1",
-            ownerScopeId: "owner-scope");
+            ownerScopeId: "owner-scope",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -1134,7 +1140,8 @@ public sealed class ProvisionWorkflowScheduleToolTests
                    accessToken: "access-token-1",
                    requestId: "transport-request-1",
                    callId: "tool-call-1",
-                   idempotencyKey: "caller-operation-1"))
+                   idempotencyKey: "caller-operation-1",
+                   nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha")))
         {
             ErrorCode(await tool.ExecuteAsync(arguments)).Should().BeNull();
         }
@@ -1145,7 +1152,8 @@ public sealed class ProvisionWorkflowScheduleToolTests
                    accessToken: "access-token-1",
                    requestId: "transport-request-2",
                    callId: "tool-call-2",
-                   idempotencyKey: "caller-operation-1"))
+                   idempotencyKey: "caller-operation-1",
+                   nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha")))
         {
             ErrorCode(await tool.ExecuteAsync(arguments)).Should().BeNull();
         }
@@ -1220,7 +1228,8 @@ public sealed class ProvisionWorkflowScheduleToolTests
             accessToken: "access-token-1",
             requestId: null,
             callId: null,
-            idempotencyKey: null);
+            idempotencyKey: null,
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
 
         var output = await tool.ExecuteAsync("""
             {
@@ -1252,7 +1261,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         };
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -1279,7 +1292,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         };
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -1306,7 +1323,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         };
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -1330,7 +1351,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         };
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -1357,7 +1382,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         };
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "member_id": "member-alpha",
@@ -1391,7 +1420,7 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
-    public async Task ScheduleMemberWorkflow_WhenOwnerSubjectMissing_ShouldReturnStructuredErrorAndNotCallPort()
+    public async Task ScheduleMemberWorkflow_WhenNyxIdCallerSubjectMissing_ShouldReturnStructuredErrorAndNotCallPort()
     {
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
@@ -1404,6 +1433,86 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
+    public async Task ScheduleMemberWorkflow_WhenLarkOwnerSubjectIsTransformedScopeAndSenderNyxUserMissing_ShouldFailBeforePreflight()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(
+            scopeId: "registration-scope",
+            ownerSubject: "rscope_transformed_owner",
+            accessToken: "access-token-1",
+            ownerScopeId: "rscope_transformed_owner",
+            senderBindingId: "binding-lark",
+            senderTenant: "tenant-lark",
+            channelPlatform: "lark",
+            channelSenderId: "ou_sender",
+            channelRegistrationScopeId: "rscope_transformed_owner");
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "m-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("caller_subject_unavailable");
+        output.Should().NotContain("rscope_transformed_owner");
+        schedulePort.PreflightRequests.Should().BeEmpty();
+        schedulePort.CreateRequests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_WhenAuthorizationResolutionFails_ShouldLogPrivacySafeDiagnostics()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var logger = new RecordingLogger<ScheduleStudioMemberWorkflowTool>();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort, logger);
+
+        using var _ = PushContext(
+            scopeId: "registration-scope",
+            ownerSubject: "owner-sensitive",
+            accessToken: "access-token-sensitive",
+            ownerScopeId: "owner-scope-sensitive",
+            senderBindingId: "binding-sensitive",
+            senderTenant: "tenant-sensitive",
+            channelPlatform: "lark-sensitive",
+            channelSenderId: "ou-sensitive",
+            channelRegistrationScopeId: "channel-scope-sensitive");
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "m-sensitive",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("caller_subject_unavailable");
+        var entry = logger.Entries.Should().ContainSingle().Subject;
+        entry.Level.Should().Be(LogLevel.Warning);
+        entry.Message.Should()
+            .Contain("code=caller_subject_unavailable")
+            .And.Contain("has_typed_authority=False")
+            .And.Contain("has_binding_id=True")
+            .And.Contain("has_sender_nyx_user_id=False")
+            .And.Contain("has_sender_tenant=True")
+            .And.Contain("has_channel_platform=True")
+            .And.Contain("has_channel_sender_id=True")
+            .And.Contain("has_owner_subject=True")
+            .And.Contain("has_owner_scope_id=True");
+        entry.Message.Should()
+            .NotContain("owner-sensitive")
+            .And.NotContain("access-token-sensitive")
+            .And.NotContain("owner-scope-sensitive")
+            .And.NotContain("binding-sensitive")
+            .And.NotContain("tenant-sensitive")
+            .And.NotContain("lark-sensitive")
+            .And.NotContain("ou-sensitive")
+            .And.NotContain("channel-scope-sensitive")
+            .And.NotContain("m-sensitive");
+    }
+
+    [Fact]
     public async Task ScheduleMemberWorkflow_WhenSenderBindingMissing_ShouldReturnAuthorizationContextUnavailable()
     {
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
@@ -1413,7 +1522,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
             scopeId: "scope-current",
             ownerSubject: "owner-1",
             accessToken: "access-token-1",
-            senderBindingId: null);
+            senderBindingId: null,
+            senderNyxUserId: "nyx-user-alpha",
+            senderTenant: "tenant-alpha",
+            channelPlatform: "lark",
+            channelSenderId: "ou-alpha");
         var output = await tool.ExecuteAsync("""{"member_id":"member-alpha","schedule_cron":"0 9 * * *","schedule_timezone":"Asia/Shanghai"}""");
 
         ErrorCode(output).Should().Be("authenticated_owner_context_unavailable");
@@ -1427,7 +1540,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-context", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-context",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""
             {
               "scope_id": "scope-model",
@@ -1448,7 +1565,11 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var schedulePort = new RecordingMemberWorkflowSchedulePort();
         var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync("""{"member_id":"member-alpha","schedule_cron":"0 9 * * *"}""");
 
         ErrorCode(output).Should().Be("invalid_arguments");
@@ -1816,8 +1937,12 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     private static async Task<IAgentTool> DiscoverScheduleMemberWorkflowToolAsync(
-        IStudioMemberWorkflowSchedulePort schedulePort)
+        IStudioMemberWorkflowSchedulePort schedulePort,
+        ILogger<ScheduleStudioMemberWorkflowTool>? logger = null)
     {
+        if (logger is not null)
+            return new ScheduleStudioMemberWorkflowTool(schedulePort, logger);
+
         var source = new ScheduleStudioMemberWorkflowToolSource(schedulePort);
         var tools = await source.DiscoverToolsAsync();
         return tools.Single(tool => tool.Name == ScheduleMemberWorkflowToolName);
@@ -1838,7 +1963,8 @@ public sealed class ProvisionWorkflowScheduleToolTests
             accessToken: "access-token-1",
             requestId: "request-shared",
             callId: "call-shared",
-            idempotencyKey: "caller-operation-shared");
+            idempotencyKey: "caller-operation-shared",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
         var output = await tool.ExecuteAsync(JsonSerializer.Serialize(new Dictionary<string, string>
         {
             ["member_id"] = memberId,
@@ -1962,6 +2088,29 @@ public sealed class ProvisionWorkflowScheduleToolTests
 
             LastRequest = request;
             return Task.FromResult(_result);
+        }
+    }
+
+    private sealed record RecordedLogEntry(LogLevel Level, string Message);
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<RecordedLogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull =>
+            null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new RecordedLogEntry(logLevel, formatter(state, exception)));
         }
     }
 

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -1093,6 +1093,68 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
+    public async Task ScheduleMemberWorkflow_WhenTypedLarkAuthorityPresent_ShouldKeepNyxIdOwnerSeparateFromChannelSubject()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(
+            scopeId: "registration-scope",
+            ownerSubject: "fallback-owner",
+            accessToken: "access-token-1",
+            ownerScopeId: "owner-scope",
+            senderBindingId: "binding-lark",
+            senderNyxUserId: "nyx-lark-user",
+            senderTenant: "tenant-binding",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("lark", "tenant-authority", "ou_authority"));
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "member-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().BeNull();
+        schedulePort.LastRequest.Should().NotBeNull();
+        schedulePort.LastRequest!.ScopeId.Should().Be("owner-scope");
+        var owner = schedulePort.LastRequest.AuthenticatedOwner;
+        owner.Owner.OwnerSubject.Should().Be("nyx-lark-user");
+        owner.SubjectPlatform.Should().Be("lark");
+        owner.SubjectTenant.Should().Be("tenant-authority");
+        owner.SubjectExternalUserId.Should().Be("ou_authority");
+        owner.VerifiedBindingId.Should().Be("binding-lark");
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_WhenTypedLarkAuthorityHasNoNyxIdOwner_ShouldFailBeforePreflight()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(
+            scopeId: "registration-scope",
+            ownerSubject: "fallback-owner",
+            accessToken: "access-token-1",
+            ownerScopeId: "owner-scope",
+            senderBindingId: "binding-lark",
+            senderTenant: "tenant-lark",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("lark", "tenant-authority", "ou_authority"));
+        var output = await tool.ExecuteAsync("""
+            {
+              "member_id": "member-alpha",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "Asia/Shanghai"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("caller_subject_unavailable");
+        output.Should().NotContain("ou_authority");
+        schedulePort.PreflightRequests.Should().BeEmpty();
+        schedulePort.CreateRequests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ScheduleMemberWorkflow_WhenBearerMissingAndTypedNyxIdAuthorityPresent_ShouldDeferTokenIssuanceToPort()
     {
         var schedulePort = new RecordingMemberWorkflowSchedulePort();


### PR DESCRIPTION
## Summary
- Stop using transformed Studio/Lark resource scope fields as the NyxID credential owner for member workflow schedules.
- Require typed NyxID authority or sender binding NyxID identity before schedule preflight/create.
- Add privacy-safe diagnostics for incomplete schedule authorization context.

## Test plan
- [x] dotnet test test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj --nologo
- [x] bash tools/ci/workflow_binding_boundary_guard.sh
- [ ] bash tools/ci/test_stability_guards.sh (blocked locally by Python pyexpat/libexpat ImportError after polling and coverage subchecks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)