### PR TITLE
Preserve workflow file refs across chat inputs

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -535,7 +535,7 @@ public sealed class AgentProfileTurnCatalogMaterializer
         ToolSetResolveResult resolved;
         try
         {
-            resolved = _toolSetRegistry.Resolve(new ChatRouteToolSetRef { Name = toolSetName ?? string.Empty });
+            resolved = _toolSetRegistry.Resolve(toolSetName);
         }
         catch (Exception)
         {

--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
@@ -308,16 +308,11 @@ public sealed class ChannelWorkflowDraftRunInteractionPort : IChannelWorkflowDra
                 throw new WorkflowAttachmentIngressException("ingress_failed", ex);
             }
 
-            inputParts.Add(new WorkflowChatInputPart
-            {
-                Kind = attachment.Kind == AttachmentKind.Image
+            inputParts.Add(WorkflowChatInputParts.FromFileRef(
+                ingress.FileRef,
+                attachment.Kind == AttachmentKind.Image
                     ? WorkflowChatInputPartKind.Image
-                    : WorkflowChatInputPartKind.Text,
-                MediaType = ingress.FileRef.MediaType,
-                Uri = ingress.FileRef.ArtifactId,
-                Name = ingress.FileRef.FileName,
-                FileRef = ingress.FileRef,
-            });
+                    : WorkflowChatInputPartKind.File));
         }
 
         return inputParts;

--- a/src/Aevatar.AI.ToolProviders.ToolSetRegistry/Aevatar.AI.ToolProviders.ToolSetRegistry.csproj
+++ b/src/Aevatar.AI.ToolProviders.ToolSetRegistry/Aevatar.AI.ToolProviders.ToolSetRegistry.csproj
@@ -10,7 +10,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
-        <ProjectReference Include="..\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Aevatar.AI.ToolProviders.ToolSetRegistry/IToolSetRegistry.cs
+++ b/src/Aevatar.AI.ToolProviders.ToolSetRegistry/IToolSetRegistry.cs
@@ -7,10 +7,18 @@ public interface IToolSetRegistry
 {
     IReadOnlyList<string> GetRegisteredNames();
 
-    ToolSetResolveResult Resolve(string? name) =>
-        Resolve(new ChatRouteToolSetRef { Name = name ?? string.Empty });
+    ToolSetResolveResult Resolve(string? name);
+}
 
-    ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef);
+public static class ToolSetRegistryExtensions
+{
+    public static ToolSetResolveResult Resolve(
+        this IToolSetRegistry registry,
+        ChatRouteToolSetRef? toolSetRef)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        return registry.Resolve(toolSetRef?.Name);
+    }
 }
 
 public sealed class ToolSetResolveResult

--- a/src/Aevatar.AI.ToolProviders.ToolSetRegistry/IToolSetRegistry.cs
+++ b/src/Aevatar.AI.ToolProviders.ToolSetRegistry/IToolSetRegistry.cs
@@ -1,5 +1,4 @@
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.ChatRouting.Abstractions;
 
 namespace Aevatar.AI.ToolProviders.ToolSetRegistry;
 
@@ -8,17 +7,6 @@ public interface IToolSetRegistry
     IReadOnlyList<string> GetRegisteredNames();
 
     ToolSetResolveResult Resolve(string? name);
-}
-
-public static class ToolSetRegistryExtensions
-{
-    public static ToolSetResolveResult Resolve(
-        this IToolSetRegistry registry,
-        ChatRouteToolSetRef? toolSetRef)
-    {
-        ArgumentNullException.ThrowIfNull(registry);
-        return registry.Resolve(toolSetRef?.Name);
-    }
 }
 
 public sealed class ToolSetResolveResult

--- a/src/Aevatar.AI.ToolProviders.ToolSetRegistry/ToolSetRegistry.cs
+++ b/src/Aevatar.AI.ToolProviders.ToolSetRegistry/ToolSetRegistry.cs
@@ -1,5 +1,4 @@
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.ChatRouting.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Aevatar.AI.ToolProviders.ToolSetRegistry;
@@ -37,9 +36,9 @@ public sealed class ToolSetRegistry : IToolSetRegistry
 
     public IReadOnlyList<string> GetRegisteredNames() => _registeredNames;
 
-    public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+    public ToolSetResolveResult Resolve(string? name)
     {
-        var name = toolSetRef?.Name?.Trim() ?? string.Empty;
+        name = name?.Trim() ?? string.Empty;
         if (string.IsNullOrWhiteSpace(name))
         {
             return ToolSetResolveResult.Failure(new ToolSetResolveError(

--- a/src/Aevatar.Mainnet.Host.Api/Status/AevatarCoreLoopStatusProbeExecutor.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Status/AevatarCoreLoopStatusProbeExecutor.cs
@@ -41,7 +41,7 @@ internal sealed class AevatarCoreLoopStatusProbeExecutor : IHealthProbeExecutor
         ToolSetResolveResult toolSet;
         try
         {
-            toolSet = _toolSetRegistry.Resolve(new ChatRouteToolSetRef { Name = toolSetName });
+            toolSet = _toolSetRegistry.Resolve(toolSetName);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/LlmRunCore.cs
@@ -202,7 +202,7 @@ public sealed class LlmRunCore(
 
         try
         {
-            var resolved = toolSetRegistry.Resolve(new ChatRouteToolSetRef { Name = toolSetName });
+            var resolved = toolSetRegistry.Resolve(toolSetName);
             if (resolved.IsSuccess)
                 return toolProviders.Append(new ToolSetResponsesToolProvider(resolved.Sources, logger));
 

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesDirectToolPlanService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesDirectToolPlanService.cs
@@ -50,7 +50,7 @@ public sealed class ResponsesDirectToolPlanService(
         if (forwardToModel.ToolSetRef is not null &&
             !string.IsNullOrWhiteSpace(forwardToModel.ToolSetRef.Name))
         {
-            var toolSet = toolSetRegistry.Resolve(forwardToModel.ToolSetRef);
+            var toolSet = toolSetRegistry.Resolve(forwardToModel.ToolSetRef.Name);
             if (!toolSet.IsSuccess)
             {
                 var error = toolSet.Error!;

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatInputParts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatInputParts.cs
@@ -1,0 +1,46 @@
+namespace Aevatar.Workflow.Application.Abstractions.Runs;
+
+public static class WorkflowChatInputParts
+{
+    public static WorkflowChatInputPart FromFileRef(
+        FileArtifactRef fileRef,
+        WorkflowChatInputPartKind? preferredKind = null)
+    {
+        ArgumentNullException.ThrowIfNull(fileRef);
+        if (string.IsNullOrWhiteSpace(fileRef.FileId) && string.IsNullOrWhiteSpace(fileRef.ArtifactId))
+            throw new ArgumentException("Workflow chat file input requires fileId or artifactId.", nameof(fileRef));
+
+        return new WorkflowChatInputPart
+        {
+            Kind = preferredKind ?? ResolveKind(fileRef.MediaType),
+            Uri = ResolveUri(fileRef),
+            MediaType = Normalize(fileRef.MediaType),
+            Name = Normalize(fileRef.FileName),
+            FileRef = fileRef,
+        };
+    }
+
+    private static WorkflowChatInputPartKind ResolveKind(string? mediaType)
+    {
+        var normalized = Normalize(mediaType);
+        if (normalized == null)
+            return WorkflowChatInputPartKind.File;
+        if (normalized.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+            return WorkflowChatInputPartKind.Image;
+        if (normalized.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
+            return WorkflowChatInputPartKind.Audio;
+        if (normalized.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
+            return WorkflowChatInputPartKind.Video;
+
+        return WorkflowChatInputPartKind.File;
+    }
+
+    private static string? ResolveUri(FileArtifactRef fileRef) =>
+        Normalize(fileRef.ArtifactId) ??
+        (string.IsNullOrWhiteSpace(fileRef.FileId)
+            ? null
+            : $"workflow-file://{fileRef.FileId.Trim()}");
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -796,7 +796,7 @@ public sealed partial class WorkflowRunGAgent
         if (fileRefs.Count == 0 || _fileArtifactOwnership == null)
             return true;
 
-        foreach (var fileRef in fileRefs.Where(static x => !string.IsNullOrWhiteSpace(x.ArtifactId)))
+        foreach (var fileRef in fileRefs)
         {
             try
             {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -489,16 +489,7 @@ internal static class ChatRunRequestNormalizer
             if (!TryParseContentPartKind(part.Type, out var kind))
                 continue;
 
-            ingested.Add(new WorkflowChatInputPart
-            {
-                Kind = kind,
-                Text = string.IsNullOrWhiteSpace(part.Text) ? null : part.Text,
-                DataBase64 = fileInputResult.DataBase64 ?? NormalizeContentPartValue(part.DataBase64),
-                MediaType = fileInputResult.MediaType ?? NormalizeContentPartValue(part.MediaType),
-                Uri = fileInputResult.Uri ?? NormalizeContentPartValue(part.Uri),
-                Name = fileInputResult.Name ?? NormalizeContentPartValue(part.Name),
-                FileRef = fileInputResult.FileRef,
-            });
+            ingested.Add(BuildWorkflowInputPart(part, kind, fileInputResult));
         }
 
         return new InputPartsNormalizationResult(
@@ -527,16 +518,7 @@ internal static class ChatRunRequestNormalizer
             if (!TryParseContentPartKind(part.Type, out var kind))
                 continue;
 
-            normalized.Add(new WorkflowChatInputPart
-            {
-                Kind = kind,
-                Text = string.IsNullOrWhiteSpace(part.Text) ? null : part.Text,
-                DataBase64 = fileInputResult.DataBase64 ?? NormalizeContentPartValue(part.DataBase64),
-                MediaType = fileInputResult.MediaType ?? NormalizeContentPartValue(part.MediaType),
-                Uri = fileInputResult.Uri ?? NormalizeContentPartValue(part.Uri),
-                Name = fileInputResult.Name ?? NormalizeContentPartValue(part.Name),
-                FileRef = fileInputResult.FileRef,
-            });
+            normalized.Add(BuildWorkflowInputPart(part, kind, fileInputResult));
         }
 
         return new InputPartsNormalizationResult(
@@ -551,6 +533,34 @@ internal static class ChatRunRequestNormalizer
         string? Name,
         FileArtifactRef? FileRef,
         WorkflowChatRunStartError Error);
+
+    private static WorkflowChatInputPart BuildWorkflowInputPart(
+        ChatInputContentPart part,
+        WorkflowChatInputPartKind kind,
+        FileInputNormalizationResult fileInputResult)
+    {
+        if (fileInputResult.FileRef is not null)
+        {
+            var filePart = WorkflowChatInputParts.FromFileRef(fileInputResult.FileRef, kind);
+            return filePart with
+            {
+                Text = string.IsNullOrWhiteSpace(part.Text) ? null : part.Text,
+                MediaType = filePart.MediaType ?? NormalizeContentPartValue(part.MediaType),
+                Uri = filePart.Uri ?? NormalizeContentPartValue(part.Uri),
+                Name = filePart.Name ?? NormalizeContentPartValue(part.Name),
+            };
+        }
+
+        return new WorkflowChatInputPart
+        {
+            Kind = kind,
+            Text = string.IsNullOrWhiteSpace(part.Text) ? null : part.Text,
+            DataBase64 = fileInputResult.DataBase64 ?? NormalizeContentPartValue(part.DataBase64),
+            MediaType = fileInputResult.MediaType ?? NormalizeContentPartValue(part.MediaType),
+            Uri = fileInputResult.Uri ?? NormalizeContentPartValue(part.Uri),
+            Name = fileInputResult.Name ?? NormalizeContentPartValue(part.Name),
+        };
+    }
 
     private static FileInputNormalizationResult NormalizeFileInput(ChatInputContentPart part)
     {

--- a/src/workflow/Aevatar.Workflow.Integration.AI/Aevatar.Workflow.Integration.AI.csproj
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/Aevatar.Workflow.Integration.AI.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\Aevatar.AI.ToolProviders.ToolSetRegistry\Aevatar.AI.ToolProviders.ToolSetRegistry.csproj" />
+    <ProjectReference Include="..\..\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Abstractions\Aevatar.Workflow.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Core\Aevatar.Workflow.Core.csproj" />

--- a/src/workflow/Aevatar.Workflow.Integration.AI/Aevatar.Workflow.Integration.AI.csproj
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/Aevatar.Workflow.Integration.AI.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\Aevatar.AI.ToolProviders.ToolSetRegistry\Aevatar.AI.ToolProviders.ToolSetRegistry.csproj" />
-    <ProjectReference Include="..\..\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Abstractions\Aevatar.Workflow.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Core\Aevatar.Workflow.Core.csproj" />

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -443,8 +443,40 @@ public class WorkflowRoleGAgent(
             Uri = ResolveFileRefUri(fileRef),
             MediaType = Normalize(fileRef.MediaType) ?? string.Empty,
             Name = Normalize(fileRef.FileName) ?? string.Empty,
+            FileRef = ToChatFileRef(fileRef),
         };
     }
+
+    private static Aevatar.AI.Abstractions.ChatFileRef ToChatFileRef(WorkflowFileRef fileRef) =>
+        new()
+        {
+            FileId = Normalize(fileRef.FileId) ?? string.Empty,
+            ArtifactId = Normalize(fileRef.ArtifactId) ?? string.Empty,
+            SourceKind = ToChatFileSourceKind(fileRef.SourceKind),
+            SourceMessageId = Normalize(fileRef.SourceMessageId) ?? string.Empty,
+            SourceResourceKey = Normalize(fileRef.SourceResourceKey) ?? string.Empty,
+            FileName = Normalize(fileRef.FileName) ?? string.Empty,
+            MediaType = Normalize(fileRef.MediaType) ?? string.Empty,
+            SizeBytes = fileRef.SizeBytes,
+            Sha256 = Normalize(fileRef.Sha256) ?? string.Empty,
+            CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+            ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+            OwnerRunId = Normalize(fileRef.OwnerRunId) ?? string.Empty,
+            OwnerScopeId = Normalize(fileRef.OwnerScopeId) ?? string.Empty,
+        };
+
+    private static Aevatar.AI.Abstractions.ChatFileSourceKind ToChatFileSourceKind(
+        WorkflowFileSourceKind sourceKind) =>
+        sourceKind switch
+        {
+            WorkflowFileSourceKind.ChatInput => Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput,
+            WorkflowFileSourceKind.FormUpload => Aevatar.AI.Abstractions.ChatFileSourceKind.FormUpload,
+            WorkflowFileSourceKind.ConnectedServiceResource =>
+                Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+            WorkflowFileSourceKind.ExternalResource => Aevatar.AI.Abstractions.ChatFileSourceKind.ExternalResource,
+            WorkflowFileSourceKind.Generated => Aevatar.AI.Abstractions.ChatFileSourceKind.Generated,
+            _ => Aevatar.AI.Abstractions.ChatFileSourceKind.Unspecified,
+        };
 
     private static ChatContentPartKind ResolveChatContentPartKind(string? mediaType)
     {

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -1537,9 +1537,9 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
 
         public IReadOnlyList<string> GetRegisteredNames() => _sources.Keys.ToArray();
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        public ToolSetResolveResult Resolve(string? name)
         {
-            var name = toolSetRef?.Name ?? string.Empty;
+            name ??= string.Empty;
             ResolveCalls.Add(name);
             return _sources.TryGetValue(name, out var sources)
                 ? ToolSetResolveResult.Success(name, sources)
@@ -1555,7 +1555,7 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => [];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+        public ToolSetResolveResult Resolve(string? name) =>
             throw new InvalidOperationException("resolve failed");
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -2846,10 +2846,10 @@ public class NyxIdChatGAgentTests
 
         public IReadOnlyList<string> GetRegisteredNames() => [];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        public ToolSetResolveResult Resolve(string? name)
         {
             ResolveCount++;
-            var name = toolSetRef?.Name ?? string.Empty;
+            name ??= string.Empty;
             return ToolSetResolveResult.Failure(new ToolSetResolveError(
                 ToolSetResolveError.UnknownNameCode,
                 name,
@@ -2866,14 +2866,14 @@ public class NyxIdChatGAgentTests
 
         public IReadOnlyList<string> GetRegisteredNames() => [name];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        public ToolSetResolveResult Resolve(string? requestedName)
         {
             ResolveCount++;
-            return string.Equals(toolSetRef?.Name, name, StringComparison.Ordinal)
+            return string.Equals(requestedName, name, StringComparison.Ordinal)
                 ? ToolSetResolveResult.Success(name, [new StaticToolSource(tools)])
                 : ToolSetResolveResult.Failure(new ToolSetResolveError(
                     ToolSetResolveError.UnknownNameCode,
-                    toolSetRef?.Name ?? string.Empty,
+                    requestedName ?? string.Empty,
                     "missing",
                     GetRegisteredNames()));
         }
@@ -2885,12 +2885,12 @@ public class NyxIdChatGAgentTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => [name];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
-            string.Equals(toolSetRef?.Name, name, StringComparison.Ordinal)
+        public ToolSetResolveResult Resolve(string? requestedName) =>
+            string.Equals(requestedName, name, StringComparison.Ordinal)
                 ? ToolSetResolveResult.Success(name, [source])
                 : ToolSetResolveResult.Failure(new ToolSetResolveError(
                     ToolSetResolveError.UnknownNameCode,
-                    toolSetRef?.Name ?? string.Empty,
+                    requestedName ?? string.Empty,
                     "missing",
                     GetRegisteredNames()));
     }
@@ -2927,9 +2927,9 @@ public class NyxIdChatGAgentTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => ["profile.route"];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+        public ToolSetResolveResult Resolve(string? name) =>
             ToolSetResolveResult.Success(
-                toolSetRef?.Name ?? string.Empty,
+                name ?? string.Empty,
                 [new StaticToolSource([new ThrowingNameTool()])]);
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatProfileRolloutEvaluationTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProfileRolloutEvaluationTests.cs
@@ -1034,12 +1034,12 @@ public sealed class NyxIdChatProfileRolloutEvaluationTests
 
         public IReadOnlyList<string> GetRegisteredNames() => [_name];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
-            string.Equals(toolSetRef?.Name, _name, StringComparison.Ordinal)
+        public ToolSetResolveResult Resolve(string? name) =>
+            string.Equals(name, _name, StringComparison.Ordinal)
                 ? ToolSetResolveResult.Success(_name, _sources)
                 : ToolSetResolveResult.Failure(new ToolSetResolveError(
                     ToolSetResolveError.UnknownNameCode,
-                    toolSetRef?.Name ?? string.Empty,
+                    name ?? string.Empty,
                     "missing",
                     GetRegisteredNames()));
     }

--- a/test/Aevatar.AI.ToolProviders.ToolSetRegistry.Tests/ToolSetRegistryTests.cs
+++ b/test/Aevatar.AI.ToolProviders.ToolSetRegistry.Tests/ToolSetRegistryTests.cs
@@ -1,5 +1,4 @@
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.ChatRouting.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -24,7 +23,7 @@ public sealed class ToolSetRegistryTests
         using var provider = services.BuildServiceProvider();
         var registry = provider.GetRequiredService<IToolSetRegistry>();
 
-        var result = registry.Resolve(new ChatRouteToolSetRef { Name = " test.default " });
+        var result = registry.Resolve(" test.default ");
 
         result.IsSuccess.Should().BeTrue();
         result.Error.Should().BeNull();
@@ -54,7 +53,7 @@ public sealed class ToolSetRegistryTests
         using var provider = services.BuildServiceProvider();
         var registry = provider.GetRequiredService<IToolSetRegistry>();
 
-        var result = registry.Resolve(new ChatRouteToolSetRef { Name = "lark.self_notify" });
+        var result = registry.Resolve("lark.self_notify");
 
         result.IsSuccess.Should().BeTrue();
         result.Name.Should().Be("lark.self_notify");
@@ -77,7 +76,7 @@ public sealed class ToolSetRegistryTests
         using var provider = services.BuildServiceProvider();
         var registry = provider.GetRequiredService<IToolSetRegistry>();
 
-        var act = () => registry.Resolve(new ChatRouteToolSetRef { Name = "lark.self_notify" });
+        var act = () => registry.Resolve("lark.self_notify");
 
         act.Should()
             .Throw<InvalidOperationException>()
@@ -95,7 +94,7 @@ public sealed class ToolSetRegistryTests
         using var provider = services.BuildServiceProvider();
         var registry = provider.GetRequiredService<IToolSetRegistry>();
 
-        var result = registry.Resolve(new ChatRouteToolSetRef { Name = "missing.set" });
+        var result = registry.Resolve("missing.set");
 
         result.IsSuccess.Should().BeFalse();
         result.Sources.Should().BeEmpty();
@@ -119,7 +118,7 @@ public sealed class ToolSetRegistryTests
         using var provider = services.BuildServiceProvider();
         var registry = provider.GetRequiredService<IToolSetRegistry>();
 
-        var result = registry.Resolve(name is null ? null : new ChatRouteToolSetRef { Name = name });
+        var result = registry.Resolve(name);
 
         result.IsSuccess.Should().BeFalse();
         result.Error.Should().NotBeNull();

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -213,7 +213,7 @@ public sealed class MainnetHostCompositionTests
             var registry = app.Services.GetRequiredService<IToolSetRegistry>();
 
             registry.GetRegisteredNames().Should().Contain("profile.route.v1");
-            registry.Resolve(new ChatRouteToolSetRef { Name = "profile.route.v1" })
+            registry.Resolve("profile.route.v1")
                 .IsSuccess.Should().BeTrue();
         }
         finally
@@ -639,7 +639,7 @@ public sealed class MainnetHostCompositionTests
             ToolSetNames.NyxIdConnectedServices,
             ToolSetNames.WorkspaceDefault);
 
-        var workspace = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.WorkspaceDefault });
+        var workspace = registry.Resolve(ToolSetNames.WorkspaceDefault);
         workspace.IsSuccess.Should().BeTrue(workspace.Error?.Message);
         workspace.Sources.Should().Contain(source => source is InvokeGAgentToolSource);
         workspace.Sources.Should().Contain(source => source is InvokeTeamToolSource);
@@ -708,23 +708,23 @@ public sealed class MainnetHostCompositionTests
         }
         workflowToolNames.Should().ContainSingle(name => name == "workflow_connected_service_resource_fetch");
 
-        var larkSelfNotify = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.LarkSelfNotify });
+        var larkSelfNotify = registry.Resolve(ToolSetNames.LarkSelfNotify);
         larkSelfNotify.IsSuccess.Should().BeTrue(larkSelfNotify.Error?.Message);
         larkSelfNotify.Sources.Select(static source => source.GetType()).Should()
             .Equal(workspace.Sources.Select(static source => source.GetType()));
         larkSelfNotify.Sources.Should().Contain(source => source is LarkAgentToolSource);
         larkSelfNotify.Sources.Should().Contain(source => source is NyxIdAgentToolSource);
 
-        var nyxIdConnectedServices = registry.Resolve(new ChatRouteToolSetRef { Name = ToolSetNames.NyxIdConnectedServices });
+        var nyxIdConnectedServices = registry.Resolve(ToolSetNames.NyxIdConnectedServices);
         nyxIdConnectedServices.IsSuccess.Should().BeTrue(nyxIdConnectedServices.Error?.Message);
         nyxIdConnectedServices.Sources.Should().ContainSingle(source => source is NyxIdConnectedServiceToolSource);
         workspace.Sources.Should().NotContain(source => source is NyxIdConnectedServiceToolSource);
 
-        var voice = registry.Resolve(new ChatRouteToolSetRef { Name = "voice.realtime" });
+        var voice = registry.Resolve("voice.realtime");
         voice.IsSuccess.Should().BeFalse();
         voice.Error!.Code.Should().Be(ToolSetResolveError.UnknownNameCode);
 
-        var unknown = registry.Resolve(new ChatRouteToolSetRef { Name = "missing.set" });
+        var unknown = registry.Resolve("missing.set");
         unknown.IsSuccess.Should().BeFalse();
         unknown.Error!.Code.Should().Be(ToolSetResolveError.UnknownNameCode);
     }

--- a/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/NyxIdChatAgentProfileOptionsTests.cs
@@ -797,12 +797,12 @@ public sealed class NyxIdChatAgentProfileOptionsTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => names;
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
-            names.Contains(toolSetRef?.Name, StringComparer.Ordinal)
-                ? ToolSetResolveResult.Success(toolSetRef!.Name, [])
+        public ToolSetResolveResult Resolve(string? name) =>
+            names.Contains(name, StringComparer.Ordinal)
+                ? ToolSetResolveResult.Success(name!, [])
                 : ToolSetResolveResult.Failure(new ToolSetResolveError(
                     ToolSetResolveError.UnknownNameCode,
-                    toolSetRef?.Name ?? string.Empty,
+                    name ?? string.Empty,
                     "Unknown test tool set.",
                     names));
     }

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -1167,11 +1167,11 @@ public sealed class ResponsesCommandFacadeTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => [];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+        public ToolSetResolveResult Resolve(string? name) =>
             ToolSetResolveResult.Failure(new ToolSetResolveError(
                 ToolSetResolveError.UnknownNameCode,
-                toolSetRef?.Name ?? string.Empty,
-                $"Tool set '{toolSetRef?.Name}' is not registered.",
+                name ?? string.Empty,
+                $"Tool set '{name}' is not registered.",
                 []));
     }
 
@@ -1179,9 +1179,9 @@ public sealed class ResponsesCommandFacadeTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => ["workspace.default"];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+        public ToolSetResolveResult Resolve(string? name) =>
             ToolSetResolveResult.Success(
-                toolSetRef?.Name ?? "workspace.default",
+                name ?? "workspace.default",
                 [new StaticAgentToolSource(tools)]);
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesDirectToolPlanServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesDirectToolPlanServiceTests.cs
@@ -94,7 +94,7 @@ public sealed class ResponsesDirectToolPlanServiceTests
     {
         public IReadOnlyList<string> GetRegisteredNames() => ["workspace.default"];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
+        public ToolSetResolveResult Resolve(string? name) =>
             ToolSetResolveResult.Success("workspace.default", sources);
     }
 

--- a/test/Aevatar.GAgentService.Tests/TestSupport/TestToolSetRegistry.cs
+++ b/test/Aevatar.GAgentService.Tests/TestSupport/TestToolSetRegistry.cs
@@ -1,5 +1,4 @@
 using Aevatar.AI.ToolProviders.ToolSetRegistry;
-using Aevatar.ChatRouting.Abstractions;
 
 namespace Aevatar.GAgentService.Tests.TestSupport;
 
@@ -16,6 +15,6 @@ internal sealed class TestToolSetRegistry(Func<string, ToolSetResolveResult> res
 
     public IReadOnlyList<string> GetRegisteredNames() => [];
 
-    public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef) =>
-        resolver(toolSetRef?.Name?.Trim() ?? string.Empty);
+    public ToolSetResolveResult Resolve(string? name) =>
+        resolver(name?.Trim() ?? string.Empty);
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
@@ -254,8 +254,12 @@ public sealed class ChannelWorkflowDraftRunTests
         workflowRequest.InputParts[0].FileRef!.SourceMessageId.Should().Be("om_123");
         workflowRequest.InputParts[0].FileRef!.SourceResourceKey.Should().Be("img_v3_1");
         workflowRequest.InputParts[0].FileRef!.MediaType.Should().Be("image/png");
-        workflowRequest.InputParts[1].Kind.Should().Be(WorkflowChatInputPartKind.Text);
+        workflowRequest.InputParts[1].Kind.Should().Be(WorkflowChatInputPartKind.File);
         workflowRequest.InputParts[1].DataBase64.Should().BeNull();
+        workflowRequest.InputParts[1].Uri.Should().NotBeNullOrWhiteSpace();
+        workflowRequest.InputParts[1].FileRef.Should().NotBeNull();
+        workflowRequest.InputParts[1].FileRef!.SourceKind.Should().Be(FileArtifactSourceKind.ConnectedServiceResource);
+        workflowRequest.InputParts[1].FileRef!.SourceMessageId.Should().Be("om_123");
         workflowRequest.InputParts[1].FileRef!.SourceResourceKey.Should().Be("file_v3_1");
         workflowRequest.InputParts[1].FileRef!.MediaType.Should().Be("application/pdf");
 

--- a/test/Aevatar.Integration.Tests/WorkflowRoleGAgentInteractionTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowRoleGAgentInteractionTests.cs
@@ -955,12 +955,12 @@ public sealed class WorkflowRoleGAgentInteractionTests : WorkflowGAgentTestBase
         {
             public IReadOnlyList<string> GetRegisteredNames() => [name];
 
-            public ToolSetResolveResult Resolve(Aevatar.ChatRouting.Abstractions.ChatRouteToolSetRef? toolSetRef) =>
-                string.Equals(toolSetRef?.Name, name, StringComparison.Ordinal)
+            public ToolSetResolveResult Resolve(string? requestedName) =>
+                string.Equals(requestedName, name, StringComparison.Ordinal)
                     ? ToolSetResolveResult.Success(name, [source])
                     : ToolSetResolveResult.Failure(new ToolSetResolveError(
                         ToolSetResolveError.UnknownNameCode,
-                        toolSetRef?.Name ?? string.Empty,
+                        requestedName ?? string.Empty,
                         "unknown",
                         [name]));
         }

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -183,6 +183,19 @@ public sealed class WorkflowRoleGAgentMappingTests
         user.ContentParts[1].MediaType.Should().Be("image/png");
         user.ContentParts[1].Name.Should().Be("file-role.png");
         user.ContentParts[1].DataBase64.Should().BeNull();
+        var fileRef = user.ContentParts[1].FileRef;
+        fileRef.Should().NotBeNull();
+        fileRef!.FileId.Should().Be("file-role");
+        fileRef.ArtifactId.Should().Be("workflow-file://file-role");
+        fileRef.SourceKind.Should().Be(Aevatar.AI.Abstractions.LLMProviders.ChatFileSourceKind.ConnectedServiceResource);
+        fileRef.SourceMessageId.Should().Be("om_1");
+        fileRef.SourceResourceKey.Should().Be("image_key_1");
+        fileRef.FileName.Should().Be("file-role.png");
+        fileRef.MediaType.Should().Be("image/png");
+        fileRef.SizeBytes.Should().Be(3);
+        fileRef.Sha256.Should().Be("sha-file-role");
+        fileRef.CreatedAtUnixMs.Should().Be(1710000000000);
+        fileRef.ExpiresAtUnixMs.Should().Be(1710003600000);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -3,7 +3,6 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.ToolSetRegistry;
-using Aevatar.ChatRouting.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Integration.AI;

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -411,9 +411,9 @@ public sealed class WorkflowRoleGAgentMappingTests
 
         public IReadOnlyList<string> GetRegisteredNames() => ["nyxid.connected_services"];
 
-        public ToolSetResolveResult Resolve(ChatRouteToolSetRef? toolSetRef)
+        public ToolSetResolveResult Resolve(string? name)
         {
-            var name = toolSetRef?.Name ?? string.Empty;
+            name ??= string.Empty;
             ResolvedNames.Add(name);
             return ToolSetResolveResult.Success(name, [source]);
         }

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentForkOnFailureTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentForkOnFailureTests.cs
@@ -131,6 +131,44 @@ public sealed class WorkflowRunGAgentForkOnFailureTests
     }
 
     [Fact]
+    public async Task ChatRequest_WithFileIdOnlyInputFileRef_ShouldBindArtifactOwnerBeforeStartingWorkflow()
+    {
+        var runId = "run-1917-" + Guid.NewGuid().ToString("N");
+        var ownershipPort = new RecordingWorkflowFileArtifactOwnershipPort();
+        var harness = await CreateRunAsync(runId, WorkflowYaml(onFailure: false), ownershipPort);
+
+        await harness.Agent.HandleEventAsync(EnvelopeFrom("api", new WorkflowChatRequestEvent
+        {
+            Prompt = "hello",
+            ScopeId = "scope-1",
+            InputParts =
+            {
+                new WorkflowChatInputPartPayload
+                {
+                    Kind = WorkflowChatInputPartKind.File,
+                    FileRef = new WorkflowFileRef
+                    {
+                        FileId = "wf-file-only-123",
+                        SourceKind = WorkflowFileSourceKind.ChatInput,
+                        FileName = "invoice.txt",
+                        MediaType = "text/plain",
+                    },
+                },
+            },
+        }));
+
+        ownershipPort.Bindings.Should().ContainSingle().Which.Should().BeEquivalentTo(new FileOwnerBinding(
+            "wf-file-only-123",
+            string.Empty,
+            runId,
+            "scope-1"));
+        harness.Publisher.Published
+            .Where(x => x.Event is StepRequestEvent)
+            .Should()
+            .ContainSingle();
+    }
+
+    [Fact]
     public async Task ChatRequest_WhenInputFileOwnerBindingFails_ShouldNotStartWorkflow()
     {
         var runId = "run-1917-" + Guid.NewGuid().ToString("N");

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowChatFileInputPartContractTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowChatFileInputPartContractTests.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
+using Aevatar.Workflow.Infrastructure.Runs;
 using FluentAssertions;
 using Google.Protobuf;
+using Microsoft.Extensions.Options;
 using ApplicationWorkflowChatInputPartKind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind;
 using ApplicationFileArtifactRef = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactRef;
 using ApplicationFileArtifactSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactSourceKind;
@@ -99,5 +101,62 @@ public sealed class WorkflowChatFileInputPartContractTests
                     Sha256 = "abc",
                 },
             });
+    }
+
+    [Fact]
+    public async Task ChatRunRequestNormalizer_ShouldIngressInlineFileAsTypedFileRef()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-chat-inline-file-contract-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var input = JsonSerializer.Deserialize<ChatInput>(
+                """
+                {
+                  "inputParts": [
+                    {
+                      "type": "file",
+                      "inlineFile": {
+                        "dataBase64": "aW52b2ljZSB0b3RhbCA0Mg==",
+                        "mediaType": "application/pdf",
+                        "name": "invoice.pdf",
+                        "sizeBytes": 16,
+                        "ownerScopeId": "scope-1"
+                      }
+                    }
+                  ]
+                }
+                """,
+                ChatWebSocketProtocol.JsonOptions)!;
+            var filePort = new FileSystemFileArtifactPort(Options.Create(new FileSystemFileArtifactOptions
+            {
+                RootDirectory = root,
+                TimeToLive = TimeSpan.FromMinutes(30),
+            }));
+
+            var result = await ChatRunRequestNormalizer.NormalizeAsync(input, filePort);
+
+            result.Succeeded.Should().BeTrue();
+            result.Request!.Prompt.Should().Be("[file]");
+            var part = result.Request.InputParts.Should().ContainSingle().Subject;
+            part.Kind.Should().Be(ApplicationWorkflowChatInputPartKind.File);
+            part.DataBase64.Should().BeNull();
+            part.Uri.Should().StartWith("workflow-file://");
+            part.MediaType.Should().Be("application/pdf");
+            part.Name.Should().Be("invoice.pdf");
+            part.FileRef.Should().NotBeNull();
+            part.FileRef!.FileId.Should().NotBeNullOrWhiteSpace();
+            part.FileRef.ArtifactId.Should().Be(part.Uri);
+            part.FileRef.SourceKind.Should().Be(ApplicationFileArtifactSourceKind.ChatInput);
+            part.FileRef.FileName.Should().Be("invoice.pdf");
+            part.FileRef.MediaType.Should().Be("application/pdf");
+            part.FileRef.SizeBytes.Should().Be(16);
+            part.FileRef.Sha256.Should().NotBeNullOrWhiteSpace();
+            part.FileRef.OwnerScopeId.Should().Be("scope-1");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowChatFileInputPartContractTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowChatFileInputPartContractTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Google.Protobuf;
 using Microsoft.Extensions.Options;
 using ApplicationWorkflowChatInputPartKind = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind;
+using ApplicationWorkflowChatInputParts = Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputParts;
 using ApplicationFileArtifactRef = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactRef;
 using ApplicationFileArtifactSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactSourceKind;
 
@@ -53,6 +54,59 @@ public sealed class WorkflowChatFileInputPartContractTests
         parsed.FileRef.Sha256.Should().Be("abc");
         parsed.FileRef.CreatedAtUnixMs.Should().Be(1710000000000);
         parsed.FileRef.ExpiresAtUnixMs.Should().Be(1710003600000);
+    }
+
+    [Fact]
+    public void WorkflowChatInputParts_FromFileRef_ShouldShapeTypedFileParts()
+    {
+        var image = ApplicationWorkflowChatInputParts.FromFileRef(new ApplicationFileArtifactRef
+        {
+            FileId = "file-image",
+            ArtifactId = "workflow-file://file-image",
+            SourceKind = ApplicationFileArtifactSourceKind.ConnectedServiceResource,
+            SourceMessageId = "om_1",
+            SourceResourceKey = "image_key_1",
+            FileName = "image.png",
+            MediaType = "image/png",
+        });
+        var audio = ApplicationWorkflowChatInputParts.FromFileRef(new ApplicationFileArtifactRef
+        {
+            FileId = "file-audio",
+            FileName = "audio.mp3",
+            MediaType = "audio/mpeg",
+        });
+        var video = ApplicationWorkflowChatInputParts.FromFileRef(new ApplicationFileArtifactRef
+        {
+            ArtifactId = "artifact://video",
+            FileName = "video.mp4",
+            MediaType = "video/mp4",
+        });
+        var document = ApplicationWorkflowChatInputParts.FromFileRef(new ApplicationFileArtifactRef
+        {
+            FileId = "file-document",
+            FileName = "invoice.pdf",
+            MediaType = "application/pdf",
+        });
+        var invalid = () => ApplicationWorkflowChatInputParts.FromFileRef(new ApplicationFileArtifactRef
+        {
+            FileName = "missing-id.pdf",
+            MediaType = "application/pdf",
+        });
+
+        image.Kind.Should().Be(ApplicationWorkflowChatInputPartKind.Image);
+        image.Uri.Should().Be("workflow-file://file-image");
+        image.DataBase64.Should().BeNull();
+        image.FileRef.Should().NotBeNull();
+        image.FileRef!.SourceMessageId.Should().Be("om_1");
+        image.FileRef.SourceResourceKey.Should().Be("image_key_1");
+        audio.Kind.Should().Be(ApplicationWorkflowChatInputPartKind.Audio);
+        audio.Uri.Should().Be("workflow-file://file-audio");
+        video.Kind.Should().Be(ApplicationWorkflowChatInputPartKind.Video);
+        video.Uri.Should().Be("artifact://video");
+        document.Kind.Should().Be(ApplicationWorkflowChatInputPartKind.File);
+        document.Uri.Should().Be("workflow-file://file-document");
+        invalid.Should().Throw<ArgumentException>()
+            .WithMessage("Workflow chat file input requires fileId or artifactId.*");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
@@ -9,6 +9,8 @@ using System.Text.Json;
 using ApplicationFileArtifactRef = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactRef;
 using ApplicationFileArtifactSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactSourceKind;
 using ProtoWorkflowCallerCredential = Aevatar.Workflow.Abstractions.WorkflowCallerCredential;
+using ProtoWorkflowFileRef = Aevatar.Workflow.Abstractions.WorkflowFileRef;
+using ProtoWorkflowFileSourceKind = Aevatar.Workflow.Abstractions.WorkflowFileSourceKind;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
@@ -771,6 +773,78 @@ public sealed class WorkflowDocumentExtractToolTests
     }
 
     [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldUseSingleInputFileRefWhenArgumentsOmitFileRef()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-input-file-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var result = await port.IngestAsync(new FileArtifactIngressRequest(
+                System.Text.Encoding.UTF8.GetBytes("invoice total 42"),
+                ApplicationFileArtifactSourceKind.ChatInput,
+                FileName: "invoice.txt",
+                MediaType: "text/plain"));
+            var tool = await GetDocumentExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                "{}",
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential(),
+                [ToProtoInputFileRef(result.FileRef)]));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            var rootElement = document.RootElement;
+            rootElement.GetProperty("extraction_kind").GetString().Should().Be("utf8_text");
+            rootElement.GetProperty("media_type").GetString().Should().Be("text/plain");
+            rootElement.GetProperty("file").GetProperty("file_id").GetString().Should().Be(result.FileRef.FileId);
+            rootElement.GetProperty("text").GetString().Should().Be("invoice total 42");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowDocumentExtractTool_ShouldNotTreatAttachmentRefAsFileIdentity()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-attachment-ref-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var tool = await GetDocumentExtractToolAsync(port);
+
+            var output = await tool.ExecuteAsync(new WorkflowToolExecutionRequest(
+                """
+                {
+                  "attachment_ref": "file_v3_1"
+                }
+                """,
+                "run-1",
+                "extract",
+                "exec-1",
+                "call-1",
+                "scope-1",
+                new ProtoWorkflowCallerCredential()));
+
+            using var document = JsonDocument.Parse(output.ResultJson);
+            document.RootElement.GetProperty("error").GetString().Should().Be("invalid_arguments");
+            document.RootElement.GetProperty("detail").GetString()
+                .Should().Contain("fileRef object or exactly one input file ref");
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task AddWorkflowInfrastructure_ShouldWireDocumentExtractImageProviderFromLlmFactory()
     {
         var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-di-image-tests", Guid.NewGuid().ToString("N"));
@@ -1186,6 +1260,32 @@ public sealed class WorkflowDocumentExtractToolTests
         var tools = await source.GetToolsAsync();
         return tools.Should().ContainSingle(x => x.Name == "document_extract").Subject;
     }
+
+    private static ProtoWorkflowFileRef ToProtoInputFileRef(ApplicationFileArtifactRef fileRef) =>
+        new()
+        {
+            FileId = fileRef.FileId ?? string.Empty,
+            ArtifactId = fileRef.ArtifactId ?? string.Empty,
+            SourceKind = fileRef.SourceKind switch
+            {
+                ApplicationFileArtifactSourceKind.ChatInput => ProtoWorkflowFileSourceKind.ChatInput,
+                ApplicationFileArtifactSourceKind.FormUpload => ProtoWorkflowFileSourceKind.FormUpload,
+                ApplicationFileArtifactSourceKind.ConnectedServiceResource => ProtoWorkflowFileSourceKind.ConnectedServiceResource,
+                ApplicationFileArtifactSourceKind.ExternalResource => ProtoWorkflowFileSourceKind.ExternalResource,
+                ApplicationFileArtifactSourceKind.Generated => ProtoWorkflowFileSourceKind.Generated,
+                _ => ProtoWorkflowFileSourceKind.Unspecified,
+            },
+            SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
+            SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
+            FileName = fileRef.FileName ?? string.Empty,
+            MediaType = fileRef.MediaType ?? string.Empty,
+            SizeBytes = fileRef.SizeBytes,
+            Sha256 = fileRef.Sha256 ?? string.Empty,
+            CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+            ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+            OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
+            OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
+        };
 
     private static string BuildDocumentExtractArguments(
         ApplicationFileArtifactRef fileRef,


### PR DESCRIPTION
## Summary
- Normalize API/chat inline files and public file refs through a shared typed workflow file input helper.
- Convert Lark draft-run attachments at the channel boundary into generic workflow file refs without base64 payloads.
- Preserve full workflow file identity when mapping workflow input refs into AI chat content parts.
- Bind all workflow input file refs with stable identity before run start, including FileId-only refs.

## Scope note
This PR intentionally keeps the full workflow file-ref path in one vertical slice: API/chat ingress, Lark channel ingress, workflow run binding, document extraction fallback, and workflow-to-AI role mapping. Splitting those pieces would leave intermediate states where file identity is accepted at one boundary but still lost or unbound later in execution.

It also includes a small ToolSetRegistry boundary cleanup: the registry contract now resolves by opaque string name instead of accepting `ChatRouteToolSetRef`. That cleanup is not the core file-ref behavior, but it removes a chat-routing DTO leak from the generic tool-set registry assembly that surfaced while tightening the chat/file/tool contract boundaries in this PR.

## Test plan
- [x] dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter WorkflowRoleGAgentMappingTests
- [x] dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter FullyQualifiedName~WorkflowRunGAgentForkOnFailureTests
- [x] dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "WorkflowChatFileInputPartContractTests|WorkflowDocumentExtractToolTests"
- [x] dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter ChannelWorkflowDraftRunTests
- [x] dotnet test test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj --nologo
- [x] dotnet test test/Aevatar.AI.ToolProviders.ToolSetRegistry.Tests/Aevatar.AI.ToolProviders.ToolSetRegistry.Tests.csproj --nologo
- [x] dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "FullyQualifiedName~ResponsesDirectToolPlanServiceTests|FullyQualifiedName~LlmRunCoreTests"
- [x] dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter FullyQualifiedName~AgentProfileTurnCatalogMaterializerTests
- [x] bash tools/ci/lark_agent_path_contract_guard.sh
- [x] git diff --check
- [x] GitHub CI for PR head e56f34593: fast-gates, coverage-quality, projection-provider-e2e, fkst-host-policy, codecov/patch
- [ ] bash tools/ci/architecture_guards.sh (blocked locally by Python pyexpat/libexpat ImportError in project_reference_layer_guard.py)
- [ ] bash tools/ci/test_stability_guards.sh (blocked locally by the same Python pyexpat/libexpat ImportError after earlier guard steps passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)