### PR TITLE
Fix Team automation schedule status decoding

### DIFF
--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -174,6 +174,28 @@ describe("teamAutomationApi", () => {
     },
   );
 
+  it.each([
+    "constructor",
+    [2],
+    ["NeedsAuthorization"],
+    {},
+    true,
+    null,
+    undefined,
+    "act-ive",
+    "n e e d s authorization",
+    "TEAM---AUTOMATION STATUS--ACTIVE",
+  ] as const)(
+    "rejects malformed Team automation lifecycle value %s",
+    (wireStatus) => {
+      expect(() =>
+        teamAutomationApiDecoders.view(
+          automationView({ teamAutomationLifecycleStatus: wireStatus }),
+        ),
+      ).toThrow(`Unknown Team automation status: ${String(wireStatus)}.`);
+    },
+  );
+
   it("decodes exact typed service and node authorization grants", () => {
     const review = teamAutomationApiDecoders.permissionReview(authorizationResult());
 

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -101,7 +101,7 @@ function automationView(overrides?: Record<string, unknown>) {
     teamOwnerMemberId: "m-alpha",
     teamId: "team-alpha",
     credentialSourceKind: "ScheduledInvocationAgentKey",
-    teamAutomationLifecycleStatus: "Active",
+    teamAutomationLifecycleStatus: 2,
     credentialExpiresAt: "2026-10-14T00:00:00Z",
     teamAutomationOperationId: "op-alpha",
     lastAuthorizationErrorCode: "",
@@ -126,6 +126,53 @@ describe("teamAutomationApi", () => {
     global.fetch = originalFetch;
     jest.restoreAllMocks();
   });
+
+  it.each([
+    [1, "provisioning_pending"],
+    [2, "active"],
+    [3, "needs_authorization"],
+    [4, "replacement_pending"],
+    [5, "deleting"],
+    [6, "revocation_pending"],
+    [7, "failed"],
+  ] as const)(
+    "decodes canonical numeric Team automation lifecycle status %s as %s",
+    (wireStatus, authorizationStatus) => {
+      expect(
+        teamAutomationApiDecoders.view(
+          automationView({ teamAutomationLifecycleStatus: wireStatus }),
+        ),
+      ).toEqual(expect.objectContaining({ authorizationStatus }));
+    },
+  );
+
+  it.each([
+    ["NeedsAuthorization", "needs_authorization"],
+    [
+      "TEAM_AUTOMATION_STATUS_REPLACEMENT_PENDING",
+      "replacement_pending",
+    ],
+  ] as const)(
+    "decodes canonical textual Team automation lifecycle status %s as %s",
+    (wireStatus, authorizationStatus) => {
+      expect(
+        teamAutomationApiDecoders.view(
+          automationView({ teamAutomationLifecycleStatus: wireStatus }),
+        ),
+      ).toEqual(expect.objectContaining({ authorizationStatus }));
+    },
+  );
+
+  it.each([0, 8, "Future"])(
+    "rejects unknown Team automation lifecycle status %s",
+    (wireStatus) => {
+      expect(() =>
+        teamAutomationApiDecoders.view(
+          automationView({ teamAutomationLifecycleStatus: wireStatus }),
+        ),
+      ).toThrow(`Unknown Team automation status: ${String(wireStatus)}.`);
+    },
+  );
 
   it("decodes exact typed service and node authorization grants", () => {
     const review = teamAutomationApiDecoders.permissionReview(authorizationResult());

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -269,21 +269,33 @@ function decodeNullableTimestamp(value: unknown, label: string): string | null {
 
 function normalizeStatus(value: unknown): TeamAutomationAuthorizationStatus {
   const normalized = String(value ?? "").trim().toLowerCase();
-  const status = normalized
-    .replace(/^studio_member_automation_status_/, "")
-    .replace(/^team_automation_status_/, "");
-  switch (status) {
-    case "provisioning_pending":
-    case "active":
-    case "needs_authorization":
-    case "replacement_pending":
-    case "deleting":
-    case "revocation_pending":
-    case "failed":
-      return status;
-    default:
-      throw new Error(`Unknown Team automation status: ${String(value)}.`);
+  const compactStatus = normalized
+    .replace(
+      /^(?:studio[_\s-]*member[_\s-]*automation[_\s-]*status|team[_\s-]*automation[_\s-]*status)[_\s-]*/,
+      "",
+    )
+    .replace(/[_\s-]+/g, "");
+  const statuses: Record<string, TeamAutomationAuthorizationStatus> = {
+    "1": "provisioning_pending",
+    "2": "active",
+    "3": "needs_authorization",
+    "4": "replacement_pending",
+    "5": "deleting",
+    "6": "revocation_pending",
+    "7": "failed",
+    provisioningpending: "provisioning_pending",
+    active: "active",
+    needsauthorization: "needs_authorization",
+    replacementpending: "replacement_pending",
+    deleting: "deleting",
+    revocationpending: "revocation_pending",
+    failed: "failed",
+  };
+  const status = statuses[compactStatus];
+  if (status === undefined) {
+    throw new Error(`Unknown Team automation status: ${String(value)}.`);
   }
+  return status;
 }
 
 function normalizeScope(value: unknown): string {

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -103,6 +103,62 @@ export type TeamAutomationAuthorizationStatus =
   | "revocation_pending"
   | "failed";
 
+const teamAutomationStatusAliases = new Map<
+  string,
+  TeamAutomationAuthorizationStatus
+>([
+  ["1", "provisioning_pending"],
+  ["2", "active"],
+  ["3", "needs_authorization"],
+  ["4", "replacement_pending"],
+  ["5", "deleting"],
+  ["6", "revocation_pending"],
+  ["7", "failed"],
+  ["provisioning_pending", "provisioning_pending"],
+  ["active", "active"],
+  ["needs_authorization", "needs_authorization"],
+  ["replacement_pending", "replacement_pending"],
+  ["deleting", "deleting"],
+  ["revocation_pending", "revocation_pending"],
+  ["failed", "failed"],
+  ["provisioningpending", "provisioning_pending"],
+  ["needsauthorization", "needs_authorization"],
+  ["replacementpending", "replacement_pending"],
+  ["revocationpending", "revocation_pending"],
+  [
+    "studio_member_automation_status_provisioning_pending",
+    "provisioning_pending",
+  ],
+  ["studio_member_automation_status_active", "active"],
+  [
+    "studio_member_automation_status_needs_authorization",
+    "needs_authorization",
+  ],
+  [
+    "studio_member_automation_status_replacement_pending",
+    "replacement_pending",
+  ],
+  ["studio_member_automation_status_deleting", "deleting"],
+  [
+    "studio_member_automation_status_revocation_pending",
+    "revocation_pending",
+  ],
+  ["studio_member_automation_status_failed", "failed"],
+  ["team_automation_status_provisioning_pending", "provisioning_pending"],
+  ["team_automation_status_active", "active"],
+  [
+    "team_automation_status_needs_authorization",
+    "needs_authorization",
+  ],
+  [
+    "team_automation_status_replacement_pending",
+    "replacement_pending",
+  ],
+  ["team_automation_status_deleting", "deleting"],
+  ["team_automation_status_revocation_pending", "revocation_pending"],
+  ["team_automation_status_failed", "failed"],
+]);
+
 export type TeamAutomationRevocationTrack =
   | "NotRequired"
   | "Pending"
@@ -268,30 +324,13 @@ function decodeNullableTimestamp(value: unknown, label: string): string | null {
 }
 
 function normalizeStatus(value: unknown): TeamAutomationAuthorizationStatus {
-  const normalized = String(value ?? "").trim().toLowerCase();
-  const compactStatus = normalized
-    .replace(
-      /^(?:studio[_\s-]*member[_\s-]*automation[_\s-]*status|team[_\s-]*automation[_\s-]*status)[_\s-]*/,
-      "",
-    )
-    .replace(/[_\s-]+/g, "");
-  const statuses: Record<string, TeamAutomationAuthorizationStatus> = {
-    "1": "provisioning_pending",
-    "2": "active",
-    "3": "needs_authorization",
-    "4": "replacement_pending",
-    "5": "deleting",
-    "6": "revocation_pending",
-    "7": "failed",
-    provisioningpending: "provisioning_pending",
-    active: "active",
-    needsauthorization: "needs_authorization",
-    replacementpending: "replacement_pending",
-    deleting: "deleting",
-    revocationpending: "revocation_pending",
-    failed: "failed",
-  };
-  const status = statuses[compactStatus];
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw new Error(`Unknown Team automation status: ${String(value)}.`);
+  }
+
+  const normalized =
+    typeof value === "string" ? value.trim().toLowerCase() : value.toString();
+  const status = teamAutomationStatusAliases.get(normalized);
   if (status === undefined) {
     throw new Error(`Unknown Team automation status: ${String(value)}.`);
   }


### PR DESCRIPTION
## Problem and root cause

The Team Automations list request succeeds, but the page renders `Automations could not load`.

The schedule API serializes `TeamAutomationLifecycleStatus` as its numeric enum value (for example, `Active = 2`). The frontend decoder accepted only textual status values, so decoding threw after the HTTP 200 response. React Query then surfaced the successful request as an error state and discarded the list result.

## Solution

- Decode the backend's numeric lifecycle values `1..7` into the typed frontend statuses.
- Preserve exact supported snake_case, PascalCase, and legacy-prefixed representations.
- Fail closed for unknown or malformed values.
- Use a module-level `Map` and accept only primitive strings or numbers, preventing inherited-key lookup and accidental object/array coercion.
- Add regression and adversarial decoder coverage using the real numeric `Active = 2` payload.

## Impacted paths

- `apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts`
- `apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts`

No architecture or documentation contract changed, so no documentation update is required.

## Local focused verification

- `pnpm --dir apps/aevatar-console-web test --runInBand --runTestsByPath src/shared/api/teamAutomationApi.test.ts src/pages/teams/tabs/TeamAutomationsTab.test.tsx` - 2 suites, 65 tests passed
- `pnpm --dir apps/aevatar-console-web tsc` - passed
- `bash tools/ci/test_stability_guards.sh` - passed
- `bash tools/ci/query_projection_priming_guard.sh` - passed
- `git diff --check origin/dev...HEAD` - passed

Full regression is intentionally not run locally; the PR's remote CI is responsible for the full suite.
