### PR TITLE
Remove Team automation member selector

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1443,12 +1443,9 @@ describe("TeamDetailPage", () => {
     expect(await screen.findByRole("heading", { name: "自动化" })).toBeTruthy();
     expect(screen.getByText("这个成员还没有自动化")).toBeTruthy();
     expect(screen.getByText("Team Alpha Operator")).toBeTruthy();
-    await waitFor(() =>
-      expect(window.location.pathname).toBe(
-        "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/automations",
-      ),
-    );
-    expect(window.location.search).toBe("");
+    expect(window.location.pathname).toBe("/scopes/scope-1/teams/t-alpha");
+    expect(window.location.search).toBe("?tab=automations");
+    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
 
@@ -2521,7 +2518,7 @@ describe("TeamDetailPage", () => {
 
   });
 
-  it("canonicalizes the selected Team member and queries its automations", async () => {
+  it("does not promote Team query hints into member automation identity", async () => {
     window.history.replaceState(
       {},
       "",
@@ -2530,21 +2527,9 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe(
-        "/scopes/scope-1/teams/t-alpha/members/member-team-alpha/automations",
-      );
-      expect(teamAutomationApi.listAll).toHaveBeenCalledWith(
-        {
-          scopeId: "scope-1",
-          teamId: "t-alpha",
-          memberId: "member-team-alpha",
-        },
-        { take: 200 },
-      );
-    });
-    expect(window.location.search).toBe("");
-    expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole("heading", { name: "自动化" })).toBeTruthy();
+    expect(window.location.pathname).toBe("/scopes/scope-1/teams/t-alpha");
+    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
     expect(scheduledDispatchApi.listAll).not.toHaveBeenCalled();
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1441,11 +1441,14 @@ describe("TeamDetailPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "自动化" }));
 
     expect(await screen.findByRole("heading", { name: "自动化" })).toBeTruthy();
-    expect(screen.getByText("这个成员还没有自动化")).toBeTruthy();
-    expect(screen.getByText("Team Alpha Operator")).toBeTruthy();
+    expect(await screen.findByText("还没有周期任务")).toBeTruthy();
+    expect(screen.queryByText("Team Alpha Operator")).toBeNull();
     expect(window.location.pathname).toBe("/scopes/scope-1/teams/t-alpha");
     expect(window.location.search).toBe("?tab=automations");
-    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
+    expect(teamAutomationApi.listAll).toHaveBeenCalledWith(
+      { scopeId: "scope-1", teamId: "t-alpha" },
+      { take: 200 },
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
 
@@ -2529,7 +2532,13 @@ describe("TeamDetailPage", () => {
 
     expect(await screen.findByRole("heading", { name: "自动化" })).toBeTruthy();
     expect(window.location.pathname).toBe("/scopes/scope-1/teams/t-alpha");
-    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(teamAutomationApi.listAll).toHaveBeenCalledWith(
+        { scopeId: "scope-1", teamId: "t-alpha" },
+        { take: 200 },
+      ),
+    );
+    expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(1);
     expect(scheduledDispatchApi.listAll).not.toHaveBeenCalled();
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1983,11 +1983,9 @@ const TeamDetailPage: React.FC = () => {
           routeState.routeMemberId,
         ])}
         members={teamRosterRows.map((row) => ({
-          automationsHref: row.automationsHref,
           canAutomateMember: row.canAutomateMember,
           disabledReason: row.automationDisabledReason,
           implementationKind: row.implementationKind,
-          isSelectedMember: row.isSelectedMember,
           key: row.key,
           lifecycleLabel: row.lifecycleLabel,
           lifecycleStyle: row.lifecycleStyle,

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
@@ -76,7 +76,6 @@ jest.mock("@/shared/auth/config", () => ({
 }));
 
 const member = {
-  automationsHref: "/scopes/scope-alpha/teams/team-alpha/members/m-alpha/automations",
   canAutomateMember: true,
   disabledReason: "",
   implementationKind: "Workflow",
@@ -214,40 +213,9 @@ describe("TeamAutomationsTab canonical member authority", () => {
     ).toBe(true);
   });
 
-  it("canonicalizes the sole eligible member from the Team shell", async () => {
-    renderTab();
-
-    expect(await screen.findByRole("heading", { name: "Automations" })).toBeInTheDocument();
-    await waitFor(() =>
-      expect(history.replace).toHaveBeenCalledWith(member.automationsHref),
-    );
-    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
-    expect(scheduledDispatchApi.listAll).not.toHaveBeenCalled();
-  });
-
-  it("canonicalizes the explicitly selected eligible member", async () => {
-    const selectedMember = {
-      ...member,
-      automationsHref: "/scopes/scope-alpha/teams/team-alpha/members/m-beta/automations",
-      isSelectedMember: true,
-      key: "m-beta",
-      memberId: "m-beta",
-      name: "Reviewer",
-      serviceId: "svc-beta",
-    };
-
-    renderTab("", [member, selectedMember]);
-
-    await waitFor(() =>
-      expect(history.replace).toHaveBeenCalledWith(selectedMember.automationsHref),
-    );
-    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
-  });
-
-  it("requires an explicit choice when multiple eligible members are unresolved", async () => {
+  it("keeps member selection inside the create form when multiple members are eligible", async () => {
     const otherMember = {
       ...member,
-      automationsHref: "/scopes/scope-alpha/teams/team-alpha/members/m-beta/automations",
       key: "m-beta",
       memberId: "m-beta",
       name: "Reviewer",
@@ -256,14 +224,16 @@ describe("TeamAutomationsTab canonical member authority", () => {
 
     renderTab("", [member, otherMember]);
 
-    expect(await screen.findByRole("combobox", { name: "Automation member" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Automations" })).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Automation member" })).not.toBeInTheDocument();
     expect(history.replace).not.toHaveBeenCalled();
     expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
 
-    fireEvent.mouseDown(screen.getByRole("combobox", { name: "Automation member" }));
-    fireEvent.click(await screen.findByText("Reviewer"));
+    fireEvent.click(screen.getByRole("button", { name: "New automation" }));
 
-    expect(history.push).toHaveBeenCalledWith(otherMember.automationsHref);
+    const form = await screen.findByRole("dialog");
+    expect(within(form).getByRole("combobox", { name: "Automation member" })).toBeEnabled();
+    expect(history.push).not.toHaveBeenCalled();
   });
 
   it("opens the complete dev form directly from the Team shell", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
@@ -227,13 +227,129 @@ describe("TeamAutomationsTab canonical member authority", () => {
     expect(await screen.findByRole("heading", { name: "Automations" })).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Automation member" })).not.toBeInTheDocument();
     expect(history.replace).not.toHaveBeenCalled();
-    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(teamAutomationApi.listAll).toHaveBeenCalledWith(
+        { scopeId: "scope-alpha", teamId: "team-alpha" },
+        { take: 200 },
+      ),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "New automation" }));
 
     const form = await screen.findByRole("dialog");
     expect(within(form).getByRole("combobox", { name: "Automation member" })).toBeEnabled();
+    expect(within(form).queryByText("Planner")).not.toBeInTheDocument();
+    expect(within(form).queryByText("Reviewer")).not.toBeInTheDocument();
     expect(history.push).not.toHaveBeenCalled();
+  });
+
+  it("stays on the Team collection after creating for an explicitly selected member", async () => {
+    const otherMember = {
+      ...member,
+      key: "m-beta",
+      memberId: "m-beta",
+      name: "Reviewer",
+      serviceId: "svc-beta",
+    };
+    (teamAutomationApi.preflightCreate as jest.Mock).mockResolvedValue(
+      authorizationReview(),
+    );
+    (teamAutomationApi.create as jest.Mock).mockResolvedValue({
+      accepted: true,
+      commandId: "cmd-beta",
+      operationId: "op-beta",
+      scheduleId: "sch-beta",
+      status: "accepted",
+    });
+
+    renderTab("", [member, otherMember]);
+
+    fireEvent.click(await screen.findByRole("button", { name: "New automation" }));
+    const form = await screen.findByRole("dialog");
+    fireEvent.mouseDown(within(form).getByRole("combobox", { name: "Automation member" }));
+    fireEvent.click(await screen.findByText("Reviewer"));
+    fireEvent.click(within(form).getByRole("button", { name: "Create automation" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Authorize and continue" }));
+
+    await waitFor(() => expect(teamAutomationApi.create).toHaveBeenCalledTimes(1));
+    expect(teamAutomationApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({ memberId: "m-beta" }),
+      "digest-alpha",
+      "scheduled-invocation-auth/v1",
+      { idempotencyKey: "idem-alpha", operationId: "op-alpha" },
+    );
+    expect(history.push).not.toHaveBeenCalled();
+  });
+
+  it("attributes Team collection rows to each automation member", async () => {
+    const otherMember = {
+      ...member,
+      key: "m-beta",
+      memberId: "m-beta",
+      name: "Reviewer",
+      serviceId: "svc-beta",
+    };
+    (teamAutomationApi.listAll as jest.Mock).mockResolvedValue({
+      items: [
+        automationView({ displayName: "Planner review" }),
+        automationView({
+          displayName: "Reviewer review",
+          memberId: "m-beta",
+          publishedServiceId: "svc-beta",
+          scheduleId: "sch-beta",
+        }),
+      ],
+      nextCursor: null,
+      totalCount: 2,
+    });
+
+    renderTab("", [member, otherMember]);
+
+    const plannerRow = await screen.findByRole("article", { name: "Planner review" });
+    const reviewerRow = await screen.findByRole("article", { name: "Reviewer review" });
+    expect(within(plannerRow).getByText("Planner")).toBeInTheDocument();
+    expect(within(reviewerRow).getByText("Reviewer")).toBeInTheDocument();
+  });
+
+  it("uses the row member authority for Team collection actions", async () => {
+    const otherMember = {
+      ...member,
+      key: "m-beta",
+      memberId: "m-beta",
+      name: "Reviewer",
+      serviceId: "svc-beta",
+    };
+    const reviewerAutomation = automationView({
+      displayName: "Reviewer review",
+      memberId: "m-beta",
+      publishedServiceId: "svc-beta",
+      scheduleId: "sch-beta",
+    });
+    (teamAutomationApi.listAll as jest.Mock).mockResolvedValue({
+      items: [reviewerAutomation],
+      nextCursor: null,
+      totalCount: 1,
+    });
+    (teamAutomationApi.runNow as jest.Mock).mockResolvedValue({
+      accepted: true,
+      commandId: "cmd-beta",
+      operationId: "op-beta",
+      scheduleId: "sch-beta",
+      status: "accepted",
+    });
+
+    renderTab("", [member, otherMember]);
+
+    const reviewerRow = await screen.findByRole("article", { name: "Reviewer review" });
+    fireEvent.click(within(reviewerRow).getByRole("button", { name: "Run now" }));
+
+    await waitFor(() =>
+      expect(teamAutomationApi.runNow).toHaveBeenCalledWith(
+        { scopeId: "scope-alpha", teamId: "team-alpha", memberId: "m-beta" },
+        "sch-beta",
+        { idempotencyKey: "idem-alpha", operationId: "op-alpha" },
+      ),
+    );
   });
 
   it("opens the complete dev form directly from the Team shell", async () => {
@@ -250,7 +366,10 @@ describe("TeamAutomationsTab canonical member authority", () => {
     expect(screen.getByRole("button", { name: "Create automation" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Review authorization" })).not.toBeInTheDocument();
     expect(history.push).not.toHaveBeenCalled();
-    expect(teamAutomationApi.listAll).not.toHaveBeenCalled();
+    expect(teamAutomationApi.listAll).toHaveBeenCalledWith(
+      { scopeId: "scope-alpha", teamId: "team-alpha" },
+      { take: 200 },
+    );
   });
 
   it("loads only the exact canonical member collection", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -65,11 +65,9 @@ import {
 } from "../teamAutomationAuthorizationDraftSession";
 
 export type TeamAutomationMemberRow = {
-  readonly automationsHref: string;
   readonly canAutomateMember: boolean;
   readonly disabledReason: string;
   readonly implementationKind: string;
-  readonly isSelectedMember?: boolean;
   readonly key: string;
   readonly lifecycleLabel: string;
   readonly lifecycleStyle: React.CSSProperties;
@@ -706,20 +704,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
     () => ({ scopeId: trim(scopeId), teamId: trim(teamId), memberId: routeMemberId }),
     [routeMemberId, scopeId, teamId],
   );
-  const eligibleMembers = React.useMemo(
-    () => members.filter((member) => member.canAutomateMember),
-    [members],
-  );
   const routeMember = members.find((member) => trim(member.memberId) === routeMemberId);
-  const selectedTeamMembers = eligibleMembers.filter((member) => member.isSelectedMember);
-  const selectedTeamMember = selectedTeamMembers.length === 1
-    ? selectedTeamMembers[0]
-    : undefined;
-  const canonicalMember = routeMember?.canAutomateMember
+  const selectedMember = routeMember?.canAutomateMember
     ? routeMember
-    : !routeMemberId
-      ? selectedTeamMember ?? (eligibleMembers.length === 1 ? eligibleMembers[0] : undefined)
-      : undefined;
+    : members.find((member) => member.canAutomateMember);
   const canQuery = Boolean(route.scopeId && route.teamId && route.memberId && routeMember?.canAutomateMember);
   const queryKey = React.useMemo(
     () => ["team-automations", route.scopeId, route.teamId, route.memberId] as const,
@@ -739,13 +727,6 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const [previewTimes, setPreviewTimes] = React.useState<readonly string[]>([]);
   const pollingStartedAtRef = React.useRef<number | null>(null);
   const recoveredRouteRef = React.useRef("");
-
-  React.useEffect(() => {
-    if (routeMemberId || !canonicalMember) {
-      return;
-    }
-    history.replace(canonicalMember.automationsHref);
-  }, [canonicalMember?.automationsHref, routeMemberId]);
 
   const automationsQuery = useQuery({
     enabled: canQuery,
@@ -889,7 +870,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const openCreate = () => {
     setDraft({
       ...initialDraft,
-      memberId: canonicalMember?.memberId ?? "",
+      memberId: selectedMember?.memberId ?? "",
       timezone: defaultTimezone(),
     });
     setEditing(null);
@@ -900,7 +881,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
   };
 
   const openSelectedMember = () => {
-    if (!canonicalMember) return;
+    if (!selectedMember) return;
     openCreate();
   };
 
@@ -1450,7 +1431,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
           ) : null}
         </div>
         <div className="team-automation-row__member" style={{ display: "grid", gap: 5, minWidth: 0 }}>
-          <Typography.Text ellipsis strong>{routeMember?.name ?? canonicalMember?.name ?? "--"}</Typography.Text>
+          <Typography.Text ellipsis strong>{routeMember?.name ?? selectedMember?.name ?? "--"}</Typography.Text>
           <FactLine
             rows={2}
             secondary
@@ -1499,7 +1480,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
         .slice(0, 3)
     : [];
   const activeFormMember =
-    members.find((member) => member.memberId === draft.memberId) ?? canonicalMember;
+    members.find((member) => member.memberId === draft.memberId) ?? selectedMember;
   const cronPresets = [
     { label: copy("teams.automations.form.preset.weekdaysMorning", "Weekdays · 09:00"), value: "weekdays-0900", cronExpression: "0 9 * * 1-5" },
     { label: copy("teams.automations.form.preset.dailyMorning", "Daily · 09:00"), value: "daily-0900", cronExpression: "0 9 * * *" },
@@ -1556,7 +1537,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
             </div>
             <Button
               className="team-automations-create-button"
-              disabled={!canonicalMember}
+              disabled={!selectedMember}
               icon={<PlusOutlined />}
               onClick={openSelectedMember}
               style={primaryHeaderButtonStyle}
@@ -1567,25 +1548,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
           </div>
 
           <div aria-live="polite" style={{ display: "grid", gap: 12, marginTop: 16 }}>
-            {!routeMember && !canonicalMember && eligibleMembers.length > 1 ? (
-              <Select
-                aria-label={copy("teams.automations.form.memberAria", "Automation member")}
-                onChange={(memberId) => {
-                  const member = eligibleMembers.find(
-                    (candidate) => candidate.memberId === memberId,
-                  );
-                  if (member) {
-                    history.push(member.automationsHref);
-                  }
-                }}
-                options={eligibleMembers.map((member) => ({
-                  label: member.name,
-                  value: member.memberId,
-                }))}
-                placeholder={copy("teams.automations.member.select", "Select a member")}
-                style={{ maxWidth: 360, width: "100%" }}
-              />
-            ) : !routeMember ? (
+            {!routeMember ? (
               <Empty
                 description={copy(
                   "teams.automations.empty.member",
@@ -1677,7 +1640,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                   )}
                 </Typography.Text>
               </div>
-              {canonicalMember ? (
+              {selectedMember ? (
                 <div
                   style={{
                     background: token.colorFillQuaternary,
@@ -1688,9 +1651,9 @@ const TeamAutomationsTab: React.FC<Props> = ({
                     padding: 14,
                   }}
                 >
-                  <Typography.Text ellipsis strong>{canonicalMember.name}</Typography.Text>
+                  <Typography.Text ellipsis strong>{selectedMember.name}</Typography.Text>
                   <FactLine secondary text={copy("teams.automations.member.publishedServiceReady", "Published service ready")} />
-                  <DetailPill compact style={canonicalMember.lifecycleStyle} text={canonicalMember.lifecycleLabel} />
+                  <DetailPill compact style={selectedMember.lifecycleStyle} text={selectedMember.lifecycleLabel} />
                 </div>
               ) : (
                 <AevatarInspectorEmpty
@@ -1704,7 +1667,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
               )}
               <Button
                 block
-                disabled={!canonicalMember}
+                disabled={!selectedMember}
                 icon={<ClockCircleOutlined />}
                 onClick={openSelectedMember}
                 style={inspectorActionButtonStyle}
@@ -1749,7 +1712,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                           {
                             memberName:
                               routeMember?.name ??
-                              canonicalMember?.name ??
+                              selectedMember?.name ??
                               copy("teams.automations.columns.member", "Member"),
                           },
                         )}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -36,6 +36,8 @@ import {
   teamAutomationApi,
   TeamAutomationApiError,
   type TeamAutomationCreateDraft,
+  type TeamAutomationListRoute,
+  type TeamAutomationMutationReceipt,
   type TeamAutomationOperationIdentity,
   type TeamAutomationPermissionReview,
   type TeamAutomationRoute,
@@ -45,7 +47,6 @@ import { previewScheduledDispatch } from "@/shared/api/scheduledDispatchApi";
 import { NyxIDAuthClient } from "@/shared/auth/client";
 import { getNyxIDRuntimeConfig } from "@/shared/auth/config";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
-import { history } from "@/shared/navigation/history";
 import {
   buildTeamMemberAutomationsHref,
 } from "@/shared/navigation/teamRoutes";
@@ -630,17 +631,25 @@ function credentialLabel(view: TeamAutomationView): string {
 }
 
 function authorizationDraft(
-  route: TeamAutomationRoute,
+  route: TeamAutomationListRoute,
   draft: Draft,
 ): TeamAutomationCreateDraft {
   return {
     ...route,
-    memberId: trim(draft.memberId) || route.memberId,
+    memberId: trim(draft.memberId) || route.memberId || "",
     displayName: trim(draft.displayName),
     prompt: trim(draft.prompt),
     cronExpression: trim(draft.cronExpression),
     timezone: trim(draft.timezone) || "UTC",
     enabled: draft.enabled,
+  };
+}
+
+function exactAutomationRoute(route: TeamAutomationRoute): TeamAutomationRoute {
+  return {
+    scopeId: route.scopeId,
+    teamId: route.teamId,
+    memberId: route.memberId,
   };
 }
 
@@ -700,15 +709,34 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const queryClient = useQueryClient();
   const { token } = theme.useToken();
   const routeMemberId = trim(routeMemberIdInput);
-  const route = React.useMemo<TeamAutomationRoute>(
-    () => ({ scopeId: trim(scopeId), teamId: trim(teamId), memberId: routeMemberId }),
+  const route = React.useMemo<TeamAutomationListRoute>(
+    () => ({
+      scopeId: trim(scopeId),
+      teamId: trim(teamId),
+      ...(routeMemberId ? { memberId: routeMemberId } : {}),
+    }),
     [routeMemberId, scopeId, teamId],
   );
-  const routeMember = members.find((member) => trim(member.memberId) === routeMemberId);
-  const selectedMember = routeMember?.canAutomateMember
-    ? routeMember
-    : members.find((member) => member.canAutomateMember);
-  const canQuery = Boolean(route.scopeId && route.teamId && route.memberId && routeMember?.canAutomateMember);
+  const membersById = React.useMemo(
+    () => new Map(members.map((member) => [trim(member.memberId), member])),
+    [members],
+  );
+  const eligibleMembers = React.useMemo(
+    () => members.filter((member) => member.canAutomateMember),
+    [members],
+  );
+  const routeMember = membersById.get(routeMemberId);
+  const routeMemberAuthority = React.useMemo<TeamAutomationRoute | null>(
+    () => route.memberId
+      ? { scopeId: route.scopeId, teamId: route.teamId, memberId: route.memberId }
+      : null,
+    [route],
+  );
+  const canQuery = Boolean(
+    route.scopeId &&
+    route.teamId &&
+    (!route.memberId || routeMember?.canAutomateMember),
+  );
   const queryKey = React.useMemo(
     () => ["team-automations", route.scopeId, route.teamId, route.memberId] as const,
     [route],
@@ -781,26 +809,32 @@ const TeamAutomationsTab: React.FC<Props> = ({
   );
 
   const redirectToBindingRecovery = React.useCallback(
-    async (input?: {
-      readonly draft: TeamAutomationCreateDraft;
-      readonly mode: AuthorizationMode;
-      readonly scheduleId?: string;
-    }) => {
+    async (
+      target:
+        | {
+            readonly draft: TeamAutomationCreateDraft;
+            readonly mode: AuthorizationMode;
+            readonly scheduleId?: string;
+          }
+        | { readonly route: TeamAutomationRoute },
+    ) => {
       if (typeof window === "undefined") {
         throw new Error("NyxID authorization recovery requires a browser environment.");
       }
-      if (input) {
+      if ("draft" in target) {
         saveTeamAutomationAuthorizationDraft(
           window.sessionStorage,
-          recoveryDraft(input.draft, input.mode, input.scheduleId),
+          recoveryDraft(target.draft, target.mode, target.scheduleId),
         );
       }
       await new NyxIDAuthClient(getNyxIDRuntimeConfig()).loginWithRedirect({
-        returnTo: buildTeamMemberAutomationsHref(input?.draft ?? route),
+        returnTo: buildTeamMemberAutomationsHref(
+          "draft" in target ? target.draft : target.route,
+        ),
         prompt: "consent",
       });
     },
-    [route],
+    [],
   );
 
   const beginPreflight = React.useCallback(
@@ -842,11 +876,14 @@ const TeamAutomationsTab: React.FC<Props> = ({
   );
 
   React.useEffect(() => {
-    if (!canQuery || typeof window === "undefined") return;
+    if (!canQuery || !routeMemberAuthority || typeof window === "undefined") return;
     const routeKey = JSON.stringify(route);
     if (recoveredRouteRef.current === routeKey) return;
     recoveredRouteRef.current = routeKey;
-    const recovered = consumeTeamAutomationAuthorizationDraft(window.sessionStorage, route);
+    const recovered = consumeTeamAutomationAuthorizationDraft(
+      window.sessionStorage,
+      routeMemberAuthority,
+    );
     if (!recovered) return;
     const recoveredDraft: Draft = {
       memberId: recovered.memberId,
@@ -865,12 +902,12 @@ const TeamAutomationsTab: React.FC<Props> = ({
       recovered.mode,
       recovered.scheduleId,
     );
-  }, [beginPreflight, canQuery, route]);
+  }, [beginPreflight, canQuery, route, routeMemberAuthority]);
 
   const openCreate = () => {
     setDraft({
       ...initialDraft,
-      memberId: selectedMember?.memberId ?? "",
+      memberId: routeMember?.memberId ?? "",
       timezone: defaultTimezone(),
     });
     setEditing(null);
@@ -878,11 +915,6 @@ const TeamAutomationsTab: React.FC<Props> = ({
     setAuthorizationFlow({ state: "idle" });
     setPreviewTimes([]);
     setFormOpen(true);
-  };
-
-  const openSelectedMember = () => {
-    if (!selectedMember) return;
-    openCreate();
   };
 
   const openEdit = (view: TeamAutomationView) => {
@@ -918,7 +950,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
     setEditing(view);
     setFormMode("edit");
     setFormOpen(true);
-    void beginPreflight(authorizationDraft(route, nextDraft), "reauthorize", view.scheduleId);
+    void beginPreflight(authorizationDraft(view, nextDraft), "reauthorize", view.scheduleId);
   };
 
   const submitAuthorization = async () => {
@@ -942,7 +974,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
             identity,
           )
         : await teamAutomationApi.reauthorize(
-            route,
+            exactAutomationRoute(confirmedDraft),
             scheduleId ?? "",
             confirmedDraft,
             review.permissionDigest,
@@ -966,9 +998,6 @@ const TeamAutomationsTab: React.FC<Props> = ({
         "Authorization request accepted",
       ));
       setFormOpen(false);
-      if (!route.memberId && mode === "create") {
-        history.push(buildTeamMemberAutomationsHref(confirmedDraft));
-      }
       await invalidate();
     } catch (error) {
       if (requiresBindingRecovery(error)) {
@@ -1015,7 +1044,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
     const identity = createTeamAutomationOperationIdentity();
     setBusyScheduleId(editing.scheduleId);
     try {
-      const receipt = await teamAutomationApi.update(route, editing.scheduleId, {
+      const receipt = await teamAutomationApi.update(exactAutomationRoute(editing), editing.scheduleId, {
         displayName: next.displayName,
         prompt: next.prompt,
         cronExpression: next.cronExpression,
@@ -1069,16 +1098,23 @@ const TeamAutomationsTab: React.FC<Props> = ({
   ) => {
     setBusyScheduleId(view.scheduleId);
     try {
-      let receipt;
+      let receipt: TeamAutomationMutationReceipt;
       if (action === "retryRevocation") {
-        receipt = await teamAutomationApi.retryRevocation(route, view.scheduleId);
+        receipt = await teamAutomationApi.retryRevocation(
+          exactAutomationRoute(view),
+          view.scheduleId,
+        );
         void message.info(copy(
           "teams.automations.messages.revocationRetryAccepted",
           "Revocation retry accepted",
         ));
       } else {
         const identity = createTeamAutomationOperationIdentity();
-        receipt = await teamAutomationApi[action](route, view.scheduleId, identity);
+        receipt = await teamAutomationApi[action](
+          exactAutomationRoute(view),
+          view.scheduleId,
+          identity,
+        );
         void message.info(
           action === "runNow"
             ? copy("teams.automations.messages.runAccepted", "Run request accepted")
@@ -1100,7 +1136,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
     } catch (error) {
       if (requiresBindingRecovery(error)) {
         try {
-          await redirectToBindingRecovery();
+          await redirectToBindingRecovery({ route: exactAutomationRoute(view) });
           return;
         } catch (redirectError) {
           void message.error(
@@ -1378,6 +1414,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
 
   const renderRow = (view: TeamAutomationView) => {
     const cadence = describeDraftCadence(view.cronExpression, view.timezone, copy);
+    const ownerMember = membersById.get(trim(view.memberId));
     const status = automationStatus(view);
     const rowBorderColor =
       status === "error"
@@ -1431,7 +1468,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
           ) : null}
         </div>
         <div className="team-automation-row__member" style={{ display: "grid", gap: 5, minWidth: 0 }}>
-          <Typography.Text ellipsis strong>{routeMember?.name ?? selectedMember?.name ?? "--"}</Typography.Text>
+          <Typography.Text ellipsis strong>{ownerMember?.name ?? "--"}</Typography.Text>
           <FactLine
             rows={2}
             secondary
@@ -1474,13 +1511,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const review = authorizationFlow.state === "reviewing" || authorizationFlow.state === "submitting"
     ? authorizationFlow.review
     : null;
-  const upcomingAutomations = routeMember
-    ? (automationsQuery.data?.items ?? [])
-        .filter((automation) => automation.enabled && automation.nextFireAt)
-        .slice(0, 3)
-    : [];
-  const activeFormMember =
-    members.find((member) => member.memberId === draft.memberId) ?? selectedMember;
+  const upcomingAutomations = (automationsQuery.data?.items ?? [])
+    .filter((automation) => automation.enabled && automation.nextFireAt)
+    .slice(0, 3);
+  const activeFormMember = membersById.get(trim(draft.memberId));
   const cronPresets = [
     { label: copy("teams.automations.form.preset.weekdaysMorning", "Weekdays · 09:00"), value: "weekdays-0900", cronExpression: "0 9 * * 1-5" },
     { label: copy("teams.automations.form.preset.dailyMorning", "Daily · 09:00"), value: "daily-0900", cronExpression: "0 9 * * *" },
@@ -1517,7 +1551,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
   return (
     <>
       <style>{responsiveStyle}</style>
-      <div
+      <section
         aria-labelledby="team-automations-title"
         className="team-automations-layout"
         style={pageGridStyle}
@@ -1537,9 +1571,9 @@ const TeamAutomationsTab: React.FC<Props> = ({
             </div>
             <Button
               className="team-automations-create-button"
-              disabled={!selectedMember}
+              disabled={eligibleMembers.length === 0}
               icon={<PlusOutlined />}
-              onClick={openSelectedMember}
+              onClick={openCreate}
               style={primaryHeaderButtonStyle}
               type="primary"
             >
@@ -1548,17 +1582,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
           </div>
 
           <div aria-live="polite" style={{ display: "grid", gap: 12, marginTop: 16 }}>
-            {!routeMember ? (
-              <Empty
-                description={copy(
-                  "teams.automations.empty.member",
-                  "No automations for this member",
-                )}
-              />
-            ) : null}
-            {routeMember && automationsQuery.isLoading ? (
+            {automationsQuery.isLoading ? (
               <div
                 aria-label={copy("teams.automations.loading", "Loading automations")}
+                role="status"
                 style={{ display: "grid", gap: 12 }}
               >
                 {[0, 1, 2].map((placeholder) => (
@@ -1571,7 +1598,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                 ))}
               </div>
             ) : null}
-            {routeMember && automationsQuery.isError ? (
+            {automationsQuery.isError ? (
               <AevatarInspectorEmpty
                 compact
                 title={copy("teams.automations.error.title", "Automations could not load")}
@@ -1581,10 +1608,14 @@ const TeamAutomationsTab: React.FC<Props> = ({
                 )}
               />
             ) : null}
-            {routeMember && !automationsQuery.isLoading && !automationsQuery.isError && !automationsQuery.data?.items.length ? (
-              <Empty description={copy("teams.automations.empty.member", "No automations for this member")} />
+            {!automationsQuery.isLoading && !automationsQuery.isError && !automationItems.length ? (
+              <Empty
+                description={routeMember
+                  ? copy("teams.automations.empty.member", "No automations for this member")
+                  : copy("teams.automations.empty.title", "No recurring work yet")}
+              />
             ) : null}
-            {routeMember && automationItems.length ? (
+            {automationItems.length ? (
               <div style={commitmentGridStyle}>
                 <div className="team-automation-summary" style={automationSummaryGridStyle}>
                   {renderSummaryTile({
@@ -1640,7 +1671,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                   )}
                 </Typography.Text>
               </div>
-              {selectedMember ? (
+              {routeMember ? (
                 <div
                   style={{
                     background: token.colorFillQuaternary,
@@ -1651,11 +1682,11 @@ const TeamAutomationsTab: React.FC<Props> = ({
                     padding: 14,
                   }}
                 >
-                  <Typography.Text ellipsis strong>{selectedMember.name}</Typography.Text>
+                  <Typography.Text ellipsis strong>{routeMember.name}</Typography.Text>
                   <FactLine secondary text={copy("teams.automations.member.publishedServiceReady", "Published service ready")} />
-                  <DetailPill compact style={selectedMember.lifecycleStyle} text={selectedMember.lifecycleLabel} />
+                  <DetailPill compact style={routeMember.lifecycleStyle} text={routeMember.lifecycleLabel} />
                 </div>
-              ) : (
+              ) : eligibleMembers.length === 0 ? (
                 <AevatarInspectorEmpty
                   compact
                   title={copy("teams.automations.noPublishedMember.title", "Publish a member first")}
@@ -1664,12 +1695,12 @@ const TeamAutomationsTab: React.FC<Props> = ({
                     "Automations need a member with a published service identity before they can run.",
                   )}
                 />
-              )}
+              ) : null}
               <Button
                 block
-                disabled={!selectedMember}
+                disabled={eligibleMembers.length === 0}
                 icon={<ClockCircleOutlined />}
-                onClick={openSelectedMember}
+                onClick={openCreate}
                 style={inspectorActionButtonStyle}
                 type="primary"
               >
@@ -1711,8 +1742,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                           "{memberName} recurring work",
                           {
                             memberName:
-                              routeMember?.name ??
-                              selectedMember?.name ??
+                              membersById.get(trim(automation.memberId))?.name ??
                               copy("teams.automations.columns.member", "Member"),
                           },
                         )}
@@ -1746,9 +1776,9 @@ const TeamAutomationsTab: React.FC<Props> = ({
             </AevatarPanel>
           ) : null}
         </div>
-      </div>
+      </section>
 
-      {activeFormMember ? <Modal
+      {formOpen ? <Modal
         aria-describedby="team-automation-form-description"
         confirmLoading={flowBusy || Boolean(busyScheduleId)}
         destroyOnHidden
@@ -1806,7 +1836,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                   options={members
                     .filter((member) => member.canAutomateMember)
                     .map((member) => ({ label: member.name, value: member.memberId }))}
-                  value={activeFormMember.memberId}
+                  value={activeFormMember?.memberId}
                 />
                 <Typography.Text style={{ fontSize: 12 }} type="secondary">
                   {copy("teams.automations.form.identityReady", "Targets the member's published service.")}

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -614,6 +614,36 @@ describe("teamAutomationApi", () => {
     ).toThrow("Unknown Team automation revocation track");
   });
 
+  it("lists every member automation in a Team without ownerMemberId", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [
+          automationView({ scheduleId: "sch-alpha" }),
+          automationView({
+            scheduleId: "sch-beta",
+            serviceId: "svc-beta",
+            teamOwnerMemberId: "m-beta",
+          }),
+        ],
+        nextCursor: null,
+        totalCount: 2,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    const result = await teamAutomationApi.listAll(
+      { scopeId: "scope-alpha", teamId: "team-alpha" },
+      { take: 200 },
+    );
+
+    expect(result.items.map((item) => item.memberId)).toEqual(["m-alpha", "m-beta"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/schedules?ownerKind=studio_member_automation&ownerScopeId=scope-alpha&ownerTeamId=team-alpha&includeTotalCount=true&take=200",
+    );
+  });
+
   it("keeps the canonical owner tuple on every list page", async () => {
     const fetchMock = jest
       .fn()

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -15,9 +15,16 @@ import {
   type ScheduledDispatchOwner,
 } from "./scheduledDispatchApi";
 
-export type TeamAutomationRoute = {
+type TeamAutomationTeamRoute = {
   readonly scopeId: string;
   readonly teamId: string;
+};
+
+export type TeamAutomationListRoute = TeamAutomationTeamRoute & {
+  readonly memberId?: string;
+};
+
+export type TeamAutomationRoute = TeamAutomationTeamRoute & {
   readonly memberId: string;
 };
 
@@ -461,6 +468,24 @@ function assertRouteMatches(
   }
 }
 
+function assertListRouteMatches(
+  actual: TeamAutomationRoute,
+  expected: TeamAutomationListRoute,
+  label: string,
+): void {
+  if (
+    actual.scopeId !== expected.scopeId ||
+    actual.teamId !== expected.teamId ||
+    (expected.memberId !== undefined && actual.memberId !== expected.memberId)
+  ) {
+    throw new Error(
+      expected.memberId
+        ? `${label} does not belong to the requested Team member route.`
+        : `${label} does not belong to the requested Team automation collection.`,
+    );
+  }
+}
+
 function decodePermissionReview(
   value: unknown,
   label = "StudioMemberWorkflowAuthorizationResult",
@@ -862,6 +887,20 @@ function normalizeRoute(route: TeamAutomationRoute): TeamAutomationRoute {
   return normalized;
 }
 
+function normalizeListRoute(route: TeamAutomationListRoute): TeamAutomationListRoute {
+  const scopeId = route.scopeId.trim();
+  const teamId = route.teamId.trim();
+  const memberId = route.memberId?.trim();
+  if (!scopeId || !teamId) {
+    throw new Error("Team automation list route requires scopeId and teamId.");
+  }
+  return {
+    scopeId,
+    teamId,
+    ...(memberId ? { memberId } : {}),
+  };
+}
+
 function scheduleOwner(route: TeamAutomationRoute): ScheduledDispatchOwner {
   const normalized = normalizeRoute(route);
   return {
@@ -873,11 +912,15 @@ function scheduleOwner(route: TeamAutomationRoute): ScheduledDispatchOwner {
 }
 
 function scheduleCollectionPath(
-  route: TeamAutomationRoute,
+  route: TeamAutomationListRoute,
   query?: { readonly cursor?: string; readonly take?: number },
 ): string {
+  const normalized = normalizeListRoute(route);
   return withQuery("/api/schedules", {
-    ...encodeScheduledDispatchOwnerQuery(scheduleOwner(route)),
+    ownerKind: "studio_member_automation",
+    ownerScopeId: normalized.scopeId,
+    ownerTeamId: normalized.teamId,
+    ownerMemberId: normalized.memberId,
     cursor: query?.cursor,
     includeTotalCount: true,
     take: query?.take,
@@ -951,17 +994,18 @@ function decodeViewForRoute(
 
 function decodeListForRoute(
   value: unknown,
-  expectedRoute: TeamAutomationRoute,
+  expectedRoute: TeamAutomationListRoute,
   label?: string,
 ): TeamAutomationListResult {
   const result = decodeList(value, label);
-  result.items.forEach((item, index) =>
-    assertRouteMatches(
+  const normalizedRoute = normalizeListRoute(expectedRoute);
+  result.items.forEach((item, index) => {
+    assertListRouteMatches(
       item,
-      normalizeRoute(expectedRoute),
+      normalizedRoute,
       `${label ?? "ScheduledDispatchListResult"}.items[${index}]`,
-    ),
-  );
+    );
+  });
   return result;
 }
 
@@ -992,7 +1036,7 @@ async function requestTeamAutomation<T>(
 }
 
 function listTeamAutomations(
-  route: TeamAutomationRoute,
+  route: TeamAutomationListRoute,
   query?: { readonly cursor?: string; readonly take?: number },
 ): Promise<TeamAutomationListResult> {
   return requestTeamAutomation(
@@ -1002,7 +1046,7 @@ function listTeamAutomations(
 }
 
 async function listAllTeamAutomations(
-  route: TeamAutomationRoute,
+  route: TeamAutomationListRoute,
   query?: { readonly cursor?: string; readonly take?: number },
 ): Promise<TeamAutomationListResult> {
   const items: TeamAutomationView[] = [];


### PR DESCRIPTION
## Problem

The Team-level Automations tab is a Team collection, but it introduced a second member selector and then stopped querying schedules unless a canonical member route supplied authority. On the Team route this left the collection empty even when Team members owned automations. The earlier flow also defaulted to the first eligible member and navigated away from the Team collection after create.

## Solution

- Keep member selection only inside the create form and do not default the Team form to the first roster member.
- On `/scopes/:scopeId/teams/:teamId?tab=automations`, call `GET /api/schedules` with `ownerKind=studio_member_automation`, `ownerScopeId`, and `ownerTeamId`, while omitting `ownerMemberId`.
- On canonical member routes, keep passing `ownerMemberId` for an exact-member collection.
- Validate every Team-wide list item against the requested scope and Team, and validate the member as well for exact-member queries.
- Resolve each rendered row through its own `memberId`; all detail and mutation calls continue to require the strict `scopeId + teamId + memberId` owner tuple.
- Keep successful Team-level creation on the Team collection instead of navigating to a member route.
- Ignore query-string identity hints as member authority.

This frontend change assumes the list endpoint supports `ownerMemberId` as an optional filter. No backend code is changed in this PR.

## Impact

- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx`
- `apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts`
- `apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts`

No architecture documentation changes are required.

## Local verification

- Related tests: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --findRelatedTests src/pages/teams/detail.tsx src/pages/teams/tabs/TeamAutomationsTab.tsx src/shared/api/teamAutomationApi.ts` - 3 suites and 134 tests passed
- Changed tests: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/shared/api/teamAutomationApi.test.ts src/pages/teams/tabs/TeamAutomationsTab.test.tsx src/pages/teams/detail.test.tsx` - 3 suites and 134 tests passed
- Changed-file static checks: `pnpm --dir apps/aevatar-console-web exec biome lint <6 affected files>` - 0 errors; 8 existing warnings and 2 infos
- Stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Diff validation: `git diff --check origin/dev...HEAD` - passed
- Local runtime: current PR worktree responds on `http://127.0.0.1:5173` and is configured for the remote backend
- Complete frontend suite, local full typecheck, and production build: deferred to GitHub CI by incremental frontend workflow policy