### PR TITLE
Fix backend chat recovery version domain

### DIFF
--- a/docs/design/2026-07-16-studio-chat-history-terminal-append.md
+++ b/docs/design/2026-07-16-studio-chat-history-terminal-append.md
@@ -136,6 +136,11 @@ It returns `404` when no matching scope-bound recovery document exists. Otherwis
 - `append_committed`
 - `append_rejected`
 
+The recovery response `stateVersion` is the committed source version of the
+`ChatTurnHistoryDeliveryGAgent` recovery resource. It reports recovery-status
+freshness only. It is not a `ChatConversationGAgent` version and must never be
+used as a Conversation continuation or reconciliation watermark.
+
 ## Console Boundary
 
 Console no longer sends remote full-transcript saves to `/api/scopes/{scopeId}/chat-history/conversations/{conversationId}`. That public `PUT` surface was removed. Durable Chat History is owned by the backend `ChatConversationGAgent` and its current-state read models.
@@ -173,6 +178,11 @@ To continue an existing Conversation under the authenticated scope, the client s
 
 Chat History integration owns the canonical `conversationId` for create and owns every persistent `turnId`. A blank `conversation.conversationId` is invalid. A nonblank `conversation.conversationId` that is absent, deleted, or outside the trusted scope returns `CONVERSATION_NOT_FOUND`; it must not fall back to create.
 
-When a persisted `/api/chat` request is accepted, the SSE stream first emits `aevatar.chat.context` with `WorkflowChatContextPayload(scope_id, conversation_id, turn_id)`, then emits the existing `aevatar.run.context` frame. `aevatar.chat.context` means the identities were allocated and the terminal delivery reservation was established; it does not mean the Conversation read model is already visible or that the terminal turn has committed.
+When a persisted `/api/chat` request is accepted, the SSE stream first emits `aevatar.chat.context` with `WorkflowChatContextPayload(scope_id, conversation_id, turn_id, state_version)`, then emits the existing `aevatar.run.context` frame. `aevatar.chat.context` means the identities were allocated and the terminal delivery reservation was established; it does not mean the Conversation read model is already visible or that the terminal turn has committed.
+
+`WorkflowChatContextPayload.state_version` is exclusively a Conversation
+watermark. Normal continuation uses the admitted Conversation version. New and
+recovered creates use 0 until the Conversation detail read model exposes the
+exact turn and its own positive `stateVersion`.
 
 `prompt` remains the workflow execution prompt and is the archived user text for backend terminal append. `sessionId` remains runtime correlation only and is never used as Conversation identity.

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunInteractionService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunInteractionService.cs
@@ -313,8 +313,7 @@ internal sealed class WorkflowChatRunInteractionService : IWorkflowChatRunIntera
             new WorkflowChatContext(
                 normalizedScopeId,
                 recovery.ConversationId.Trim(),
-                recovery.TurnId.Trim(),
-                recovery.StateVersion));
+                recovery.TurnId.Trim()));
 
         return WorkflowChatRunInteractionResult.Success(
             receipt,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowChatRunInteractionServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowChatRunInteractionServiceTests.cs
@@ -204,7 +204,7 @@ public sealed class WorkflowChatRunInteractionServiceTests
             "create-command-1",
             "create-command-1",
             WorkflowChatCreateRequestFingerprint.Compute(request),
-            2,
+            4,
             DateTimeOffset.Parse("2026-07-21T01:00:00Z"));
         var actorResolver = new RecordingActorResolver();
         var inner = new RecordingInteractionService();
@@ -223,7 +223,7 @@ public sealed class WorkflowChatRunInteractionServiceTests
         result.Receipt!.Run.ActorId.Should().Be("run-stable");
         result.Receipt.Run.CommandId.Should().Be("create-command-1");
         result.Receipt.ChatContext.Should().BeEquivalentTo(
-            new WorkflowChatContext("scope-a", "conversation-stable", "turn-stable", 2));
+            new WorkflowChatContext("scope-a", "conversation-stable", "turn-stable", 0));
         actorResolver.Requests.Should().BeEmpty();
         inner.Requests.Should().BeEmpty();
         recovery.Requests.Should().ContainSingle().Which.Should().Be(("scope-a", "create-command-1"));


### PR DESCRIPTION
## Problem

Create recovery reads `stateVersion` from the `ChatTurnHistoryDeliveryGAgent` recovery resource. The Workflow Application copied that delivery-resource version into `WorkflowChatContext.StateVersion`, whose SSE contract represents a `ChatConversationGAgent` watermark. Distinct actor version domains could therefore be conflated.

## Backend solution

- Preserve the delivery version on the recovery read model for recovery-resource freshness.
- Do not copy that version into recovered `WorkflowChatContext`; recovered creates use the context default `0` until Conversation detail exposes its authoritative watermark.
- Add a regression using delivery version `4` and expected Conversation context version `0`.
- Document the recovery-response and SSE version-domain contracts.

## Scope

This PR contains only backend implementation, backend tests, and canonical contract documentation. It has no frontend files. The independently effective frontend hardening is tracked in #3067.

## Validation

- [x] `/Users/abigaildeng/.dotnet/dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo --no-restore` (457 passed)
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `bash tools/ci/projection_state_version_guard.sh`
- [x] `bash tools/docs/lint.sh` (83 files, 0 errors)