### PR TITLE
Preserve invocation file refs and avoid activation state link path

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -2013,20 +2013,7 @@ public sealed class AevatarInvocationDispatcher
             {
                 FileId = fileRef.FileId ?? string.Empty,
                 ArtifactId = fileRef.ArtifactId ?? string.Empty,
-                SourceKind = fileRef.SourceKind switch
-                {
-                    Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput =>
-                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ChatInput,
-                    Aevatar.AI.Abstractions.ChatFileSourceKind.FormUpload =>
-                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.FormUpload,
-                    Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource =>
-                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ConnectedServiceResource,
-                    Aevatar.AI.Abstractions.ChatFileSourceKind.ExternalResource =>
-                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ExternalResource,
-                    Aevatar.AI.Abstractions.ChatFileSourceKind.Generated =>
-                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Generated,
-                    _ => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Unspecified,
-                },
+                SourceKind = ToWorkflowFileSourceKind(fileRef.SourceKind),
                 SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
                 SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
                 FileName = fileRef.FileName ?? string.Empty,
@@ -2038,6 +2025,15 @@ public sealed class AevatarInvocationDispatcher
                 OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
                 OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
             };
+
+    private static Aevatar.Workflow.Abstractions.WorkflowFileSourceKind ToWorkflowFileSourceKind(
+        Aevatar.AI.Abstractions.ChatFileSourceKind sourceKind)
+    {
+        var sourceKindValue = (int)sourceKind;
+        return System.Enum.IsDefined(typeof(Aevatar.Workflow.Abstractions.WorkflowFileSourceKind), sourceKindValue)
+            ? (Aevatar.Workflow.Abstractions.WorkflowFileSourceKind)sourceKindValue
+            : Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Unspecified;
+    }
 
     private static InvocationWaitMode ResolveWait(InvocationWaitMode wait) =>
         wait == InvocationWaitMode.Unspecified

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -1905,6 +1905,7 @@ public sealed class AevatarInvocationDispatcher
             Kind = part.Kind switch
             {
                 InvocationContentPartKind.Text => ChatContentPartKind.Text,
+                InvocationContentPartKind.File => ChatContentPartKind.Text,
                 InvocationContentPartKind.Image => ChatContentPartKind.Image,
                 InvocationContentPartKind.Audio => ChatContentPartKind.Audio,
                 InvocationContentPartKind.Video => ChatContentPartKind.Video,
@@ -1915,6 +1916,7 @@ public sealed class AevatarInvocationDispatcher
             MediaType = part.MediaType,
             Uri = part.Uri,
             Name = part.Name,
+            FileRef = part.FileRef?.Clone(),
         }).ToArray();
 
     private static IReadOnlyList<GAgentDraftRunInputPart>? ToGAgentInputParts(InvocationPayload payload)
@@ -1927,6 +1929,7 @@ public sealed class AevatarInvocationDispatcher
             Kind = part.Kind switch
             {
                 InvocationContentPartKind.Text => GAgentDraftRunInputPartKind.Text,
+                InvocationContentPartKind.File => GAgentDraftRunInputPartKind.Text,
                 InvocationContentPartKind.Image => GAgentDraftRunInputPartKind.Image,
                 InvocationContentPartKind.Audio => GAgentDraftRunInputPartKind.Audio,
                 InvocationContentPartKind.Video => GAgentDraftRunInputPartKind.Video,
@@ -1950,6 +1953,7 @@ public sealed class AevatarInvocationDispatcher
             Kind = part.Kind switch
             {
                 InvocationContentPartKind.Text => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Text,
+                InvocationContentPartKind.File => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.File,
                 InvocationContentPartKind.Image => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Image,
                 InvocationContentPartKind.Audio => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Audio,
                 InvocationContentPartKind.Video => Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.Video,
@@ -1960,8 +1964,41 @@ public sealed class AevatarInvocationDispatcher
             MediaType = EmptyToNull(part.MediaType),
             Uri = EmptyToNull(part.Uri),
             Name = EmptyToNull(part.Name),
+            FileRef = ToWorkflowFileRef(part.FileRef),
         }).ToArray();
     }
+
+    private static FileArtifactRef? ToWorkflowFileRef(Aevatar.AI.Abstractions.ChatFileRef? fileRef) =>
+        fileRef is null || !HasFileRefIdentity(fileRef)
+            ? null
+            : new FileArtifactRef
+            {
+                FileId = EmptyToNull(fileRef.FileId),
+                ArtifactId = EmptyToNull(fileRef.ArtifactId),
+                SourceKind = fileRef.SourceKind switch
+                {
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput => FileArtifactSourceKind.ChatInput,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.FormUpload => FileArtifactSourceKind.FormUpload,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource => FileArtifactSourceKind.ConnectedServiceResource,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.ExternalResource => FileArtifactSourceKind.ExternalResource,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.Generated => FileArtifactSourceKind.Generated,
+                    _ => FileArtifactSourceKind.Unspecified,
+                },
+                SourceMessageId = EmptyToNull(fileRef.SourceMessageId),
+                SourceResourceKey = EmptyToNull(fileRef.SourceResourceKey),
+                FileName = EmptyToNull(fileRef.FileName),
+                MediaType = EmptyToNull(fileRef.MediaType),
+                SizeBytes = fileRef.SizeBytes,
+                Sha256 = EmptyToNull(fileRef.Sha256),
+                CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+                ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+                OwnerRunId = EmptyToNull(fileRef.OwnerRunId),
+                OwnerScopeId = EmptyToNull(fileRef.OwnerScopeId),
+            };
+
+    private static bool HasFileRefIdentity(Aevatar.AI.Abstractions.ChatFileRef fileRef) =>
+        !string.IsNullOrWhiteSpace(fileRef.FileId) ||
+        !string.IsNullOrWhiteSpace(fileRef.ArtifactId);
 
     private static InvocationWaitMode ResolveWait(InvocationWaitMode wait) =>
         wait == InvocationWaitMode.Unspecified

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -624,6 +624,10 @@ public sealed class AevatarInvocationDispatcher
                 : workflowRuntimeContext.RootRunId.Trim(),
             RequestedDepth = Math.Max(0, workflowRuntimeContext.Depth) + 1,
         };
+        managedStart.InputFileRefs.Add(request.Inputs.InputParts
+            .Select(static part => ToWorkflowEventFileRef(part.FileRef))
+            .Where(static fileRef => fileRef != null)
+            .Select(static fileRef => fileRef!.Clone()));
 
         if (workflowYamls is { Count: > 0 })
         {
@@ -1940,6 +1944,7 @@ public sealed class AevatarInvocationDispatcher
             MediaType = EmptyToNull(part.MediaType),
             Uri = EmptyToNull(part.Uri),
             Name = EmptyToNull(part.Name),
+            FileRef = part.FileRef?.Clone(),
         }).ToArray();
     }
 
@@ -1999,6 +2004,40 @@ public sealed class AevatarInvocationDispatcher
     private static bool HasFileRefIdentity(Aevatar.AI.Abstractions.ChatFileRef fileRef) =>
         !string.IsNullOrWhiteSpace(fileRef.FileId) ||
         !string.IsNullOrWhiteSpace(fileRef.ArtifactId);
+
+    private static Aevatar.Workflow.Abstractions.WorkflowFileRef? ToWorkflowEventFileRef(
+        Aevatar.AI.Abstractions.ChatFileRef? fileRef) =>
+        fileRef is null || !HasFileRefIdentity(fileRef)
+            ? null
+            : new Aevatar.Workflow.Abstractions.WorkflowFileRef
+            {
+                FileId = fileRef.FileId ?? string.Empty,
+                ArtifactId = fileRef.ArtifactId ?? string.Empty,
+                SourceKind = fileRef.SourceKind switch
+                {
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput =>
+                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ChatInput,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.FormUpload =>
+                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.FormUpload,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource =>
+                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ConnectedServiceResource,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.ExternalResource =>
+                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ExternalResource,
+                    Aevatar.AI.Abstractions.ChatFileSourceKind.Generated =>
+                        Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Generated,
+                    _ => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Unspecified,
+                },
+                SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
+                SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
+                FileName = fileRef.FileName ?? string.Empty,
+                MediaType = fileRef.MediaType ?? string.Empty,
+                SizeBytes = fileRef.SizeBytes,
+                Sha256 = fileRef.Sha256 ?? string.Empty,
+                CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+                ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+                OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
+                OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
+            };
 
     private static InvocationWaitMode ResolveWait(InvocationWaitMode wait) =>
         wait == InvocationWaitMode.Unspecified

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
@@ -6,7 +6,7 @@ internal static class AevatarInvocationToolSchemas
         new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
         {
             ["wait"] = ["ack", "stream", "complete"],
-            ["kind"] = ["text", "image", "audio", "video"],
+            ["kind"] = ["text", "image", "audio", "video", "file"],
         };
 
     public static readonly string InvokeGAgent = ProtoToolSchema.Build(

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
@@ -205,10 +205,12 @@ internal static class ProtoToolArguments
             "image" => "INVOCATION_CONTENT_PART_KIND_IMAGE",
             "audio" => "INVOCATION_CONTENT_PART_KIND_AUDIO",
             "video" => "INVOCATION_CONTENT_PART_KIND_VIDEO",
+            "file" => "INVOCATION_CONTENT_PART_KIND_FILE",
             "invocation_content_part_kind_text" => "INVOCATION_CONTENT_PART_KIND_TEXT",
             "invocation_content_part_kind_image" => "INVOCATION_CONTENT_PART_KIND_IMAGE",
             "invocation_content_part_kind_audio" => "INVOCATION_CONTENT_PART_KIND_AUDIO",
             "invocation_content_part_kind_video" => "INVOCATION_CONTENT_PART_KIND_VIDEO",
+            "invocation_content_part_kind_file" => "INVOCATION_CONTENT_PART_KIND_FILE",
             _ => raw,
         };
 }

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto
@@ -19,6 +19,7 @@ enum InvocationContentPartKind {
   INVOCATION_CONTENT_PART_KIND_IMAGE = 2;
   INVOCATION_CONTENT_PART_KIND_AUDIO = 3;
   INVOCATION_CONTENT_PART_KIND_VIDEO = 4;
+  INVOCATION_CONTENT_PART_KIND_FILE = 5;
 }
 
 message InvocationContentPart {
@@ -28,6 +29,7 @@ message InvocationContentPart {
   string media_type = 4;
   string uri = 5;
   string name = 6;
+  aevatar.ai.ChatFileRef file_ref = 7;
 }
 
 message InvocationPayload {

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Actors/OrleansActorRuntime.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Actors/OrleansActorRuntime.cs
@@ -18,14 +18,12 @@ public sealed class OrleansActorRuntime : IActorRuntime
     private readonly IActorRuntimeCallbackScheduler _callbackScheduler;
     private readonly ILogger<OrleansActorRuntime> _logger;
     private readonly IAgentKindRegistry _agentKindRegistry;
-    private readonly IRuntimeActorStateBindingAccessor _stateBindingAccessor;
 
     public OrleansActorRuntime(
         IGrainFactory grainFactory,
         Aevatar.Foundation.Abstractions.IStreamProvider streams,
         IActorRuntimeCallbackScheduler callbackScheduler,
         IAgentKindRegistry agentKindRegistry,
-        IRuntimeActorStateBindingAccessor stateBindingAccessor,
         IStreamLifecycleManager? streamLifecycleManager = null,
         ILogger<OrleansActorRuntime>? logger = null)
     {
@@ -33,7 +31,6 @@ public sealed class OrleansActorRuntime : IActorRuntime
         _streams = streams;
         _callbackScheduler = callbackScheduler ?? throw new ArgumentNullException(nameof(callbackScheduler));
         _agentKindRegistry = agentKindRegistry ?? throw new ArgumentNullException(nameof(agentKindRegistry));
-        _stateBindingAccessor = stateBindingAccessor ?? throw new ArgumentNullException(nameof(stateBindingAccessor));
         _streamLifecycleManager = streamLifecycleManager ?? NullStreamLifecycleManager.Instance;
         _logger = logger ?? NullLogger<OrleansActorRuntime>.Instance;
     }
@@ -129,21 +126,7 @@ public sealed class OrleansActorRuntime : IActorRuntime
             throw new InvalidOperationException($"Child actor {childId} is not initialized.");
 
         using var reentrancyScope = RequestContext.AllowCallChainReentrancy();
-        var boundParentState = _stateBindingAccessor.Current;
-        if (boundParentState != null &&
-            string.Equals(boundParentState.State.AgentId, parentId, StringComparison.Ordinal))
-        {
-            if (!boundParentState.State.Children.Contains(childId, StringComparer.Ordinal))
-            {
-                boundParentState.State.Children.Add(childId);
-                await boundParentState.WriteStateAsync();
-            }
-        }
-        else
-        {
-            await parent.AddChildAsync(childId);
-        }
-
+        await parent.AddChildAsync(childId);
         await child.SetParentAsync(parentId);
         await _streams.GetStream(parentId).UpsertRelayAsync(
             StreamForwardingRules.CreateHierarchyBinding(parentId, childId),

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs
@@ -21,6 +21,7 @@ public sealed record GAgentDraftRunInputPart
     public string? MediaType { get; init; }
     public string? Uri { get; init; }
     public string? Name { get; init; }
+    public Aevatar.AI.Abstractions.ChatFileRef? FileRef { get; init; }
 }
 
 // Refactor (iter1353/cluster-001): Old pattern: draft-run commands rebuilt trusted caller/control facts from headers and legacy scalars.

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
@@ -480,6 +480,7 @@ internal sealed class GAgentDraftRunCommandEnvelopeFactory
             MediaType = source.MediaType ?? string.Empty,
             Uri = source.Uri ?? string.Empty,
             Name = source.Name ?? string.Empty,
+            FileRef = source.FileRef?.Clone(),
         };
     }
 

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
@@ -325,21 +325,16 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
         };
         foreach (var part in source.InputParts)
         {
+            var fileRef = ToWorkflowFileRef(part.FileRef);
             request.InputParts.Add(new WorkflowChatInputPartPayload
             {
-                Kind = part.Kind switch
-                {
-                    ChatContentPartKind.Text => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Text,
-                    ChatContentPartKind.Image => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Image,
-                    ChatContentPartKind.Audio => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Audio,
-                    ChatContentPartKind.Video => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Video,
-                    _ => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Unspecified,
-                },
+                Kind = ResolveWorkflowInputPartKind(part, fileRef),
                 Text = part.Text ?? string.Empty,
                 DataBase64 = part.DataBase64 ?? string.Empty,
                 MediaType = part.MediaType ?? string.Empty,
                 Uri = part.Uri ?? string.Empty,
                 Name = part.Name ?? string.Empty,
+                FileRef = fileRef,
             });
         }
         foreach (var (key, value) in source.Headers)
@@ -360,6 +355,71 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
             invocationRequest.WorkflowCompletionNotificationTarget);
         return request;
     }
+
+    private static Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind ResolveWorkflowInputPartKind(
+        ChatContentPart part,
+        Aevatar.Workflow.Abstractions.WorkflowFileRef? fileRef)
+    {
+        if (fileRef != null)
+        {
+            var mediaType = string.IsNullOrWhiteSpace(part.MediaType)
+                ? fileRef.MediaType
+                : part.MediaType;
+            if (IsMediaType(mediaType, "image/"))
+                return Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Image;
+            if (IsMediaType(mediaType, "audio/"))
+                return Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Audio;
+            if (IsMediaType(mediaType, "video/"))
+                return Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Video;
+            if (part.Kind == ChatContentPartKind.Text)
+                return Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.File;
+        }
+
+        return part.Kind switch
+        {
+            ChatContentPartKind.Text => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Text,
+            ChatContentPartKind.Image => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Image,
+            ChatContentPartKind.Audio => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Audio,
+            ChatContentPartKind.Video => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Video,
+            _ => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Unspecified,
+        };
+    }
+
+    private static bool IsMediaType(string? mediaType, string prefix) =>
+        !string.IsNullOrWhiteSpace(mediaType) &&
+        mediaType.Trim().StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+
+    private static Aevatar.Workflow.Abstractions.WorkflowFileRef? ToWorkflowFileRef(ChatFileRef? fileRef) =>
+        fileRef is null || !HasFileRefIdentity(fileRef)
+            ? null
+            : new Aevatar.Workflow.Abstractions.WorkflowFileRef
+            {
+                FileId = fileRef.FileId ?? string.Empty,
+                ArtifactId = fileRef.ArtifactId ?? string.Empty,
+                SourceKind = fileRef.SourceKind switch
+                {
+                    ChatFileSourceKind.ChatInput => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ChatInput,
+                    ChatFileSourceKind.FormUpload => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.FormUpload,
+                    ChatFileSourceKind.ConnectedServiceResource => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ConnectedServiceResource,
+                    ChatFileSourceKind.ExternalResource => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ExternalResource,
+                    ChatFileSourceKind.Generated => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Generated,
+                    _ => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Unspecified,
+                },
+                SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
+                SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
+                FileName = fileRef.FileName ?? string.Empty,
+                MediaType = fileRef.MediaType ?? string.Empty,
+                SizeBytes = fileRef.SizeBytes,
+                Sha256 = fileRef.Sha256 ?? string.Empty,
+                CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+                ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+                OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
+                OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
+            };
+
+    private static bool HasFileRefIdentity(ChatFileRef fileRef) =>
+        !string.IsNullOrWhiteSpace(fileRef.FileId) ||
+        !string.IsNullOrWhiteSpace(fileRef.ArtifactId);
 
     private static void ApplyWorkflowCompletionNotificationTarget(
         WorkflowChatRequestEvent workflowRequest,

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
@@ -375,14 +375,10 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
                 return Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.File;
         }
 
-        return part.Kind switch
-        {
-            ChatContentPartKind.Text => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Text,
-            ChatContentPartKind.Image => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Image,
-            ChatContentPartKind.Audio => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Audio,
-            ChatContentPartKind.Video => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Video,
-            _ => Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Unspecified,
-        };
+        var kindValue = (int)part.Kind;
+        return System.Enum.IsDefined(typeof(Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind), kindValue)
+            ? (Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind)kindValue
+            : Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Unspecified;
     }
 
     private static bool IsMediaType(string? mediaType, string prefix) =>
@@ -396,15 +392,7 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
             {
                 FileId = fileRef.FileId ?? string.Empty,
                 ArtifactId = fileRef.ArtifactId ?? string.Empty,
-                SourceKind = fileRef.SourceKind switch
-                {
-                    ChatFileSourceKind.ChatInput => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ChatInput,
-                    ChatFileSourceKind.FormUpload => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.FormUpload,
-                    ChatFileSourceKind.ConnectedServiceResource => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ConnectedServiceResource,
-                    ChatFileSourceKind.ExternalResource => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ExternalResource,
-                    ChatFileSourceKind.Generated => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Generated,
-                    _ => Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Unspecified,
-                },
+                SourceKind = ToWorkflowFileSourceKind(fileRef.SourceKind),
                 SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
                 SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
                 FileName = fileRef.FileName ?? string.Empty,
@@ -416,6 +404,15 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
                 OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
                 OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
             };
+
+    private static Aevatar.Workflow.Abstractions.WorkflowFileSourceKind ToWorkflowFileSourceKind(
+        ChatFileSourceKind sourceKind)
+    {
+        var sourceKindValue = (int)sourceKind;
+        return System.Enum.IsDefined(typeof(Aevatar.Workflow.Abstractions.WorkflowFileSourceKind), sourceKindValue)
+            ? (Aevatar.Workflow.Abstractions.WorkflowFileSourceKind)sourceKindValue
+            : Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.Unspecified;
+    }
 
     private static bool HasFileRefIdentity(ChatFileRef fileRef) =>
         !string.IsNullOrWhiteSpace(fileRef.FileId) ||

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -601,6 +601,7 @@ message SubWorkflowInvokeRequestedEvent
   string requested_by_actor_id = 7;
   string root_run_id = 8;
   int32 requested_depth = 9;
+  repeated WorkflowFileRef input_file_refs = 10;
 }
 message WorkflowDefinitionSnapshot
 {
@@ -659,6 +660,7 @@ message SubWorkflowDefinitionResolutionRegisteredEvent
   int32 timeout_callback_slot_epoch = 13;
   string root_run_id = 14;
   int32 requested_depth = 15;
+  repeated WorkflowFileRef input_file_refs = 16;
 }
 message SubWorkflowDefinitionResolutionClearedEvent
 {
@@ -690,6 +692,7 @@ message SubWorkflowInvocationRegisteredEvent
   map<string, string> inline_workflow_yamls = 14;
   string root_run_id = 15;
   int32 depth = 16;
+  repeated WorkflowFileRef input_file_refs = 17;
 }
 message SubWorkflowInvocationHandoffAdvancedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/WorkflowCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/WorkflowCallModule.cs
@@ -92,6 +92,7 @@ public sealed class WorkflowCallModule : IEventModule<IWorkflowExecutionContext>
             RootRunId = runtimeContext.RootRunId,
             RequestedDepth = Math.Max(0, runtimeContext.Depth) + 1,
         };
+        invocation.InputFileRefs.Add(request.InputFileRefs.Select(static fileRef => fileRef.Clone()));
 
         await ctx.PublishAsync(invocation, TopologyAudience.Self, ct);
     }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/SubWorkflowOrchestrator.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/SubWorkflowOrchestrator.cs
@@ -153,6 +153,7 @@ internal sealed class SubWorkflowOrchestrator
                     inlineSnapshot,
                     rootRunId,
                     requestedDepth,
+                    request.InputFileRefs,
                     state,
                     ct);
                 return;
@@ -196,6 +197,7 @@ internal sealed class SubWorkflowOrchestrator
                 TimeoutMs = timeoutMs,
                 RootRunId = rootRunId,
                 RequestedDepth = requestedDepth,
+                InputFileRefs = { CloneFileRefs(request.InputFileRefs) },
             }, ct);
 
             await _sendToAsync(
@@ -331,6 +333,7 @@ internal sealed class SubWorkflowOrchestrator
                 definition,
                 ResolveRootRunId(pending.RootRunId, state, pending.ParentRunId),
                 WorkflowCallLimitPolicy.ResolveChildDepth(pending.RequestedDepth, ResolveParentDepth(state, pending.ParentRunId)),
+                pending.InputFileRefs,
                 state,
                 ct);
             await TryCancelDefinitionResolutionTimeoutAsync(pending, CancellationToken.None);
@@ -398,6 +401,7 @@ internal sealed class SubWorkflowOrchestrator
         WorkflowDefinitionSnapshot definition,
         string rootRunId,
         int depth,
+        IReadOnlyList<WorkflowFileRef> inputFileRefs,
         WorkflowRunState state,
         CancellationToken ct)
     {
@@ -417,6 +421,7 @@ internal sealed class SubWorkflowOrchestrator
             definition,
             rootRunId,
             depth,
+            inputFileRefs,
             state);
 
         await _persistDomainEventAsync(new SubWorkflowInvocationRegisteredEvent
@@ -437,6 +442,7 @@ internal sealed class SubWorkflowOrchestrator
             RootRunId = registered.RootRunId,
             Depth = registered.Depth,
             InlineWorkflowYamls = { registered.InlineWorkflowYamls },
+            InputFileRefs = { CloneFileRefs(registered.InputFileRefs) },
         }, ct);
 
         await DrivePendingSubWorkflowInvocationHandoffAsync(registered, definition, state, ct);
@@ -689,6 +695,7 @@ internal sealed class SubWorkflowOrchestrator
             TimeoutMs = evt.TimeoutMs,
             RootRunId = ResolveRootRunId(evt.RootRunId, current, evt.ParentRunId),
             RequestedDepth = Math.Max(0, evt.RequestedDepth),
+            InputFileRefs = { CloneFileRefs(evt.InputFileRefs) },
         };
 
         RemovePendingDefinitionResolution(next, invocationId);
@@ -731,6 +738,7 @@ internal sealed class SubWorkflowOrchestrator
             RootRunId = ResolveRootRunId(evt.RootRunId, current, evt.ParentRunId),
             Depth = Math.Max(0, evt.Depth),
             InlineWorkflowYamls = { evt.InlineWorkflowYamls },
+            InputFileRefs = { CloneFileRefs(evt.InputFileRefs) },
         };
         RemovePendingDefinitionResolution(next, invocationId);
         RemovePendingInvocation(next, invocationId, childRunId);
@@ -790,6 +798,7 @@ internal sealed class SubWorkflowOrchestrator
         WorkflowDefinitionSnapshot definition,
         string rootRunId,
         int depth,
+        IReadOnlyList<WorkflowFileRef> inputFileRefs,
         WorkflowRunState state)
     {
         var normalizedLifecycle = WorkflowCallLifecycle.Normalize(lifecycle);
@@ -814,6 +823,7 @@ internal sealed class SubWorkflowOrchestrator
                 : definition.ScopeId,
             RootRunId = ResolveRootRunId(rootRunId, state, parentRunId),
             Depth = Math.Max(0, depth),
+            InputFileRefs = { CloneFileRefs(inputFileRefs) },
         };
 
         foreach (var (inlineWorkflowName, inlineWorkflowYaml) in definition.InlineWorkflowYamls.Count > 0
@@ -1009,6 +1019,7 @@ internal sealed class SubWorkflowOrchestrator
                 Depth = Math.Max(0, pending.Depth),
             },
         };
+        start.InputFileRefs.Add(CloneFileRefs(pending.InputFileRefs));
         start.Parameters[WorkflowCallInvocationIdMetadataKey] = pending.InvocationId;
         start.Parameters[WorkflowCallParentRunIdMetadataKey] = pending.ParentRunId;
         start.Parameters[WorkflowCallParentStepIdMetadataKey] = pending.ParentStepId;
@@ -1211,6 +1222,9 @@ internal sealed class SubWorkflowOrchestrator
             throw new InvalidOperationException($"workflow_call {sourceDescription} is invalid: {ex.Message}", ex);
         }
     }
+
+    private static IEnumerable<WorkflowFileRef> CloneFileRefs(IEnumerable<WorkflowFileRef>? fileRefs) =>
+        fileRefs?.Select(static fileRef => fileRef.Clone()) ?? [];
 
     private async Task PublishWorkflowCallFailureAsync(
         string parentStepId,

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -38,6 +38,7 @@ message WorkflowState
     map<string, string> inline_workflow_yamls = 14;
     string root_run_id = 15;
     int32 depth = 16;
+    repeated WorkflowFileRef input_file_refs = 17;
   }
 
   message PendingSubWorkflowDefinitionResolution
@@ -54,6 +55,7 @@ message WorkflowState
     int32 timeout_ms = 10;
     string root_run_id = 11;
     int32 requested_depth = 12;
+    repeated WorkflowFileRef input_file_refs = 13;
   }
 
   message ChildRunIdSet
@@ -112,6 +114,7 @@ message WorkflowRunState
     map<string, string> inline_workflow_yamls = 14;
     string root_run_id = 15;
     int32 depth = 16;
+    repeated WorkflowFileRef input_file_refs = 17;
   }
 
   message PendingSubWorkflowDefinitionResolution
@@ -128,6 +131,7 @@ message WorkflowRunState
     int32 timeout_ms = 10;
     string root_run_id = 11;
     int32 requested_depth = 12;
+    repeated WorkflowFileRef input_file_refs = 13;
   }
 
   message ChildRunIdSet

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -770,6 +770,21 @@ public sealed class AevatarInvocationToolSourceTests
               "member_id": "m-alpha",
               "payload": {
                 "prompt": "run member workflow",
+                "input_parts": [
+                  {
+                    "kind": "file",
+                    "file_ref": {
+                      "file_id": "file-lark-1",
+                      "artifact_id": "workflow-file://file-lark-1",
+                      "source_kind": 3,
+                      "source_message_id": "om_lark_1",
+                      "source_resource_key": "file_key_1",
+                      "file_name": "invoice.pdf",
+                      "media_type": "application/pdf",
+                      "size_bytes": 1234
+                    }
+                  }
+                ],
                 "headers": { "x-workflow": "yes" }
               },
               "wait": "stream"
@@ -798,7 +813,22 @@ public sealed class AevatarInvocationToolSourceTests
         dispatch.Request.Identity!.TenantId.Should().Be("scope-1");
         dispatch.Request.Identity.ServiceId.Should().Be("svc-alpha");
         dispatch.Request.EndpointId.Should().Be("chat");
-        dispatch.Request.Payload!.Unpack<ChatRequestEvent>().Prompt.Should().Be("run member workflow");
+        var chatPayload = dispatch.Request.Payload!.Unpack<ChatRequestEvent>();
+        chatPayload.Prompt.Should().Be("run member workflow");
+        chatPayload.InputParts.Should().ContainSingle();
+        var inputPart = chatPayload.InputParts.Single();
+        inputPart.Kind.Should().Be(ChatContentPartKind.Text);
+        inputPart.DataBase64.Should().BeEmpty();
+        inputPart.FileRef.Should().NotBeNull();
+        var fileRef = inputPart.FileRef!;
+        fileRef.FileId.Should().Be("file-lark-1");
+        fileRef.ArtifactId.Should().Be("workflow-file://file-lark-1");
+        fileRef.SourceKind.Should().Be(Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource);
+        fileRef.SourceMessageId.Should().Be("om_lark_1");
+        fileRef.SourceResourceKey.Should().Be("file_key_1");
+        fileRef.FileName.Should().Be("invoice.pdf");
+        fileRef.MediaType.Should().Be("application/pdf");
+        fileRef.SizeBytes.Should().Be(1234);
         harness.AdmissionAuthorizer.Calls.Should().ContainSingle();
     }
 
@@ -1396,6 +1426,21 @@ public sealed class AevatarInvocationToolSourceTests
               "workflow_id": "wf-main",
               "inputs": {
                 "prompt": "run workflow",
+                "input_parts": [
+                  {
+                    "kind": "file",
+                    "file_ref": {
+                      "file_id": "file-lark-1",
+                      "artifact_id": "workflow-file://file-lark-1",
+                      "source_kind": 3,
+                      "source_message_id": "om_lark_1",
+                      "source_resource_key": "file_key_1",
+                      "file_name": "invoice.pdf",
+                      "media_type": "application/pdf",
+                      "size_bytes": 1234
+                    }
+                  }
+                ],
                 "headers": { "x-workflow": "yes" }
               },
               "wait": "stream"
@@ -1408,6 +1453,20 @@ public sealed class AevatarInvocationToolSourceTests
         harness.WorkflowDispatch.Command.Prompt.Should().Be("run workflow");
         harness.WorkflowDispatch.Command.ScopeId.Should().Be("scope-1");
         harness.WorkflowDispatch.Command.CallerCredential!.BearerToken.Should().Be("access-token");
+        harness.WorkflowDispatch.Command.InputParts.Should().ContainSingle();
+        var inputPart = harness.WorkflowDispatch.Command.InputParts!.Single();
+        inputPart.Kind.Should().Be(Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.File);
+        inputPart.DataBase64.Should().BeNull();
+        inputPart.FileRef.Should().NotBeNull();
+        var fileRef = inputPart.FileRef!;
+        fileRef.FileId.Should().Be("file-lark-1");
+        fileRef.ArtifactId.Should().Be("workflow-file://file-lark-1");
+        fileRef.SourceKind.Should().Be(FileArtifactSourceKind.ConnectedServiceResource);
+        fileRef.SourceMessageId.Should().Be("om_lark_1");
+        fileRef.SourceResourceKey.Should().Be("file_key_1");
+        fileRef.FileName.Should().Be("invoice.pdf");
+        fileRef.MediaType.Should().Be("application/pdf");
+        fileRef.SizeBytes.Should().Be(1234);
         harness.WorkflowDispatch.Command.Metadata.Should().Contain("x-workflow", "yes");
         ShouldNotCarryTrustedCallerValues(harness.WorkflowDispatch.Command.Metadata);
         ShouldCarryWorkflowLlmControlValues(harness.WorkflowDispatch.Command.LlmControl);

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1099,7 +1099,24 @@ public sealed class AevatarInvocationToolSourceTests
             {
               "team_id": "team-1",
               "endpoint_id": "entry",
-              "payload": { "prompt": "go" },
+              "payload": {
+                "prompt": "go",
+                "input_parts": [
+                  {
+                    "kind": "file",
+                    "file_ref": {
+                      "file_id": "file-static-1",
+                      "artifact_id": "workflow-file://file-static-1",
+                      "source_kind": 3,
+                      "source_message_id": "om_static_1",
+                      "source_resource_key": "file_key_static_1",
+                      "file_name": "invoice.pdf",
+                      "media_type": "application/pdf",
+                      "size_bytes": 1234
+                    }
+                  }
+                ]
+              },
               "wait": "stream"
             }
             """);
@@ -1111,6 +1128,17 @@ public sealed class AevatarInvocationToolSourceTests
         result.ServiceId.Should().Be("service-1");
         result.StreamTopic.Should().Be("aevatar://scopes/scope-1/services/service-1/runs/team-command");
         harness.TeamInvocation.Request.Should().NotBeNull();
+        var inputPart = harness.TeamInvocation.Request!.Input.InputParts.Should().ContainSingle().Which;
+        inputPart.Kind.Should().Be(GAgentDraftRunInputPartKind.Text);
+        inputPart.FileRef.Should().NotBeNull();
+        inputPart.FileRef!.FileId.Should().Be("file-static-1");
+        inputPart.FileRef.ArtifactId.Should().Be("workflow-file://file-static-1");
+        inputPart.FileRef.SourceKind.Should().Be(Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource);
+        inputPart.FileRef.SourceMessageId.Should().Be("om_static_1");
+        inputPart.FileRef.SourceResourceKey.Should().Be("file_key_static_1");
+        inputPart.FileRef.FileName.Should().Be("invoice.pdf");
+        inputPart.FileRef.MediaType.Should().Be("application/pdf");
+        inputPart.FileRef.SizeBytes.Should().Be(1234);
         harness.WorkflowDispatch.Command.Should().BeNull();
         harness.ServiceRunRegistration.Records.Should().BeEmpty();
         harness.AdmissionAuthorizer.Calls.Should().ContainSingle();
@@ -2256,7 +2284,24 @@ public sealed class AevatarInvocationToolSourceTests
         var output = await tool.ExecuteAsync("""
             {
               "workflow_id": "child-flow",
-              "inputs": { "prompt": "run child" },
+              "inputs": {
+                "prompt": "run child",
+                "input_parts": [
+                  {
+                    "kind": "file",
+                    "file_ref": {
+                      "file_id": "file-child-1",
+                      "artifact_id": "workflow-file://file-child-1",
+                      "source_kind": 3,
+                      "source_message_id": "om_child_1",
+                      "source_resource_key": "file_key_child_1",
+                      "file_name": "child.pdf",
+                      "media_type": "application/pdf",
+                      "size_bytes": 456
+                    }
+                  }
+                ]
+              },
               "wait": "stream"
             }
             """);
@@ -2486,7 +2531,24 @@ public sealed class AevatarInvocationToolSourceTests
         var output = await tool.ExecuteAsync("""
             {
               "workflow_id": "child-flow",
-              "inputs": { "prompt": "run child" },
+              "inputs": {
+                "prompt": "run child",
+                "input_parts": [
+                  {
+                    "kind": "file",
+                    "file_ref": {
+                      "file_id": "file-child-1",
+                      "artifact_id": "workflow-file://file-child-1",
+                      "source_kind": 3,
+                      "source_message_id": "om_child_1",
+                      "source_resource_key": "file_key_child_1",
+                      "file_name": "child.pdf",
+                      "media_type": "application/pdf",
+                      "size_bytes": 456
+                    }
+                  }
+                ]
+              },
               "wait": "stream"
             }
             """);
@@ -2509,6 +2571,15 @@ public sealed class AevatarInvocationToolSourceTests
         requested.RequestedByActorId.Should().Be("parent-actor");
         requested.RootRunId.Should().Be("root-run");
         requested.RequestedDepth.Should().Be(3);
+        requested.InputFileRefs.Should().ContainSingle();
+        requested.InputFileRefs[0].FileId.Should().Be("file-child-1");
+        requested.InputFileRefs[0].ArtifactId.Should().Be("workflow-file://file-child-1");
+        requested.InputFileRefs[0].SourceKind.Should().Be(WorkflowFileSourceKind.ConnectedServiceResource);
+        requested.InputFileRefs[0].SourceMessageId.Should().Be("om_child_1");
+        requested.InputFileRefs[0].SourceResourceKey.Should().Be("file_key_child_1");
+        requested.InputFileRefs[0].FileName.Should().Be("child.pdf");
+        requested.InputFileRefs[0].MediaType.Should().Be("application/pdf");
+        requested.InputFileRefs[0].SizeBytes.Should().Be(456);
 
         var result = Read(output);
         result.GetProperty("run_id").GetString().Should().Be(requested.InvocationId);

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorRuntimeForwardingTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorRuntimeForwardingTests.cs
@@ -74,35 +74,28 @@ public sealed class OrleansActorRuntimeForwardingTests
     }
 
     [Fact]
-    public async Task LinkAsync_WithBoundCurrentParent_ShouldPersistChildWithoutCallingParentGrain()
+    public async Task LinkAsync_WithBoundCurrentParent_ShouldUseParentGrainWithoutTouchingBoundState()
     {
         var stateBindingAccessor = new AsyncLocalRuntimeActorStateBindingAccessor();
-        var runtime = CreateRuntime(
-            out _,
-            out var grains,
-            out _,
-            stateBindingAccessor: stateBindingAccessor);
+        var runtime = CreateRuntime(out _, out var grains, out _);
         var boundState = CreatePersistentState("parent");
         var stateProxy = (RuntimeActorPersistentStateProxy)(object)boundState;
 
         using (stateBindingAccessor.Bind(boundState))
             await runtime.LinkAsync("parent", "child");
 
-        stateProxy.State.Children.Should().ContainSingle("child");
-        stateProxy.WriteCount.Should().Be(1);
-        grains["parent"].AddChildCallCount.Should().Be(0);
+        stateProxy.State.Children.Should().BeEmpty();
+        stateProxy.WriteCount.Should().Be(0);
+        grains["parent"].AddChildCallCount.Should().Be(1);
+        grains["parent"].Children.Should().ContainSingle("child");
         grains["child"].ParentId.Should().Be("parent");
     }
 
     [Fact]
-    public async Task LinkAsync_WithBoundCurrentParent_WhenRepeated_ShouldRemainIdempotent()
+    public async Task LinkAsync_WithBoundCurrentParent_WhenRepeated_ShouldLeaveTopologyIdempotent()
     {
         var stateBindingAccessor = new AsyncLocalRuntimeActorStateBindingAccessor();
-        var runtime = CreateRuntime(
-            out _,
-            out var grains,
-            out _,
-            stateBindingAccessor: stateBindingAccessor);
+        var runtime = CreateRuntime(out _, out var grains, out _);
         var boundState = CreatePersistentState("parent");
         var stateProxy = (RuntimeActorPersistentStateProxy)(object)boundState;
 
@@ -112,9 +105,10 @@ public sealed class OrleansActorRuntimeForwardingTests
             await runtime.LinkAsync("parent", "child");
         }
 
-        stateProxy.State.Children.Should().ContainSingle("child");
-        stateProxy.WriteCount.Should().Be(1);
-        grains["parent"].AddChildCallCount.Should().Be(0);
+        stateProxy.State.Children.Should().BeEmpty();
+        stateProxy.WriteCount.Should().Be(0);
+        grains["parent"].Children.Should().ContainSingle("child");
+        grains["parent"].AddChildCallCount.Should().Be(2);
         grains["child"].ParentId.Should().Be("parent");
     }
 
@@ -305,8 +299,7 @@ public sealed class OrleansActorRuntimeForwardingTests
         out InMemoryStreamForwardingRegistry registry,
         out Dictionary<string, RecordingRuntimeActorGrain> grains,
         out Dictionary<string, RecordingCallbackSchedulerGrain> callbackSchedulerGrains,
-        IStreamLifecycleManager? streamLifecycleManager = null,
-        IRuntimeActorStateBindingAccessor? stateBindingAccessor = null)
+        IStreamLifecycleManager? streamLifecycleManager = null)
     {
         var grainMap = new Dictionary<string, RecordingRuntimeActorGrain>(StringComparer.Ordinal);
         var callbackSchedulerGrainMap = new Dictionary<string, RecordingCallbackSchedulerGrain>(StringComparer.Ordinal);
@@ -344,7 +337,6 @@ public sealed class OrleansActorRuntimeForwardingTests
             streams,
             new OrleansActorRuntimeDurableCallbackScheduler(grainFactory),
             new AgentKindRegistry([]),
-            stateBindingAccessor ?? new AsyncLocalRuntimeActorStateBindingAccessor(),
             streamLifecycleManager: streamLifecycleManager);
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInputFileRefTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInputFileRefTests.cs
@@ -1,0 +1,68 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Application.ScopeGAgents;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class GAgentDraftRunInputFileRefTests
+{
+    [Fact]
+    public void EnvelopeFactory_ShouldPreserveInputPartFileRef()
+    {
+        var factory = new GAgentDraftRunCommandEnvelopeFactory();
+
+        var envelope = factory.CreateEnvelope(
+            new GAgentDraftRunCommand(
+                ScopeId: "scope-a",
+                AgentKind: "RoleGAgent",
+                Prompt: "hello",
+                InputParts:
+                [
+                    new GAgentDraftRunInputPart
+                    {
+                        Kind = GAgentDraftRunInputPartKind.Text,
+                        Text = "see attachment",
+                        FileRef = new ChatFileRef
+                        {
+                            FileId = "file-static-1",
+                            ArtifactId = "artifact-static-1",
+                            SourceKind = ChatFileSourceKind.FormUpload,
+                            SourceMessageId = "om_static_1",
+                            SourceResourceKey = "resource_static_1",
+                            FileName = "notes.txt",
+                            MediaType = "text/plain",
+                            SizeBytes = 42,
+                            Sha256 = "sha-static-1",
+                            CreatedAtUnixMs = 1710000000000,
+                            ExpiresAtUnixMs = 1710003600000,
+                            OwnerRunId = "run-static-1",
+                            OwnerScopeId = "scope-a",
+                        },
+                    },
+                ]),
+            new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>()));
+
+        var inputPart = envelope.Payload.Unpack<ChatRequestEvent>()
+            .InputParts.Should()
+            .ContainSingle()
+            .Which;
+        inputPart.Kind.Should().Be(ChatContentPartKind.Text);
+        inputPart.FileRef.Should().NotBeNull();
+        inputPart.FileRef.FileId.Should().Be("file-static-1");
+        inputPart.FileRef.ArtifactId.Should().Be("artifact-static-1");
+        inputPart.FileRef.SourceKind.Should().Be(ChatFileSourceKind.FormUpload);
+        inputPart.FileRef.SourceMessageId.Should().Be("om_static_1");
+        inputPart.FileRef.SourceResourceKey.Should().Be("resource_static_1");
+        inputPart.FileRef.FileName.Should().Be("notes.txt");
+        inputPart.FileRef.MediaType.Should().Be("text/plain");
+        inputPart.FileRef.SizeBytes.Should().Be(42);
+        inputPart.FileRef.Sha256.Should().Be("sha-static-1");
+        inputPart.FileRef.CreatedAtUnixMs.Should().Be(1710000000000);
+        inputPart.FileRef.ExpiresAtUnixMs.Should().Be(1710003600000);
+        inputPart.FileRef.OwnerRunId.Should().Be("run-static-1");
+        inputPart.FileRef.OwnerScopeId.Should().Be("scope-a");
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
@@ -506,6 +506,82 @@ public sealed class DefaultServiceInvocationDispatcherTests
     }
 
     [Fact]
+    public async Task DispatchAsync_ShouldMapChatInputFileRefToWorkflowChatRequest()
+    {
+        var workflowPort = new RecordingWorkflowRunActorPort();
+        var dispatchPort = new RecordingDispatchPort();
+        var dispatcher = new DefaultServiceInvocationDispatcher(
+            dispatchPort,
+            new RecordingScriptRuntimeCommandPort(),
+            workflowPort,
+            new RecordingServiceRunRegistrationPort());
+        var target = CreateTarget(
+            ServiceImplementationKind.Workflow,
+            endpointId: "chat",
+            requestTypeUrl: Any.Pack(new ChatRequestEvent()).TypeUrl);
+        target.Artifact.DeploymentPlan.WorkflowPlan = new WorkflowServiceDeploymentPlan
+        {
+            WorkflowName = "wf",
+            WorkflowYaml = "name: wf",
+        };
+
+        await dispatcher.DispatchAsync(target, new ServiceInvocationRequest
+        {
+            Identity = GAgentServiceTestKit.CreateIdentity(),
+            EndpointId = "chat",
+            CommandId = "cmd-file-ref",
+            Payload = Any.Pack(new ChatRequestEvent
+            {
+                Prompt = "hello",
+                InputParts =
+                {
+                    new ChatContentPart
+                    {
+                        Kind = ChatContentPartKind.Text,
+                        Text = "see attachment",
+                        MediaType = "application/pdf",
+                        FileRef = new ChatFileRef
+                        {
+                            FileId = "file-1",
+                            ArtifactId = "artifact-1",
+                            SourceKind = ChatFileSourceKind.ConnectedServiceResource,
+                            SourceMessageId = "om_1",
+                            SourceResourceKey = "file_key_1",
+                            FileName = "invoice.pdf",
+                            MediaType = "application/pdf",
+                            SizeBytes = 1234,
+                            Sha256 = "abc",
+                            CreatedAtUnixMs = 1710000000000,
+                            ExpiresAtUnixMs = 1710003600000,
+                            OwnerRunId = "run-1",
+                            OwnerScopeId = "scope-1",
+                        },
+                    },
+                },
+            }),
+        });
+
+        var inputPart = dispatchPort.Calls.Should().ContainSingle().Which
+            .envelope.Payload.Unpack<WorkflowChatRequestEvent>()
+            .InputParts.Should().ContainSingle().Which;
+        inputPart.Kind.Should().Be(Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.File);
+        inputPart.FileRef.Should().NotBeNull();
+        inputPart.FileRef.FileId.Should().Be("file-1");
+        inputPart.FileRef.ArtifactId.Should().Be("artifact-1");
+        inputPart.FileRef.SourceKind.Should().Be(WorkflowFileSourceKind.ConnectedServiceResource);
+        inputPart.FileRef.SourceMessageId.Should().Be("om_1");
+        inputPart.FileRef.SourceResourceKey.Should().Be("file_key_1");
+        inputPart.FileRef.FileName.Should().Be("invoice.pdf");
+        inputPart.FileRef.MediaType.Should().Be("application/pdf");
+        inputPart.FileRef.SizeBytes.Should().Be(1234);
+        inputPart.FileRef.Sha256.Should().Be("abc");
+        inputPart.FileRef.CreatedAtUnixMs.Should().Be(1710000000000);
+        inputPart.FileRef.ExpiresAtUnixMs.Should().Be(1710003600000);
+        inputPart.FileRef.OwnerRunId.Should().Be("run-1");
+        inputPart.FileRef.OwnerScopeId.Should().Be("scope-1");
+    }
+
+    [Fact]
     public async Task DispatchAsync_ShouldMapConnectorAuthorizationToWorkflowCallerCredential()
     {
         var workflowPort = new RecordingWorkflowRunActorPort();

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
@@ -581,6 +581,64 @@ public sealed class DefaultServiceInvocationDispatcherTests
         inputPart.FileRef.OwnerScopeId.Should().Be("scope-1");
     }
 
+    [Theory]
+    [InlineData("image/png", Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Image)]
+    [InlineData("audio/mpeg", Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Audio)]
+    [InlineData("video/mp4", Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind.Video)]
+    public async Task DispatchAsync_ShouldResolveWorkflowFileInputKindFromMediaType(
+        string mediaType,
+        Aevatar.Workflow.Abstractions.WorkflowChatInputPartKind expectedKind)
+    {
+        var workflowPort = new RecordingWorkflowRunActorPort();
+        var dispatchPort = new RecordingDispatchPort();
+        var dispatcher = new DefaultServiceInvocationDispatcher(
+            dispatchPort,
+            new RecordingScriptRuntimeCommandPort(),
+            workflowPort,
+            new RecordingServiceRunRegistrationPort());
+        var target = CreateTarget(
+            ServiceImplementationKind.Workflow,
+            endpointId: "chat",
+            requestTypeUrl: Any.Pack(new ChatRequestEvent()).TypeUrl);
+        target.Artifact.DeploymentPlan.WorkflowPlan = new WorkflowServiceDeploymentPlan
+        {
+            WorkflowName = "wf",
+            WorkflowYaml = "name: wf",
+        };
+
+        await dispatcher.DispatchAsync(target, new ServiceInvocationRequest
+        {
+            Identity = GAgentServiceTestKit.CreateIdentity(),
+            EndpointId = "chat",
+            CommandId = $"cmd-{expectedKind}",
+            Payload = Any.Pack(new ChatRequestEvent
+            {
+                Prompt = "hello",
+                InputParts =
+                {
+                    new ChatContentPart
+                    {
+                        Kind = ChatContentPartKind.Text,
+                        MediaType = mediaType,
+                        FileRef = new ChatFileRef
+                        {
+                            FileId = $"file-{expectedKind}",
+                            SourceKind = ChatFileSourceKind.FormUpload,
+                            MediaType = mediaType,
+                        },
+                    },
+                },
+            }),
+        });
+
+        var inputPart = dispatchPort.Calls.Should().ContainSingle().Which
+            .envelope.Payload.Unpack<WorkflowChatRequestEvent>()
+            .InputParts.Should().ContainSingle().Which;
+        inputPart.Kind.Should().Be(expectedKind);
+        inputPart.FileRef.Should().NotBeNull();
+        inputPart.FileRef.SourceKind.Should().Be(WorkflowFileSourceKind.FormUpload);
+    }
+
     [Fact]
     public async Task DispatchAsync_ShouldMapConnectorAuthorizationToWorkflowCallerCredential()
     {

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -186,19 +186,22 @@ public sealed class WorkflowRuntimeModuleBranchTests
         var module = new WorkflowCallModule();
         var ctx = new RecordingWorkflowContext();
 
-        await module.HandleAsync(
-            Wrap(new StepRequestEvent
+        var request = new StepRequestEvent
+        {
+            StepId = "step-b",
+            StepType = "workflow_call",
+            RunId = "parent-run",
+            Input = "payload",
+            Parameters =
             {
-                StepId = "step-b",
-                StepType = "workflow_call",
-                RunId = "parent-run",
-                Input = "payload",
-                Parameters =
-                {
-                    ["workflow"] = "child_flow",
-                    ["lifecycle"] = "scope",
-                },
-            }),
+                ["workflow"] = "child_flow",
+                ["lifecycle"] = "scope",
+            },
+        };
+        request.InputFileRefs.Add(BuildWorkflowFileRef("file-workflow-call"));
+
+        await module.HandleAsync(
+            Wrap(request),
             ctx,
             CancellationToken.None);
 
@@ -209,6 +212,7 @@ public sealed class WorkflowRuntimeModuleBranchTests
         invocation.Input.Should().Be("payload");
         invocation.Lifecycle.Should().Be(WorkflowCallLifecycle.Scope);
         invocation.InvocationId.Should().StartWith("parent-run:workflow_call:step-b:");
+        invocation.InputFileRefs.Should().ContainSingle().Which.FileId.Should().Be("file-workflow-call");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/SubWorkflowOrchestratorTests.cs
@@ -235,27 +235,42 @@ public sealed class SubWorkflowOrchestratorTests
             DefinitionActorId = definitionActorId,
             DefinitionVersion = 7,
         });
+        var fileRef = BuildWorkflowFileRef("file-sub-1");
+
+        var invokeRequested = new SubWorkflowInvokeRequestedEvent
+        {
+            InvocationId = "invoke-1",
+            ParentRunId = "parent-run",
+            ParentStepId = "step-a",
+            WorkflowName = "sub_flow",
+            Input = "payload-a",
+            Lifecycle = WorkflowCallLifecycle.Singleton,
+            RootRunId = "root-run",
+            RequestedDepth = 2,
+        };
+        invokeRequested.InputFileRefs.Add(fileRef.Clone());
 
         await harness.Orchestrator.HandleInvokeRequestedAsync(
-            new SubWorkflowInvokeRequestedEvent
-            {
-                InvocationId = "invoke-1",
-                ParentRunId = "parent-run",
-                ParentStepId = "step-a",
-                WorkflowName = "sub_flow",
-                Input = "payload-a",
-                Lifecycle = WorkflowCallLifecycle.Singleton,
-                RootRunId = "root-run",
-                RequestedDepth = 2,
-            },
+            invokeRequested,
             state,
             CancellationToken.None);
 
-        harness.Persisted.Should().ContainSingle(x => x is SubWorkflowDefinitionResolutionRegisteredEvent);
+        var registeredResolution = harness.Persisted
+            .OfType<SubWorkflowDefinitionResolutionRegisteredEvent>()
+            .Should()
+            .ContainSingle()
+            .Subject;
+        registeredResolution.InputFileRefs.Should().ContainSingle().Which.FileId.Should().Be("file-sub-1");
         harness.Sent.Should().ContainSingle(x => x.TargetActorId == definitionActorId);
         var resolutionState = SubWorkflowOrchestrator.ApplySubWorkflowDefinitionResolutionRegistered(
             state,
-            harness.Persisted.OfType<SubWorkflowDefinitionResolutionRegisteredEvent>().Single());
+            registeredResolution);
+        resolutionState.PendingSubWorkflowDefinitionResolutions.Should()
+            .ContainSingle()
+            .Which.InputFileRefs.Should()
+            .ContainSingle()
+            .Which.FileId.Should()
+            .Be("file-sub-1");
 
         harness.Persisted.Clear();
         harness.Sent.Clear();
@@ -283,6 +298,7 @@ public sealed class SubWorkflowOrchestratorTests
         var registeredInvocation = harness.Persisted.OfType<SubWorkflowInvocationRegisteredEvent>().Should().ContainSingle(x => x.InvocationId == "invoke-1").Subject;
         registeredInvocation.RootRunId.Should().Be("root-run");
         registeredInvocation.Depth.Should().Be(2);
+        registeredInvocation.InputFileRefs.Should().ContainSingle().Which.FileId.Should().Be("file-sub-1");
         harness.Persisted.Should().NotContain(x => x is SubWorkflowBindingUpsertedEvent);
         harness.CancelledLeases.Should().ContainSingle(x => x.CallbackId == resolutionState.PendingSubWorkflowDefinitionResolutions[0].TimeoutCallbackId);
         harness.Sent.Should().ContainSingle(x => x.TargetActorId == childActorId);
@@ -295,6 +311,7 @@ public sealed class SubWorkflowOrchestratorTests
         start.WorkflowRuntime.ParentStepId.Should().Be("step-a");
         start.WorkflowRuntime.RootRunId.Should().Be("root-run");
         start.WorkflowRuntime.Depth.Should().Be(2);
+        start.InputFileRefs.Should().ContainSingle().Which.FileId.Should().Be("file-sub-1");
         start.Parameters.Keys.Should().NotContain(key => key.StartsWith("workflow_runtime.", StringComparison.Ordinal));
     }
 
@@ -1496,6 +1513,24 @@ public sealed class SubWorkflowOrchestratorTests
         failure.Success.Should().BeFalse();
         failure.Error.Should().Contain(expectedText);
     }
+
+    private static WorkflowFileRef BuildWorkflowFileRef(string fileId) =>
+        new()
+        {
+            FileId = fileId,
+            ArtifactId = $"workflow-file://{fileId}",
+            SourceKind = WorkflowFileSourceKind.ConnectedServiceResource,
+            SourceMessageId = "om_1",
+            SourceResourceKey = "file_key_1",
+            FileName = $"{fileId}.pdf",
+            MediaType = "application/pdf",
+            SizeBytes = 1234,
+            Sha256 = $"sha-{fileId}",
+            CreatedAtUnixMs = 1710000000000,
+            ExpiresAtUnixMs = 1710003600000,
+            OwnerRunId = "parent-run",
+            OwnerScopeId = "scope-1",
+        };
 
     private sealed record OrchestratorHarness(
         SubWorkflowOrchestrator Orchestrator,


### PR DESCRIPTION
## Summary
- Add typed `file_ref` support to Aevatar invocation payload content parts, including schema/parser support for `kind: \"file\"`.
- Preserve typed file identity through `aevatar_invoke_member` chat dispatch and `aevatar_start_workflow` workflow input mapping.
- Remove the Orleans actor runtime `LinkAsync` activation-state fast path so topology updates go through grain calls instead of touching activation-bound persistent state from a non-activation thread.

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo`
- [x] `dotnet test test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj --nologo`

## Notes
- Existing unrelated local files are not included: `fkst.lock`, `fkst.workspace.toml`, `.claude/worktrees/`.
- Broader guard scripts were not rerun in this PR pass; earlier local runs in this workspace were blocked by the Homebrew Python `pyexpat` / system `libexpat` mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)