### PR TITLE
Normalize Lark resource URLs before file ingress

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -706,7 +706,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                     continue;
                 }
 
-                var resourceKey = NormalizeOptional(attachment.AttachmentId);
+                var resourceKey = LarkAttachmentResourceKeys.Normalize(attachment.AttachmentId);
                 if (resourceKey is null)
                 {
                     _logger.LogWarning(
@@ -882,7 +882,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             return false;
         }
 
-        var resourceKey = NormalizeOptional(attachment.AttachmentId);
+        var resourceKey = LarkAttachmentResourceKeys.Normalize(attachment.AttachmentId);
         if (resourceKey is null)
         {
             _logger.LogWarning(
@@ -974,7 +974,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             return false;
         }
 
-        var resourceKey = NormalizeOptional(attachment.AttachmentId);
+        var resourceKey = LarkAttachmentResourceKeys.Normalize(attachment.AttachmentId);
         if (resourceKey is null)
         {
             _logger.LogWarning(

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -12,6 +12,7 @@ using Aevatar.AI.ToolProviders.Lark;
 using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/agents/Aevatar.GAgents.NyxidChat/LarkAttachmentResourceKeys.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/LarkAttachmentResourceKeys.cs
@@ -1,0 +1,24 @@
+namespace Aevatar.GAgents.NyxidChat;
+
+internal static class LarkAttachmentResourceKeys
+{
+    public static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var resourceKey = value.Trim();
+        if (!Uri.TryCreate(resourceKey, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            return resourceKey;
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (string.Equals(segments[i], "resources", StringComparison.OrdinalIgnoreCase))
+                return Uri.UnescapeDataString(segments[i + 1]);
+        }
+
+        return null;
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
@@ -261,7 +261,7 @@ public sealed class ChannelWorkflowDraftRunInteractionPort : IChannelWorkflowDra
         var inputParts = new List<WorkflowChatInputPart>(attachments.Length);
         foreach (var attachment in attachments)
         {
-            var resourceKey = NormalizeOptional(attachment.AttachmentId);
+            var resourceKey = LarkAttachmentResourceKeys.Normalize(attachment.AttachmentId);
             if (resourceKey is null)
                 throw new WorkflowAttachmentIngressException("resource_key_missing");
 
@@ -363,10 +363,8 @@ public sealed class ChannelWorkflowDraftRunInteractionPort : IChannelWorkflowDra
         {
             if (attachment.Kind is not (AttachmentKind.Image or AttachmentKind.File))
                 continue;
-            var resourceKey = NormalizeOptional(attachment.AttachmentId);
-            if (resourceKey is null || IsHttpUrl(resourceKey))
-                continue;
-            if (!string.IsNullOrWhiteSpace(attachment.ExternalUrl))
+            var resourceKey = LarkAttachmentResourceKeys.Normalize(attachment.AttachmentId);
+            if (resourceKey is null)
                 continue;
 
             yield return attachment;
@@ -380,10 +378,6 @@ public sealed class ChannelWorkflowDraftRunInteractionPort : IChannelWorkflowDra
         return string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
     }
-
-    private static bool IsHttpUrl(string value) =>
-        Uri.TryCreate(value, UriKind.Absolute, out var uri) &&
-        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
@@ -2,6 +2,7 @@ using Aevatar.AI.ToolProviders.Lark;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf;

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/LarkAttachmentResourceKeys.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/LarkAttachmentResourceKeys.cs
@@ -1,6 +1,6 @@
-namespace Aevatar.GAgents.NyxidChat;
+namespace Aevatar.GAgents.Channel.NyxIdRelay;
 
-internal static class LarkAttachmentResourceKeys
+public static class LarkAttachmentResourceKeys
 {
     public static string? Normalize(string? value)
     {

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -260,29 +260,9 @@ public sealed class NyxIdRelayTransport
     private static string BuildAttachmentDedupeKey(AttachmentRef attachment, string platform)
     {
         var attachmentId = IsLark(platform)
-            ? NormalizeLarkResourceKey(attachment.AttachmentId) ?? attachment.AttachmentId
+            ? LarkAttachmentResourceKeys.Normalize(attachment.AttachmentId) ?? attachment.AttachmentId
             : attachment.AttachmentId;
         return $"{attachment.Kind}:{attachmentId}";
-    }
-
-    private static string? NormalizeLarkResourceKey(string? value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-            return null;
-
-        var resourceKey = value.Trim();
-        if (!Uri.TryCreate(resourceKey, UriKind.Absolute, out var uri) ||
-            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-            return resourceKey;
-
-        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        for (var i = 0; i < segments.Length - 1; i++)
-        {
-            if (string.Equals(segments[i], "resources", StringComparison.OrdinalIgnoreCase))
-                return Uri.UnescapeDataString(segments[i + 1]);
-        }
-
-        return null;
     }
 
     private static AttachmentRef? BuildAttachment(NyxIdRelayAttachmentPayload attachment)

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -233,14 +233,14 @@ public sealed class NyxIdRelayTransport
             {
                 var attachment = BuildAttachment(callbackAttachment);
                 if (attachment is not null)
-                    AddAttachment(attachments, seenAttachmentKeys, attachment);
+                    AddAttachment(attachments, seenAttachmentKeys, attachment, platform);
             }
         }
 
         if (IsLark(platform))
         {
             foreach (var candidate in EnumerateLarkRawAttachmentCandidates(payload))
-                AddAttachment(attachments, seenAttachmentKeys, BuildLarkAttachment(candidate));
+                AddAttachment(attachments, seenAttachmentKeys, BuildLarkAttachment(candidate), platform);
         }
 
         return attachments;
@@ -249,11 +249,40 @@ public sealed class NyxIdRelayTransport
     private static void AddAttachment(
         List<AttachmentRef> attachments,
         HashSet<string> seenAttachmentKeys,
-        AttachmentRef attachment)
+        AttachmentRef attachment,
+        string platform)
     {
-        var dedupeKey = $"{attachment.Kind}:{attachment.AttachmentId}";
+        var dedupeKey = BuildAttachmentDedupeKey(attachment, platform);
         if (seenAttachmentKeys.Add(dedupeKey))
             attachments.Add(attachment);
+    }
+
+    private static string BuildAttachmentDedupeKey(AttachmentRef attachment, string platform)
+    {
+        var attachmentId = IsLark(platform)
+            ? NormalizeLarkResourceKey(attachment.AttachmentId) ?? attachment.AttachmentId
+            : attachment.AttachmentId;
+        return $"{attachment.Kind}:{attachmentId}";
+    }
+
+    private static string? NormalizeLarkResourceKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var resourceKey = value.Trim();
+        if (!Uri.TryCreate(resourceKey, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            return resourceKey;
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 0; i < segments.Length - 1; i++)
+        {
+            if (string.Equals(segments[i], "resources", StringComparison.OrdinalIgnoreCase))
+                return Uri.UnescapeDataString(segments[i + 1]);
+        }
+
+        return null;
     }
 
     private static AttachmentRef? BuildAttachment(NyxIdRelayAttachmentPayload attachment)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
@@ -285,6 +285,53 @@ public sealed class ChannelWorkflowDraftRunTests
     }
 
     [Fact]
+    public async Task InteractionPort_ShouldNormalizeLarkResourceUrlAttachmentIds()
+    {
+        var lark = Substitute.For<ILarkNyxClient>();
+        lark.DownloadMessageResourceAsync(
+                "user-token-1",
+                Arg.Any<LarkMessageResourceDownloadRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new LarkMessageResourceDownloadResult(
+                true,
+                [4, 5, 6, 7],
+                "application/pdf",
+                "invoice.pdf")));
+        var ingress = new RecordingWorkflowFileIngressPort();
+        var workflow = new RecordingWorkflowChatRunInteractionPort();
+        var dispatch = new RecordingActorDispatchPort();
+        var port = CreateInteractionPort(dispatch, workflow, lark, ingress);
+        var request = BuildWorkflowRequestWithLarkAttachments();
+        request.Activity.Content.Attachments.Clear();
+        request.Activity.Content.Attachments.Add(new AttachmentRef
+        {
+            AttachmentId = "https://open.larksuite.com/open-apis/im/v1/messages/om_123/resources/file_v3_1?type=file",
+            ExternalUrl = "https://open.larksuite.com/open-apis/im/v1/messages/om_123/resources/file_v3_1?type=file",
+            Kind = AttachmentKind.File,
+            Name = "invoice.pdf",
+            ContentType = "file",
+        });
+
+        await port.StartWorkflowInteractionAsync(
+            "channel-workflow-draft-run:workflow-draft-run-1",
+            request,
+            CancellationToken.None);
+
+        var workflowRequest = await workflow.WaitForRequestAsync();
+        workflowRequest.InputParts.Should().ContainSingle();
+        workflowRequest.InputParts![0].FileRef.Should().NotBeNull();
+        workflowRequest.InputParts[0].FileRef!.SourceResourceKey.Should().Be("file_v3_1");
+        ingress.Requests.Should().ContainSingle().Which.SourceResourceKey.Should().Be("file_v3_1");
+        await lark.Received(1).DownloadMessageResourceAsync(
+            "user-token-1",
+            Arg.Is<LarkMessageResourceDownloadRequest>(x =>
+                x.MessageId == "om_123" &&
+                x.ResourceKey == "file_v3_1" &&
+                x.Kind == LarkMessageResourceKind.File),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task InteractionPort_ShouldRouteLarkAttachmentDownloadsThroughInboundProviderSlug()
     {
         var defaultLark = Substitute.For<ILarkNyxClient>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -1109,7 +1109,8 @@ public sealed class ConversationReplyGeneratorTests
             token: "user-token");
         activity.Content.Attachments.Add(new AttachmentRef
         {
-            AttachmentId = "file_key",
+            AttachmentId = "https://open.larksuite.com/open-apis/im/v1/messages/om_file_pdf/resources/file_key?type=file",
+            ExternalUrl = "https://open.larksuite.com/open-apis/im/v1/messages/om_file_pdf/resources/file_key?type=file",
             Kind = AttachmentKind.File,
             ContentType = "application/pdf",
             Name = "report.pdf",

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -365,6 +365,57 @@ public sealed class NyxIdRelayTransportTests
     }
 
     [Fact]
+    public void Parse_ShouldDeduplicateLarkResourceUrlAndRawFileKeyAttachments()
+    {
+        var body = """
+            {
+              "message_id": "msg-lark-file-dedupe",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "route-uuid", "platform_id": "oc_group_1", "type": "group" },
+              "sender": { "platform_id": "ou_user_1", "display_name": "User One" },
+              "content": {
+                "type": "file",
+                "text": "   ",
+                "attachments": [
+                  {
+                    "content_type": "file",
+                    "url": "https://open.larksuite.com/open-apis/im/v1/messages/om_file_1/resources/file_v3_abc?type=file",
+                    "filename": "report.pdf",
+                    "mime_type": "application/pdf"
+                  }
+                ]
+              },
+              "raw_platform_data": {
+                "event": {
+                  "message": {
+                    "message_id": "om_file_1",
+                    "chat_id": "oc_group_1",
+                    "chat_type": "group",
+                    "message_type": "file",
+                    "content": {
+                      "file_key": "file_v3_abc",
+                      "file_name": "report.pdf",
+                      "mime_type": "application/pdf"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.Content.Text.Should().BeEmpty();
+        parsed.Activity.Content.Attachments.Should().ContainSingle();
+        var attachment = parsed.Activity.Content.Attachments.Single();
+        attachment.AttachmentId.Should().Be("https://open.larksuite.com/open-apis/im/v1/messages/om_file_1/resources/file_v3_abc?type=file");
+        attachment.Kind.Should().Be(AttachmentKind.File);
+        attachment.ExternalUrl.Should().Be("https://open.larksuite.com/open-apis/im/v1/messages/om_file_1/resources/file_v3_abc?type=file");
+    }
+
+    [Fact]
     public void Parse_ShouldIgnorePayload_WhenAttachmentIdentifiersAreMissing()
     {
         var body = """


### PR DESCRIPTION
## Summary
- Normalize Lark attachment resource URLs into bare resource keys before NyxID download calls.
- Preserve workflow typed file refs when Lark relay provides `AttachmentId` as a full `/resources/{key}` URL.
- Add regression coverage for both workflow draft-run ingress and chat PDF materialization paths.

## Root cause
Production `aevatar-console-backend` logs showed PDF attachments arriving with `AttachmentId` as a full Lark resource URL. The chat path attempted a Nyx proxy download with that full URL as the resource key and received `400 Invalid proxy path`; the workflow draft-run path skipped HTTP URL attachment ids entirely, so no typed workflow input file ref was created.

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- [x] `PATH="/usr/bin:$PATH" bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)