### PR TITLE
Carry input file refs through tool context

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -345,6 +345,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 attachmentContext,
                 ct)
             .ConfigureAwait(false);
+        var inputFileRefs = CollectInputFileRefs(input.Parts);
+        effectiveToolContext = WithInputFileRefs(effectiveToolContext, inputFileRefs);
+        var ownerFallbackToolContext = WithInputFileRefs(replyPlan.OwnerFallbackToolContext, inputFileRefs);
 
         var runtime = BuildRuntime(
             activity,
@@ -379,7 +382,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             ResolveMaxToolRounds(replyPlan.PrimaryControl),
             disableTools,
             replyPlan.OwnerFallbackControl,
-            replyPlan.OwnerFallbackToolContext);
+            ownerFallbackToolContext);
     }
 
     // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
@@ -455,6 +458,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 ct)
             .ConfigureAwait(false);
         input = await MaterializeUserInputPartsAsync(input, ct).ConfigureAwait(false);
+        toolContext = WithInputFileRefs(toolContext, CollectInputFileRefs(input.Parts));
 
         // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
         //   Old pattern: NyxID reply construction passed stream_buffer_capacity into ChatRuntime after the stream loop moved to Task.Run + Channel.
@@ -564,6 +568,99 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         string Text,
         IReadOnlyList<ContentPart> Parts,
         string? AttachmentVisibilityInstruction = null);
+
+    private static AgentToolExecutionContext? WithInputFileRefs(
+        AgentToolExecutionContext? context,
+        IReadOnlyList<Aevatar.AI.Abstractions.ChatFileRef> inputFileRefs)
+    {
+        if (context is null || inputFileRefs.Count == 0)
+            return context;
+
+        var merged = new List<Aevatar.AI.Abstractions.ChatFileRef>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var fileRef in context.InputFileRefs.Concat(inputFileRefs))
+        {
+            var key = FileRefIdentityKey(fileRef);
+            if (key is null || !seen.Add(key))
+                continue;
+
+            merged.Add(fileRef.Clone());
+        }
+
+        return context with { InputFileRefs = merged };
+    }
+
+    private static IReadOnlyList<Aevatar.AI.Abstractions.ChatFileRef> CollectInputFileRefs(
+        IReadOnlyList<ContentPart> parts)
+    {
+        var refs = new List<Aevatar.AI.Abstractions.ChatFileRef>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var part in parts)
+        {
+            if (part.FileRef is null || !HasFileRefIdentity(part.FileRef))
+                continue;
+
+            var key = FileRefIdentityKey(part.FileRef);
+            if (key is null || !seen.Add(key))
+                continue;
+
+            refs.Add(ToProtoChatFileRef(part.FileRef));
+        }
+
+        return refs;
+    }
+
+    private static Aevatar.AI.Abstractions.ChatFileRef ToProtoChatFileRef(LlmChatFileRef fileRef) =>
+        new()
+        {
+            FileId = fileRef.FileId ?? string.Empty,
+            ArtifactId = fileRef.ArtifactId ?? string.Empty,
+            SourceKind = fileRef.SourceKind switch
+            {
+                LlmChatFileSourceKind.ChatInput => Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput,
+                LlmChatFileSourceKind.FormUpload => Aevatar.AI.Abstractions.ChatFileSourceKind.FormUpload,
+                LlmChatFileSourceKind.ConnectedServiceResource => Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+                LlmChatFileSourceKind.ExternalResource => Aevatar.AI.Abstractions.ChatFileSourceKind.ExternalResource,
+                LlmChatFileSourceKind.Generated => Aevatar.AI.Abstractions.ChatFileSourceKind.Generated,
+                _ => Aevatar.AI.Abstractions.ChatFileSourceKind.Unspecified,
+            },
+            SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
+            SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
+            FileName = fileRef.FileName ?? string.Empty,
+            MediaType = fileRef.MediaType ?? string.Empty,
+            SizeBytes = fileRef.SizeBytes,
+            Sha256 = fileRef.Sha256 ?? string.Empty,
+            CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+            ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+            OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
+            OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
+        };
+
+    private static bool HasFileRefIdentity(LlmChatFileRef fileRef) =>
+        !string.IsNullOrWhiteSpace(fileRef.FileId) ||
+        !string.IsNullOrWhiteSpace(fileRef.ArtifactId);
+
+    private static string? FileRefIdentityKey(LlmChatFileRef fileRef)
+    {
+        if (!string.IsNullOrWhiteSpace(fileRef.ArtifactId))
+            return $"artifact:{fileRef.ArtifactId.Trim()}";
+
+        if (!string.IsNullOrWhiteSpace(fileRef.FileId))
+            return $"file:{fileRef.FileId.Trim()}";
+
+        return null;
+    }
+
+    private static string? FileRefIdentityKey(Aevatar.AI.Abstractions.ChatFileRef fileRef)
+    {
+        if (!string.IsNullOrWhiteSpace(fileRef.ArtifactId))
+            return $"artifact:{fileRef.ArtifactId.Trim()}";
+
+        if (!string.IsNullOrWhiteSpace(fileRef.FileId))
+            return $"file:{fileRef.FileId.Trim()}";
+
+        return null;
+    }
 
     private async Task<UserInputParts> BuildUserInputPartsAsync(
         ChatActivity activity,

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTurnOperationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTurnOperationExecutor.cs
@@ -461,12 +461,56 @@ public sealed class NyxIdChatTurnOperationExecutor
             CorrelationId = command.Key.OperationId,
             TargetActorId = command.Key.ConversationActorId,
             Activity = activity,
-            ToolContext = chat.ToolContext?.Clone(),
+            ToolContext = MergeDirectInputFileRefs(chat.ToolContext, chat.InputParts),
             LlmControl = chat.LlmControl?.Clone(),
         };
         foreach (var pair in chat.Metadata)
             request.Metadata[pair.Key] = pair.Value;
         return request;
+    }
+
+    private static AgentToolExecutionContextPayload? MergeDirectInputFileRefs(
+        AgentToolExecutionContextPayload? toolContext,
+        IReadOnlyList<ChatContentPart> inputParts)
+    {
+        if (inputParts.Count == 0)
+            return toolContext?.Clone();
+
+        var explicitFileRefs = inputParts
+            .Where(static part => part.FileRef is not null && HasFileRefIdentity(part.FileRef))
+            .Select(static part => part.FileRef!)
+            .ToArray();
+        if (explicitFileRefs.Length == 0)
+            return toolContext?.Clone();
+
+        var context = AgentToolExecutionContextMapper.FromPayload(toolContext);
+        var merged = new List<Aevatar.AI.Abstractions.ChatFileRef>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var fileRef in context.InputFileRefs.Concat(explicitFileRefs))
+        {
+            var key = FileRefIdentityKey(fileRef);
+            if (key is null || !seen.Add(key))
+                continue;
+
+            merged.Add(fileRef.Clone());
+        }
+
+        return (context with { InputFileRefs = merged }).ToPayload();
+    }
+
+    private static bool HasFileRefIdentity(Aevatar.AI.Abstractions.ChatFileRef fileRef) =>
+        !string.IsNullOrWhiteSpace(fileRef.FileId) ||
+        !string.IsNullOrWhiteSpace(fileRef.ArtifactId);
+
+    private static string? FileRefIdentityKey(Aevatar.AI.Abstractions.ChatFileRef fileRef)
+    {
+        if (!string.IsNullOrWhiteSpace(fileRef.ArtifactId))
+            return $"artifact:{fileRef.ArtifactId.Trim()}";
+
+        if (!string.IsNullOrWhiteSpace(fileRef.FileId))
+            return $"file:{fileRef.FileId.Trim()}";
+
+        return null;
     }
 
     private static void OverlayDirectInputParts(

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContext.cs
@@ -86,6 +86,8 @@ public sealed record AgentToolExecutionContext(
     public AgentToolInvocationSurface InvocationSurface { get; init; } =
         AgentToolInvocationSurface.Unspecified;
 
+    public IReadOnlyList<Aevatar.AI.Abstractions.ChatFileRef> InputFileRefs { get; init; } = [];
+
     public static AgentToolExecutionContext Empty { get; } = new(
         AgentToolRequestIdentity.Empty,
         AgentToolCredentials.Empty,

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolExecutionContextMapper.cs
@@ -166,6 +166,7 @@ public static class AgentToolExecutionContextMapper
                 AgentToolExecutionContext.Normalize(payload.NyxIdAuthority?.ExternalUserId),
                 AgentToolExecutionContext.Normalize(payload.NyxIdAuthority?.Scope)),
             InvocationSurface = FromInvocationSurfacePayload(payload.InvocationSurface),
+            InputFileRefs = FromInputFileRefsPayload(payload.InputFileRefs),
         };
     }
 
@@ -312,6 +313,9 @@ public static class AgentToolExecutionContextMapper
 
         if (context.ToolVisibility.IsRestricted)
             payload.ToolVisibility = ToToolVisibilityPayload(context.ToolVisibility);
+
+        foreach (var fileRef in ToInputFileRefsPayload(context.InputFileRefs))
+            payload.InputFileRefs.Add(fileRef);
     }
 
     private static AgentToolNyxIdAuthorityContextPayload ToNyxIdAuthorityPayload(
@@ -472,6 +476,58 @@ public static class AgentToolExecutionContextMapper
 
         return payload;
     }
+
+    private static IReadOnlyList<Aevatar.AI.Abstractions.ChatFileRef> FromInputFileRefsPayload(
+        IEnumerable<Aevatar.AI.Abstractions.ChatFileRef>? payloads)
+    {
+        if (payloads is null)
+            return [];
+
+        var refs = new List<Aevatar.AI.Abstractions.ChatFileRef>();
+        foreach (var payload in payloads)
+        {
+            if (!HasFileRefIdentity(payload))
+                continue;
+
+            refs.Add(new Aevatar.AI.Abstractions.ChatFileRef
+            {
+                FileId = AgentToolExecutionContext.Normalize(payload.FileId) ?? string.Empty,
+                ArtifactId = AgentToolExecutionContext.Normalize(payload.ArtifactId) ?? string.Empty,
+                SourceKind = payload.SourceKind,
+                SourceMessageId = AgentToolExecutionContext.Normalize(payload.SourceMessageId) ?? string.Empty,
+                SourceResourceKey = AgentToolExecutionContext.Normalize(payload.SourceResourceKey) ?? string.Empty,
+                FileName = AgentToolExecutionContext.Normalize(payload.FileName) ?? string.Empty,
+                MediaType = AgentToolExecutionContext.Normalize(payload.MediaType) ?? string.Empty,
+                SizeBytes = payload.SizeBytes,
+                Sha256 = AgentToolExecutionContext.Normalize(payload.Sha256) ?? string.Empty,
+                CreatedAtUnixMs = payload.CreatedAtUnixMs,
+                ExpiresAtUnixMs = payload.ExpiresAtUnixMs,
+                OwnerRunId = AgentToolExecutionContext.Normalize(payload.OwnerRunId) ?? string.Empty,
+                OwnerScopeId = AgentToolExecutionContext.Normalize(payload.OwnerScopeId) ?? string.Empty,
+            });
+        }
+
+        return refs;
+    }
+
+    private static IEnumerable<Aevatar.AI.Abstractions.ChatFileRef> ToInputFileRefsPayload(
+        IEnumerable<Aevatar.AI.Abstractions.ChatFileRef>? fileRefs)
+    {
+        if (fileRefs is null)
+            yield break;
+
+        foreach (var fileRef in fileRefs)
+        {
+            if (!HasFileRefIdentity(fileRef))
+                continue;
+
+            yield return fileRef.Clone();
+        }
+    }
+
+    private static bool HasFileRefIdentity(Aevatar.AI.Abstractions.ChatFileRef fileRef) =>
+        !string.IsNullOrWhiteSpace(fileRef.FileId) ||
+        !string.IsNullOrWhiteSpace(fileRef.ArtifactId);
 
     public static IReadOnlyDictionary<string, string> StripOwnedControlKeys(IReadOnlyDictionary<string, string>? metadata)
     {

--- a/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolRequestContext.cs
+++ b/src/Aevatar.AI.Abstractions/ToolProviders/AgentToolRequestContext.cs
@@ -44,6 +44,9 @@ public static class AgentToolRequestContext
     public static AgentToolVisibilityScope ToolVisibility =>
         s_context.Value?.ToolVisibility ?? AgentToolVisibilityScope.Unrestricted;
 
+    public static IReadOnlyList<Aevatar.AI.Abstractions.ChatFileRef> InputFileRefs =>
+        s_context.Value?.InputFileRefs ?? [];
+
     public static string? TryGetExternalMetadata(string key)
     {
         var metadata = s_context.Value?.ExternalMetadata;

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -149,6 +149,7 @@ message AgentToolExecutionContextPayload {
   AgentToolScheduleContextPayload schedule = 13;
   AgentToolNyxIdAuthorityContextPayload nyx_id_authority = 14;
   AgentToolInvocationSurfacePayload invocation_surface = 15;
+  repeated ChatFileRef input_file_refs = 16;
 }
 
 enum AgentToolInvocationSurfacePayload {

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -624,7 +624,7 @@ public sealed class AevatarInvocationDispatcher
                 : workflowRuntimeContext.RootRunId.Trim(),
             RequestedDepth = Math.Max(0, workflowRuntimeContext.Depth) + 1,
         };
-        managedStart.InputFileRefs.Add(EnumerateInputPartsWithAmbientRefs(request.Inputs)
+        managedStart.InputFileRefs.Add(request.Inputs.InputParts
             .Select(static part => ToWorkflowEventFileRef(part.FileRef))
             .Where(static fileRef => fileRef != null)
             .Select(static fileRef => fileRef!.Clone()));
@@ -1415,7 +1415,7 @@ public sealed class AevatarInvocationDispatcher
                 AppId = ScopeServiceIdentityDefaults.ServiceAppId,
                 ServiceKey = string.Empty,
             },
-            ToolContext: ToInvocationToolContext(payload),
+            ToolContext: AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty,
             LlmControl: ToLlmControlContext(AgentToolRequestContext.Current));
         return new StaticGAgentStreamInvocationRequest(identity, endpointId.Trim(), input);
     }
@@ -1437,7 +1437,8 @@ public sealed class AevatarInvocationDispatcher
             Prompt = payload.Prompt,
             SessionId = ResolveSessionId(),
             ScopeId = resolution.ScopeId,
-            ToolContext = AgentToolExecutionContextMapper.ToPayload(ToInvocationToolContext(payload)),
+            ToolContext = AgentToolExecutionContextMapper.ToPayload(
+                AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty),
             LlmControl = ToLlmControlPayload(AgentToolRequestContext.Current),
         };
         chatRequest.InputParts.AddRange(ToChatInputParts(payload));
@@ -1735,7 +1736,8 @@ public sealed class AevatarInvocationDispatcher
             Prompt = payload.Prompt,
             SessionId = commandId,
             ScopeId = scope.ScopeId,
-            ToolContext = AgentToolExecutionContextMapper.ToPayload(ToInvocationToolContext(payload)),
+            ToolContext = AgentToolExecutionContextMapper.ToPayload(
+                AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty),
             LlmControl = ToLlmControlPayload(AgentToolRequestContext.Current),
         };
         AppendMetadata(request.Headers, headers);
@@ -1882,19 +1884,6 @@ public sealed class AevatarInvocationDispatcher
                string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static AgentToolExecutionContext ToInvocationToolContext(InvocationPayload payload)
-    {
-        var context = AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty;
-        var inputFileRefs = EnumerateInputPartsWithAmbientRefs(payload)
-            .Select(static part => part.FileRef)
-            .Where(static fileRef => fileRef is not null && HasFileRefIdentity(fileRef))
-            .Select(static fileRef => fileRef!.Clone())
-            .ToArray();
-        return inputFileRefs.Length == 0
-            ? context
-            : context with { InputFileRefs = inputFileRefs };
-    }
-
     private CallerScopeResolution ResolveTeamInvocationScope()
     {
         var baseScope = ResolveCallerScope();
@@ -1914,63 +1903,8 @@ public sealed class AevatarInvocationDispatcher
         });
     }
 
-    private static IEnumerable<InvocationContentPart> EnumerateInputPartsWithAmbientRefs(InvocationPayload payload)
-    {
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var part in payload.InputParts)
-        {
-            AddSeenFileRef(seen, part.FileRef);
-            yield return part;
-        }
-
-        foreach (var fileRef in AgentToolRequestContext.InputFileRefs)
-        {
-            if (!HasFileRefIdentity(fileRef))
-                continue;
-
-            var key = FileRefIdentityKey(fileRef);
-            if (key is null || !seen.Add(key))
-                continue;
-
-            yield return new InvocationContentPart
-            {
-                Kind = InvocationContentPartKind.File,
-                MediaType = fileRef.MediaType,
-                Name = fileRef.FileName,
-                FileRef = fileRef.Clone(),
-            };
-        }
-    }
-
-    private static void AddSeenFileRef(HashSet<string> seen, Aevatar.AI.Abstractions.ChatFileRef? fileRef)
-    {
-        if (fileRef is null || !HasFileRefIdentity(fileRef))
-            return;
-
-        var key = FileRefIdentityKey(fileRef);
-        if (key is not null)
-            seen.Add(key);
-    }
-
-    private static string? FileRefIdentityKey(Aevatar.AI.Abstractions.ChatFileRef fileRef)
-    {
-        if (!string.IsNullOrWhiteSpace(fileRef.ArtifactId))
-            return $"artifact:{fileRef.ArtifactId.Trim()}";
-
-        if (!string.IsNullOrWhiteSpace(fileRef.FileId))
-            return $"file:{fileRef.FileId.Trim()}";
-
-        if (!string.IsNullOrWhiteSpace(fileRef.SourceMessageId) &&
-            !string.IsNullOrWhiteSpace(fileRef.SourceResourceKey))
-        {
-            return $"source:{(int)fileRef.SourceKind}:{fileRef.SourceMessageId.Trim()}:{fileRef.SourceResourceKey.Trim()}";
-        }
-
-        return null;
-    }
-
     private static IReadOnlyList<ChatContentPart> ToChatInputParts(InvocationPayload payload) =>
-        EnumerateInputPartsWithAmbientRefs(payload).Select(static part => new ChatContentPart
+        payload.InputParts.Select(static part => new ChatContentPart
         {
             Kind = part.Kind switch
             {
@@ -1991,11 +1925,10 @@ public sealed class AevatarInvocationDispatcher
 
     private static IReadOnlyList<GAgentDraftRunInputPart>? ToGAgentInputParts(InvocationPayload payload)
     {
-        var parts = EnumerateInputPartsWithAmbientRefs(payload).ToArray();
-        if (parts.Length == 0)
+        if (payload.InputParts.Count == 0)
             return null;
 
-        return parts.Select(static part => new GAgentDraftRunInputPart
+        return payload.InputParts.Select(static part => new GAgentDraftRunInputPart
         {
             Kind = part.Kind switch
             {
@@ -2017,11 +1950,10 @@ public sealed class AevatarInvocationDispatcher
 
     private static IReadOnlyList<WorkflowChatInputPart>? ToWorkflowInputParts(InvocationPayload payload)
     {
-        var parts = EnumerateInputPartsWithAmbientRefs(payload).ToArray();
-        if (parts.Length == 0)
+        if (payload.InputParts.Count == 0)
             return null;
 
-        return parts.Select(static part => new WorkflowChatInputPart
+        return payload.InputParts.Select(static part => new WorkflowChatInputPart
         {
             Kind = part.Kind switch
             {

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -624,7 +624,7 @@ public sealed class AevatarInvocationDispatcher
                 : workflowRuntimeContext.RootRunId.Trim(),
             RequestedDepth = Math.Max(0, workflowRuntimeContext.Depth) + 1,
         };
-        managedStart.InputFileRefs.Add(request.Inputs.InputParts
+        managedStart.InputFileRefs.Add(EnumerateInputPartsWithAmbientRefs(request.Inputs)
             .Select(static part => ToWorkflowEventFileRef(part.FileRef))
             .Where(static fileRef => fileRef != null)
             .Select(static fileRef => fileRef!.Clone()));
@@ -1415,7 +1415,7 @@ public sealed class AevatarInvocationDispatcher
                 AppId = ScopeServiceIdentityDefaults.ServiceAppId,
                 ServiceKey = string.Empty,
             },
-            ToolContext: AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty,
+            ToolContext: ToInvocationToolContext(payload),
             LlmControl: ToLlmControlContext(AgentToolRequestContext.Current));
         return new StaticGAgentStreamInvocationRequest(identity, endpointId.Trim(), input);
     }
@@ -1437,8 +1437,7 @@ public sealed class AevatarInvocationDispatcher
             Prompt = payload.Prompt,
             SessionId = ResolveSessionId(),
             ScopeId = resolution.ScopeId,
-            ToolContext = AgentToolExecutionContextMapper.ToPayload(
-                AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty),
+            ToolContext = AgentToolExecutionContextMapper.ToPayload(ToInvocationToolContext(payload)),
             LlmControl = ToLlmControlPayload(AgentToolRequestContext.Current),
         };
         chatRequest.InputParts.AddRange(ToChatInputParts(payload));
@@ -1736,8 +1735,7 @@ public sealed class AevatarInvocationDispatcher
             Prompt = payload.Prompt,
             SessionId = commandId,
             ScopeId = scope.ScopeId,
-            ToolContext = AgentToolExecutionContextMapper.ToPayload(
-                AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty),
+            ToolContext = AgentToolExecutionContextMapper.ToPayload(ToInvocationToolContext(payload)),
             LlmControl = ToLlmControlPayload(AgentToolRequestContext.Current),
         };
         AppendMetadata(request.Headers, headers);
@@ -1884,6 +1882,19 @@ public sealed class AevatarInvocationDispatcher
                string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
     }
 
+    private static AgentToolExecutionContext ToInvocationToolContext(InvocationPayload payload)
+    {
+        var context = AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty;
+        var inputFileRefs = EnumerateInputPartsWithAmbientRefs(payload)
+            .Select(static part => part.FileRef)
+            .Where(static fileRef => fileRef is not null && HasFileRefIdentity(fileRef))
+            .Select(static fileRef => fileRef!.Clone())
+            .ToArray();
+        return inputFileRefs.Length == 0
+            ? context
+            : context with { InputFileRefs = inputFileRefs };
+    }
+
     private CallerScopeResolution ResolveTeamInvocationScope()
     {
         var baseScope = ResolveCallerScope();
@@ -1903,8 +1914,63 @@ public sealed class AevatarInvocationDispatcher
         });
     }
 
+    private static IEnumerable<InvocationContentPart> EnumerateInputPartsWithAmbientRefs(InvocationPayload payload)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var part in payload.InputParts)
+        {
+            AddSeenFileRef(seen, part.FileRef);
+            yield return part;
+        }
+
+        foreach (var fileRef in AgentToolRequestContext.InputFileRefs)
+        {
+            if (!HasFileRefIdentity(fileRef))
+                continue;
+
+            var key = FileRefIdentityKey(fileRef);
+            if (key is null || !seen.Add(key))
+                continue;
+
+            yield return new InvocationContentPart
+            {
+                Kind = InvocationContentPartKind.File,
+                MediaType = fileRef.MediaType,
+                Name = fileRef.FileName,
+                FileRef = fileRef.Clone(),
+            };
+        }
+    }
+
+    private static void AddSeenFileRef(HashSet<string> seen, Aevatar.AI.Abstractions.ChatFileRef? fileRef)
+    {
+        if (fileRef is null || !HasFileRefIdentity(fileRef))
+            return;
+
+        var key = FileRefIdentityKey(fileRef);
+        if (key is not null)
+            seen.Add(key);
+    }
+
+    private static string? FileRefIdentityKey(Aevatar.AI.Abstractions.ChatFileRef fileRef)
+    {
+        if (!string.IsNullOrWhiteSpace(fileRef.ArtifactId))
+            return $"artifact:{fileRef.ArtifactId.Trim()}";
+
+        if (!string.IsNullOrWhiteSpace(fileRef.FileId))
+            return $"file:{fileRef.FileId.Trim()}";
+
+        if (!string.IsNullOrWhiteSpace(fileRef.SourceMessageId) &&
+            !string.IsNullOrWhiteSpace(fileRef.SourceResourceKey))
+        {
+            return $"source:{(int)fileRef.SourceKind}:{fileRef.SourceMessageId.Trim()}:{fileRef.SourceResourceKey.Trim()}";
+        }
+
+        return null;
+    }
+
     private static IReadOnlyList<ChatContentPart> ToChatInputParts(InvocationPayload payload) =>
-        payload.InputParts.Select(static part => new ChatContentPart
+        EnumerateInputPartsWithAmbientRefs(payload).Select(static part => new ChatContentPart
         {
             Kind = part.Kind switch
             {
@@ -1925,10 +1991,11 @@ public sealed class AevatarInvocationDispatcher
 
     private static IReadOnlyList<GAgentDraftRunInputPart>? ToGAgentInputParts(InvocationPayload payload)
     {
-        if (payload.InputParts.Count == 0)
+        var parts = EnumerateInputPartsWithAmbientRefs(payload).ToArray();
+        if (parts.Length == 0)
             return null;
 
-        return payload.InputParts.Select(static part => new GAgentDraftRunInputPart
+        return parts.Select(static part => new GAgentDraftRunInputPart
         {
             Kind = part.Kind switch
             {
@@ -1950,10 +2017,11 @@ public sealed class AevatarInvocationDispatcher
 
     private static IReadOnlyList<WorkflowChatInputPart>? ToWorkflowInputParts(InvocationPayload payload)
     {
-        if (payload.InputParts.Count == 0)
+        var parts = EnumerateInputPartsWithAmbientRefs(payload).ToArray();
+        if (parts.Length == 0)
             return null;
 
-        return payload.InputParts.Select(static part => new WorkflowChatInputPart
+        return parts.Select(static part => new WorkflowChatInputPart
         {
             Kind = part.Kind switch
             {

--- a/test/Aevatar.AI.Tests/AgentToolExecutionContextInputFileRefTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolExecutionContextInputFileRefTests.cs
@@ -1,0 +1,54 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using FluentAssertions;
+using Google.Protobuf;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class AgentToolExecutionContextInputFileRefTests
+{
+    [Fact]
+    public void AgentToolExecutionContext_ShouldRoundTripInputFileRefs()
+    {
+        var payload = (AgentToolExecutionContext.Empty with
+        {
+            InputFileRefs =
+            [
+                new Aevatar.AI.Abstractions.ChatFileRef
+                {
+                    FileId = "file-1",
+                    ArtifactId = "workflow-file://file-1",
+                    SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+                    SourceMessageId = "om_1",
+                    SourceResourceKey = "file_key_1",
+                    FileName = "invoice.pdf",
+                    MediaType = "application/pdf",
+                    SizeBytes = 1234,
+                    Sha256 = "sha-1",
+                    CreatedAtUnixMs = 10,
+                    ExpiresAtUnixMs = 20,
+                    OwnerRunId = "run-1",
+                    OwnerScopeId = "scope-1",
+                },
+            ],
+        }).ToPayload();
+
+        var copy = AgentToolExecutionContextMapper.FromPayload(
+            AgentToolExecutionContextPayload.Parser.ParseFrom(payload.ToByteArray()));
+
+        var fileRef = copy.InputFileRefs.Should().ContainSingle().Subject;
+        fileRef.FileId.Should().Be("file-1");
+        fileRef.ArtifactId.Should().Be("workflow-file://file-1");
+        fileRef.SourceKind.Should().Be(Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource);
+        fileRef.SourceMessageId.Should().Be("om_1");
+        fileRef.SourceResourceKey.Should().Be("file_key_1");
+        fileRef.FileName.Should().Be("invoice.pdf");
+        fileRef.MediaType.Should().Be("application/pdf");
+        fileRef.SizeBytes.Should().Be(1234);
+        fileRef.Sha256.Should().Be("sha-1");
+        fileRef.CreatedAtUnixMs.Should().Be(10);
+        fileRef.ExpiresAtUnixMs.Should().Be(20);
+        fileRef.OwnerRunId.Should().Be("run-1");
+        fileRef.OwnerScopeId.Should().Be("scope-1");
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1507,6 +1507,56 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task StartWorkflow_ShouldMergeAmbientInputFileRefs_WhenPayloadHasNoExplicitFileRef()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+        var ambientFileRef = new Aevatar.AI.Abstractions.ChatFileRef
+        {
+            FileId = "file-current-1",
+            ArtifactId = "workflow-file://file-current-1",
+            SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+            SourceMessageId = "om_current_1",
+            SourceResourceKey = "file_key_current_1",
+            FileName = "Invoice-O3XHKQSN-0004.pdf",
+            MediaType = "application/pdf",
+            SizeBytes = 4321,
+        };
+
+        using var _ = PushContext(
+            callId: "call-workflow-ambient-file",
+            inputFileRefs: [ambientFileRef]);
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "wf-main",
+              "inputs": {
+                "prompt": "run workflow from the current invoice"
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        var command = harness.WorkflowDispatch.Command!;
+        command.InputParts.Should().ContainSingle();
+        var inputPart = command.InputParts!.Single();
+        inputPart.Kind.Should().Be(Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.File);
+        inputPart.DataBase64.Should().BeNull();
+        inputPart.FileRef.Should().NotBeNull();
+        inputPart.FileRef!.FileId.Should().Be("file-current-1");
+        inputPart.FileRef.ArtifactId.Should().Be("workflow-file://file-current-1");
+        inputPart.FileRef.SourceKind.Should().Be(FileArtifactSourceKind.ConnectedServiceResource);
+        inputPart.FileRef.SourceMessageId.Should().Be("om_current_1");
+        inputPart.FileRef.SourceResourceKey.Should().Be("file_key_current_1");
+        inputPart.FileRef.FileName.Should().Be("Invoice-O3XHKQSN-0004.pdf");
+        inputPart.FileRef.MediaType.Should().Be("application/pdf");
+        inputPart.FileRef.SizeBytes.Should().Be(4321);
+    }
+
+    [Fact]
     public async Task StartWorkflow_ShouldUseOwnerScope_WhenLarkChannelCarriesOwnerScope()
     {
         var harness = new Harness();
@@ -3390,7 +3440,8 @@ public sealed class AevatarInvocationToolSourceTests
         AgentWorkflowRuntimeContext? workflowRuntime = null,
         string? durableReplyCredentialRef = "secrets://nyx/default-reply",
         long durableReplyCredentialExpiresAtUnixMs = 0,
-        IReadOnlyDictionary<string, string>? externalMetadata = null) =>
+        IReadOnlyDictionary<string, string>? externalMetadata = null,
+        IReadOnlyList<Aevatar.AI.Abstractions.ChatFileRef>? inputFileRefs = null) =>
         AgentToolContextScope.Push(new AgentToolExecutionContext(
             new AgentToolRequestIdentity(requestId, callId),
             new AgentToolCredentials(accessToken, "org-token", "sender-token"),
@@ -3409,7 +3460,10 @@ public sealed class AevatarInvocationToolSourceTests
             new AgentToolConnectedServicesContext("""{"service":"ctx"}"""),
             workflowRuntime ?? AgentWorkflowRuntimeContext.Empty,
             AgentSkillRecoveryContext.Empty,
-            BuildExternalMetadata(externalMetadata)));
+            BuildExternalMetadata(externalMetadata)) with
+        {
+            InputFileRefs = inputFileRefs ?? [],
+        });
 
     private static ChannelWorkflowResultDeliveryCredential? ToDeliveryCredential(
         string? secretRef,

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1507,56 +1507,6 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task StartWorkflow_ShouldMergeAmbientInputFileRefs_WhenPayloadHasNoExplicitFileRef()
-    {
-        var harness = new Harness();
-        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
-            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
-        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
-        var ambientFileRef = new Aevatar.AI.Abstractions.ChatFileRef
-        {
-            FileId = "file-current-1",
-            ArtifactId = "workflow-file://file-current-1",
-            SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
-            SourceMessageId = "om_current_1",
-            SourceResourceKey = "file_key_current_1",
-            FileName = "Invoice-O3XHKQSN-0004.pdf",
-            MediaType = "application/pdf",
-            SizeBytes = 4321,
-        };
-
-        using var _ = PushContext(
-            callId: "call-workflow-ambient-file",
-            inputFileRefs: [ambientFileRef]);
-        var output = await tool.ExecuteAsync("""
-            {
-              "workflow_id": "wf-main",
-              "inputs": {
-                "prompt": "run workflow from the current invoice"
-              },
-              "wait": "stream"
-            }
-            """);
-
-        ErrorCodeOrNull(output).Should().BeNull(output);
-        harness.WorkflowDispatch.Command.Should().NotBeNull();
-        var command = harness.WorkflowDispatch.Command!;
-        command.InputParts.Should().ContainSingle();
-        var inputPart = command.InputParts!.Single();
-        inputPart.Kind.Should().Be(Aevatar.Workflow.Application.Abstractions.Runs.WorkflowChatInputPartKind.File);
-        inputPart.DataBase64.Should().BeNull();
-        inputPart.FileRef.Should().NotBeNull();
-        inputPart.FileRef!.FileId.Should().Be("file-current-1");
-        inputPart.FileRef.ArtifactId.Should().Be("workflow-file://file-current-1");
-        inputPart.FileRef.SourceKind.Should().Be(FileArtifactSourceKind.ConnectedServiceResource);
-        inputPart.FileRef.SourceMessageId.Should().Be("om_current_1");
-        inputPart.FileRef.SourceResourceKey.Should().Be("file_key_current_1");
-        inputPart.FileRef.FileName.Should().Be("Invoice-O3XHKQSN-0004.pdf");
-        inputPart.FileRef.MediaType.Should().Be("application/pdf");
-        inputPart.FileRef.SizeBytes.Should().Be(4321);
-    }
-
-    [Fact]
     public async Task StartWorkflow_ShouldUseOwnerScope_WhenLarkChannelCarriesOwnerScope()
     {
         var harness = new Harness();
@@ -2314,6 +2264,54 @@ public sealed class AevatarInvocationToolSourceTests
         chatRequest.ToolContext.WorkflowRuntime.RootRunId.Should().Be("root-run");
         chatRequest.ToolContext.WorkflowRuntime.Depth.Should().Be(2);
         chatRequest.ToolContext.SkillRecovery.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task InvokeGAgentForChatRun_ShouldPreserveInputFileRefsInCanonicalToolContextPayload()
+    {
+        var harness = new Harness();
+        var dispatcher = harness.CreateDispatcher();
+        var inputFileRef = new Aevatar.AI.Abstractions.ChatFileRef
+        {
+            FileId = "file-current-1",
+            ArtifactId = "workflow-file://file-current-1",
+            SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+            SourceMessageId = "om_current_1",
+            SourceResourceKey = "file_key_current_1",
+            FileName = "Invoice-O3XHKQSN-0004.pdf",
+            MediaType = "application/pdf",
+            SizeBytes = 4321,
+        };
+
+        using var _ = PushContext(
+            callId: "call-gagent-input-file-ref",
+            inputFileRefs: [inputFileRef]);
+        var request = BuildChatRunRequest(
+            "response-gagent",
+            "call-gagent-input-file-ref-tool",
+            "aevatar_invoke_gagent",
+            """
+            {
+              "actor_id": "actor-1",
+              "payload": { "prompt": "run gagent" }
+            }
+            """);
+
+        var result = await dispatcher.InvokeGAgentForChatRunAsync(request, request.ArgumentsJson);
+
+        result.ErrorCode.Should().BeEmpty();
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var chatRequest = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        chatRequest.InputParts.Should().BeEmpty();
+        var fileRef = chatRequest.ToolContext.InputFileRefs.Should().ContainSingle().Subject;
+        fileRef.FileId.Should().Be("file-current-1");
+        fileRef.ArtifactId.Should().Be("workflow-file://file-current-1");
+        fileRef.SourceKind.Should().Be(Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource);
+        fileRef.SourceMessageId.Should().Be("om_current_1");
+        fileRef.SourceResourceKey.Should().Be("file_key_current_1");
+        fileRef.FileName.Should().Be("Invoice-O3XHKQSN-0004.pdf");
+        fileRef.MediaType.Should().Be("application/pdf");
+        fileRef.SizeBytes.Should().Be(4321);
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1507,6 +1507,43 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task StartWorkflow_ShouldNotPopulateInputPartsFromAmbientInputFileRefs()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+        var ambientFileRef = new Aevatar.AI.Abstractions.ChatFileRef
+        {
+            FileId = "file-ambient-1",
+            ArtifactId = "workflow-file://file-ambient-1",
+            SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+            SourceMessageId = "om_ambient_1",
+            SourceResourceKey = "file_key_ambient_1",
+            FileName = "ambient.pdf",
+            MediaType = "application/pdf",
+            SizeBytes = 789,
+        };
+
+        using var _ = PushContext(
+            callId: "call-workflow-ambient-file-ref",
+            inputFileRefs: [ambientFileRef]);
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "wf-main",
+              "inputs": {
+                "prompt": "run workflow"
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.InputParts.Should().BeNull();
+    }
+
+    [Fact]
     public async Task StartWorkflow_ShouldUseOwnerScope_WhenLarkChannelCarriesOwnerScope()
     {
         var harness = new Harness();
@@ -2362,6 +2399,49 @@ public sealed class AevatarInvocationToolSourceTests
         receipt.ManagedWorkflowHandoff.ParentStepId.Should().Be("parent-step");
         receipt.ManagedWorkflowHandoff.InvocationId.Should().Be("parent-run:workflow_tool:parent-step:call-managed-workflow");
         receipt.ManagedWorkflowHandoff.ChildRunId.Should().Be("parent-run:workflow_tool:parent-step:call-managed-workflow");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WhenManagedRuntimeExists_ShouldNotPopulateInputFileRefsFromAmbientRefs()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+        var ambientFileRef = new Aevatar.AI.Abstractions.ChatFileRef
+        {
+            FileId = "file-ambient-child-1",
+            ArtifactId = "workflow-file://file-ambient-child-1",
+            SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+            SourceMessageId = "om_ambient_child_1",
+            SourceResourceKey = "file_key_ambient_child_1",
+            FileName = "ambient-child.pdf",
+            MediaType = "application/pdf",
+            SizeBytes = 654,
+        };
+
+        using var _ = PushContext(
+            callId: "call-managed-workflow-ambient-file-ref",
+            workflowRuntime: new AgentWorkflowRuntimeContext(
+                "parent-actor",
+                "parent-run",
+                "parent-step",
+                "root-run",
+                2),
+            inputFileRefs: [ambientFileRef]);
+
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "child-flow",
+              "inputs": { "prompt": "run child" },
+              "wait": "stream"
+            }
+            """);
+        var receipt = tool.CreateSuccessReceipt("call-managed-workflow-ambient-file-ref", tool.Name, output);
+
+        receipt.Should().NotBeNull();
+        receipt!.ManagedWorkflowHandoff.Should().NotBeNull();
+        var requested = harness.ActorDispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload
+            .Unpack<SubWorkflowInvokeRequestedEvent>();
+        requested.InputFileRefs.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
@@ -305,6 +305,103 @@ public sealed class AgentRunReplyGenerationExecutorTests
     }
 
     [Fact]
+    public async Task NyxIdChatTurnExecutor_ShouldMergeDirectInputPartFileRefsIntoInitialPlanningToolContext()
+    {
+        var generationExecutor = new RecordingTurnGenerationExecutor();
+        var executor = new NyxIdChatTurnOperationExecutor(generationExecutor);
+        var session = new NyxIdChatTransientExecutionSession();
+        var baseContext = AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity("request-direct", "call-direct"),
+            Caller = new AgentToolCallerContext("scope-direct", "owner-direct", "response-direct"),
+            InputFileRefs =
+            [
+                new Aevatar.AI.Abstractions.ChatFileRef
+                {
+                    FileId = "file-existing",
+                    ArtifactId = "workflow-file://file-existing",
+                    SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.Generated,
+                    FileName = "existing.txt",
+                    MediaType = "text/plain",
+                },
+            ],
+        };
+
+        await executor.ExecuteAsync(
+            new NyxIdChatOperationDispatchCommand
+            {
+                Key = BuildOperationKey("step-llm", "operation-llm"),
+                Llm = new NyxIdChatLLMOperationInput
+                {
+                    Request = new ChatRequestEvent
+                    {
+                        Prompt = "summarize files",
+                        ToolContext = baseContext.ToPayload(),
+                        InputParts =
+                        {
+                            new ChatContentPart
+                            {
+                                Kind = ChatContentPartKind.Text,
+                                Text = "see direct file",
+                                FileRef = new Aevatar.AI.Abstractions.ChatFileRef
+                                {
+                                    FileId = "file-direct",
+                                    ArtifactId = "workflow-file://file-direct",
+                                    SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput,
+                                    SourceMessageId = "om_direct",
+                                    SourceResourceKey = "file_key_direct",
+                                    FileName = "direct.pdf",
+                                    MediaType = "application/pdf",
+                                    SizeBytes = 123,
+                                },
+                            },
+                            new ChatContentPart
+                            {
+                                Kind = ChatContentPartKind.Text,
+                                Text = "duplicate",
+                                FileRef = new Aevatar.AI.Abstractions.ChatFileRef
+                                {
+                                    FileId = "file-direct-copy",
+                                    ArtifactId = "workflow-file://file-direct",
+                                    SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput,
+                                    FileName = "direct-copy.pdf",
+                                    MediaType = "application/pdf",
+                                },
+                            },
+                            new ChatContentPart
+                            {
+                                Kind = ChatContentPartKind.Text,
+                                Text = "file id only",
+                                FileRef = new Aevatar.AI.Abstractions.ChatFileRef
+                                {
+                                    FileId = "file-only",
+                                    SourceKind = Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput,
+                                    FileName = "file-only.txt",
+                                    MediaType = "text/plain",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            session,
+            static (_, _) => Task.CompletedTask,
+            CancellationToken.None);
+
+        generationExecutor.InitialRequest.Should().NotBeNull();
+        var toolContext = AgentToolExecutionContextMapper.FromPayload(generationExecutor.InitialRequest!.ToolContext);
+        toolContext.Request.RequestId.Should().Be("request-direct");
+        toolContext.Caller.ScopeId.Should().Be("scope-direct");
+        toolContext.InputFileRefs.Select(static fileRef => fileRef.FileId)
+            .Should().Equal("file-existing", "file-direct", "file-only");
+        toolContext.InputFileRefs.Select(static fileRef => fileRef.ArtifactId)
+            .Should().Equal("workflow-file://file-existing", "workflow-file://file-direct", string.Empty);
+        toolContext.InputFileRefs[1].SourceMessageId.Should().Be("om_direct");
+        toolContext.InputFileRefs[1].SourceResourceKey.Should().Be("file_key_direct");
+        toolContext.InputFileRefs[1].SizeBytes.Should().Be(123);
+    }
+
+    [Fact]
     public async Task BuildLlmStepContinuation_WhenMiddlewareRemovesTools_ShouldRejectFabricatedToolCall()
     {
         var tool = new CountingTool("use_skill");
@@ -599,6 +696,53 @@ public sealed class AgentRunReplyGenerationExecutorTests
         }
 
         return workItem with { StepState = stepState };
+    }
+
+    private sealed class RecordingTurnGenerationExecutor : IAgentRunReplyGenerationExecutorPort
+    {
+        public NeedsLlmReplyEvent? InitialRequest { get; private set; }
+
+        public Task<AgentRunReplyStepState> BuildInitialStepStateAsync(
+            AgentRunReplyGenerationExecutionRequest request,
+            CancellationToken ct)
+        {
+            InitialRequest = request.Request.Clone();
+            return Task.FromResult(new AgentRunReplyStepState
+            {
+                RunId = request.RunId,
+                CorrelationId = request.Request.CorrelationId,
+                TargetActorId = request.Request.TargetActorId,
+                Attempt = request.Attempt,
+                NextStepIndex = 1,
+                MaxToolRounds = 1,
+                ToolContext = request.Request.ToolContext?.Clone(),
+                LlmControl = request.Request.LlmControl?.Clone(),
+            });
+        }
+
+        public Task<AgentRunLlmStepExecution> BuildLlmStepExecutionAsync(
+            AgentRunReplyStepExecutionRequest request,
+            CancellationToken ct) =>
+            Task.FromResult(new AgentRunLlmStepExecution(
+                new AgentRunNextLlmStepRequestedEvent
+                {
+                    RunId = request.RunId,
+                    CorrelationId = request.Request.CorrelationId,
+                    TargetActorId = request.Request.TargetActorId,
+                    Attempt = request.Attempt,
+                    StepIndex = request.StepIndex + 1,
+                    LlmStepResult = new AgentRunLlmStepResult
+                    {
+                        FinishReason = "stop",
+                    },
+                },
+                AuthorizedToolStep: null));
+
+        public Task<AgentRunNextToolStepRequestedEvent> BuildToolStepContinuationAsync(
+            AgentRunReplyStepExecutionRequest request,
+            AgentRunAuthorizedToolStep? authorizedToolStep,
+            CancellationToken ct) =>
+            throw new NotSupportedException();
     }
 
     private sealed class RecordingProvider : ILLMProvider


### PR DESCRIPTION
## Summary
- Add typed current input file refs to `AgentToolExecutionContext` and its protobuf mapper so file identity survives tool context roundtrips.
- Collect file refs from NyxID chat input parts after attachment materialization and attach them to the current tool context.
- Merge explicit direct API/chat `input_parts[].fileRef` values into the typed tool context before NyxID initial step planning.
- Preserve current input file refs through canonical agent/service invocation tool context without implicitly injecting ambient refs into workflow input parts; workflow file parameters still come from explicit tool payload input parts.

## Test plan
- [x] `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --no-restore -v:minimal /clp:ErrorsOnly`
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo --no-restore -v:minimal /clp:ErrorsOnly`
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --no-restore -v:minimal /clp:ErrorsOnly`
- [x] `PATH="/usr/bin:$PATH" bash tools/ci/test_stability_guards.sh`
- [x] `PATH="/usr/bin:$PATH" bash tools/ci/architecture_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)