### PR TITLE
Route implicit workflow file requests by scope

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunAdmission.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunAdmission.cs
@@ -59,13 +59,23 @@ public sealed class ChannelWorkflowDraftRunAdmission
         if (_workflowQueryPort is null)
             return ChannelWorkflowDraftRunAdmissionResult.Rejected("Workflow 查询服务暂不可用,请稍后重试。");
 
-        var lookup = await _workflowQueryPort.LookupByWorkflowIdAsync(scopeId, intent.WorkflowId, ct)
-            .ConfigureAwait(false);
+        var lookup = string.IsNullOrWhiteSpace(intent.WorkflowId)
+            ? await ResolveSingleRunnableWorkflowAsync(scopeId, ct).ConfigureAwait(false)
+            : await _workflowQueryPort.LookupByWorkflowIdAsync(scopeId, intent.WorkflowId, ct).ConfigureAwait(false);
         if (lookup.Status == ScopeWorkflowLookupStatus.NotFound)
-            return ChannelWorkflowDraftRunAdmissionResult.Rejected($"未找到 workflow `{intent.WorkflowId}`。");
+            return ChannelWorkflowDraftRunAdmissionResult.Rejected(string.IsNullOrWhiteSpace(intent.WorkflowId)
+                ? "当前 scope 没有可运行 workflow,请先创建并绑定 workflow。"
+                : $"未找到 workflow `{intent.WorkflowId}`。");
+
+        if (lookup.Status == ScopeWorkflowLookupStatus.Stale)
+            return ChannelWorkflowDraftRunAdmissionResult.Rejected(lookup.Reason);
 
         if (!lookup.IsRunnable)
-            return ChannelWorkflowDraftRunAdmissionResult.Rejected($"Workflow `{intent.WorkflowId}` 暂未绑定可运行的 actor,请稍后重试。");
+            return ChannelWorkflowDraftRunAdmissionResult.Rejected(string.IsNullOrWhiteSpace(intent.WorkflowId)
+                ? string.IsNullOrWhiteSpace(lookup.Reason)
+                    ? "当前 scope 没有唯一可运行 workflow,请用 `/workflow run <workflow_id>` 指定。"
+                    : lookup.Reason
+                : $"Workflow `{intent.WorkflowId}` 暂未绑定可运行的 actor,请稍后重试。");
 
         var workflow = lookup.Workflow!;
 
@@ -98,6 +108,35 @@ public sealed class ChannelWorkflowDraftRunAdmission
 
         return ChannelWorkflowDraftRunAdmissionResult.Accepted(request);
     }
+
+    private async Task<ScopeWorkflowLookupResult> ResolveSingleRunnableWorkflowAsync(
+        string scopeId,
+        CancellationToken ct)
+    {
+        var workflows = await _workflowQueryPort!.ListAsync(scopeId, ct).ConfigureAwait(false);
+        var runnable = new List<ScopeWorkflowSummary>();
+        foreach (var workflow in workflows)
+        {
+            if (string.IsNullOrWhiteSpace(workflow.WorkflowId))
+                continue;
+
+            var lookup = await _workflowQueryPort.LookupByWorkflowIdAsync(scopeId, workflow.WorkflowId, ct)
+                .ConfigureAwait(false);
+            if (lookup.IsRunnable)
+                runnable.Add(lookup.Workflow!);
+        }
+
+        return runnable.Count switch
+        {
+            0 => new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.NotFound, null, "no_runnable_scope_workflow"),
+            1 => new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.Runnable, runnable[0], "single_runnable_scope_workflow"),
+            _ => new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.NotReady, null, FormatAmbiguousWorkflowMessage(runnable)),
+        };
+    }
+
+    private static string FormatAmbiguousWorkflowMessage(IReadOnlyList<ScopeWorkflowSummary> workflows) =>
+        "当前 scope 有多个可运行 workflow,请用 `/workflow run <workflow_id>` 指定: " +
+        string.Join(", ", workflows.Select(static workflow => workflow.WorkflowId));
 
     private static string? NormalizeOptional(string? value)
     {

--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunIntentParser.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunIntentParser.cs
@@ -21,7 +21,13 @@ public sealed class ChannelWorkflowDraftRunIntentParser
 
         var normalized = text.Trim();
         if (!TryParseSlashCommand(normalized, out var commandName, out var argumentText))
-            return false;
+        {
+            if (!IsImplicitWorkflowFileRequest(normalized))
+                return false;
+
+            intent = new ChannelWorkflowDraftRunIntent(string.Empty, normalized);
+            return true;
+        }
 
         var handler = _slashCommandRegistry?.Find(commandName);
         if (handler is not IChannelWorkflowDraftRunCommand workflowCommand)
@@ -33,6 +39,21 @@ public sealed class ChannelWorkflowDraftRunIntentParser
         intent = new ChannelWorkflowDraftRunIntent(workflowId, normalized);
         return true;
     }
+
+    private static bool IsImplicitWorkflowFileRequest(string text) =>
+        Contains(text, "workflow") &&
+        (Contains(text, "pdf") ||
+         Contains(text, "file") ||
+         Contains(text, "document") ||
+         Contains(text, "attachment") ||
+         Contains(text, "invoice") ||
+         Contains(text, "文件") ||
+         Contains(text, "文档") ||
+         Contains(text, "附件") ||
+         Contains(text, "发票"));
+
+    private static bool Contains(string text, string value) =>
+        text.Contains(value, StringComparison.OrdinalIgnoreCase);
 
     private static bool TryParseSlashCommand(string text, out string commandName, out string argumentText)
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
@@ -50,6 +50,20 @@ public sealed class ChannelWorkflowDraftRunTests
     }
 
     [Theory]
+    [InlineData("让 workflow 处理一下这个 PDF")]
+    [InlineData("use workflow to process this attachment")]
+    public void IntentParser_ShouldMatchImplicitWorkflowFileRequest(string text)
+    {
+        var parser = new ChannelWorkflowDraftRunIntentParser(BuildWorkflowSlashRegistry());
+
+        var matched = parser.TryParse(text, out var intent);
+
+        matched.Should().BeTrue();
+        intent.WorkflowId.Should().BeEmpty();
+        intent.Prompt.Should().Be(text);
+    }
+
+    [Theory]
     [InlineData("missing-scope", null, "user-token-1", true, true, "scope")]
     [InlineData("missing-token", "scope-1", null, true, true, "授权")]
     [InlineData("missing-query-port", "scope-1", "user-token-1", false, true, "查询服务")]
@@ -130,6 +144,68 @@ public sealed class ChannelWorkflowDraftRunTests
         result.Request.WorkflowSource.DefinitionActorId.Should().Be("scope-workflow-definition-actor-1");
         result.Request.Headers.Should().Contain("workflow_id", "daily-greeting");
         result.Request.NyxUserAccessToken.Should().Be("user-token-1");
+    }
+
+    [Fact]
+    public async Task Admission_ShouldUseSingleRunnableWorkflow_ForImplicitWorkflowFileRequest()
+    {
+        var workflow = BuildWorkflowSummary(
+            "scope-1",
+            "invoice-review",
+            actorId: "scope-workflow-definition-actor-1");
+        var admission = new ChannelWorkflowDraftRunAdmission(
+            new ChannelWorkflowDraftRunIntentParser(BuildWorkflowSlashRegistry()),
+            new StubScopeWorkflowQueryPort(workflow));
+
+        var result = await admission.TryAdmitAsync(
+            BuildWorkflowActivity("scope-1", "user-token-1", "让 workflow 处理一下这个 PDF"),
+            new ChannelBotRegistrationEntry { Id = "reg-1", ScopeId = "scope-1" },
+            new ChannelInboundEvent
+            {
+                Text = "让 workflow 处理一下这个 PDF",
+                Platform = "lark",
+                MessageId = "msg-1",
+                ConversationId = "oc_group_chat_1",
+            },
+            new ConversationTurnRuntimeContext(null, "user-token-1"),
+            CancellationToken.None);
+
+        result.Matched.Should().BeTrue();
+        result.Rejection.Should().BeNull();
+        result.Request.Should().NotBeNull();
+        result.Request!.WorkflowSource.WorkflowId.Should().Be("invoice-review");
+        result.Request.WorkflowSource.DefinitionActorId.Should().Be("scope-workflow-definition-actor-1");
+        result.Request.Prompt.Should().Be("让 workflow 处理一下这个 PDF");
+    }
+
+    [Fact]
+    public async Task Admission_ShouldRejectImplicitWorkflowFileRequest_WhenMultipleRunnableWorkflowsExist()
+    {
+        var admission = new ChannelWorkflowDraftRunAdmission(
+            new ChannelWorkflowDraftRunIntentParser(BuildWorkflowSlashRegistry()),
+            new StubScopeWorkflowQueryPort(
+                BuildWorkflowSummary("scope-1", "invoice-review"),
+                BuildWorkflowSummary("scope-1", "receipt-review")));
+
+        var result = await admission.TryAdmitAsync(
+            BuildWorkflowActivity("scope-1", "user-token-1", "让 workflow 处理一下这个 PDF"),
+            new ChannelBotRegistrationEntry { Id = "reg-1", ScopeId = "scope-1" },
+            new ChannelInboundEvent
+            {
+                Text = "让 workflow 处理一下这个 PDF",
+                Platform = "lark",
+                MessageId = "msg-1",
+                ConversationId = "oc_group_chat_1",
+            },
+            new ConversationTurnRuntimeContext(null, "user-token-1"),
+            CancellationToken.None);
+
+        result.Matched.Should().BeTrue();
+        result.Request.Should().BeNull();
+        result.Rejection.Should().NotBeNull();
+        result.Rejection!.Text.Should().Contain("/workflow run <workflow_id>");
+        result.Rejection.Text.Should().Contain("invoice-review");
+        result.Rejection.Text.Should().Contain("receipt-review");
     }
 
     [Fact]
@@ -1013,11 +1089,14 @@ public sealed class ChannelWorkflowDraftRunTests
         return request;
     }
 
-    private static ChatActivity BuildWorkflowActivity(string? scopeId, string? userToken) =>
+    private static ChatActivity BuildWorkflowActivity(
+        string? scopeId,
+        string? userToken,
+        string text = "/workflow run daily-greeting") =>
         new()
         {
             Id = "msg-1",
-            Content = new MessageContent { Text = "/workflow run daily-greeting" },
+            Content = new MessageContent { Text = text },
             TransportExtras = new TransportExtras
             {
                 NyxRegistrationScopeId = scopeId ?? string.Empty,
@@ -1195,21 +1274,27 @@ public sealed class ChannelWorkflowDraftRunTests
         }
     }
 
-    private sealed class StubScopeWorkflowQueryPort(ScopeWorkflowSummary? workflow) : Aevatar.GAgentService.Abstractions.Ports.IScopeWorkflowQueryPort
+    private sealed class StubScopeWorkflowQueryPort : Aevatar.GAgentService.Abstractions.Ports.IScopeWorkflowQueryPort
     {
+        private readonly IReadOnlyList<ScopeWorkflowSummary> _workflows;
+
+        public StubScopeWorkflowQueryPort(params ScopeWorkflowSummary?[] workflows)
+        {
+            _workflows = workflows.Where(static workflow => workflow is not null).Cast<ScopeWorkflowSummary>().ToArray();
+        }
+
         public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>(workflow is null ? [] : [workflow]);
+            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>(
+                _workflows.Where(workflow => string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal)).ToArray());
 
         public Task<ScopeWorkflowLookupResult> LookupByWorkflowIdAsync(
             string scopeId,
             string workflowId,
             CancellationToken ct = default)
         {
-            var summary = workflow is not null &&
-                          string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
-                          string.Equals(workflow.WorkflowId, workflowId, StringComparison.Ordinal)
-                ? workflow
-                : null;
+            var summary = _workflows.FirstOrDefault(workflow =>
+                string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
+                string.Equals(workflow.WorkflowId, workflowId, StringComparison.Ordinal));
             return Task.FromResult(summary switch
             {
                 null => new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.NotFound, null, "test_not_found"),
@@ -1222,21 +1307,17 @@ public sealed class ChannelWorkflowDraftRunTests
             string scopeId,
             string workflowId,
             CancellationToken ct = default) =>
-            Task.FromResult(workflow is not null &&
-                            string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
-                            string.Equals(workflow.WorkflowId, workflowId, StringComparison.Ordinal)
-                ? workflow
-                : null);
+            Task.FromResult(_workflows.FirstOrDefault(workflow =>
+                string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
+                string.Equals(workflow.WorkflowId, workflowId, StringComparison.Ordinal)));
 
         public Task<ScopeWorkflowSummary?> GetByActorIdAsync(
             string scopeId,
             string actorId,
             CancellationToken ct = default) =>
-            Task.FromResult(workflow is not null &&
-                            string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
-                            string.Equals(workflow.ActorId, actorId, StringComparison.Ordinal)
-                ? workflow
-                : null);
+            Task.FromResult(_workflows.FirstOrDefault(workflow =>
+                string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
+                string.Equals(workflow.ActorId, actorId, StringComparison.Ordinal)));
     }
 
     private sealed class RecordingActorRuntime : IActorRuntime


### PR DESCRIPTION
## Summary
- Route natural-language channel requests like “let workflow handle this PDF” through the existing scope workflow draft-run path.
- Resolve the current scope's single runnable workflow instead of letting the model guess `aevatar_start_workflow.workflow_id`.
- Return a clear `/workflow run <workflow_id>` prompt when multiple runnable workflows exist.

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- [x] `PATH=\"/usr/bin:$PATH\" bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)