### PR TITLE
Fix channel workflow file ownership binding

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
@@ -298,7 +298,6 @@ public sealed class ChannelWorkflowDraftRunInteractionPort : IChannelWorkflowDra
                             SourceResourceKey: resourceKey,
                             FileName: NormalizeOptional(download.FileName) ?? NormalizeOptional(attachment.Name),
                             MediaType: NormalizeOptional(download.ContentType) ?? NormalizeOptional(attachment.ContentType),
-                            OwnerRunId: NormalizeOptional(request.RunId),
                             OwnerScopeId: NormalizeOptional(request.WorkflowSource?.ScopeId)),
                         ct)
                     .ConfigureAwait(false);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
@@ -263,7 +263,11 @@ public sealed class ChannelWorkflowDraftRunTests
         ingress.Requests[0].Content.ToArray().Should().Equal(1, 2, 3);
         ingress.Requests[0].SourceMessageId.Should().Be("om_123");
         ingress.Requests[0].SourceResourceKey.Should().Be("img_v3_1");
+        ingress.Requests[0].OwnerRunId.Should().BeNull();
+        ingress.Requests[0].OwnerScopeId.Should().Be("scope-1");
         ingress.Requests[1].Content.ToArray().Should().Equal(4, 5, 6, 7);
+        ingress.Requests[1].OwnerRunId.Should().BeNull();
+        ingress.Requests[1].OwnerScopeId.Should().Be("scope-1");
         await lark.Received(1).DownloadMessageResourceAsync(
             "user-token-1",
             Arg.Is<LarkMessageResourceDownloadRequest>(x =>


### PR DESCRIPTION
## Summary
- Leave channel-ingressed Lark workflow attachments unbound to draft-run ids so the actual workflow run can claim file ownership.
- Preserve scope ownership on ingressed attachments to keep workflow file access scoped.
- Add regression assertions for channel attachment ingress ownership fields.

Fixes #3092

## Test plan
- [x] dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo
- [x] git diff --check -- agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
- [ ] bash tools/ci/test_stability_guards.sh (blocked by local Python pyexpat/libexpat import failure after earlier guard sections passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)