### PR TITLE
Resolve current-scope workflow starts

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -87,6 +87,7 @@ public sealed class AevatarInvocationDispatcher
     private readonly IGAgentRunTerminalQueryPort _terminalQueryPort;
     private readonly IWorkflowExecutionQueryApplicationService _workflowQueryService;
     private readonly IWorkflowRunBackgroundDeliveryRegistrationPort? _workflowRunDeliveryRegistrationPort;
+    private readonly IScopeWorkflowQueryPort? _scopeWorkflowQueryPort;
     private readonly ILogger<AevatarInvocationDispatcher> _logger;
 
     public AevatarInvocationDispatcher(
@@ -103,7 +104,8 @@ public sealed class AevatarInvocationDispatcher
         IGAgentRunTerminalQueryPort terminalQueryPort,
         IWorkflowExecutionQueryApplicationService workflowQueryService,
         IWorkflowRunBackgroundDeliveryRegistrationPort? workflowRunDeliveryRegistrationPort = null,
-        ILogger<AevatarInvocationDispatcher>? logger = null)
+        ILogger<AevatarInvocationDispatcher>? logger = null,
+        IScopeWorkflowQueryPort? scopeWorkflowQueryPort = null)
     {
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
         _actorRegistryQueryPort = actorRegistryQueryPort ?? throw new ArgumentNullException(nameof(actorRegistryQueryPort));
@@ -118,6 +120,7 @@ public sealed class AevatarInvocationDispatcher
         _terminalQueryPort = terminalQueryPort ?? throw new ArgumentNullException(nameof(terminalQueryPort));
         _workflowQueryService = workflowQueryService ?? throw new ArgumentNullException(nameof(workflowQueryService));
         _workflowRunDeliveryRegistrationPort = workflowRunDeliveryRegistrationPort;
+        _scopeWorkflowQueryPort = scopeWorkflowQueryPort;
         _logger = logger ?? NullLogger<AevatarInvocationDispatcher>.Instance;
     }
 
@@ -446,11 +449,13 @@ public sealed class AevatarInvocationDispatcher
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(callerCredential.Error), callerCredential.Error);
 
         var metadata = BuildPayloadHeaders(request.Inputs.Headers);
-        var source = workflowYamls is { Length: > 0 }
-            ? WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId)
-            : string.IsNullOrWhiteSpace(actorId)
-                ? WorkflowChatSource.CatalogWorkflow(workflowName)
-                : WorkflowChatSource.DefinitionActor(actorId, workflowName);
+        var source = await ResolveWorkflowStartSourceAsync(
+                scope.Value!.ScopeId,
+                workflowName,
+                actorId,
+                workflowYamls,
+                ct)
+            .ConfigureAwait(false);
         var command = new WorkflowChatRunRequest(
             Prompt: request.Inputs.Prompt,
             Source: source,
@@ -468,6 +473,58 @@ public sealed class AevatarInvocationDispatcher
             scope.Value!.ScopeId,
             backgroundDelivery,
             ct);
+    }
+
+    private async ValueTask<WorkflowChatSource> ResolveWorkflowStartSourceAsync(
+        string scopeId,
+        string workflowName,
+        string? actorId,
+        string[]? workflowYamls,
+        CancellationToken ct)
+    {
+        if (workflowYamls is { Length: > 0 })
+            return WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId);
+
+        if (!string.IsNullOrWhiteSpace(actorId))
+            return WorkflowChatSource.DefinitionActor(actorId, workflowName);
+
+        var scopeWorkflow = await TryResolveScopeWorkflowAsync(scopeId, workflowName, ct).ConfigureAwait(false);
+        if (scopeWorkflow is not null)
+        {
+            var resolvedWorkflowName = string.IsNullOrWhiteSpace(scopeWorkflow.WorkflowName)
+                ? null
+                : scopeWorkflow.WorkflowName.Trim();
+            return WorkflowChatSource.DefinitionActor(scopeWorkflow.ActorId.Trim(), resolvedWorkflowName);
+        }
+
+        return WorkflowChatSource.CatalogWorkflow(workflowName);
+    }
+
+    private async ValueTask<ScopeWorkflowSummary?> TryResolveScopeWorkflowAsync(
+        string scopeId,
+        string workflowId,
+        CancellationToken ct)
+    {
+        if (_scopeWorkflowQueryPort is null)
+            return null;
+
+        try
+        {
+            var lookup = await _scopeWorkflowQueryPort.LookupByWorkflowIdAsync(scopeId, workflowId, ct)
+                .ConfigureAwait(false);
+            if (lookup.IsRunnable && !string.IsNullOrWhiteSpace(lookup.Workflow!.ActorId))
+                return lookup.Workflow;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Scope workflow lookup failed before workflow start: scopeId={ScopeId} workflowId={WorkflowId}",
+                scopeId,
+                workflowId);
+        }
+
+        return null;
     }
 
     private async Task<ChatRunToolCompletionRequest> DispatchWorkflowForChatRunAsync(

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -449,16 +449,19 @@ public sealed class AevatarInvocationDispatcher
             return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(callerCredential.Error), callerCredential.Error);
 
         var metadata = BuildPayloadHeaders(request.Inputs.Headers);
-        var source = await ResolveWorkflowStartSourceAsync(
+        var sourceResolution = await ResolveWorkflowStartSourceAsync(
                 scope.Value!.ScopeId,
                 workflowName,
                 actorId,
                 workflowYamls,
                 ct)
             .ConfigureAwait(false);
+        if (sourceResolution.Error != null)
+            return ToChatRunRequest(chatRunRequest, AevatarInvocationJson.Error(sourceResolution.Error), sourceResolution.Error);
+
         var command = new WorkflowChatRunRequest(
             Prompt: request.Inputs.Prompt,
-            Source: source,
+            Source: sourceResolution.Source!,
             SessionId: ResolveSessionId(),
             InputParts: ToWorkflowInputParts(request.Inputs),
             Metadata: metadata,
@@ -475,7 +478,7 @@ public sealed class AevatarInvocationDispatcher
             ct);
     }
 
-    private async ValueTask<WorkflowChatSource> ResolveWorkflowStartSourceAsync(
+    private async ValueTask<WorkflowStartSourceResolution> ResolveWorkflowStartSourceAsync(
         string scopeId,
         string workflowName,
         string? actorId,
@@ -483,37 +486,46 @@ public sealed class AevatarInvocationDispatcher
         CancellationToken ct)
     {
         if (workflowYamls is { Length: > 0 })
-            return WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId);
+            return WorkflowStartSourceResolution.Success(
+                WorkflowChatSource.InlineYamlBundle(workflowYamls, workflowName, actorId));
 
         if (!string.IsNullOrWhiteSpace(actorId))
-            return WorkflowChatSource.DefinitionActor(actorId, workflowName);
+            return WorkflowStartSourceResolution.Success(
+                WorkflowChatSource.DefinitionActor(actorId, workflowName));
 
         var scopeWorkflow = await TryResolveScopeWorkflowAsync(scopeId, workflowName, ct).ConfigureAwait(false);
-        if (scopeWorkflow is not null)
+        if (scopeWorkflow.Error != null)
+            return scopeWorkflow;
+
+        if (scopeWorkflow.Workflow is not null)
         {
-            var resolvedWorkflowName = string.IsNullOrWhiteSpace(scopeWorkflow.WorkflowName)
+            var resolvedWorkflowName = string.IsNullOrWhiteSpace(scopeWorkflow.Workflow.WorkflowName)
                 ? null
-                : scopeWorkflow.WorkflowName.Trim();
-            return WorkflowChatSource.DefinitionActor(scopeWorkflow.ActorId.Trim(), resolvedWorkflowName);
+                : scopeWorkflow.Workflow.WorkflowName.Trim();
+            return WorkflowStartSourceResolution.Success(
+                WorkflowChatSource.DefinitionActor(scopeWorkflow.Workflow.ActorId.Trim(), resolvedWorkflowName));
         }
 
-        return WorkflowChatSource.CatalogWorkflow(workflowName);
+        return WorkflowStartSourceResolution.Success(WorkflowChatSource.CatalogWorkflow(workflowName));
     }
 
-    private async ValueTask<ScopeWorkflowSummary?> TryResolveScopeWorkflowAsync(
+    private async ValueTask<WorkflowStartSourceResolution> TryResolveScopeWorkflowAsync(
         string scopeId,
         string workflowId,
         CancellationToken ct)
     {
         if (_scopeWorkflowQueryPort is null)
-            return null;
+            return WorkflowStartSourceResolution.NotResolved();
 
         try
         {
             var lookup = await _scopeWorkflowQueryPort.LookupByWorkflowIdAsync(scopeId, workflowId, ct)
                 .ConfigureAwait(false);
             if (lookup.IsRunnable && !string.IsNullOrWhiteSpace(lookup.Workflow!.ActorId))
-                return lookup.Workflow;
+                return WorkflowStartSourceResolution.Resolved(lookup.Workflow);
+
+            if (lookup.Status != ScopeWorkflowLookupStatus.NotFound)
+                return WorkflowStartSourceResolution.Failed(ScopeWorkflowUnavailableError(scopeId, workflowId, lookup));
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -524,7 +536,7 @@ public sealed class AevatarInvocationDispatcher
                 workflowId);
         }
 
-        return null;
+        return WorkflowStartSourceResolution.NotResolved();
     }
 
     private async Task<ChatRunToolCompletionRequest> DispatchWorkflowForChatRunAsync(
@@ -1417,6 +1429,15 @@ public sealed class AevatarInvocationDispatcher
                 ExpiresAtUnixMs = deliveryReservation.Reservation.ExpiresAtUnixMs,
             };
 
+    private static InvocationToolError ScopeWorkflowUnavailableError(
+        string scopeId,
+        string workflowId,
+        ScopeWorkflowLookupResult lookup) =>
+        Error(
+            "scope_workflow_not_runnable",
+            $"Current-scope workflow '{workflowId}' in scope '{scopeId}' is {lookup.Status} and cannot be started yet: {lookup.Reason}. List current scope workflows and retry when the descriptor is runnable.",
+            "workflow_id");
+
     private static InvocationToolError ChannelWorkflowDeliveryUnavailableError() =>
         Error(
             AgentToolFailureCodes.ChannelWorkflowResultDeliveryUnavailable,
@@ -2145,6 +2166,20 @@ public sealed class AevatarInvocationDispatcher
         string ScopeId,
         string MemberId,
         string PublishedServiceId);
+
+    private sealed record WorkflowStartSourceResolution(
+        WorkflowChatSource? Source,
+        ScopeWorkflowSummary? Workflow,
+        InvocationToolError? Error)
+    {
+        public static WorkflowStartSourceResolution Success(WorkflowChatSource source) => new(source, null, null);
+
+        public static WorkflowStartSourceResolution Resolved(ScopeWorkflowSummary workflow) => new(null, workflow, null);
+
+        public static WorkflowStartSourceResolution NotResolved() => new(null, null, null);
+
+        public static WorkflowStartSourceResolution Failed(InvocationToolError error) => new(null, null, error);
+    }
 
     private sealed record CallerScopeResolution(InvocationCallerScope? Value, InvocationToolError? Error)
     {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunStartErrorGuidance.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunStartErrorGuidance.cs
@@ -3,5 +3,5 @@ namespace Aevatar.Workflow.Application.Abstractions.Runs;
 public static class WorkflowChatRunStartErrorGuidance
 {
     public const string WorkflowNotFound =
-        "Workflow is not in the current scope catalog. For Studio/current-scope workflows, list the current scope workflows, choose one runnable descriptor, and retry with its exact workflow_id; when the descriptor includes a definition actor, pass it as actor_id instead of reusing stale opaque ids as workflow_id. If it is published as a NyxID downstream service, call list_external_workflow_capabilities, choose one structured descriptor, and copy its exact typed selector before invoking it. If it is a skill-provided workflow, call use_skill first, then retry with workflow_id.";
+        "Workflow is not in the current scope catalog. For Studio/current-scope workflows, list the current scope workflows, choose one runnable descriptor, and retry with its exact workflow_id. If you intentionally use a definition actor selector, pass actor_id with the descriptor's workflow name, not the stable scope workflow_id. If it is published as a NyxID downstream service, call list_external_workflow_capabilities, choose one structured descriptor, and copy its exact typed selector before invoking it. If it is a skill-provided workflow, call use_skill first, then retry with workflow_id.";
 }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunStartErrorGuidance.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowChatRunStartErrorGuidance.cs
@@ -3,5 +3,5 @@ namespace Aevatar.Workflow.Application.Abstractions.Runs;
 public static class WorkflowChatRunStartErrorGuidance
 {
     public const string WorkflowNotFound =
-        "Workflow is not in the current scope catalog. If it is published as a NyxID downstream service, call list_external_workflow_capabilities, choose one structured descriptor, and copy its exact typed selector before invoking it. If it is a skill-provided workflow, call use_skill first, then retry with workflow_id.";
+        "Workflow is not in the current scope catalog. For Studio/current-scope workflows, list the current scope workflows, choose one runnable descriptor, and retry with its exact workflow_id; when the descriptor includes a definition actor, pass it as actor_id instead of reusing stale opaque ids as workflow_id. If it is published as a NyxID downstream service, call list_external_workflow_capabilities, choose one structured descriptor, and copy its exact typed selector before invoking it. If it is a skill-provided workflow, call use_skill first, then retry with workflow_id.";
 }

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1544,6 +1544,44 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task StartWorkflow_ShouldResolveScopeWorkflowIdToDefinitionActorSource()
+    {
+        var harness = new Harness();
+        harness.ScopeWorkflowQuery.Workflows["98a81d707d4f4294b9b06f61a9fa8ac0"] = new ScopeWorkflowSummary(
+            "scope-1",
+            "98a81d707d4f4294b9b06f61a9fa8ac0",
+            "Invoice PDF Workflow",
+            "scope-1:aevatar:workflows:98a81d707d4f4294b9b06f61a9fa8ac0",
+            "invoice_pdf_workflow",
+            "workflow-definition-actor-98a81d707d4f4294b9b06f61a9fa8ac0",
+            "revision-1",
+            "deployment-1",
+            "Active",
+            DateTimeOffset.UtcNow);
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-run-actor", "invoice_pdf_workflow", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-scope-workflow");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "98a81d707d4f4294b9b06f61a9fa8ac0",
+              "inputs": { "prompt": "process pdf" },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ScopeWorkflowQuery.Lookups.Should().ContainSingle()
+            .Which.Should().Be(("scope-1", "98a81d707d4f4294b9b06f61a9fa8ac0"));
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.Source.Kind.Should().Be(WorkflowChatSourceKind.DefinitionActor);
+        harness.WorkflowDispatch.Command.Source.ActorId.Should()
+            .Be("workflow-definition-actor-98a81d707d4f4294b9b06f61a9fa8ac0");
+        harness.WorkflowDispatch.Command.Source.WorkflowName.Should().Be("invoice_pdf_workflow");
+    }
+
+    [Fact]
     public async Task StartWorkflow_ShouldUseOwnerScope_WhenLarkChannelCarriesOwnerScope()
     {
         var harness = new Harness();
@@ -3644,6 +3682,7 @@ public sealed class AevatarInvocationToolSourceTests
         public RecordingServiceRunQueryPort ServiceRunQuery { get; } = new();
         public RecordingTerminalQueryPort TerminalQuery { get; } = new();
         public StubWorkflowExecutionQueryService WorkflowQuery { get; } = new();
+        public RecordingScopeWorkflowQueryPort ScopeWorkflowQuery { get; } = new();
         public RecordingWorkflowRunBindingReader RunBindingReader { get; } = new();
 
         public Harness()
@@ -3669,7 +3708,8 @@ public sealed class AevatarInvocationToolSourceTests
                 ServiceRunQuery,
                 TerminalQuery,
                 WorkflowQuery,
-                withWorkflowRunDeliveryRegistrationPort ? WorkflowRunDelivery : null);
+                withWorkflowRunDeliveryRegistrationPort ? WorkflowRunDelivery : null,
+                scopeWorkflowQueryPort: ScopeWorkflowQuery);
 
         public void ConfigureServiceTarget(
             ServiceImplementationKind implementationKind,
@@ -3757,6 +3797,7 @@ public sealed class AevatarInvocationToolSourceTests
             services.AddSingleton<IServiceRunQueryPort>(ServiceRunQuery);
             services.AddSingleton<IGAgentRunTerminalQueryPort>(TerminalQuery);
             services.AddSingleton<IWorkflowExecutionQueryApplicationService>(WorkflowQuery);
+            services.AddSingleton<IScopeWorkflowQueryPort>(ScopeWorkflowQuery);
             services.AddSingleton<IWorkflowRunBindingReader>(RunBindingReader);
             services.AddSingleton<IWorkflowRunBackgroundDeliveryRegistrationPort>(WorkflowRunDelivery);
         }
@@ -3902,6 +3943,48 @@ public sealed class AevatarInvocationToolSourceTests
                 GAgentDraftRunCompletionStatus.RunFinished,
                 true);
         }
+    }
+
+    private sealed class RecordingScopeWorkflowQueryPort : IScopeWorkflowQueryPort
+    {
+        public Dictionary<string, ScopeWorkflowSummary> Workflows { get; } = new(StringComparer.Ordinal);
+        public List<(string ScopeId, string WorkflowId)> Lookups { get; } = [];
+
+        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(
+            string scopeId,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>(Workflows.Values
+                .Where(workflow => string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal))
+                .ToArray());
+
+        public Task<ScopeWorkflowLookupResult> LookupByWorkflowIdAsync(
+            string scopeId,
+            string workflowId,
+            CancellationToken ct = default)
+        {
+            Lookups.Add((scopeId, workflowId));
+            return Task.FromResult(Workflows.TryGetValue(workflowId, out var workflow) &&
+                                   string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal)
+                ? new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.Runnable, workflow, "runnable")
+                : new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.NotFound, null, "service_catalog_missing"));
+        }
+
+        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(
+            string scopeId,
+            string workflowId,
+            CancellationToken ct = default) =>
+            Task.FromResult(Workflows.TryGetValue(workflowId, out var workflow) &&
+                            string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal)
+                ? workflow
+                : null);
+
+        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(
+            string scopeId,
+            string actorId,
+            CancellationToken ct = default) =>
+            Task.FromResult<ScopeWorkflowSummary?>(Workflows.Values.FirstOrDefault(workflow =>
+                string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) &&
+                string.Equals(workflow.ActorId, actorId, StringComparison.Ordinal)));
     }
 
     private sealed class RecordingWorkflowDispatchService

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1581,6 +1581,35 @@ public sealed class AevatarInvocationToolSourceTests
         harness.WorkflowDispatch.Command.Source.WorkflowName.Should().Be("invoice_pdf_workflow");
     }
 
+    [Theory]
+    [InlineData(ScopeWorkflowLookupStatus.NotReady, "deployment_readmodel_missing")]
+    [InlineData(ScopeWorkflowLookupStatus.Stale, "workflow_actor_binding_mismatched")]
+    public async Task StartWorkflow_WhenScopeWorkflowIsNotRunnable_ShouldNotFallbackToCatalog(
+        ScopeWorkflowLookupStatus status,
+        string reason)
+    {
+        var harness = new Harness();
+        harness.ScopeWorkflowQuery.LookupResults["98a81d707d4f4294b9b06f61a9fa8ac0"] =
+            new ScopeWorkflowLookupResult(status, null, reason);
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-scope-workflow-not-runnable");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "98a81d707d4f4294b9b06f61a9fa8ac0",
+              "inputs": { "prompt": "process pdf" },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("scope_workflow_not_runnable");
+        ErrorMessage(output).Should().Contain(status.ToString());
+        ErrorMessage(output).Should().Contain(reason);
+        harness.ScopeWorkflowQuery.Lookups.Should().ContainSingle()
+            .Which.Should().Be(("scope-1", "98a81d707d4f4294b9b06f61a9fa8ac0"));
+        harness.WorkflowDispatch.Command.Should().BeNull();
+    }
+
     [Fact]
     public async Task StartWorkflow_ShouldUseOwnerScope_WhenLarkChannelCarriesOwnerScope()
     {
@@ -3948,6 +3977,7 @@ public sealed class AevatarInvocationToolSourceTests
     private sealed class RecordingScopeWorkflowQueryPort : IScopeWorkflowQueryPort
     {
         public Dictionary<string, ScopeWorkflowSummary> Workflows { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, ScopeWorkflowLookupResult> LookupResults { get; } = new(StringComparer.Ordinal);
         public List<(string ScopeId, string WorkflowId)> Lookups { get; } = [];
 
         public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(
@@ -3963,6 +3993,9 @@ public sealed class AevatarInvocationToolSourceTests
             CancellationToken ct = default)
         {
             Lookups.Add((scopeId, workflowId));
+            if (LookupResults.TryGetValue(workflowId, out var lookupResult))
+                return Task.FromResult(lookupResult);
+
             return Task.FromResult(Workflows.TryGetValue(workflowId, out var workflow) &&
                                    string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal)
                 ? new ScopeWorkflowLookupResult(ScopeWorkflowLookupStatus.Runnable, workflow, "runnable")

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
@@ -43,7 +43,8 @@ public class ChatRunStartErrorMapperTests
         mapped.Message.Should().Contain("current scope catalog");
         mapped.Message.Should().Contain("list the current scope workflows");
         mapped.Message.Should().Contain("actor_id");
-        mapped.Message.Should().Contain("stale opaque ids");
+        mapped.Message.Should().Contain("descriptor's workflow name");
+        mapped.Message.Should().Contain("not the stable scope workflow_id");
         mapped.Message.Should().Contain("list_external_workflow_capabilities");
         mapped.Message.Should().Contain("exact typed selector");
         mapped.Message.Should().Contain("structured descriptor");

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatRunStartErrorMapperTests.cs
@@ -41,6 +41,9 @@ public class ChatRunStartErrorMapperTests
         mapped.Code.Should().Be("WORKFLOW_NOT_FOUND");
         mapped.Message.Should().Be(WorkflowChatRunStartErrorGuidance.WorkflowNotFound);
         mapped.Message.Should().Contain("current scope catalog");
+        mapped.Message.Should().Contain("list the current scope workflows");
+        mapped.Message.Should().Contain("actor_id");
+        mapped.Message.Should().Contain("stale opaque ids");
         mapped.Message.Should().Contain("list_external_workflow_capabilities");
         mapped.Message.Should().Contain("exact typed selector");
         mapped.Message.Should().Contain("structured descriptor");


### PR DESCRIPTION
## Summary
- Resolve plain `workflow_id` through the current scope workflow catalog before falling back to static catalog lookup.
- Start runnable scope workflows through their definition actor source so Studio workflow retry ids can launch correctly.
- Expand workflow-not-found guidance and cover selector mapping with focused tests.

Fixes #3097

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo --filter StartWorkflow_ShouldResolveScopeWorkflowIdToDefinitionActorSource`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter ChatRunStartErrorMapperTests`
- [x] `git diff --check HEAD~1..HEAD`
- [ ] `bash tools/ci/test_stability_guards.sh` blocked after initial checks by local Python `pyexpat/libexpat` import failure: `ImportError: No module named expat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)