### PR TITLE
Fix nullable owner LLM automation authorization

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -808,6 +808,8 @@ const enUSMessages = {
   'teams.automations.authorization.error': 'Authorization could not continue',
   'teams.automations.authorization.exactAccess': 'Exact access',
   'teams.automations.authorization.expiry': 'Credential expiry',
+  'teams.automations.authorization.noExternalGrants': 'No external NyxID service or owner LLM model grant is required.',
+  'teams.automations.authorization.noOwnerLLMGrant': 'No owner LLM model grant is required for this workflow.',
   'teams.automations.authorization.preparing': 'Preparing authorization review',
   'teams.automations.authorization.review': 'Review authorization',
   'teams.automations.authorization.reviewAgain': 'Review again',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -767,6 +767,8 @@ const zhCNMessages = {
   'teams.automations.authorization.error': '无法继续授权',
   'teams.automations.authorization.exactAccess': '精确权限',
   'teams.automations.authorization.expiry': '凭证有效期',
+  'teams.automations.authorization.noExternalGrants': '无需外部 NyxID 服务或所有者 LLM 模型授权。',
+  'teams.automations.authorization.noOwnerLLMGrant': '此工作流无需所有者 LLM 模型授权。',
   'teams.automations.authorization.preparing': '正在准备授权检查',
   'teams.automations.authorization.review': '检查授权',
   'teams.automations.authorization.reviewAgain': '重新检查',

--- a/apps/aevatar-console-web/src/pages/teams/components/TeamAutomationAuthorizationReview.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamAutomationAuthorizationReview.tsx
@@ -1,42 +1,46 @@
 import { CheckCircleOutlined, SafetyCertificateOutlined } from "@ant-design/icons";
-import { Alert, Button, Space, Tag, Typography } from "antd";
+import { Alert, Space, Tag, Typography } from "antd";
 import { useIntl } from "@umijs/max";
 import React from "react";
 import type { TeamAutomationPermissionReview } from "@/shared/api/teamAutomationApi";
 
 type Props = {
-  readonly busy: boolean;
-  readonly onCancel: () => void;
-  readonly onConfirm: () => void;
   readonly review: TeamAutomationPermissionReview;
 };
 
 export default function TeamAutomationAuthorizationReview({
-  busy,
-  onCancel,
-  onConfirm,
   review,
 }: Props) {
   const intl = useIntl();
   const selection = review.ownerLLMSelection;
+  const exactAccessOccurrences = new Map<string, number>();
+  const exactAccessKey = (semanticKey: string) => {
+    const occurrence = exactAccessOccurrences.get(semanticKey) ?? 0;
+    exactAccessOccurrences.set(semanticKey, occurrence + 1);
+    return `${semanticKey}:${occurrence}`;
+  };
   const disclosureLabel = (disclosure: string) =>
     intl.formatMessage({
       id: `teams.automations.authorization.disclosure.${disclosure}`,
       defaultMessage: disclosure.replaceAll("_", " "),
     });
   return (
-    <div aria-describedby="team-automation-authorization-description">
+    <div>
       <Alert
         icon={<SafetyCertificateOutlined />}
         message={intl.formatMessage({
           id: "teams.automations.authorization.title",
           defaultMessage: "Dedicated Agent Key",
         })}
-        description={intl.formatMessage({
-          id: "teams.automations.authorization.description",
-          defaultMessage:
-            "Aevatar keeps this schedule's restricted key in its Vault. The browser never receives the key. Pausing preserves it; deleting revokes it.",
-        })}
+        description={(
+          <span id="team-automation-authorization-description">
+            {intl.formatMessage({
+              id: "teams.automations.authorization.description",
+              defaultMessage:
+                "Aevatar keeps this schedule's restricted key in its Vault. The browser never receives the key. Pausing preserves it; deleting revokes it.",
+            })}
+          </span>
+        )}
         showIcon
         type="info"
       />
@@ -49,7 +53,18 @@ export default function TeamAutomationAuthorizationReview({
             })}
           </Typography.Text>
           <Typography.Paragraph strong style={{ margin: "4px 0 0" }}>
-            {selection.serviceSlugSnapshot || selection.routeKind} / {selection.model}
+            {selection
+              ? `${selection.serviceSlugSnapshot || selection.routeKind} / ${selection.model}`
+              : review.serviceGrants.length === 0
+                ? intl.formatMessage({
+                    id: "teams.automations.authorization.noExternalGrants",
+                    defaultMessage:
+                      "No external NyxID service or owner LLM model grant is required.",
+                  })
+                : intl.formatMessage({
+                    id: "teams.automations.authorization.noOwnerLLMGrant",
+                    defaultMessage: "No owner LLM model grant is required for this workflow.",
+                  })}
           </Typography.Paragraph>
         </div>
         <div>
@@ -60,9 +75,18 @@ export default function TeamAutomationAuthorizationReview({
             })}
           </Typography.Text>
           <Space size={[6, 6]} wrap style={{ display: "flex", marginTop: 6 }}>
-            {review.credentialPlan.scopes.map((scope) => <Tag key={scope}>{scope}</Tag>)}
+            {review.credentialPlan.scopes.map((scope) => (
+              <Tag key={exactAccessKey(`scope:${scope}`)}>{scope}</Tag>
+            ))}
+            {review.serviceGrants.map((grant) => (
+              <Tag key={exactAccessKey(`service:${grant.grantId}`)}>{grant.displayName}</Tag>
+            ))}
             {review.serviceGrants.flatMap((grant) =>
-              grant.nodeIds.map((nodeId) => <Tag key={`${grant.targetId}:${nodeId}`}>{nodeId}</Tag>),
+              grant.nodeIds.map((nodeId) => (
+                <Tag key={exactAccessKey(`node:${grant.grantId}:${nodeId}`)}>
+                  {nodeId}
+                </Tag>
+              )),
             )}
           </Space>
         </div>
@@ -77,7 +101,7 @@ export default function TeamAutomationAuthorizationReview({
             {new Date(review.credentialPlan.expiresAt).toLocaleString()}
           </Typography.Paragraph>
         </div>
-        <div id="team-automation-authorization-description">
+        <div>
           {review.disclosures.map((disclosure) => (
             <div key={disclosure} style={{ alignItems: "center", display: "flex", gap: 8, marginTop: 6 }}>
               <CheckCircleOutlined style={{ color: "var(--ant-color-success)" }} />
@@ -97,20 +121,6 @@ export default function TeamAutomationAuthorizationReview({
           </Typography.Paragraph>
         </details>
       </div>
-      <Space style={{ display: "flex", justifyContent: "flex-end", marginTop: 20 }}>
-        <Button disabled={busy} onClick={onCancel}>
-          {intl.formatMessage({
-            id: "teams.automations.authorization.back",
-            defaultMessage: "Back",
-          })}
-        </Button>
-        <Button loading={busy} onClick={onConfirm} type="primary">
-          {intl.formatMessage({
-            id: "teams.automations.authorization.confirm",
-            defaultMessage: "Authorize and continue",
-          })}
-        </Button>
-      </Space>
     </div>
   );
 }

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import TeamAutomationsTab, {
   mutationObservationComplete,
 } from "./TeamAutomationsTab";
+import TeamAutomationAuthorizationReview from "../components/TeamAutomationAuthorizationReview";
 import {
   teamAutomationApi,
   TeamAutomationApiError,
@@ -110,7 +111,6 @@ function renderTab(
 function authorizationReview() {
   return {
     status: "ready",
-    schemaVersion: "scheduled-invocation-authorization/v1",
     permissionDigest: "digest-alpha",
     policyVersion: "scheduled-invocation-auth/v1",
     serviceGrants: [
@@ -130,11 +130,17 @@ function authorizationReview() {
       allowAllServices: false,
       browserReceivesRawKey: false,
       expiresAt: "2026-10-14T00:00:00Z",
+      hostedBy: "Aevatar",
+      mode: "dedicated-per-schedule",
+      nodeGrantRequirement: "required",
+      serviceGrantRequirement: "required",
       scopes: ["read", "proxy"],
     },
     ownerLLMSelection: {
       model: "gpt-5",
+      nyxIdUserServiceId: "us-alpha",
       routeKind: "nyx_id_user_service",
+      routeValue: "us-alpha",
       serviceSlugSnapshot: "connector-alpha",
     },
     disclosures: [
@@ -145,7 +151,37 @@ function authorizationReview() {
       "pause_resume_preserves_credential",
       "node_ids_are_permission_set",
     ],
-  };
+  } satisfies import("@/shared/api/teamAutomationApi").TeamAutomationPermissionReview;
+}
+
+function noServiceAuthorizationReview() {
+  return {
+    status: "ready",
+    permissionDigest: "digest-no-service",
+    policyVersion: "scheduled-invocation-auth/v1",
+    serviceGrants: [],
+    nodeGrants: [],
+    credentialPlan: {
+      allowAllNodes: false,
+      allowAllServices: false,
+      browserReceivesRawKey: false,
+      expiresAt: "2026-10-14T00:00:00Z",
+      hostedBy: "Aevatar",
+      mode: "dedicated-per-schedule",
+      nodeGrantRequirement: "not_required",
+      serviceGrantRequirement: "not_required",
+      scopes: ["read", "proxy"],
+    },
+    ownerLLMSelection: null,
+    disclosures: [
+      "dedicated_credential",
+      "aevatar_secret_custody",
+      "browser_never_receives_secret",
+      "delete_revokes_credential",
+      "pause_resume_preserves_credential",
+      "node_ids_are_permission_set",
+    ],
+  } satisfies import("@/shared/api/teamAutomationApi").TeamAutomationPermissionReview;
 }
 
 function automationView(overrides: Record<string, unknown> = {}) {
@@ -211,6 +247,32 @@ describe("TeamAutomationsTab canonical member authority", () => {
         [],
       ),
     ).toBe(true);
+  });
+
+  it("renders repeated exact grant occurrences without duplicate React keys", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const review = authorizationReview();
+    const duplicateGrant = {
+      ...review.serviceGrants[0],
+      nodeIds: ["node-alpha", "node-alpha"],
+    };
+
+    render(
+      <TeamAutomationAuthorizationReview
+        review={{
+          ...review,
+          serviceGrants: [duplicateGrant, duplicateGrant],
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText("Connector Alpha")).toHaveLength(2);
+    expect(screen.getAllByText("node-alpha")).toHaveLength(4);
+    expect(
+      consoleError.mock.calls.some((call) =>
+        call.join(" ").includes("Encountered two children with the same key"),
+      ),
+    ).toBe(false);
   });
 
   it("keeps member selection inside the create form when multiple members are eligible", async () => {
@@ -444,6 +506,67 @@ describe("TeamAutomationsTab canonical member authority", () => {
     await waitFor(() => expect(teamAutomationApi.create).toHaveBeenCalledTimes(1));
     expect(await screen.findByText("Authorization request accepted")).toBeInTheDocument();
     expect(screen.queryByText("Automation created")).not.toBeInTheDocument();
+  });
+
+  it("shows a no-service authorization review and requires confirmation before creating", async () => {
+    (teamAutomationApi.preflightCreate as jest.Mock).mockResolvedValue(
+      noServiceAuthorizationReview(),
+    );
+    (teamAutomationApi.create as jest.Mock).mockResolvedValue({
+      accepted: true,
+      status: "accepted",
+      scheduleId: "sch-no-service",
+      operationId: "op-alpha",
+      commandId: "cmd-no-service",
+    });
+    renderTab("m-alpha");
+
+    fireEvent.click(await screen.findByRole("button", { name: "New automation" }));
+    fireEvent.change(screen.getByLabelText("Recurring prompt"), {
+      target: { value: "Summarize open work." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create automation" }));
+
+    await waitFor(() => expect(teamAutomationApi.preflightCreate).toHaveBeenCalledTimes(1));
+    expect(teamAutomationApi.create).not.toHaveBeenCalled();
+
+    const reviewDialog = await screen.findByRole("dialog");
+    expect(reviewDialog).toHaveAttribute(
+      "aria-describedby",
+      "team-automation-authorization-description",
+    );
+    expect(
+      within(reviewDialog).getByText(
+        "No external NyxID service or owner LLM model grant is required.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(reviewDialog).queryByText(/gateway\s*\//)).not.toBeInTheDocument();
+    expect(within(reviewDialog).queryByText("gpt-5")).not.toBeInTheDocument();
+
+    const confirmation = within(reviewDialog).getByRole("button", {
+      name: "Authorize and continue",
+    });
+    const modalFooter = reviewDialog.querySelector(".ant-modal-footer");
+    const modalBody = reviewDialog.querySelector(".ant-modal-body");
+    expect(modalFooter).toContainElement(confirmation);
+    expect(modalBody).not.toContainElement(confirmation);
+    expect(modalBody).toHaveStyle({
+      maxHeight: "min(70vh, 640px)",
+      overflowY: "auto",
+    });
+
+    fireEvent.click(confirmation);
+
+    await waitFor(() => expect(teamAutomationApi.create).toHaveBeenCalledTimes(1));
+    expect(teamAutomationApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: "m-alpha",
+        prompt: "Summarize open work.",
+      }),
+      "digest-no-service",
+      "scheduled-invocation-auth/v1",
+      { idempotencyKey: "idem-alpha", operationId: "op-alpha" },
+    );
   });
 
   it("reports authorization preflight failures through the shared toast without changing the modal layout", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -755,6 +755,18 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const [previewTimes, setPreviewTimes] = React.useState<readonly string[]>([]);
   const pollingStartedAtRef = React.useRef<number | null>(null);
   const recoveredRouteRef = React.useRef("");
+  const modalPanelRef = React.useRef<HTMLDivElement | null>(null);
+  const flowBusy = authorizationFlow.state === "preflighting" || authorizationFlow.state === "submitting";
+  const review = authorizationFlow.state === "reviewing" || authorizationFlow.state === "submitting"
+    ? authorizationFlow.review
+    : null;
+  const modalDescriptionId = review
+    ? "team-automation-authorization-description"
+    : "team-automation-form-description";
+
+  React.useEffect(() => {
+    modalPanelRef.current?.setAttribute("aria-describedby", modalDescriptionId);
+  }, [formOpen, modalDescriptionId]);
 
   const automationsQuery = useQuery({
     enabled: canQuery,
@@ -1507,10 +1519,6 @@ const TeamAutomationsTab: React.FC<Props> = ({
     );
   }
 
-  const flowBusy = authorizationFlow.state === "preflighting" || authorizationFlow.state === "submitting";
-  const review = authorizationFlow.state === "reviewing" || authorizationFlow.state === "submitting"
-    ? authorizationFlow.review
-    : null;
   const upcomingAutomations = (automationsQuery.data?.items ?? [])
     .filter((automation) => automation.enabled && automation.nextFireAt)
     .slice(0, 3);
@@ -1779,10 +1787,19 @@ const TeamAutomationsTab: React.FC<Props> = ({
       </section>
 
       {formOpen ? <Modal
-        aria-describedby="team-automation-form-description"
+        aria-describedby={modalDescriptionId}
         confirmLoading={flowBusy || Boolean(busyScheduleId)}
         destroyOnHidden
-        footer={review ? null : undefined}
+        footer={review ? (
+          <Space>
+            <Button disabled={flowBusy} onClick={() => setAuthorizationFlow({ state: "idle" })}>
+              {copy("teams.automations.authorization.back", "Back")}
+            </Button>
+            <Button loading={flowBusy} onClick={() => void submitAuthorization()} type="primary">
+              {copy("teams.automations.authorization.confirm", "Authorize and continue")}
+            </Button>
+          </Space>
+        ) : undefined}
         onCancel={() => {
           setFormOpen(false);
           setAuthorizationFlow({ state: "idle" });
@@ -1795,18 +1812,17 @@ const TeamAutomationsTab: React.FC<Props> = ({
           ? copy("teams.automations.form.save", "Save changes")
           : copy("teams.automations.form.create", "Create automation")}
         open={formOpen}
+        panelRef={modalPanelRef}
+        styles={review ? {
+          body: { maxHeight: "min(70vh, 640px)", overflowY: "auto" },
+        } : undefined}
         title={formMode === "edit"
           ? copy("teams.automations.form.editTitle", "Edit automation")
           : copy("teams.automations.form.title", "New member automation")}
         width={720}
       >
         {review ? (
-          <TeamAutomationAuthorizationReview
-            busy={flowBusy}
-            onCancel={() => setAuthorizationFlow({ state: "idle" })}
-            onConfirm={() => void submitAuthorization()}
-            review={review}
-          />
+          <TeamAutomationAuthorizationReview review={review} />
         ) : (
           <div style={{ display: "grid", gap: 16 }}>
             <div

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -401,6 +401,50 @@ describe("teamAutomationApi", () => {
   });
 
   it.each([
+    [
+      "requires nodes but returns none",
+      "AUTHORIZATION_GRANT_REQUIREMENT_REQUIRED",
+      [],
+      "AUTHORIZATION_GRANT_REQUIREMENT_REQUIRED",
+    ],
+    [
+      "does not require nodes but returns one",
+      "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED",
+      ["node-alpha"],
+      "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED",
+    ],
+  ] as const)(
+    "fails closed when a service grant %s",
+    (
+      _caseName,
+      serviceNodeGrantRequirement,
+      nodeIds,
+      credentialNodeGrantRequirement,
+    ) => {
+      const base = authorizationResult();
+      const result = {
+        ...base,
+        plan: {
+          ...base.plan,
+          nyxIdServiceGrants: base.plan.nyxIdServiceGrants.map((grant) => ({
+            ...grant,
+            nodeGrantRequirement: serviceNodeGrantRequirement,
+            nodeIds,
+          })),
+          credentialPolicy: {
+            ...base.plan.credentialPolicy,
+            nodeGrantRequirement: credentialNodeGrantRequirement,
+          },
+        },
+      };
+
+      expect(() => teamAutomationApiDecoders.permissionReview(result)).toThrow(
+        "Team Automation authorization node grant requirement does not match per-service node grants.",
+      );
+    },
+  );
+
+  it.each([
     ["service policy", () => {
       const base = authorizationResult();
       return {

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -43,6 +43,8 @@ function authorizationResult() {
       ],
       credentialPolicy: {
         scopes: ["NYX_ID_CREDENTIAL_SCOPE_READ", "NYX_ID_CREDENTIAL_SCOPE_PROXY"],
+        serviceGrantRequirement: "AUTHORIZATION_GRANT_REQUIREMENT_REQUIRED",
+        nodeGrantRequirement: "AUTHORIZATION_GRANT_REQUIREMENT_REQUIRED",
         allowAllServices: false,
         allowAllNodes: false,
         expiresAt: "2026-10-14T00:00:00Z",
@@ -65,6 +67,50 @@ function authorizationResult() {
         model: "gpt-5",
       },
     },
+  };
+}
+
+function noServiceAuthorizationResult() {
+  return {
+    success: true,
+    failureCode: "SCHEDULED_INVOCATION_AUTHORIZATION_FAILURE_CODE_UNSPECIFIED",
+    detail: "",
+    plan: {
+      schemaVersion: "scheduled-invocation-authorization/v2",
+      invocationTarget: {
+        studioMember: {
+          scopeId: "scope-alpha",
+          teamId: "team-alpha",
+          memberId: "m-alpha",
+          publishedServiceId: "svc-alpha",
+          draftWorkflowId: "wf-alpha",
+          workflowRevisionId: "rev-alpha",
+        },
+      },
+      nyxIdServiceGrants: [],
+      credentialPolicy: {
+        scopes: [1, 2],
+        serviceGrantRequirement: 2,
+        nodeGrantRequirement: 2,
+        allowAllServices: false,
+        allowAllNodes: false,
+        expiresAt: { seconds: "1791936000", nanos: 0 },
+        policyVersion: "scheduled-invocation-auth/v2",
+      },
+      disclosures: [1, 2, 3, 4, 5, 6],
+      permissionDigest: "digest-no-service",
+      catalogAuthority: null,
+      ownerLlmSelection: null,
+    },
+  };
+}
+
+function authorizationResultWithoutOwnerLlmSelection() {
+  const result = authorizationResult();
+  const { ownerLlmSelection: _ownerLlmSelection, ...plan } = result.plan;
+  return {
+    ...result,
+    plan,
   };
 }
 
@@ -237,6 +283,169 @@ describe("teamAutomationApi", () => {
     expect(JSON.stringify(review)).not.toContain("m-alpha");
     expect(JSON.stringify(review)).not.toContain("wf-alpha");
     expect(JSON.stringify(review)).not.toContain("svc-alpha");
+  });
+
+  it("decodes a v2 non-LLM plan without service or node authorization", () => {
+    const review = teamAutomationApiDecoders.permissionReview(
+      noServiceAuthorizationResult(),
+    );
+
+    expect(review).toEqual(
+      expect.objectContaining({
+        status: "ready",
+        ownerLLMSelection: null,
+        serviceGrants: [],
+        nodeGrants: [],
+        credentialPlan: expect.objectContaining({
+          serviceGrantRequirement: "not_required",
+          nodeGrantRequirement: "not_required",
+        }),
+      }),
+    );
+  });
+
+  it("keeps an absent owner LLM selection independent from required workflow service grants", () => {
+    const base = authorizationResult();
+    const result = {
+      ...base,
+      plan: {
+        ...base.plan,
+        ownerLlmSelection: null,
+        nyxIdServiceGrants: base.plan.nyxIdServiceGrants.map((grant) => ({
+          ...grant,
+          nodeGrantRequirement: "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED",
+          nodeIds: [],
+        })),
+        credentialPolicy: {
+          ...base.plan.credentialPolicy,
+          nodeGrantRequirement: "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED",
+        },
+      },
+    };
+
+    expect(teamAutomationApiDecoders.permissionReview(result)).toEqual(
+      expect.objectContaining({
+        ownerLLMSelection: null,
+        serviceGrants: [
+          expect.objectContaining({
+            targetId: "us-alpha",
+            nodeGrantRequirement: "not_required",
+          }),
+        ],
+        credentialPlan: expect.objectContaining({
+          serviceGrantRequirement: "required",
+          nodeGrantRequirement: "not_required",
+        }),
+      }),
+    );
+  });
+
+  it("decodes an omitted owner LLM selection as null", () => {
+    expect(
+      teamAutomationApiDecoders.permissionReview(
+        authorizationResultWithoutOwnerLlmSelection(),
+      ),
+    ).toEqual(expect.objectContaining({ ownerLLMSelection: null }));
+  });
+
+  it.each([
+    ["requires services but returns none", () => {
+      const base = noServiceAuthorizationResult();
+      return {
+        ...base,
+        plan: {
+          ...base.plan,
+          credentialPolicy: {
+            ...base.plan.credentialPolicy,
+            serviceGrantRequirement: 1,
+          },
+        },
+      };
+    }],
+    ["does not require services but returns one", () => {
+      const base = authorizationResult();
+      return {
+        ...base,
+        plan: {
+          ...base.plan,
+          credentialPolicy: {
+            ...base.plan.credentialPolicy,
+            serviceGrantRequirement:
+              "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED",
+          },
+        },
+      };
+    }],
+  ])("fails closed when the service-grant policy %s", (_caseName, createResult) => {
+    expect(() => teamAutomationApiDecoders.permissionReview(createResult())).toThrow(
+      "Team Automation authorization service grant requirement does not match exact service grants.",
+    );
+  });
+
+  it("fails closed when node policy disagrees with required service nodes", () => {
+    const base = authorizationResult();
+    const result = {
+      ...base,
+      plan: {
+        ...base.plan,
+        credentialPolicy: {
+          ...base.plan.credentialPolicy,
+          nodeGrantRequirement: "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED",
+        },
+      },
+    };
+
+    expect(() => teamAutomationApiDecoders.permissionReview(result)).toThrow(
+      "Team Automation authorization node grant requirement does not match exact service grants.",
+    );
+  });
+
+  it.each([
+    ["service policy", () => {
+      const base = authorizationResult();
+      return {
+        ...base,
+        plan: {
+          ...base.plan,
+          credentialPolicy: {
+            ...base.plan.credentialPolicy,
+            serviceGrantRequirement:
+              "AUTHORIZATION_GRANT_REQUIREMENT_UNSPECIFIED",
+          },
+        },
+      };
+    }],
+    ["node policy", () => {
+      const base = authorizationResult();
+      return {
+        ...base,
+        plan: {
+          ...base.plan,
+          credentialPolicy: {
+            ...base.plan.credentialPolicy,
+            nodeGrantRequirement: 0,
+          },
+        },
+      };
+    }],
+    ["service grant", () => {
+      const base = authorizationResult();
+      return {
+        ...base,
+        plan: {
+          ...base.plan,
+          nyxIdServiceGrants: base.plan.nyxIdServiceGrants.map((grant) => ({
+            ...grant,
+            nodeGrantRequirement:
+              "AUTHORIZATION_GRANT_REQUIREMENT_CONDITIONAL_REQUIRED",
+          })),
+        },
+      };
+    }],
+  ])("fails closed on unspecified or unknown %s grant requirements", (_label, createResult) => {
+    expect(() => teamAutomationApiDecoders.permissionReview(createResult())).toThrow(
+      "grant requirement",
+    );
   });
 
   it("fails closed when a preflight plan allows all services", () => {

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -613,6 +613,13 @@ function decodePermissionReview(
           return nodeId.trim();
         },
       );
+      if (
+        (nodeGrantRequirement === "required") !== (nodeIds.length > 0)
+      ) {
+        throw new Error(
+          "Team Automation authorization node grant requirement does not match per-service node grants.",
+        );
+      }
       return {
         grantId: `service:${targetId}`,
         kind: "service" as const,

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -44,9 +44,11 @@ type TeamAutomationGrantBase = {
 
 export type TeamAutomationNodeRole = "primary" | "fallback";
 
+export type TeamAutomationGrantRequirement = "required" | "not_required";
+
 export type TeamAutomationServiceGrant = TeamAutomationGrantBase & {
   readonly kind: "service";
-  readonly nodeGrantRequirement: "required" | "not_required";
+  readonly nodeGrantRequirement: TeamAutomationGrantRequirement;
   readonly nodeIds: readonly string[];
   readonly serviceSlug: string | null;
 };
@@ -81,6 +83,8 @@ export type TeamAutomationCredentialPlan = {
   readonly allowAllServices: false;
   readonly allowAllNodes: false;
   readonly expiresAt: string;
+  readonly serviceGrantRequirement: TeamAutomationGrantRequirement;
+  readonly nodeGrantRequirement: TeamAutomationGrantRequirement;
 };
 
 export type TeamAutomationPermissionReview = {
@@ -90,13 +94,15 @@ export type TeamAutomationPermissionReview = {
   readonly credentialPlan: TeamAutomationCredentialPlan;
   readonly serviceGrants: readonly TeamAutomationServiceGrant[];
   readonly nodeGrants: readonly TeamAutomationNodeGrant[];
-  readonly ownerLLMSelection: {
-    readonly model: string;
-    readonly nyxIdUserServiceId: string;
-    readonly routeKind: "gateway" | "nyx_id_user_service";
-    readonly routeValue: string;
-    readonly serviceSlugSnapshot: string;
-  };
+  readonly ownerLLMSelection:
+    | {
+        readonly model: string;
+        readonly nyxIdUserServiceId: string;
+        readonly routeKind: "gateway" | "nyx_id_user_service";
+        readonly routeValue: string;
+        readonly serviceSlugSnapshot: string;
+      }
+    | null;
   readonly disclosures: readonly TeamAutomationDisclosure[];
   readonly warning?: string;
 };
@@ -380,23 +386,23 @@ function normalizeDisclosure(value: unknown): TeamAutomationDisclosure {
   }
 }
 
-function normalizeNodeGrantRequirement(
+function normalizeGrantRequirement(
   value: unknown,
-): TeamAutomationServiceGrant["nodeGrantRequirement"] {
-  const normalized = String(value ?? "").trim().toLowerCase();
+  label: string,
+): TeamAutomationGrantRequirement {
   if (
-    normalized === "1" ||
-    normalized === "authorization_grant_requirement_required"
+    value === 1 ||
+    value === "AUTHORIZATION_GRANT_REQUIREMENT_REQUIRED"
   ) {
     return "required";
   }
   if (
-    normalized === "2" ||
-    normalized === "authorization_grant_requirement_not_required"
+    value === 2 ||
+    value === "AUTHORIZATION_GRANT_REQUIREMENT_NOT_REQUIRED"
   ) {
     return "not_required";
   }
-  throw new Error(`Unknown NyxID node grant requirement: ${String(value)}.`);
+  throw new Error(`Unknown ${label} grant requirement: ${String(value)}.`);
 }
 
 function normalizeOwnerLLMRouteKind(value: unknown): "gateway" | "nyx_id_user_service" {
@@ -517,16 +523,12 @@ function decodePermissionReview(
           allowAllServices: false,
           allowAllNodes: false,
           expiresAt: "",
+          serviceGrantRequirement: "not_required",
+          nodeGrantRequirement: "not_required",
         },
         serviceGrants: [],
         nodeGrants: [],
-        ownerLLMSelection: {
-          model: "",
-          nyxIdUserServiceId: "",
-          routeKind: "gateway",
-          routeValue: "",
-          serviceSlugSnapshot: "",
-        },
+        ownerLLMSelection: null,
         disclosures: [],
         warning: detail || failureCode,
       };
@@ -568,6 +570,22 @@ function decodePermissionReview(
     field(plan, "credentialPolicy", "CredentialPolicy"),
     `${label}.plan.credentialPolicy`,
   );
+  const serviceGrantRequirement = normalizeGrantRequirement(
+    field(
+      credentialPolicy,
+      "serviceGrantRequirement",
+      "ServiceGrantRequirement",
+    ),
+    "Team automation service",
+  );
+  const nodeGrantRequirement = normalizeGrantRequirement(
+    field(
+      credentialPolicy,
+      "nodeGrantRequirement",
+      "NodeGrantRequirement",
+    ),
+    "Team automation node",
+  );
   const serviceGrants = readOptionalArray(
     plan,
     ["nyxIdServiceGrants", "NyxIdServiceGrants"],
@@ -580,8 +598,9 @@ function decodePermissionReview(
         `${grantLabel}.userServiceId`,
       );
       const serviceSlug = optionalString(grant, ["serviceSlug", "ServiceSlug"]);
-      const nodeGrantRequirement = normalizeNodeGrantRequirement(
+      const nodeGrantRequirement = normalizeGrantRequirement(
         field(grant, "nodeGrantRequirement", "NodeGrantRequirement"),
+        "NyxID node",
       );
       const nodeIds = readOptionalArray(
         grant,
@@ -615,18 +634,63 @@ function decodePermissionReview(
       userServiceId: grant.targetId,
     })),
   );
-  const ownerLLM = expectRecord(
-    field(plan, "ownerLlmSelection", "OwnerLlmSelection", "ownerLLMSelection", "OwnerLLMSelection"),
-    `${label}.plan.ownerLlmSelection`,
+  if (
+    (serviceGrantRequirement === "required") !== (serviceGrants.length > 0)
+  ) {
+    throw new Error(
+      "Team Automation authorization service grant requirement does not match exact service grants.",
+    );
+  }
+  if (
+    (nodeGrantRequirement === "required") !==
+      serviceGrants.some(
+        (grant) => grant.nodeGrantRequirement === "required",
+      )
+  ) {
+    throw new Error(
+      "Team Automation authorization node grant requirement does not match exact service grants.",
+    );
+  }
+  const ownerLLMValue = field(
+    plan,
+    "ownerLlmSelection",
+    "OwnerLlmSelection",
+    "ownerLLMSelection",
+    "OwnerLLMSelection",
   );
-  const ownerLLMSelection = {
-    routeKind: normalizeOwnerLLMRouteKind(field(ownerLLM, "routeKind", "RouteKind")),
-    routeValue: requiredString(ownerLLM, ["routeValue", "RouteValue"], `${label}.plan.ownerLlmSelection.routeValue`),
-    nyxIdUserServiceId: optionalString(ownerLLM, ["nyxIdUserServiceId", "NyxIdUserServiceId"]),
-    serviceSlugSnapshot: optionalString(ownerLLM, ["serviceSlugSnapshot", "ServiceSlugSnapshot"]),
-    model: requiredString(ownerLLM, ["model", "Model"], `${label}.plan.ownerLlmSelection.model`),
-  };
-  if (ownerLLMSelection.routeKind === "nyx_id_user_service") {
+  const ownerLLMSelection: TeamAutomationPermissionReview["ownerLLMSelection"] =
+    ownerLLMValue === undefined || ownerLLMValue === null
+      ? null
+      : (() => {
+          const ownerLLM = expectRecord(
+            ownerLLMValue,
+            `${label}.plan.ownerLlmSelection`,
+          );
+          return {
+            routeKind: normalizeOwnerLLMRouteKind(
+              field(ownerLLM, "routeKind", "RouteKind"),
+            ),
+            routeValue: requiredString(
+              ownerLLM,
+              ["routeValue", "RouteValue"],
+              `${label}.plan.ownerLlmSelection.routeValue`,
+            ),
+            nyxIdUserServiceId: optionalString(
+              ownerLLM,
+              ["nyxIdUserServiceId", "NyxIdUserServiceId"],
+            ),
+            serviceSlugSnapshot: optionalString(
+              ownerLLM,
+              ["serviceSlugSnapshot", "ServiceSlugSnapshot"],
+            ),
+            model: requiredString(
+              ownerLLM,
+              ["model", "Model"],
+              `${label}.plan.ownerLlmSelection.model`,
+            ),
+          };
+        })();
+  if (ownerLLMSelection?.routeKind === "nyx_id_user_service") {
     const matchingGrant = serviceGrants.find(
       (grant) => grant.targetId === ownerLLMSelection.nyxIdUserServiceId,
     );
@@ -702,6 +766,8 @@ function decodePermissionReview(
         field(credentialPolicy, "expiresAt", "ExpiresAt"),
         `${label}.plan.credentialPolicy.expiresAt`,
       ),
+      serviceGrantRequirement,
+      nodeGrantRequirement,
     },
     serviceGrants,
     nodeGrants,

--- a/docs/superpowers/plans/2026-07-31-team-automation-optional-owner-llm.md
+++ b/docs/superpowers/plans/2026-07-31-team-automation-optional-owner-llm.md
@@ -1,0 +1,65 @@
+# Team Automation Optional Owner LLM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decode and review valid Team automation authorization plans that omit the owner LLM selection, while keeping confirmation controls reachable in short viewports.
+
+**Architecture:** Keep protobuf authorization semantics at the `teamAutomationApi` boundary: decode both grant requirements, retain an optional owner LLM selection, and reject inconsistent exact-grant plans. Render the resulting review without inferred identities and use the owning Modal's footer plus a bounded body for confirmation actions.
+
+**Tech Stack:** React 19, TypeScript, Ant Design 6, Jest, Testing Library, pnpm.
+
+---
+
+## File Map
+
+- Modify `apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts`: add typed policy requirements, decode nullable owner LLM selection, and validate plan invariants.
+- Modify `apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts`: add the exact no-service v2 response and fail-closed invariant tests.
+- Modify `apps/aevatar-console-web/src/pages/teams/components/TeamAutomationAuthorizationReview.tsx`: render selected and not-required authorization variants without owning Modal actions.
+- Modify `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx`: move review actions into the Modal footer and bound the review body height.
+- Modify `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx`: exercise no-service preflight through confirmed creation and assert footer placement.
+- Modify `apps/aevatar-console-web/src/locales/en-US.ts` and `apps/aevatar-console-web/src/locales/zh-CN.ts`: add user-facing no-service and no-owner-LLM copy.
+
+### Task 1: Lock The Nullable Authorization Contract
+
+- [ ] Add a `noServiceAuthorizationResult()` fixture containing `schemaVersion: "scheduled-invocation-authorization/v2"`, numeric grant requirement `2`, `nyxIdServiceGrants: []`, and `ownerLlmSelection: null`.
+- [ ] Assert `permissionReview()` returns `status: "ready"`, both requirements as `"not_required"`, empty grants, and `ownerLLMSelection: null`.
+- [ ] Assert a null owner LLM selection also remains valid when a non-LLM workflow capability has an exact required service grant.
+- [ ] Add rejected cases for an empty grant list marked `required`, a non-empty grant list marked `not_required`, and a credential-level node requirement that disagrees with its service grants.
+- [ ] Run `pnpm --dir apps/aevatar-console-web exec jest --runInBand --verbose src/shared/api/teamAutomationApi.test.ts` and verify the no-service case fails at `ownerLlmSelection must be an object` before production edits.
+
+### Task 2: Decode The Plan Without Inventing Identity
+
+- [ ] Introduce one grant requirement normalizer returning `"required" | "not_required"`; use it for policy and service grant fields.
+- [ ] Change the review contract to:
+
+```ts
+readonly ownerLLMSelection: {
+  readonly model: string;
+  readonly nyxIdUserServiceId: string;
+  readonly routeKind: "gateway" | "nyx_id_user_service";
+  readonly routeValue: string;
+  readonly serviceSlugSnapshot: string;
+} | null;
+```
+
+- [ ] Decode `null` or an absent protobuf message as `null`; continue exact route/grant validation when a selection exists.
+- [ ] Decode `serviceGrantRequirement` and `nodeGrantRequirement` into `credentialPlan`, then reject inconsistent required/not-required grant sets.
+- [ ] Re-run the focused API test and verify green.
+
+### Task 3: Render And Confirm The No-Service Review
+
+- [ ] Add a page test whose mocked review has `ownerLLMSelection: null`, no grants, and both policy requirements `not_required`.
+- [ ] Assert the dialog says `No external NyxID service or owner LLM model grant is required`, does not display a fabricated gateway/model, and does not call create before confirmation.
+- [ ] Assert `Authorize and continue` belongs to `.ant-modal-footer`, then click it and verify one create request with the preflight digest and policy version.
+- [ ] Run `pnpm --dir apps/aevatar-console-web exec jest --runInBand --verbose src/pages/teams/tabs/TeamAutomationsTab.test.tsx` and verify the new behavior fails before UI edits.
+- [ ] Render the nullable selection branch, include exact service display-name tags where present, add English and Chinese copy, move actions to the Modal footer, and give only the review body `maxHeight: "min(70vh, 640px)"` with vertical scrolling.
+- [ ] Re-run the focused page test and verify green.
+
+### Task 4: Focused Verification And Delivery
+
+- [ ] Run the frontend change-scope analyzer with `--base origin/dev`.
+- [ ] Run Jest `--findRelatedTests` for changed production files and explicitly run both changed test files.
+- [ ] Run Biome only for analyzer `staticCheckFiles`; do not run a local full typecheck or production build.
+- [ ] Run `bash tools/ci/test_stability_guards.sh` because frontend tests changed.
+- [ ] Run `git diff --check`, review the complete `origin/dev...HEAD` diff, stage only this task's files, and commit with an imperative message.
+- [ ] Push `fix/2026-07-31_nullable-owner-llm-plan` and create a PR to `dev` linked to issue #3002. Record focused commands and delegate the full frontend suite/build to GitHub CI.

--- a/docs/superpowers/specs/2026-07-31-team-automation-optional-owner-llm-design.md
+++ b/docs/superpowers/specs/2026-07-31-team-automation-optional-owner-llm-design.md
@@ -1,0 +1,84 @@
+---
+title: "Team Automation Optional Owner LLM Authorization"
+status: approved
+owner: AbigailDeng
+---
+
+# Team Automation Optional Owner LLM Authorization
+
+## Goal
+
+Allow the Team automation authorization flow to consume a valid scheduled
+invocation v2 plan when the workflow needs no owner LLM route and no external
+NyxID service grants. Preserve fail-closed decoding for malformed or broader
+plans, and keep the explicit preflight, review, confirmation, and create flow.
+
+## Verified Root Cause
+
+The backend planner omits the protobuf `owner_llm_selection` message when the
+workflow revision does not require an owner LLM route. For a workflow with no
+external capabilities it also returns an empty `nyxIdServiceGrants` array and
+`NOT_REQUIRED` service and node grant requirements. That is a successful,
+deliberately supported plan.
+
+The frontend decoder currently passes `ownerLlmSelection` unconditionally to
+`expectRecord`. A JSON `null` therefore throws before the page can enter its
+`reviewing` state. The create request is never sent because the user never
+receives the second confirmation action.
+
+## Contract Mapping
+
+`TeamAutomationCredentialPlan` will expose both protobuf grant requirements as
+the typed union `"required" | "not_required"`. Unknown, missing, or
+`UNSPECIFIED` values continue to fail closed.
+
+`TeamAutomationPermissionReview.ownerLLMSelection` will be the decoded
+selection object or `null`. `null` means that this invocation plan does not
+require an owner LLM route; it must not be replaced with a gateway, model, or
+service inferred by the browser.
+
+The decoder will keep these plan invariants:
+
+- `serviceGrantRequirement = not_required` requires no service grants.
+- `serviceGrantRequirement = required` requires at least one exact service
+  grant.
+- `nodeGrantRequirement` must agree with the exact per-service node grant
+  requirements.
+- a NyxID owner LLM selection must still match an exact service grant by
+  `userServiceId`, route value, and optional slug snapshot.
+- a gateway owner LLM selection remains valid without a service grant.
+- an absent owner LLM selection is valid independently of whether non-LLM
+  workflow capabilities require exact service grants.
+
+## Authorization Review
+
+When an owner LLM selection exists, the review keeps showing its service route
+and model. When it is absent, the review says that no owner LLM model grant is
+required. If the service grant list is also empty, it additionally states that
+no external NyxID service grant is required. Exact service grant display names,
+node IDs, and the `read`/`proxy` credential scopes remain visible without
+inventing identities.
+
+The confirmation actions move into the Ant Design Modal footer. During review,
+the Modal body gets a viewport-bounded internal scroll area. This keeps Back
+and Authorize and continue available when DevTools or a short viewport reduces
+the visible height.
+
+## Test Contract
+
+The API regression fixture mirrors the reported v2 JSON: numeric enum values,
+empty service grants, protobuf timestamp, null catalog authority, and null
+owner LLM selection. Tests prove it decodes to a ready review and that invalid
+requirement/grant combinations are rejected.
+
+The page regression test proves a no-service review is rendered, remains a
+two-step confirmation, and sends the create request only after confirmation.
+It also proves the primary action is in the Modal footer rather than the
+scrollable review body.
+
+## Scope
+
+This change does not alter backend evidence, infer whether a workflow should
+require an LLM, change the dedicated Agent Key lifecycle, or add a compatibility
+API. If a workflow that actually uses an owner LLM still produces a null
+selection, its revision evidence remains a separate backend defect.


### PR DESCRIPTION
## Problem

Backend PR #3032 deliberately allows a valid scheduled-invocation v2 preflight plan to contain no external NyxID service grants, `NOT_REQUIRED` service/node policies, and a null or omitted `ownerLlmSelection`. The Console decoder still required an owner LLM object, so these successful preflights failed before the authorization review and the create request was never available.

This explains the environment-dependent behavior: workflows/revisions whose authorization evidence includes an owner LLM selection followed the existing path, while a revision that legitimately produced the no-service/null-owner plan stopped after preflight.

## Solution

- Decode credential-level service/node grant requirements from numeric protobuf JSON values and exact protobuf enum names.
- Treat a null or omitted owner LLM selection as a first-class no-owner-LLM plan without inventing gateway, service, or model identity in the browser.
- Keep decoding fail-closed for unknown requirements, allow-all policies, mismatched exact service grants, credential-level node policy disagreements, and per-service `nodeGrantRequirement`/`nodeIds` contradictions.
- Show no-service plans in the explicit authorization review, preserve exact service/node/scope details when present, and keep confirmation as a separate user action.
- Move review actions into the native Modal footer, bound the body for short viewports, and keep the dialog description wired to real content.
- Add English/Chinese copy, decoder regressions, UI flow coverage, duplicate-key coverage, and design/implementation documentation.

## Impacted paths

- `apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts`
- `apps/aevatar-console-web/src/pages/teams/components/TeamAutomationAuthorizationReview.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx`
- Focused API/UI tests and `en-US` / `zh-CN` locale catalogs
- `docs/superpowers/specs` and `docs/superpowers/plans`

This frontend change does not infer whether a workflow should require an LLM. If an LLM-using revision still returns a null selection, that remains a backend evidence issue.

## Local verification

- Change scope: `python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/dev` (7 frontend static-check files, 5 production source files, 2 changed tests)
- Related tests for the UI/locale/API source set: `pnpm exec jest --findRelatedTests src/locales/en-US.ts src/locales/zh-CN.ts src/pages/teams/components/TeamAutomationAuthorizationReview.tsx src/pages/teams/tabs/TeamAutomationsTab.tsx src/shared/api/teamAutomationApi.ts --runInBand --verbose` (85 suites passed, 1018 tests passed)
- Post-review API dependency rerun: `pnpm exec jest --findRelatedTests src/shared/api/teamAutomationApi.ts --runInBand --verbose` (3 suites passed, 149 tests passed)
- Changed test files: `pnpm exec jest src/pages/teams/tabs/TeamAutomationsTab.test.tsx src/shared/api/teamAutomationApi.test.ts --runInBand --verbose` (2 suites passed, 80 tests passed)
- Changed-file static checks: `pnpm exec biome lint src/locales/en-US.ts src/locales/zh-CN.ts src/pages/teams/components/TeamAutomationAuthorizationReview.tsx src/pages/teams/tabs/TeamAutomationsTab.test.tsx src/pages/teams/tabs/TeamAutomationsTab.tsx src/shared/api/teamAutomationApi.test.ts src/shared/api/teamAutomationApi.ts` (7 files checked, no errors)
- Test stability: `bash tools/ci/test_stability_guards.sh` (passed)
- Patch integrity: `git diff --check origin/dev...HEAD` (passed)
- A reliable repository-native affected typecheck target is unavailable, so local typecheck was skipped.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

Closes #3002

Backend contract: #3032
