### PR TITLE
Fix automation post-create visibility

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { message } from "antd";
 import * as React from "react";
 import TeamAutomationsTab, {
@@ -242,6 +242,7 @@ describe("TeamAutomationsTab canonical member authority", () => {
         {
           kind: "retryRevocation",
           scheduleId: "sch-alpha",
+          acceptedAt: 0,
           baselineStateVersion: 4,
         },
         [],
@@ -643,6 +644,136 @@ describe("TeamAutomationsTab canonical member authority", () => {
     ).toBeInTheDocument();
     expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(3);
     expect(screen.queryByText("Still pending")).not.toBeInTheDocument();
+  });
+
+  it("shows an accepted create while the authoritative row is unavailable", async () => {
+    (teamAutomationApi.preflightCreate as jest.Mock).mockResolvedValue(
+      authorizationReview(),
+    );
+    (teamAutomationApi.create as jest.Mock).mockResolvedValue({
+      accepted: true,
+      status: "accepted",
+      scheduleId: "sch-pending",
+      operationId: "op-alpha",
+      commandId: "cmd-alpha",
+    });
+    renderTab("m-alpha");
+
+    fireEvent.click(await screen.findByRole("button", { name: "New automation" }));
+    fireEvent.change(screen.getByLabelText("Automation name"), {
+      target: { value: "Daily review" },
+    });
+    fireEvent.change(screen.getByLabelText("Recurring prompt"), {
+      target: { value: "Summarize open work." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create automation" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Authorize and continue" }));
+
+    const acceptedRow = await screen.findByRole("article", { name: "Daily review" });
+    expect(
+      within(acceptedRow).getByRole("status", {
+        name: "Waiting for schedule sync",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers an explicit one-shot list refresh", async () => {
+    renderTab("m-alpha");
+
+    await screen.findByText("No automations for this member");
+    expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not poll for an existing pending automation", async () => {
+    jest.useFakeTimers({ now: 0 });
+    try {
+      (teamAutomationApi.listAll as jest.Mock).mockResolvedValue({
+        items: [automationView({ authorizationStatus: "provisioning_pending" })],
+        nextCursor: null,
+        totalCount: 1,
+      });
+      renderTab("m-alpha");
+
+      await act(async () => {
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(20_000);
+      });
+
+      expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("stops create polling after six seconds and manual refresh stays one-shot", async () => {
+    (teamAutomationApi.preflightCreate as jest.Mock).mockResolvedValue(
+      authorizationReview(),
+    );
+    (teamAutomationApi.create as jest.Mock).mockResolvedValue({
+      accepted: true,
+      status: "accepted",
+      scheduleId: "sch-pending",
+      operationId: "op-alpha",
+      commandId: "cmd-alpha",
+    });
+    renderTab("m-alpha");
+
+    fireEvent.click(await screen.findByRole("button", { name: "New automation" }));
+    fireEvent.change(screen.getByLabelText("Automation name"), {
+      target: { value: "Daily review" },
+    });
+    fireEvent.change(screen.getByLabelText("Recurring prompt"), {
+      target: { value: "Summarize open work." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create automation" }));
+    const authorizeButton = await screen.findByRole("button", {
+      name: "Authorize and continue",
+    });
+    jest.useFakeTimers({ now: Date.now() });
+    try {
+      fireEvent.click(authorizeButton);
+      await act(async () => {
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getByRole("article", { name: "Daily review" })).toBeInTheDocument();
+
+      const callsAtAcceptance = (teamAutomationApi.listAll as jest.Mock).mock.calls.length;
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(6_000);
+      });
+      const callsAtDeadline = (teamAutomationApi.listAll as jest.Mock).mock.calls.length;
+      expect(callsAtDeadline).toBeGreaterThan(callsAtAcceptance);
+      expect(screen.getByText("Still pending")).toBeInTheDocument();
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(20_000);
+      });
+      expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(callsAtDeadline);
+
+      const refreshButton = screen.getByRole("button", { name: "Refresh" });
+      fireEvent.click(refreshButton);
+      await act(async () => {
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(callsAtDeadline + 1);
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(20_000);
+      });
+      expect(teamAutomationApi.listAll).toHaveBeenCalledTimes(callsAtDeadline + 1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("recovers a confirmed create when the fresh binding is missing", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -107,6 +107,7 @@ export type MutationObservation = {
     | "delete"
     | "retryRevocation";
   readonly scheduleId: string;
+  readonly acceptedAt: number;
   readonly baselineStateVersion: number;
   readonly expectedDraft?: TeamAutomationCreateDraft;
   readonly baselineLastFireAt?: string | null;
@@ -150,7 +151,7 @@ type AuthorizationFlow =
 const listTake = 200;
 const promptMaxLength = 4_000;
 const pendingPollIntervalMs = 2_000;
-const pendingPollDurationMs = 60_000;
+const pendingPollDurationMs = 6_000;
 const retryablePreflightCodes = new Set([
   "TEAM_AUTOMATION_AUTHORIZATION_PROJECTION_PENDING",
   "TEAM_AUTOMATION_AUTHORIZATION_REFRESH_SUPERSEDED",
@@ -751,9 +752,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const [authorizationFlow, setAuthorizationFlow] = React.useState<AuthorizationFlow>({ state: "idle" });
   const [mutationObservation, setMutationObservation] =
     React.useState<MutationObservation | null>(null);
+  const [expiredMutationObservation, setExpiredMutationObservation] =
+    React.useState<MutationObservation | null>(null);
   const [busyScheduleId, setBusyScheduleId] = React.useState("");
   const [previewTimes, setPreviewTimes] = React.useState<readonly string[]>([]);
-  const pollingStartedAtRef = React.useRef<number | null>(null);
   const recoveredRouteRef = React.useRef("");
   const modalPanelRef = React.useRef<HTMLDivElement | null>(null);
   const flowBusy = authorizationFlow.state === "preflighting" || authorizationFlow.state === "submitting";
@@ -777,22 +779,34 @@ const TeamAutomationsTab: React.FC<Props> = ({
       error instanceof TeamAutomationApiError &&
       Boolean(error.code && retryablePreflightCodes.has(error.code)),
     retryDelay: (attempt) => [500, 1_000, 2_000][Math.min(attempt, 2)],
-    refetchInterval: (query) => {
-      const data = query.state.data;
-      const pending =
-        mutationObservation !== null ||
-        Boolean(data?.items.some(isPending));
-      if (!pending) {
-        pollingStartedAtRef.current = null;
-        return false;
-      }
-      pollingStartedAtRef.current ??= Date.now();
-      return Date.now() - pollingStartedAtRef.current < pendingPollDurationMs
+    refetchInterval: () => {
+      if (!mutationObservation) return false;
+      return Date.now() - mutationObservation.acceptedAt < pendingPollDurationMs
         ? pendingPollIntervalMs
         : false;
     },
     refetchOnWindowFocus: true,
   });
+
+  React.useEffect(() => {
+    if (!mutationObservation) {
+      setExpiredMutationObservation(null);
+      return;
+    }
+    const remainingMs = Math.max(
+      0,
+      mutationObservation.acceptedAt + pendingPollDurationMs - Date.now(),
+    );
+    if (remainingMs === 0) {
+      setExpiredMutationObservation(mutationObservation);
+      return;
+    }
+    const timeoutId = window.setTimeout(
+      () => setExpiredMutationObservation(mutationObservation),
+      remainingMs,
+    );
+    return () => window.clearTimeout(timeoutId);
+  }, [mutationObservation]);
 
   React.useEffect(() => {
     const data = automationsQuery.data;
@@ -812,7 +826,6 @@ const TeamAutomationsTab: React.FC<Props> = ({
         ? { state: "idle" }
         : current,
     );
-    pollingStartedAtRef.current = null;
   }, [automationsQuery.data, mutationObservation]);
 
   const invalidate = React.useCallback(
@@ -1001,10 +1014,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
       setMutationObservation({
         kind: mode,
         scheduleId: receipt.scheduleId,
+        acceptedAt: Date.now(),
         baselineStateVersion: mode === "reauthorize" ? editing?.stateVersion ?? 0 : 0,
         expectedDraft: confirmedDraft,
       });
-      pollingStartedAtRef.current = Date.now();
       void message.info(copy(
         "teams.automations.messages.authorizationAccepted",
         "Authorization request accepted",
@@ -1066,10 +1079,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
       setMutationObservation({
         kind: "update",
         scheduleId: receipt.scheduleId,
+        acceptedAt: Date.now(),
         baselineStateVersion: editing.stateVersion,
         expectedDraft: next,
       });
-      pollingStartedAtRef.current = Date.now();
       void message.info(copy("teams.automations.messages.updateAccepted", "Update request accepted"));
       setFormOpen(false);
       await invalidate();
@@ -1140,10 +1153,10 @@ const TeamAutomationsTab: React.FC<Props> = ({
       setMutationObservation({
         kind: action,
         scheduleId: receipt.scheduleId,
+        acceptedAt: Date.now(),
         baselineStateVersion: view.stateVersion,
         baselineLastFireAt: action === "runNow" ? view.lastFireAt : undefined,
       });
-      pollingStartedAtRef.current = Date.now();
       await invalidate();
     } catch (error) {
       if (requiresBindingRecovery(error)) {
@@ -1545,6 +1558,14 @@ const TeamAutomationsTab: React.FC<Props> = ({
   const formCadence = describeDraftCadence(draft.cronExpression, draft.timezone, copy);
   const promptTooLong = draft.prompt.trim().length > promptMaxLength;
   const automationItems = automationsQuery.data?.items ?? [];
+  const acceptedCreateObservation =
+    mutationObservation?.kind === "create" &&
+    mutationObservation.expectedDraft &&
+    !automationItems.some(
+      (automation) => automation.scheduleId === mutationObservation.scheduleId,
+    )
+      ? mutationObservation
+      : null;
   const activeAutomationCount = automationItems.filter(
     (automation) => automationStatus(automation) === "active",
   ).length;
@@ -1555,6 +1576,92 @@ const TeamAutomationsTab: React.FC<Props> = ({
     (automation) => automationStatus(automation) === "error",
   ).length;
   const unavailableMembers = members.filter((member) => !member.canAutomateMember);
+  const mutationObservationExpired =
+    mutationObservation !== null &&
+    expiredMutationObservation === mutationObservation;
+  const renderAcceptedCreateRow = (observation: MutationObservation) => {
+    const expectedDraft = observation.expectedDraft;
+    if (!expectedDraft) return null;
+    const cadence = describeDraftCadence(
+      expectedDraft.cronExpression,
+      expectedDraft.timezone,
+      copy,
+    );
+    const ownerMember = membersById.get(trim(expectedDraft.memberId));
+    const statusLabel = copy(
+      "teams.automations.row.awaitingReadModel",
+      "Waiting for schedule sync",
+    );
+    const displayName = expectedDraft.displayName || copy(
+      "teams.automations.form.title",
+      "New member automation",
+    );
+
+    return (
+      <article
+        aria-label={displayName}
+        className="team-automation-row"
+        key={`accepted:${observation.scheduleId}`}
+        style={{
+          ...commitmentRowStyle,
+          borderColor: token.colorInfoBorder,
+          boxShadow: "none",
+        }}
+      >
+        <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+          <span
+            aria-label={statusLabel}
+            role="status"
+            style={{
+              ...automationStatusBadgeStyle,
+              background: token.colorInfoBg,
+              border: `1px solid ${token.colorInfoBorder}`,
+              color: token.colorInfo,
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{ ...automationStatusDotStyle, background: "currentColor" }}
+            />
+            {statusLabel}
+          </span>
+          <Typography.Text ellipsis strong>{displayName}</Typography.Text>
+          <FactLine
+            rows={2}
+            secondary
+            text={expectedDraft.prompt || copy(
+              "teams.automations.row.noPrompt",
+              "No recurring prompt",
+            )}
+          />
+        </div>
+        <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+          <Typography.Text ellipsis strong>{ownerMember?.name ?? "--"}</Typography.Text>
+          <FactLine
+            rows={2}
+            secondary
+            text={copy(
+              "teams.automations.preview.runsThroughService",
+              "Runs through published service",
+            )}
+          />
+        </div>
+        <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
+          <FactLine
+            monospace={false}
+            text={cadence.summary}
+            tooltipText={`${cadence.detail} · ${expectedDraft.cronExpression}`}
+          />
+          <Typography.Text style={{ fontSize: 12 }} type="secondary">
+            {statusLabel}
+          </Typography.Text>
+        </div>
+        <div style={{ justifySelf: "end" }}>
+          <Spin size="small" />
+        </div>
+      </article>
+    );
+  };
 
   return (
     <>
@@ -1577,16 +1684,26 @@ const TeamAutomationsTab: React.FC<Props> = ({
                 )}
               </Typography.Text>
             </div>
-            <Button
-              className="team-automations-create-button"
-              disabled={eligibleMembers.length === 0}
-              icon={<PlusOutlined />}
-              onClick={openCreate}
-              style={primaryHeaderButtonStyle}
-              type="primary"
-            >
-              {copy("teams.automations.actions.create", "New automation")}
-            </Button>
+            <Space>
+              <Tooltip title={copy("teams.automations.actions.refresh", "Refresh")}>
+                <Button
+                  aria-label={copy("teams.automations.actions.refresh", "Refresh")}
+                  icon={<ReloadOutlined />}
+                  loading={automationsQuery.isFetching}
+                  onClick={() => void automationsQuery.refetch()}
+                />
+              </Tooltip>
+              <Button
+                className="team-automations-create-button"
+                disabled={eligibleMembers.length === 0}
+                icon={<PlusOutlined />}
+                onClick={openCreate}
+                style={primaryHeaderButtonStyle}
+                type="primary"
+              >
+                {copy("teams.automations.actions.create", "New automation")}
+              </Button>
+            </Space>
           </div>
 
           <div aria-live="polite" style={{ display: "grid", gap: 12, marginTop: 16 }}>
@@ -1616,14 +1733,28 @@ const TeamAutomationsTab: React.FC<Props> = ({
                 )}
               />
             ) : null}
-            {!automationsQuery.isLoading && !automationsQuery.isError && !automationItems.length ? (
+            {mutationObservationExpired ? (
+              <Alert
+                description={copy(
+                  "teams.automations.pending.description",
+                  "Automatic refresh stopped. Use Refresh to check authoritative state.",
+                )}
+                message={copy("teams.automations.pending.title", "Still pending")}
+                showIcon
+                type="warning"
+              />
+            ) : null}
+            {!automationsQuery.isLoading &&
+            !automationsQuery.isError &&
+            !automationItems.length &&
+            !acceptedCreateObservation ? (
               <Empty
                 description={routeMember
                   ? copy("teams.automations.empty.member", "No automations for this member")
                   : copy("teams.automations.empty.title", "No recurring work yet")}
               />
             ) : null}
-            {automationItems.length ? (
+            {automationItems.length || acceptedCreateObservation ? (
               <div style={commitmentGridStyle}>
                 <div className="team-automation-summary" style={automationSummaryGridStyle}>
                   {renderSummaryTile({
@@ -1659,6 +1790,9 @@ const TeamAutomationsTab: React.FC<Props> = ({
                     {copy("teams.automations.columns.actions", "Actions")}
                   </Typography.Text>
                 </div>
+                {acceptedCreateObservation
+                  ? renderAcceptedCreateRow(acceptedCreateObservation)
+                  : null}
                 {automationItems.map(renderRow)}
               </div>
             ) : null}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -1584,7 +1584,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
     if (!expectedDraft) return null;
     const cadence = describeDraftCadence(
       expectedDraft.cronExpression,
-      expectedDraft.timezone,
+      expectedDraft.timezone ?? "UTC",
       copy,
     );
     const ownerMember = membersById.get(trim(expectedDraft.memberId));

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.test.ts
@@ -192,6 +192,28 @@ describe("teamAutomationApi", () => {
     },
   );
 
+  it("decodes canonical no-owner LLM runtime evidence", () => {
+    expect(
+      teamAutomationApiDecoders.view(
+        automationView({
+          ownerLlmRouteKind: "unspecified",
+          ownerLlmRoute: "",
+          ownerLlmUserServiceId: "",
+          ownerLlmServiceSlug: "",
+          ownerLlmModel: "",
+        }),
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        ownerLLMRouteKind: "unspecified",
+        ownerLLMRoute: "",
+        ownerLLMUserServiceId: "",
+        ownerLLMServiceSlug: "",
+        ownerLLMModel: "",
+      }),
+    );
+  });
+
   it.each([
     ["NeedsAuthorization", "needs_authorization"],
     [

--- a/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts
@@ -793,6 +793,33 @@ function decodeView(value: unknown, label = "ScheduledDispatchSummary"): TeamAut
   if (!teamOwned) {
     throw new Error(`${label} is not a Team-owned automation schedule.`);
   }
+  const ownerLLMRouteKind = requiredString(
+    record,
+    ["ownerLlmRouteKind", "OwnerLlmRouteKind", "ownerLLMRouteKind", "OwnerLLMRouteKind"],
+    `${label}.ownerLlmRouteKind`,
+  );
+  const ownerLLMRoute = ownerLLMRouteKind === "unspecified"
+    ? readString(
+        record,
+        ["ownerLlmRoute", "OwnerLlmRoute", "ownerLLMRoute", "OwnerLLMRoute"],
+        `${label}.ownerLlmRoute`,
+      ).trim()
+    : requiredString(
+        record,
+        ["ownerLlmRoute", "OwnerLlmRoute", "ownerLLMRoute", "OwnerLLMRoute"],
+        `${label}.ownerLlmRoute`,
+      );
+  const ownerLLMModel = ownerLLMRouteKind === "unspecified"
+    ? readString(
+        record,
+        ["ownerLlmModel", "OwnerLlmModel", "ownerLLMModel", "OwnerLLMModel"],
+        `${label}.ownerLlmModel`,
+      ).trim()
+    : requiredString(
+        record,
+        ["ownerLlmModel", "OwnerLlmModel", "ownerLLMModel", "OwnerLLMModel"],
+        `${label}.ownerLlmModel`,
+      );
 
   return {
     scopeId: requiredString(
@@ -869,16 +896,8 @@ function decodeView(value: unknown, label = "ScheduledDispatchSummary"): TeamAut
     vaultRevocationStatus: normalizeRevocationTrack(
       field(record, "vaultRevocationStatus", "VaultRevocationStatus"),
     ),
-    ownerLLMRouteKind: requiredString(
-      record,
-      ["ownerLlmRouteKind", "OwnerLlmRouteKind", "ownerLLMRouteKind", "OwnerLLMRouteKind"],
-      `${label}.ownerLlmRouteKind`,
-    ),
-    ownerLLMRoute: requiredString(
-      record,
-      ["ownerLlmRoute", "OwnerLlmRoute", "ownerLLMRoute", "OwnerLLMRoute"],
-      `${label}.ownerLlmRoute`,
-    ),
+    ownerLLMRouteKind,
+    ownerLLMRoute,
     ownerLLMUserServiceId: readString(
       record,
       ["ownerLlmUserServiceId", "OwnerLlmUserServiceId", "ownerLLMUserServiceId", "OwnerLLMUserServiceId"],
@@ -889,11 +908,7 @@ function decodeView(value: unknown, label = "ScheduledDispatchSummary"): TeamAut
       ["ownerLlmServiceSlug", "OwnerLlmServiceSlug", "ownerLLMServiceSlug", "OwnerLLMServiceSlug"],
       `${label}.ownerLlmServiceSlug`,
     ),
-    ownerLLMModel: requiredString(
-      record,
-      ["ownerLlmModel", "OwnerLlmModel", "ownerLLMModel", "OwnerLLMModel"],
-      `${label}.ownerLlmModel`,
-    ),
+    ownerLLMModel,
     stateVersion: requiredNonNegativeInteger(
       record,
       ["stateVersion", "StateVersion"],


### PR DESCRIPTION
## Problem

Team Automations could reject a valid no-owner-LLM schedule because canonical `unspecified` runtime evidence contains empty route/model values. The failed list decode hid the newly created automation. The page also polled every two seconds for up to 60 seconds whenever any projected row was pending.

## Solution

- Accept empty owner LLM route/model only for canonical `unspecified` runtime evidence; keep other route kinds strict.
- Show an accepted create immediately as a page-local `Waiting for schedule sync` row until the authoritative schedule arrives.
- Poll only for a mutation accepted on the current page, stop after six seconds, and show a stopped-refresh warning.
- Do not poll for historical pending rows. Add one-shot manual Refresh without restarting the automatic window.
- Normalize an omitted accepted-draft timezone to `UTC` so the CI type contract matches runtime behavior.

## Impacted paths

- `apps/aevatar-console-web/src/shared/api/teamAutomationApi.ts`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx`
- Focused regression tests for both paths

## Local verification

- Changed tests: `pnpm exec jest src/shared/api/teamAutomationApi.test.ts src/pages/teams/tabs/TeamAutomationsTab.test.tsx --runInBand --verbose` (85 passed)
- Related tests: `pnpm exec jest --findRelatedTests src/pages/teams/tabs/TeamAutomationsTab.tsx src/shared/api/teamAutomationApi.ts --runInBand --verbose` (154 passed)
- CI failure reproduction: `CODEX_ALLOW_FULL_FRONTEND_VALIDATION=1 pnpm tsc` (passed after the timezone fix)
- Focused UI regression: `pnpm exec jest src/pages/teams/tabs/TeamAutomationsTab.test.tsx --runInBand --verbose` (27 passed)
- Changed-file static checks: `pnpm exec biome lint src/pages/teams/tabs/TeamAutomationsTab.test.tsx src/pages/teams/tabs/TeamAutomationsTab.tsx src/shared/api/teamAutomationApi.test.ts src/shared/api/teamAutomationApi.ts` (passed)
- Test stability guard: `bash tools/ci/test_stability_guards.sh` (passed)
- Diff validation: `git diff --check` (passed)
- Full frontend test suite/build: deferred to GitHub CI by personal local workflow policy