### PR TITLE
Verify Studio tool outcomes with receipts

### DIFF
--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Studio.Application.Provisioning;
 using Aevatar.Workflow.Abstractions;
@@ -56,6 +57,26 @@ internal sealed class BindStudioMemberWorkflowTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.workflow.bind";
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateMutationResultReceipt(
+            Name,
+            SideEffectKind,
+            "studio_member_workflow_binding",
+            callId,
+            toolName,
+            resultJson,
+            null,
+            null,
+            "member_id",
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("operation"),
+            StudioQueryToolJson.StringProperty("status"),
+            StudioQueryToolJson.StringProperty("member_workflow_url"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Studio.Application.Provisioning;
 
@@ -64,6 +65,28 @@ internal sealed class CreateStudioMemberTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.create";
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateMutationResultReceipt(
+            Name,
+            SideEffectKind,
+            "studio_member",
+            callId,
+            toolName,
+            resultJson,
+            null,
+            null,
+            "member_id",
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("display_name"),
+            StudioQueryToolJson.StringProperty("implementation_kind"),
+            StudioQueryToolJson.StringProperty("lifecycle_stage"),
+            StudioQueryToolJson.StringProperty("published_service_id"),
+            StudioQueryToolJson.StringProperty("member_url"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberWorkflowDraftTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberWorkflowDraftTool.cs
@@ -72,24 +72,12 @@ internal sealed class CreateStudioMemberWorkflowDraftTool : IAgentTool
         string toolName,
         string argumentsJson,
         string resultJson) =>
-        StudioQueryToolJson.CreateMutationResultReceipt(
+        StudioQueryToolJson.CreateMutationErrorResultReceipt(
             Name,
             SideEffectKind,
-            "studio_member_workflow_draft",
             callId,
             toolName,
-            resultJson,
-            "status",
-            StudioMemberWorkflowDraftStatusNames.SaveAccepted,
-            "workflow_id",
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("team_id"),
-            StudioQueryToolJson.StringProperty("member_id"),
-            StudioQueryToolJson.StringProperty("studio_url"),
-            StudioQueryToolJson.StringProperty("command_id"),
-            StudioQueryToolJson.StringProperty("ack_stage"),
-            StudioQueryToolJson.StringProperty("actor_id"),
-            StudioQueryToolJson.StringProperty("workspace_id"));
+            resultJson);
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberWorkflowDraftTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberWorkflowDraftTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Studio.Application.Provisioning;
 
@@ -65,6 +66,30 @@ internal sealed class CreateStudioMemberWorkflowDraftTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.workflow_draft.create";
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateMutationResultReceipt(
+            Name,
+            SideEffectKind,
+            "studio_member_workflow_draft",
+            callId,
+            toolName,
+            resultJson,
+            "status",
+            StudioMemberWorkflowDraftStatusNames.SaveAccepted,
+            "workflow_id",
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("team_id"),
+            StudioQueryToolJson.StringProperty("member_id"),
+            StudioQueryToolJson.StringProperty("studio_url"),
+            StudioQueryToolJson.StringProperty("command_id"),
+            StudioQueryToolJson.StringProperty("ack_stage"),
+            StudioQueryToolJson.StringProperty("actor_id"),
+            StudioQueryToolJson.StringProperty("workspace_id"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioTeamTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioTeamTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Studio.Application.Provisioning;
 
@@ -58,6 +59,26 @@ internal sealed class CreateStudioTeamTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.team.create";
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateMutationResultReceipt(
+            Name,
+            SideEffectKind,
+            "studio_team",
+            callId,
+            toolName,
+            resultJson,
+            null,
+            null,
+            "team_id",
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("display_name"),
+            StudioQueryToolJson.StringProperty("lifecycle_stage"),
+            StudioQueryToolJson.StringProperty("team_url"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -76,6 +76,27 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.workflow.schedule";
 
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateMutationResultReceipt(
+            Name,
+            SideEffectKind,
+            "studio_member_workflow_schedule",
+            callId,
+            toolName,
+            resultJson,
+            null,
+            null,
+            "schedule_id",
+            StudioQueryToolJson.StringProperty("status"),
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("member_id"),
+            StudioQueryToolJson.StringProperty("published_service_id"),
+            StudioQueryToolJson.StringProperty("observatory_url"));
+
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
         var scopeId = StudioToolScopeResolver.ResolveOwnerScopeOrCallerScope();

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioQueryTools.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioQueryTools.cs
@@ -804,6 +804,35 @@ internal static class StudioQueryToolJson
         }
     }
 
+    public static AgentToolReceipt? CreateMutationErrorResultReceipt(
+        string defaultToolName,
+        string sideEffectKind,
+        string callId,
+        string toolName,
+        string resultJson)
+    {
+        if (!TryParseObject(resultJson, out var document))
+            return null;
+
+        using (document)
+        {
+            if (!TryReadError(document.RootElement, out var errorCode, out var errorMessage))
+                return null;
+
+            return new AgentToolReceipt
+            {
+                CallId = callId ?? string.Empty,
+                ToolName = ResolveToolName(defaultToolName, toolName),
+                Status = AgentToolReceiptStatus.Error,
+                ApprovalMode = AgentToolReceiptApprovalMode.Unspecified,
+                SideEffectKind = sideEffectKind,
+                ErrorCode = errorCode,
+                ErrorMessage = errorMessage,
+                ResultJson = resultJson ?? string.Empty,
+            };
+        }
+    }
+
     public static AgentToolReceipt? CreateMutationResultReceipt(
         string defaultToolName,
         string sideEffectKind,
@@ -814,7 +843,30 @@ internal static class StudioQueryToolJson
         string? successStatusPropertyName,
         string? successStatusValue,
         string subjectIdPropertyName,
-        params ResultPropertyRequirement[] resultRequirements)
+        params ResultPropertyRequirement[] resultRequirements) =>
+        CreateSuccessfulMutationResultReceipt(
+            defaultToolName,
+            sideEffectKind,
+            subjectKind,
+            callId,
+            toolName,
+            resultJson,
+            successStatusPropertyName,
+            successStatusValue,
+            subjectIdPropertyName,
+            resultRequirements);
+
+    private static AgentToolReceipt? CreateSuccessfulMutationResultReceipt(
+        string defaultToolName,
+        string sideEffectKind,
+        string subjectKind,
+        string callId,
+        string toolName,
+        string resultJson,
+        string? successStatusPropertyName,
+        string? successStatusValue,
+        string subjectIdPropertyName,
+        IReadOnlyCollection<ResultPropertyRequirement> resultRequirements)
     {
         if (!TryParseObject(resultJson, out var document))
             return null;

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioQueryTools.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioQueryTools.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgentService.Abstractions.Schedules;
 using Aevatar.Studio.Application.Provisioning;
@@ -43,6 +44,19 @@ internal sealed class ListStudioTeamsTool : IAgentTool
 
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.ArrayProperty("teams"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -138,6 +152,22 @@ internal sealed class GetStudioTeamTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("team_id"),
+            StudioQueryToolJson.StringProperty("display_name"),
+            StudioQueryToolJson.StringProperty("lifecycle_stage"),
+            StudioQueryToolJson.StringProperty("team_url"));
+
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
         var scopeId = StudioToolScopeResolver.ResolveOwnerScopeOrCallerScope();
@@ -231,6 +261,19 @@ internal sealed class ListStudioMembersTool : IAgentTool
 
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.ArrayProperty("members"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -334,6 +377,23 @@ internal sealed class GetStudioMemberTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.ObjectProperty("summary"),
+            StudioQueryToolJson.StringProperty("summary", "scope_id"),
+            StudioQueryToolJson.StringProperty("summary", "member_id"),
+            StudioQueryToolJson.StringProperty("summary", "display_name"),
+            StudioQueryToolJson.StringProperty("summary", "implementation_kind"),
+            StudioQueryToolJson.StringProperty("summary", "member_url"));
+
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
         var scopeId = StudioToolScopeResolver.ResolveOwnerScopeOrCallerScope();
@@ -436,6 +496,20 @@ internal sealed class ListStudioSchedulesTool : IAgentTool
 
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("team_id"),
+            StudioQueryToolJson.ArrayProperty("schedules"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -564,6 +638,24 @@ internal sealed class GetStudioScheduleTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.StringProperty("team_id"),
+            StudioQueryToolJson.StringProperty("member_id"),
+            StudioQueryToolJson.StringProperty("schedule_id"),
+            StudioQueryToolJson.StringProperty("published_service_id"),
+            StudioQueryToolJson.StringProperty("schedule_cron"),
+            StudioQueryToolJson.StringProperty("schedule_timezone"));
+
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
         var scopeId = StudioToolScopeResolver.ResolveOwnerScopeOrCallerScope();
@@ -671,11 +763,226 @@ internal static class StudioQueryToolJson
                 new StudioQueryToolErrorBody(code, message)),
             Options);
 
+    public static AgentToolReceipt? CreateReadOnlyResultReceipt(
+        string defaultToolName,
+        string callId,
+        string toolName,
+        string resultJson,
+        params ResultPropertyRequirement[] resultRequirements)
+    {
+        if (!TryParseObject(resultJson, out var document))
+            return null;
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (TryReadError(root, out var errorCode, out var errorMessage))
+            {
+                return new AgentToolReceipt
+                {
+                    CallId = callId ?? string.Empty,
+                    ToolName = ResolveToolName(defaultToolName, toolName),
+                    Status = AgentToolReceiptStatus.Error,
+                    ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
+                    ErrorCode = errorCode,
+                    ErrorMessage = errorMessage,
+                    ResultJson = resultJson ?? string.Empty,
+                };
+            }
+
+            if (!HasRequiredProperties(root, resultRequirements))
+                return null;
+
+            return new AgentToolReceipt
+            {
+                CallId = callId ?? string.Empty,
+                ToolName = ResolveToolName(defaultToolName, toolName),
+                Status = AgentToolReceiptStatus.Success,
+                ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
+                ResultJson = resultJson ?? string.Empty,
+            };
+        }
+    }
+
+    public static AgentToolReceipt? CreateMutationResultReceipt(
+        string defaultToolName,
+        string sideEffectKind,
+        string subjectKind,
+        string callId,
+        string toolName,
+        string resultJson,
+        string? successStatusPropertyName,
+        string? successStatusValue,
+        string subjectIdPropertyName,
+        params ResultPropertyRequirement[] resultRequirements)
+    {
+        if (!TryParseObject(resultJson, out var document))
+            return null;
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (TryReadError(root, out var errorCode, out var errorMessage))
+            {
+                return new AgentToolReceipt
+                {
+                    CallId = callId ?? string.Empty,
+                    ToolName = ResolveToolName(defaultToolName, toolName),
+                    Status = AgentToolReceiptStatus.Error,
+                    ApprovalMode = AgentToolReceiptApprovalMode.Unspecified,
+                    SideEffectKind = sideEffectKind,
+                    ErrorCode = errorCode,
+                    ErrorMessage = errorMessage,
+                    ResultJson = resultJson ?? string.Empty,
+                };
+            }
+
+            if (!IsVerifiedMutationSuccess(root, successStatusPropertyName, successStatusValue) ||
+                !HasRequiredProperties(root, resultRequirements))
+            {
+                return null;
+            }
+
+            var subjectId = TryGetString(root, subjectIdPropertyName);
+            if (string.IsNullOrWhiteSpace(subjectId))
+                return null;
+
+            return new AgentToolReceipt
+            {
+                CallId = callId ?? string.Empty,
+                ToolName = ResolveToolName(defaultToolName, toolName),
+                Status = AgentToolReceiptStatus.Success,
+                ApprovalMode = AgentToolReceiptApprovalMode.Unspecified,
+                SideEffectKind = sideEffectKind,
+                SubjectKind = subjectKind,
+                SubjectId = subjectId,
+                ResultJson = resultJson ?? string.Empty,
+            };
+        }
+    }
+
+    public static ResultPropertyRequirement StringProperty(params string[] path) =>
+        new(path, JsonValueKind.String);
+
+    public static ResultPropertyRequirement ArrayProperty(params string[] path) =>
+        new(path, JsonValueKind.Array);
+
+    public static ResultPropertyRequirement ObjectProperty(params string[] path) =>
+        new(path, JsonValueKind.Object);
+
     public static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static string NormalizeArgumentsJson(string argumentsJson) =>
         string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson;
+
+    private static bool TryParseObject(string? resultJson, out JsonDocument document)
+    {
+        document = null!;
+        if (string.IsNullOrWhiteSpace(resultJson))
+            return false;
+
+        try
+        {
+            document = JsonDocument.Parse(resultJson);
+            if (document.RootElement.ValueKind == JsonValueKind.Object)
+                return true;
+
+            document.Dispose();
+            document = null!;
+            return false;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadError(JsonElement root, out string errorCode, out string errorMessage)
+    {
+        errorCode = string.Empty;
+        errorMessage = string.Empty;
+
+        if (!root.TryGetProperty("error", out var error) || error.ValueKind != JsonValueKind.Object)
+            return false;
+
+        errorCode = TryGetString(error, "code") ?? string.Empty;
+        errorMessage = TryGetString(error, "message") ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(errorCode) || !string.IsNullOrWhiteSpace(errorMessage);
+    }
+
+    private static string? TryGetString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static bool HasRequiredProperties(
+        JsonElement element,
+        IReadOnlyCollection<ResultPropertyRequirement> resultRequirements)
+    {
+        foreach (var resultRequirement in resultRequirements)
+        {
+            if (!TryGetProperty(element, resultRequirement.Path, out var property) ||
+                property.ValueKind != resultRequirement.ValueKind)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetProperty(
+        JsonElement element,
+        IReadOnlyList<string> path,
+        out JsonElement property)
+    {
+        property = element;
+        foreach (var segment in path)
+        {
+            if (property.ValueKind != JsonValueKind.Object || !property.TryGetProperty(segment, out property))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsVerifiedMutationSuccess(
+        JsonElement root,
+        string? successStatusPropertyName,
+        string? successStatusValue)
+    {
+        if (!string.IsNullOrWhiteSpace(successStatusPropertyName) &&
+            !string.IsNullOrWhiteSpace(successStatusValue))
+        {
+            return string.Equals(
+                TryGetString(root, successStatusPropertyName),
+                successStatusValue,
+                StringComparison.Ordinal);
+        }
+
+        return TryGetBoolean(root, "success", out var success) && success;
+    }
+
+    private static bool TryGetBoolean(JsonElement element, string propertyName, out bool result)
+    {
+        result = false;
+        if (!element.TryGetProperty(propertyName, out var value) ||
+            (value.ValueKind != JsonValueKind.True && value.ValueKind != JsonValueKind.False))
+        {
+            return false;
+        }
+
+        result = value.GetBoolean();
+        return true;
+    }
+
+    private static string ResolveToolName(string defaultToolName, string toolName) =>
+        string.IsNullOrWhiteSpace(toolName) ? defaultToolName : toolName;
+
+    public sealed record ResultPropertyRequirement(
+        IReadOnlyList<string> Path,
+        JsonValueKind ValueKind);
 
     private sealed record StudioQueryToolErrorJson(StudioQueryToolErrorBody Error);
 

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioWorkflowQueryTools.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioWorkflowQueryTools.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -46,6 +47,19 @@ internal sealed class ListStudioWorkflowsTool : IAgentTool
     public bool IsReadOnly => true;
 
     public bool IsDestructive => false;
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        StudioQueryToolJson.CreateReadOnlyResultReceipt(
+            Name,
+            callId,
+            toolName,
+            resultJson,
+            StudioQueryToolJson.StringProperty("scope_id"),
+            StudioQueryToolJson.ArrayProperty("workflows"));
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.StudioProvisioning\Aevatar.AI.ToolProviders.StudioProvisioning.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Studio.Application.Abstractions\Aevatar.Studio.Application.Abstractions.csproj" />

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -567,29 +567,35 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
-    public async Task CreateMemberWorkflowDraft_ThroughStreamingExecutor_ShouldKeepVerifiedMutationSuccess()
+    public async Task CreateMemberWorkflowDraft_CreateResultReceipt_WithAcceptedDraftAck_ShouldReturnNull()
     {
-        var draftPort = new RecordingMemberWorkflowDraftProvisioningPort();
-        var tool = await DiscoverCreateMemberWorkflowDraftToolAsync(draftPort);
+        var tool = await DiscoverCreateMemberWorkflowDraftToolAsync(new RecordingMemberWorkflowDraftProvisioningPort());
 
-        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
-        var toolResult = await ExecuteToolThroughExecutorAsync(
-            tool,
-            "tc-create-draft",
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
             CreateMemberWorkflowDraftToolName,
-            """{"team_id":"team-alpha","display_name":"Draft Workflow","workflow_yaml":"name: draft\nsteps: []\n","member_id":"member-alpha","workflow_id":"workflow-alpha"}""");
+            "{}",
+            """{"status":"draft_save_accepted","runnable":false,"binding_status":"not_bound","scope_id":"scope-current","team_id":"team-alpha","member_id":"member-alpha","workflow_id":"workflow-alpha","studio_url":"/studio/workflows/workflow-alpha","command_id":"command-alpha","ack_stage":"dispatch_accepted","actor_id":"actor-alpha","workspace_id":"workspace-alpha","acked_at_utc":"2026-07-01T00:00:00Z","readiness":{"readable":true,"stage":"draft_saved","message":"Draft saved."},"blockers":[]}""");
 
-        toolResult.IsError.Should().BeFalse();
-        toolResult.Result.Should().Contain("\"workflow_id\":\"workflow-alpha\"");
-        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
-        var receipt = toolResult.Receipt;
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateMemberWorkflowDraft_CreateResultReceipt_WithStructuredError_ShouldReturnErrorReceipt()
+    {
+        var tool = await DiscoverCreateMemberWorkflowDraftToolAsync(new RecordingMemberWorkflowDraftProvisioningPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            CreateMemberWorkflowDraftToolName,
+            "{}",
+            """{"error":{"code":"invalid_arguments","message":"workflow_yaml is required."}}""");
+
         receipt.Should().NotBeNull();
-        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
         receipt.SideEffectKind.Should().Be("studio.workflow_draft.create");
-        receipt.SubjectKind.Should().Be("studio_member_workflow_draft");
-        receipt.SubjectId.Should().Be("workflow-alpha");
-        receipt.ResultJson.Should().Be(toolResult.Result);
-        draftPort.LastRequest.Should().NotBeNull();
+        receipt.ErrorCode.Should().Be("invalid_arguments");
+        receipt.ResultJson.Should().Contain("workflow_yaml is required");
     }
 
     [Fact]

--- a/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
+++ b/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/ProvisionWorkflowScheduleToolTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Tools;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Schedules;
 using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
@@ -433,6 +434,237 @@ public sealed class ProvisionWorkflowScheduleToolTests
     }
 
     [Fact]
+    public async Task CreateTeam_ThroughStreamingExecutor_ShouldKeepVerifiedMutationSuccess()
+    {
+        var teamPort = new RecordingTeamProvisioningPort();
+        var tool = await DiscoverCreateTeamToolAsync(teamPort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var toolResult = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "tc-create-team",
+            CreateTeamToolName,
+            """{"display_name":"Alpha Team","team_id":"team-alpha"}""");
+
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"team_id\":\"team-alpha\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.NeverRequire);
+        receipt.SideEffectKind.Should().Be("studio.team.create");
+        receipt.SubjectKind.Should().Be("studio_team");
+        receipt.SubjectId.Should().Be("team-alpha");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+        teamPort.LastRequest.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateTeam_ThroughStreamingExecutor_ShouldKeepStructuredMutationError()
+    {
+        var teamPort = new RecordingTeamProvisioningPort();
+        var tool = await DiscoverCreateTeamToolAsync(teamPort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var toolResult = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "tc-create-team-error",
+            CreateTeamToolName,
+            """{"scope_id":"scope-model","display_name":"Alpha Team"}""");
+
+        toolResult.IsError.Should().BeTrue();
+        toolResult.Result.Should().Contain("invalid_arguments");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+        receipt.ErrorCode.Should().Be("invalid_arguments");
+        receipt.SideEffectKind.Should().Be("studio.team.create");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+        teamPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTeam_CreateResultReceipt_WithPartialMutationJson_ShouldReturnNull()
+    {
+        var tool = await DiscoverCreateTeamToolAsync(new RecordingTeamProvisioningPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            CreateTeamToolName,
+            "{}",
+            """{"team_id":"team-alpha"}""");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTeam_CreateResultReceipt_WithSuccessButPartialMutationJson_ShouldReturnNull()
+    {
+        var tool = await DiscoverCreateTeamToolAsync(new RecordingTeamProvisioningPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            CreateTeamToolName,
+            "{}",
+            """{"success":true,"team_id":"team-alpha"}""");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTeam_CreateResultReceipt_WithSuccessButWrongMutationJsonKind_ShouldReturnNull()
+    {
+        var tool = await DiscoverCreateTeamToolAsync(new RecordingTeamProvisioningPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            CreateTeamToolName,
+            "{}",
+            """{"success":true,"team_id":"team-alpha","scope_id":123,"display_name":"Alpha Team","lifecycle_stage":"active","team_url":"/teams/team-alpha"}""");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateTeam_CreateResultReceipt_WithMalformedMutationJson_ShouldReturnNull()
+    {
+        var tool = await DiscoverCreateTeamToolAsync(new RecordingTeamProvisioningPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            CreateTeamToolName,
+            "{}",
+            "{");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateMember_ThroughStreamingExecutor_ShouldKeepVerifiedMutationSuccess()
+    {
+        var memberPort = new RecordingMemberProvisioningPort();
+        var tool = await DiscoverCreateMemberToolAsync(memberPort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var toolResult = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "tc-create-member",
+            CreateMemberToolName,
+            """{"display_name":"Alpha Member","implementation_kind":"workflow","member_id":"member-alpha","team_id":"team-alpha"}""");
+
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"member_id\":\"member-alpha\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("studio.member.create");
+        receipt.SubjectKind.Should().Be("studio_member");
+        receipt.SubjectId.Should().Be("member-alpha");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+    }
+
+    [Fact]
+    public async Task CreateMemberWorkflowDraft_ThroughStreamingExecutor_ShouldKeepVerifiedMutationSuccess()
+    {
+        var draftPort = new RecordingMemberWorkflowDraftProvisioningPort();
+        var tool = await DiscoverCreateMemberWorkflowDraftToolAsync(draftPort);
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        var toolResult = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "tc-create-draft",
+            CreateMemberWorkflowDraftToolName,
+            """{"team_id":"team-alpha","display_name":"Draft Workflow","workflow_yaml":"name: draft\nsteps: []\n","member_id":"member-alpha","workflow_id":"workflow-alpha"}""");
+
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"workflow_id\":\"workflow-alpha\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("studio.workflow_draft.create");
+        receipt.SubjectKind.Should().Be("studio_member_workflow_draft");
+        receipt.SubjectId.Should().Be("workflow-alpha");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+        draftPort.LastRequest.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateMemberWorkflowDraft_CreateResultReceipt_WithSuccessButNoDraftStatus_ShouldReturnNull()
+    {
+        var tool = await DiscoverCreateMemberWorkflowDraftToolAsync(new RecordingMemberWorkflowDraftProvisioningPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            CreateMemberWorkflowDraftToolName,
+            "{}",
+            """{"success":true,"workflow_id":"workflow-alpha"}""");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task BindMemberWorkflow_ThroughStreamingExecutor_ShouldKeepVerifiedMutationSuccess()
+    {
+        var bindingPort = new RecordingMemberWorkflowBindingPort();
+        var tool = await DiscoverBindMemberWorkflowToolAsync(bindingPort);
+
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
+        var toolResult = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "tc-bind-member-workflow",
+            BindMemberWorkflowToolName,
+            """{"member_id":"member-alpha","workflow_yaml":"name: demo\n","workflow_id":"workflow-alpha"}""");
+
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"member_id\":\"member-alpha\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("studio.member.workflow.bind");
+        receipt.SubjectKind.Should().Be("studio_member_workflow_binding");
+        receipt.SubjectId.Should().Be("member-alpha");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+    }
+
+    [Fact]
+    public async Task ScheduleMemberWorkflow_ThroughStreamingExecutor_ShouldKeepVerifiedMutationSuccess()
+    {
+        var schedulePort = new RecordingMemberWorkflowSchedulePort();
+        var tool = await DiscoverScheduleMemberWorkflowToolAsync(schedulePort);
+
+        using var _ = PushContext(
+            scopeId: "scope-current",
+            ownerSubject: "owner-1",
+            accessToken: "access-token-1",
+            nyxIdAuthority: new AgentToolNyxIdAuthorityContext("nyxid", "tenant-alpha", "nyx-user-alpha"));
+        var toolResult = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "tc-schedule-member-workflow",
+            ScheduleMemberWorkflowToolName,
+            """{"member_id":"member-alpha","schedule_cron":"0 9 * * *","schedule_timezone":"Asia/Shanghai"}""");
+
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"schedule_id\":\"schedule-member-1\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("studio.member.workflow.schedule");
+        receipt.SubjectKind.Should().Be("studio_member_workflow_schedule");
+        receipt.SubjectId.Should().Be("schedule-member-1");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+    }
+
+    [Fact]
     public async Task ListTeams_ShouldCallReadPortWithCallerScopeAndPage()
     {
         var teamQueryPort = new RecordingTeamQueryPort();
@@ -456,6 +688,150 @@ public sealed class ProvisionWorkflowScheduleToolTests
         root.GetProperty("teams")[0].GetProperty("team_url").GetString()
             .Should().Be("/api/scopes/scope-current/teams/team-alpha");
         root.GetProperty("next_page_token").GetString().Should().Be("next-page");
+    }
+
+    [Fact]
+    public async Task ListTeams_ThroughStreamingExecutor_ShouldKeepVerifiedReadOnlySuccess()
+    {
+        var teamQueryPort = new RecordingTeamQueryPort();
+        var tool = await DiscoverListTeamsToolAsync(teamQueryPort);
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        executor.AddTool(executionState, new ToolCall
+        {
+            Id = "tc-list-teams",
+            Name = ListTeamsToolName,
+            ArgumentsJson = "{}",
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        var toolResult = results.Should().ContainSingle().Which;
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"teams\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.NeverRequire);
+        receipt.IsDestructive.Should().BeFalse();
+        receipt.SideEffectKind.Should().BeEmpty();
+        receipt.ResultJson.Should().Be(toolResult.Result);
+    }
+
+    [Fact]
+    public async Task ListTeams_CreateResultReceipt_WithPartialReadOnlyJson_ShouldReturnNull()
+    {
+        var tool = await DiscoverListTeamsToolAsync(new RecordingTeamQueryPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            ListTeamsToolName,
+            "{}",
+            """{"scope_id":"scope-current"}""");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListTeams_CreateResultReceipt_WithWrongReadOnlyJsonKind_ShouldReturnNull()
+    {
+        var tool = await DiscoverListTeamsToolAsync(new RecordingTeamQueryPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            ListTeamsToolName,
+            "{}",
+            """{"scope_id":"scope-current","teams":null}""");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListTeams_CreateResultReceipt_WithMalformedReadOnlyJson_ShouldReturnNull()
+    {
+        var tool = await DiscoverListTeamsToolAsync(new RecordingTeamQueryPort());
+
+        var receipt = tool.CreateResultReceipt(
+            "call-1",
+            ListTeamsToolName,
+            "{}",
+            "{");
+
+        receipt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ListTeams_ThroughStreamingExecutor_ShouldKeepStructuredReadOnlyError()
+    {
+        var teamQueryPort = new RecordingTeamQueryPort();
+        var tool = await DiscoverListTeamsToolAsync(teamQueryPort);
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+
+        using var _ = PushContext(scopeId: "scope-context", ownerSubject: "owner-1", accessToken: "access-token-1");
+        executor.AddTool(executionState, new ToolCall
+        {
+            Id = "tc-list-teams-error",
+            Name = ListTeamsToolName,
+            ArgumentsJson = """{"scope_id":"scope-model"}""",
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        var toolResult = results.Should().ContainSingle().Which;
+        toolResult.IsError.Should().BeTrue();
+        toolResult.Result.Should().Contain("invalid_arguments");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+        receipt.ErrorCode.Should().Be("invalid_arguments");
+        receipt.ResultJson.Should().Be(toolResult.Result);
+        teamQueryPort.ListCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ListWorkflows_ThroughStreamingExecutor_ShouldKeepVerifiedReadOnlySuccess()
+    {
+        var memberQueryPort = new RecordingMemberQueryPort();
+        var tool = await DiscoverListWorkflowsToolAsync(memberQueryPort);
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+
+        using var _ = PushContext(scopeId: "scope-current", ownerSubject: "owner-1", accessToken: "access-token-1");
+        executor.AddTool(executionState, new ToolCall
+        {
+            Id = "tc-list-workflows",
+            Name = ListWorkflowsToolName,
+            ArgumentsJson = "{}",
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        var toolResult = results.Should().ContainSingle().Which;
+        toolResult.IsError.Should().BeFalse();
+        toolResult.Result.Should().Contain("\"workflows\"");
+        toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+        var receipt = toolResult.Receipt;
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.ResultJson.Should().Be(toolResult.Result);
+        memberQueryPort.LastListScopeId.Should().Be("scope-current");
     }
 
     [Fact]
@@ -2044,6 +2420,14 @@ public sealed class ProvisionWorkflowScheduleToolTests
         return tools.Single(tool => tool.Name == CreateMemberToolName);
     }
 
+    private static async Task<IAgentTool> DiscoverCreateMemberWorkflowDraftToolAsync(
+        IStudioMemberWorkflowDraftProvisioningPort draftPort)
+    {
+        var source = new CreateStudioMemberWorkflowDraftToolSource(draftPort);
+        var tools = await source.DiscoverToolsAsync();
+        return tools.Single(tool => tool.Name == CreateMemberWorkflowDraftToolName);
+    }
+
     private static async Task<IAgentTool> DiscoverListMembersToolAsync(IStudioMemberQueryPort memberQueryPort)
     {
         var source = new StudioMemberQueryToolSource(memberQueryPort);
@@ -2056,6 +2440,13 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var source = new StudioMemberQueryToolSource(memberQueryPort);
         var tools = await source.DiscoverToolsAsync();
         return tools.Single(tool => tool.Name == GetMemberToolName);
+    }
+
+    private static async Task<IAgentTool> DiscoverListWorkflowsToolAsync(IStudioMemberQueryPort memberQueryPort)
+    {
+        var source = new StudioWorkflowQueryToolSource(memberQueryPort);
+        var tools = await source.DiscoverToolsAsync();
+        return tools.Single(tool => tool.Name == ListWorkflowsToolName);
     }
 
     private static async Task<IAgentTool> DiscoverListSchedulesToolAsync(
@@ -2091,6 +2482,30 @@ public sealed class ProvisionWorkflowScheduleToolTests
         var source = new ScheduleStudioMemberWorkflowToolSource(schedulePort);
         var tools = await source.DiscoverToolsAsync();
         return tools.Single(tool => tool.Name == ScheduleMemberWorkflowToolName);
+    }
+
+    private static async Task<ToolExecutionResult> ExecuteToolThroughExecutorAsync(
+        IAgentTool tool,
+        string toolCallId,
+        string toolName,
+        string argumentsJson)
+    {
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+        executor.AddTool(executionState, new ToolCall
+        {
+            Id = toolCallId,
+            Name = toolName,
+            ArgumentsJson = argumentsJson,
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        return results.Should().ContainSingle().Which;
     }
 
     private static async Task ExecuteScheduleMemberWorkflowAsync(
@@ -2361,10 +2776,34 @@ public sealed class ProvisionWorkflowScheduleToolTests
     private sealed class RecordingMemberWorkflowDraftProvisioningPort :
         IStudioMemberWorkflowDraftProvisioningPort
     {
+        public StudioMemberWorkflowDraftProvisioningRequest? LastRequest { get; private set; }
+
         public Task<StudioMemberWorkflowDraftProvisioningResult> SaveAsync(
             StudioMemberWorkflowDraftProvisioningRequest request,
-            CancellationToken ct = default) =>
-            throw new NotSupportedException();
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new StudioMemberWorkflowDraftProvisioningResult(
+                StudioMemberWorkflowDraftStatusNames.SaveAccepted,
+                Runnable: false,
+                StudioMemberWorkflowDraftStatusNames.NotBound,
+                request.ScopeId,
+                request.TeamId,
+                request.MemberId ?? "member-generated",
+                request.WorkflowId ?? "workflow-generated",
+                "/studio/workflows/workflow-alpha",
+                "command-alpha",
+                "dispatch_accepted",
+                "actor-alpha",
+                "workspace-alpha",
+                7,
+                DateTimeOffset.Parse("2026-07-01T00:00:00Z"),
+                new StudioMemberWorkflowDraftReadiness(
+                    Readable: true,
+                    Stage: "draft_saved",
+                    Message: "Draft saved."),
+                []));
+        }
     }
 
     private sealed class RecordingMemberQueryPort : IStudioMemberQueryPort


### PR DESCRIPTION
## Summary
- Add provider result receipts for Studio read-only query tools so verified structured reads are not rewritten to `tool_outcome_unknown`.
- Add provider result receipts for Studio mutation tools with side-effect and subject metadata, including team/member creation, draft creation, binding, and scheduling.
- Keep malformed, partial, wrong-kind, or otherwise unverifiable outputs on the existing unknown fallback path.

Fixes #3105

## Test plan
- [x] `dotnet test "/private/tmp/aevatar-3098-fix/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj" --nologo -maxcpucount:1` (131 passed)
- [x] `bash "/private/tmp/aevatar-3098-fix/tools/ci/test_stability_guards.sh"` partially passed: polling wait guard and coverage file guard passed; blocked by local Python `pyexpat/libexpat` dynamic link error (`Symbol not found: _XML_SetAllocTrackerActivationThreshold`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)