### PR TITLE
feat(console): add reviewable AI workflow proposals

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -1128,6 +1128,24 @@ const enUSMessages = {
   'pages.runs.memberPublishedRuns.refresh': 'Refresh',
   'pages.runs.memberPublishedRuns.selectPublishedRun': 'Select a published run',
   'pages.runs.memberPublishedRuns.timeline': 'Timeline',
+  'teamMemberWorkflowStudio.aiProposal.apply': 'Apply proposal',
+  'teamMemberWorkflowStudio.aiProposal.changeRequest': 'Change request',
+  'teamMemberWorkflowStudio.aiProposal.generate': 'Generate proposal',
+  'teamMemberWorkflowStudio.aiProposal.outdated': 'Outdated proposal',
+  'teamMemberWorkflowStudio.aiProposal.panelAria':
+    'AI workflow proposal panel',
+  'teamMemberWorkflowStudio.aiProposal.promptPlaceholder':
+    'Add an approval step after triage',
+  'teamMemberWorkflowStudio.aiProposal.proposedYaml':
+    'Proposed workflow YAML',
+  'teamMemberWorkflowStudio.aiProposal.ready': 'Ready to review',
+  'teamMemberWorkflowStudio.aiProposal.reasoning': 'Reasoning',
+  'teamMemberWorkflowStudio.aiProposal.reasoningAria': 'Proposal reasoning',
+  'teamMemberWorkflowStudio.aiProposal.retry': 'Retry proposal',
+  'teamMemberWorkflowStudio.aiProposal.stale':
+    'Draft changed after this proposal was generated. Generate a new proposal from the current draft.',
+  'teamMemberWorkflowStudio.aiProposal.subtitle': 'Candidate workflow change',
+  'teamMemberWorkflowStudio.aiProposal.title': 'Ask AI',
   'teamMemberWorkflowStudio.alerts.linkedWorkflowMissing.description':
     'You can build or edit the workflow YAML here. Saving creates a reusable workflow draft until the member link is materialized.',
   'teamMemberWorkflowStudio.alerts.linkedWorkflowMissing.publishedDescription':
@@ -1216,6 +1234,11 @@ const enUSMessages = {
   'teamMemberWorkflowStudio.header.activation.publishing': 'Publishing',
   'teamMemberWorkflowStudio.header.activation.ready': 'Ready',
   'teamMemberWorkflowStudio.header.addNode': 'Add node',
+  'teamMemberWorkflowStudio.header.askAi': 'Ask AI',
+  'teamMemberWorkflowStudio.header.askAiTitle':
+    'Generate a reviewable workflow proposal',
+  'teamMemberWorkflowStudio.header.askAiUnavailable':
+    'Load the workflow draft before asking AI.',
   'teamMemberWorkflowStudio.header.automations.publishFirst':
     'Publish this member before adding recurring work.',
   'teamMemberWorkflowStudio.header.automations.saveFirst':

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -1061,6 +1061,22 @@ const zhCNMessages = {
   'pages.runs.memberPublishedRuns.refresh': '刷新',
   'pages.runs.memberPublishedRuns.selectPublishedRun': '选择一次发布运行',
   'pages.runs.memberPublishedRuns.timeline': '时间线',
+  'teamMemberWorkflowStudio.aiProposal.apply': '应用提案',
+  'teamMemberWorkflowStudio.aiProposal.changeRequest': '变更请求',
+  'teamMemberWorkflowStudio.aiProposal.generate': '生成提案',
+  'teamMemberWorkflowStudio.aiProposal.outdated': '提案已过期',
+  'teamMemberWorkflowStudio.aiProposal.panelAria': 'AI Workflow 提案面板',
+  'teamMemberWorkflowStudio.aiProposal.promptPlaceholder':
+    '在分流节点后添加审批步骤',
+  'teamMemberWorkflowStudio.aiProposal.proposedYaml': '提案 Workflow YAML',
+  'teamMemberWorkflowStudio.aiProposal.ready': '可供审阅',
+  'teamMemberWorkflowStudio.aiProposal.reasoning': '推理摘要',
+  'teamMemberWorkflowStudio.aiProposal.reasoningAria': '提案推理摘要',
+  'teamMemberWorkflowStudio.aiProposal.retry': '重试提案',
+  'teamMemberWorkflowStudio.aiProposal.stale':
+    '生成提案后草稿已发生更改。请基于当前草稿重新生成提案。',
+  'teamMemberWorkflowStudio.aiProposal.subtitle': '候选 Workflow 变更',
+  'teamMemberWorkflowStudio.aiProposal.title': '询问 AI',
   'teamMemberWorkflowStudio.alerts.linkedWorkflowMissing.description':
     '你可以在这里搭建或编辑 Workflow YAML。保存时会创建可恢复的 Workflow 草稿，直到成员关联完成物化。',
   'teamMemberWorkflowStudio.alerts.linkedWorkflowMissing.publishedDescription':
@@ -1149,6 +1165,10 @@ const zhCNMessages = {
   'teamMemberWorkflowStudio.header.activation.publishing': '发布中',
   'teamMemberWorkflowStudio.header.activation.ready': '就绪',
   'teamMemberWorkflowStudio.header.addNode': '添加节点',
+  'teamMemberWorkflowStudio.header.askAi': '询问 AI',
+  'teamMemberWorkflowStudio.header.askAiTitle': '生成可审阅的 Workflow 提案',
+  'teamMemberWorkflowStudio.header.askAiUnavailable':
+    '加载 Workflow 草稿后才能询问 AI。',
   'teamMemberWorkflowStudio.header.automations.publishFirst':
     '先发布这个成员，再添加周期任务。',
   'teamMemberWorkflowStudio.header.automations.saveFirst':

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioAiProposalPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioAiProposalPanel.tsx
@@ -1,0 +1,203 @@
+import {
+  CheckCircleOutlined,
+  ReloadOutlined,
+  RobotOutlined,
+} from "@ant-design/icons";
+import { Alert, Button, Input, Space, Tag, Typography } from "antd";
+import React from "react";
+import { t } from "@/shared/i18n/messages";
+import { aevatarMonoFontFamily } from "@/shared/ui/compactText";
+import WorkflowStudioSidePanel from "./WorkflowStudioSidePanel";
+
+type WorkflowStudioAiProposalPanelProps = {
+  readonly error: string;
+  readonly hasConflict: boolean;
+  readonly onApply: () => void;
+  readonly onClose: () => void;
+  readonly onGenerate: () => void;
+  readonly onPromptChange: (prompt: string) => void;
+  readonly open: boolean;
+  readonly pending: boolean;
+  readonly prompt: string;
+  readonly proposalYaml: string;
+  readonly reasoning: string;
+  readonly width: number;
+};
+
+const proposalStackStyle: React.CSSProperties = {
+  alignContent: "start",
+  display: "grid",
+  gap: 16,
+  minWidth: 0,
+};
+
+const proposalSectionStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 8,
+  minWidth: 0,
+};
+
+const proposalLabelStyle: React.CSSProperties = {
+  color: "#374151",
+  fontSize: 12,
+  fontWeight: 700,
+};
+
+const proposalYamlStyle: React.CSSProperties = {
+  fontFamily: aevatarMonoFontFamily,
+  fontSize: 12,
+  lineHeight: 1.6,
+  minHeight: 220,
+  resize: "vertical",
+};
+
+const WorkflowStudioAiProposalPanel: React.FC<
+  WorkflowStudioAiProposalPanelProps
+> = ({
+  error,
+  hasConflict,
+  onApply,
+  onClose,
+  onGenerate,
+  onPromptChange,
+  open,
+  pending,
+  prompt,
+  proposalYaml,
+  reasoning,
+  width,
+}) => {
+  if (!open) {
+    return null;
+  }
+
+  const hasProposal = Boolean(proposalYaml.trim());
+  const canGenerate = Boolean(prompt.trim()) && !pending;
+  const generateLabel = error
+    ? t("teamMemberWorkflowStudio.aiProposal.retry", "Retry proposal")
+    : t("teamMemberWorkflowStudio.aiProposal.generate", "Generate proposal");
+
+  return (
+    <WorkflowStudioSidePanel
+      ariaLabel={t(
+        "teamMemberWorkflowStudio.aiProposal.panelAria",
+        "AI workflow proposal panel",
+      )}
+      onClose={onClose}
+      subtitle={t(
+        "teamMemberWorkflowStudio.aiProposal.subtitle",
+        "Candidate workflow change",
+      )}
+      title={t("teamMemberWorkflowStudio.aiProposal.title", "Ask AI")}
+      width={width}
+    >
+      <div style={proposalStackStyle}>
+        <section style={proposalSectionStyle}>
+          <label
+            htmlFor="workflow-ai-change-request"
+            style={proposalLabelStyle}
+          >
+            {t(
+              "teamMemberWorkflowStudio.aiProposal.changeRequest",
+              "Change request",
+            )}
+          </label>
+          <Input.TextArea
+            autoSize={{ minRows: 4, maxRows: 9 }}
+            disabled={pending}
+            id="workflow-ai-change-request"
+            onChange={(event) => onPromptChange(event.target.value)}
+            placeholder={t(
+              "teamMemberWorkflowStudio.aiProposal.promptPlaceholder",
+              "Add an approval step after triage",
+            )}
+            value={prompt}
+          />
+          <Button
+            disabled={!canGenerate}
+            icon={error ? <ReloadOutlined /> : <RobotOutlined />}
+            loading={pending}
+            onClick={onGenerate}
+            type="primary"
+          >
+            {generateLabel}
+          </Button>
+        </section>
+
+        {error ? <Alert message={error} showIcon type="error" /> : null}
+        {hasConflict ? (
+          <Alert
+            message={t(
+              "teamMemberWorkflowStudio.aiProposal.stale",
+              "Draft changed after this proposal was generated. Generate a new proposal from the current draft.",
+            )}
+            showIcon
+            type="warning"
+          />
+        ) : null}
+
+        {reasoning ? (
+          <section aria-label={t(
+            "teamMemberWorkflowStudio.aiProposal.reasoningAria",
+            "Proposal reasoning",
+          )} style={proposalSectionStyle}>
+            <Typography.Text strong>
+              {t("teamMemberWorkflowStudio.aiProposal.reasoning", "Reasoning")}
+            </Typography.Text>
+            <Typography.Paragraph
+              style={{ color: "#4b5563", margin: 0, whiteSpace: "pre-wrap" }}
+            >
+              {reasoning}
+            </Typography.Paragraph>
+          </section>
+        ) : null}
+
+        {hasProposal ? (
+          <section style={proposalSectionStyle}>
+            <Space align="center" wrap>
+              <Tag color={hasConflict ? "warning" : "success"}>
+                {hasConflict
+                  ? t(
+                      "teamMemberWorkflowStudio.aiProposal.outdated",
+                      "Outdated proposal",
+                    )
+                  : t(
+                      "teamMemberWorkflowStudio.aiProposal.ready",
+                      "Ready to review",
+                    )}
+              </Tag>
+            </Space>
+            <label
+              htmlFor="workflow-ai-proposed-yaml"
+              style={proposalLabelStyle}
+            >
+              {t(
+                "teamMemberWorkflowStudio.aiProposal.proposedYaml",
+                "Proposed workflow YAML",
+              )}
+            </label>
+            <Input.TextArea
+              id="workflow-ai-proposed-yaml"
+              readOnly
+              style={proposalYamlStyle}
+              value={proposalYaml}
+            />
+            <Button
+              disabled={hasConflict || pending}
+              icon={<CheckCircleOutlined />}
+              onClick={onApply}
+              type="primary"
+            >
+              {t(
+                "teamMemberWorkflowStudio.aiProposal.apply",
+                "Apply proposal",
+              )}
+            </Button>
+          </section>
+        ) : null}
+      </div>
+    </WorkflowStudioSidePanel>
+  );
+};
+
+export default WorkflowStudioAiProposalPanel;

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -10,6 +10,7 @@ import {
   PlayCircleOutlined,
   PlusOutlined,
   ReloadOutlined,
+  RobotOutlined,
   SaveOutlined,
 } from '@ant-design/icons';
 import type { InputRef, MenuProps } from 'antd';
@@ -25,6 +26,7 @@ type WorkflowStudioHeaderProps = {
   readonly canOpenAutomations: boolean;
   readonly canOpenInvoke: boolean;
   readonly canOpenPublishedRuns: boolean;
+  readonly canAskAi: boolean;
   readonly invokeHref: string;
   readonly invokePlaceholderReason?: string;
   readonly memberPublished: boolean;
@@ -51,6 +53,7 @@ type WorkflowStudioHeaderProps = {
   readonly onOpenAutomations: () => void;
   readonly onOpenInvoke: () => void;
   readonly onOpenPublishedRuns: () => void;
+  readonly onOpenAiProposal: () => void;
   readonly onRefreshPublishStatus: () => void;
   readonly onAddNode: () => void;
   readonly onDeleteConnection: () => void;
@@ -640,6 +643,7 @@ type HeaderActionsProps = {
   readonly canOpenDraftRunPanel: boolean;
   readonly canOpenInvoke: boolean;
   readonly canOpenPublishedRuns: boolean;
+  readonly canAskAi: boolean;
   readonly canSave: boolean;
   readonly canEditYaml: boolean;
   readonly invokeHref: string;
@@ -651,6 +655,7 @@ type HeaderActionsProps = {
   readonly onOpenDraftRunPanel: () => void;
   readonly onOpenInvoke: () => void;
   readonly onOpenPublishedRuns: () => void;
+  readonly onOpenAiProposal: () => void;
   readonly onEditYaml: () => void;
   readonly onPublishMember: () => void;
   readonly onRefreshPublishStatus: () => void;
@@ -677,6 +682,7 @@ const HeaderActions: React.FC<HeaderActionsProps> = ({
   canOpenDraftRunPanel,
   canOpenInvoke,
   canOpenPublishedRuns,
+  canAskAi,
   canSave,
   canEditYaml,
   invokeHref,
@@ -689,6 +695,7 @@ const HeaderActions: React.FC<HeaderActionsProps> = ({
   onEditYaml,
   onOpenInvoke,
   onOpenPublishedRuns,
+  onOpenAiProposal,
   onPublishMember,
   onRefreshPublishStatus,
   onSave,
@@ -793,6 +800,29 @@ const HeaderActions: React.FC<HeaderActionsProps> = ({
         className="workflow-studio-header__action-group workflow-studio-header__action-group--edit"
         data-testid="workflow-header-edit-actions"
       >
+        <Button
+          aria-label={t('teamMemberWorkflowStudio.header.askAi', 'Ask AI')}
+          className="workflow-studio-header__compact-button"
+          disabled={!canAskAi}
+          icon={<RobotOutlined />}
+          onClick={onOpenAiProposal}
+          size="small"
+          title={
+            canAskAi
+              ? t(
+                  'teamMemberWorkflowStudio.header.askAiTitle',
+                  'Generate a reviewable workflow proposal',
+                )
+              : t(
+                  'teamMemberWorkflowStudio.header.askAiUnavailable',
+                  'Load the workflow draft before asking AI.',
+                )
+          }
+        >
+          <span className="workflow-studio-header__action-label">
+            {t('teamMemberWorkflowStudio.header.askAi', 'Ask AI')}
+          </span>
+        </Button>
         <Button
           aria-label={t('teamMemberWorkflowStudio.header.addNode', 'Add node')}
           className="workflow-studio-header__compact-button"
@@ -1022,6 +1052,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   canOpenAutomations,
   canOpenInvoke,
   canOpenPublishedRuns,
+  canAskAi,
   invokeHref,
   invokePlaceholderReason,
   memberPublished,
@@ -1043,6 +1074,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
   onOpenAutomations,
   onOpenInvoke,
   onOpenPublishedRuns,
+  onOpenAiProposal,
   onRefreshPublishStatus,
   onAddNode,
   onDeleteConnection,
@@ -1113,6 +1145,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
           canOpenDraftRunPanel={canOpenDraftRunPanel}
           canOpenInvoke={canOpenInvoke}
           canOpenPublishedRuns={canOpenPublishedRuns}
+          canAskAi={canAskAi}
           canSave={canSave}
           canEditYaml={canEditYaml}
           invokeHref={invokeHref}
@@ -1125,6 +1158,7 @@ const WorkflowStudioHeader: React.FC<WorkflowStudioHeaderProps> = ({
           onEditYaml={onEditYaml}
           onOpenInvoke={onOpenInvoke}
           onOpenPublishedRuns={onOpenPublishedRuns}
+          onOpenAiProposal={onOpenAiProposal}
           onPublishMember={onPublishMember}
           onRefreshPublishStatus={onRefreshPublishStatus}
           onSave={onSave}

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -168,7 +168,16 @@ type WorkflowSourceSignature = {
 };
 
 type TeamMemberWorkflowStudioState = {
+  readonly aiProposalError: string;
+  readonly aiProposalHasConflict: boolean;
+  readonly aiProposalOpen: boolean;
+  readonly aiProposalPending: boolean;
+  readonly aiProposalPrompt: string;
+  readonly aiProposalReasoning: string;
+  readonly aiProposalYaml: string;
+  readonly applyAiProposal: () => void;
   readonly automationsHref: string;
+  readonly canAskAi: boolean;
   readonly canOpenAutomations: boolean;
   readonly automationsPlaceholderReason: string;
   readonly canOpenInvoke: boolean;
@@ -201,6 +210,7 @@ type TeamMemberWorkflowStudioState = {
   readonly canEditYaml: boolean;
   readonly applyYamlEdit: () => Promise<void>;
   readonly closeNodeLibrary: () => void;
+  readonly closeAiProposalPanel: () => void;
   readonly closeYamlPanel: () => void;
   readonly connectNodes: (sourceNodeId: string, targetNodeId: string) => void;
   readonly deleteSelectedConnection: () => void;
@@ -232,6 +242,7 @@ type TeamMemberWorkflowStudioState = {
   readonly navigateBack: () => void;
   readonly nodeLibraryOpen: boolean;
   readonly openNodeLibrary: () => void;
+  readonly openAiProposalPanel: () => void;
   readonly openDraftRunPanel: () => void;
   readonly openYamlPanel: () => void;
   readonly save: () => void;
@@ -249,6 +260,7 @@ type TeamMemberWorkflowStudioState = {
   readonly selectExecutionLog: (index: number | null) => void;
   readonly selectNode: (nodeId: string) => void;
   readonly setExecutionRunMessage: (message: string) => void;
+  readonly setAiProposalPrompt: (prompt: string) => void;
   readonly setWorkflowTitle: (title: string) => void;
   readonly teamName: string;
   readonly workflowTitle: string;
@@ -263,6 +275,7 @@ type TeamMemberWorkflowStudioState = {
   readonly yamlEditOpening: boolean;
   readonly yamlEditPending: boolean;
   readonly yamlPanelOpen: boolean;
+  readonly generateAiProposal: () => void;
 };
 
 const AVAILABLE_STEP_TYPES = STUDIO_GRAPH_CATEGORIES.flatMap(
@@ -282,6 +295,12 @@ const YAML_EDIT_VALIDATE_DEBOUNCE_MS =
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
+}
+
+function stripWorkflowMarkdownFence(value: string): string {
+  const trimmed = value.trim();
+  const fenced = /^```(?:ya?ml)?\s*\n([\s\S]*?)\n```$/i.exec(trimmed);
+  return fenced?.[1]?.trim() || trimmed;
 }
 
 function normalizeWorkflowSaveResult(
@@ -1109,6 +1128,15 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const [publishErrorVisible, setPublishErrorVisible] = React.useState(true);
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
   const [draftRunPanelOpen, setDraftRunPanelOpen] = React.useState(false);
+  const [aiProposalOpen, setAiProposalOpen] = React.useState(false);
+  const [aiProposalPrompt, setAiProposalPrompt] = React.useState("");
+  const [aiProposalReasoning, setAiProposalReasoning] = React.useState("");
+  const [aiProposalYaml, setAiProposalYaml] = React.useState("");
+  const [aiProposalDocument, setAiProposalDocument] =
+    React.useState<StudioWorkflowDocument | null>(null);
+  const [aiProposalError, setAiProposalError] = React.useState("");
+  const [aiProposalPending, setAiProposalPending] = React.useState(false);
+  const [aiProposalBaseRevision, setAiProposalBaseRevision] = React.useState(0);
   const [yamlPanelOpen, setYamlPanelOpen] = React.useState(false);
   const [yamlEditBuffer, setYamlEditBufferState] = React.useState("");
   const [yamlEditSnapshot, setYamlEditSnapshot] = React.useState("");
@@ -1137,6 +1165,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   const appliedSourceKeyRef = React.useRef("");
   const yamlEditRequestIdRef = React.useRef(0);
   const yamlEditValidationRequestIdRef = React.useRef(0);
+  const aiProposalRequestIdRef = React.useRef(0);
+  const aiProposalAbortControllerRef = React.useRef<AbortController | null>(null);
   const suppressedSourceSignatureRef =
     React.useRef<WorkflowSourceSignature | null>(null);
   const latestSourceKeyRef = React.useRef("");
@@ -1161,6 +1191,16 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlPanelOpen && yamlEditBuffer !== yamlEditSnapshot,
   );
   const yamlEditHasBlockingFindings = hasBlockingFindings(yamlEditDiagnostics);
+  const aiProposalHasConflict = Boolean(
+    aiProposalDocument && aiProposalBaseRevision !== draftRevision,
+  );
+  const closeAiProposalPanel = React.useCallback(() => {
+    aiProposalRequestIdRef.current += 1;
+    aiProposalAbortControllerRef.current?.abort();
+    aiProposalAbortControllerRef.current = null;
+    setAiProposalPending(false);
+    setAiProposalOpen(false);
+  }, []);
   const closeYamlPanelWithConfirmation = React.useCallback(() => {
     if (yamlEditHasUnappliedChanges && !confirmDiscardYamlEdits()) {
       return false;
@@ -1958,6 +1998,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     [],
   );
   const openYamlEditor = React.useCallback(async () => {
+    closeAiProposalPanel();
     setSelectedEdgeId("");
     setSelectedNodeId("");
     setSelectedStepConfigurationError("");
@@ -2038,6 +2079,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
     }
   }, [
+    closeAiProposalPanel,
     closeDraftRunPanel,
     editableDocument,
     routeFallbackTitle,
@@ -2171,6 +2213,195 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlEditDiagnostics,
     yamlEditParsedDocument,
     yamlEditValidatedBuffer,
+  ]);
+  const openAiProposalPanel = React.useCallback(() => {
+    if (!editableDocument || !closeYamlPanelWithConfirmation()) {
+      return;
+    }
+
+    closeDraftRunPanel();
+    setNodeLibraryOpen(false);
+    setSelectedEdgeId("");
+    setSelectedNodeId("");
+    setSelectedStepConfigurationError("");
+    setAiProposalError("");
+    setAiProposalOpen(true);
+  }, [closeDraftRunPanel, closeYamlPanelWithConfirmation, editableDocument]);
+  const generateAiProposal = React.useCallback(async () => {
+    const prompt = trimOptional(aiProposalPrompt);
+    if (!prompt || !editableDocument || aiProposalPending) {
+      return;
+    }
+
+    const requestId = aiProposalRequestIdRef.current + 1;
+    aiProposalRequestIdRef.current = requestId;
+    aiProposalAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    aiProposalAbortControllerRef.current = controller;
+    const baseRevision = draftRevisionRef.current;
+    const normalizedTitle =
+      trimOptional(workflowTitle) ||
+      trimOptional(editableDocument.name) ||
+      routeFallbackTitle;
+
+    setAiProposalPending(true);
+    setAiProposalError("");
+    setAiProposalReasoning("");
+    setAiProposalYaml("");
+    setAiProposalDocument(null);
+    setAiProposalBaseRevision(baseRevision);
+
+    try {
+      const serialized = await studioApi.serializeYaml({
+        document: {
+          ...editableDocument,
+          name: normalizedTitle,
+        },
+        availableStepTypes: AVAILABLE_STEP_TYPES,
+      });
+      assertNoBlockingFindings(serialized.findings);
+      if (controller.signal.aborted || aiProposalRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      const generated = await studioApi.authorWorkflow(
+        {
+          currentYaml: serialized.yaml,
+          prompt,
+        },
+        {
+          signal: controller.signal,
+          onReasoning: (reasoning) => {
+            if (
+              !controller.signal.aborted &&
+              aiProposalRequestIdRef.current === requestId
+            ) {
+              setAiProposalReasoning(reasoning);
+            }
+          },
+        },
+      );
+      if (controller.signal.aborted || aiProposalRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      const proposalYaml = stripWorkflowMarkdownFence(generated);
+      if (!proposalYaml) {
+        throw new Error("AI authoring returned an empty workflow proposal.");
+      }
+
+      const parsed = await studioApi.parseYaml({
+        yaml: proposalYaml,
+        availableStepTypes: AVAILABLE_STEP_TYPES,
+      });
+      const proposalDocument = cloneWorkflowDocument(parsed.document);
+      if (!proposalDocument) {
+        throw new Error(
+          formatBlockingFindingsMessage(parsed.findings) ||
+            "The AI proposal did not produce a workflow document.",
+        );
+      }
+      assertNoBlockingFindings(parsed.findings);
+      if (controller.signal.aborted || aiProposalRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setAiProposalYaml(proposalYaml);
+      setAiProposalDocument(proposalDocument);
+      setAiProposalBaseRevision(baseRevision);
+    } catch (error) {
+      if (!controller.signal.aborted && aiProposalRequestIdRef.current === requestId) {
+        setAiProposalError(
+          error instanceof Error
+            ? error.message
+            : "Failed to generate a workflow proposal.",
+        );
+      }
+    } finally {
+      if (aiProposalRequestIdRef.current === requestId) {
+        aiProposalAbortControllerRef.current = null;
+        setAiProposalPending(false);
+      }
+    }
+  }, [
+    aiProposalPending,
+    aiProposalPrompt,
+    editableDocument,
+    routeFallbackTitle,
+    workflowTitle,
+  ]);
+  const applyAiProposal = React.useCallback(async () => {
+    if (!aiProposalDocument || aiProposalPending) {
+      return;
+    }
+
+    const baseIsCurrent = () =>
+      aiProposalBaseRevision === draftRevisionRef.current;
+    if (!baseIsCurrent()) {
+      setAiProposalError(
+        "Draft changed after this proposal was generated. Generate a new proposal from the current draft.",
+      );
+      return;
+    }
+
+    try {
+      const nextTitle =
+        trimOptional(aiProposalDocument.name) ||
+        trimOptional(workflowTitle) ||
+        routeFallbackTitle;
+      const serialized = await studioApi.serializeYaml({
+        document: {
+          ...aiProposalDocument,
+          name: nextTitle,
+        },
+        availableStepTypes: AVAILABLE_STEP_TYPES,
+      });
+      assertNoBlockingFindings(serialized.findings);
+      if (!baseIsCurrent()) {
+        throw new Error(
+          "Draft changed after this proposal was generated. Generate a new proposal from the current draft.",
+        );
+      }
+
+      const nextDocument =
+        cloneWorkflowDocument(serialized.document) ?? aiProposalDocument;
+      const nextGraph = buildStudioGraphElements(nextDocument, editableLayout);
+      const nextLayout = buildStudioWorkflowLayout(
+        nextTitle,
+        nextGraph.nodes,
+        editableLayout,
+      );
+
+      markDraftDirty();
+      setEditableDocument(nextDocument);
+      setEditableLayout(nextLayout);
+      setWorkflowTitleState(nextTitle);
+      setSelectedEdgeId("");
+      setSelectedNodeId("");
+      setSelectedStepConfigurationError("");
+      setAiProposalOpen(false);
+      setAiProposalPrompt("");
+      setAiProposalReasoning("");
+      setAiProposalYaml("");
+      setAiProposalDocument(null);
+      setAiProposalError("");
+      void message.success("AI workflow proposal applied to the local draft.");
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to apply the workflow proposal.";
+      setAiProposalError(errorMessage);
+      void message.error(errorMessage);
+    }
+  }, [
+    aiProposalBaseRevision,
+    aiProposalDocument,
+    aiProposalPending,
+    editableLayout,
+    markDraftDirty,
+    routeFallbackTitle,
+    workflowTitle,
   ]);
   React.useEffect(() => {
     if (!yamlPanelOpen || yamlEditOpening) {
@@ -3075,7 +3306,20 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
   );
 
   return {
+    aiProposalError,
+    aiProposalHasConflict,
+    aiProposalOpen,
+    aiProposalPending,
+    aiProposalPrompt,
+    aiProposalReasoning,
+    aiProposalYaml,
+    applyAiProposal: () => {
+      void applyAiProposal();
+    },
     automationsHref,
+    canAskAi: Boolean(
+      editableDocument && !workflowLoading && !workflowDraftEditingBlocked,
+    ),
     canOpenAutomations,
     automationsPlaceholderReason,
     canOpenInvoke,
@@ -3164,6 +3408,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       editableDocument && !workflowLoading && !workflowDraftEditingBlocked,
     ),
     closeNodeLibrary: () => setNodeLibraryOpen(false),
+    closeAiProposalPanel,
     closeYamlPanel: () => {
       closeYamlPanelWithConfirmation();
     },
@@ -3263,9 +3508,11 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       }
 
       if (closeYamlPanelWithConfirmation()) {
+        closeAiProposalPanel();
         setNodeLibraryOpen(true);
       }
     },
+    openAiProposalPanel,
     openDraftRunPanel: () => {
       if (!canOpenDraftRunPanel) {
         return;
@@ -3275,6 +3522,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         return;
       }
 
+      closeAiProposalPanel();
       setSelectedEdgeId("");
       setSelectedNodeId("");
       setSelectedStepConfigurationError("");
@@ -3342,6 +3590,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
         return;
       }
 
+      closeAiProposalPanel();
       setSelectedEdgeId("");
       setSelectedNodeId("");
       setSelectedStepConfigurationError("");
@@ -3377,6 +3626,7 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       closeDraftRunPanel();
     },
     setExecutionRunMessage,
+    setAiProposalPrompt,
     setSelectedStepConfigurationError,
     setWorkflowTitle,
     teamName,
@@ -3408,5 +3658,8 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     yamlEditOpening,
     yamlEditPending,
     yamlPanelOpen,
+    generateAiProposal: () => {
+      void generateAiProposal();
+    },
   };
 }

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -128,6 +128,7 @@ jest.mock("@/shared/studio/api", () => {
     isStudioApiStatus: (error: unknown, status: number) =>
       error instanceof MockStudioApiError && error.status === status,
     studioApi: {
+      authorWorkflow: jest.fn(),
       bindMemberWorkflow: jest.fn(),
       getMember: jest.fn(),
       getTeam: jest.fn(),
@@ -4350,6 +4351,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(screen.queryByTestId("workflow-header-node-actions")).toBeNull();
     expect(readActionButtonNames()).toEqual([
       "Run",
+      "Ask AI",
       "Add node",
       "Edit YAML",
       "Save",
@@ -4382,6 +4384,7 @@ describe("TeamMemberWorkflowStudioPage", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
     expect(readActionButtonNames()).toEqual([
       "Run",
+      "Ask AI",
       "Add node",
       "Edit YAML",
       "Save",
@@ -4978,6 +4981,217 @@ describe("TeamMemberWorkflowStudioPage", () => {
     });
     expect(screen.getByLabelText("Workflow YAML panel")).toBeTruthy();
     expect(screen.getByText("Unsaved changes")).toBeTruthy();
+  });
+
+  it("keeps AI workflow changes reviewable until the proposal is explicitly applied", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/member-alpha/workflow?workflowId=workflow-alpha",
+    );
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      implementationRef: {
+        implementationKind: "workflow",
+        workflowId: "workflow-alpha",
+      },
+      summary: {
+        createdAt: "2026-06-08T00:00:00Z",
+        description: "",
+        displayName: "Workflow Alpha",
+        implementationKind: "workflow",
+        lastBoundRevisionId: null,
+        lifecycleStage: "created",
+        memberId: "member-alpha",
+        publishedServiceId: "",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        updatedAt: "2026-06-08T00:00:00Z",
+      },
+    });
+    (studioApi.getWorkflow as jest.Mock).mockResolvedValue({
+      directoryId: "scope:scope-1",
+      directoryLabel: "scope-1",
+      draftExists: true,
+      fileName: "workflow-alpha.yaml",
+      filePath: "scope://scope-1/workflow-alpha.yaml",
+      findings: [],
+      layout: null,
+      name: "Workflow Alpha",
+      workflowId: "workflow-alpha",
+      yaml: "name: Workflow Alpha\nsteps:\n  - id: triage\n    type: llm_call\n",
+      document: mockWorkflowDocument,
+      updatedAtUtc: "2026-06-08T00:00:00Z",
+    });
+    (studioApi.authorWorkflow as jest.Mock).mockImplementation(
+      async (_input, options) => {
+        options?.onReasoning?.("Add a guard after triage.");
+        return [
+          "name: Workflow Alpha",
+          "steps:",
+          "  - id: triage",
+          "    type: llm_call",
+          "  - id: guard",
+          "    type: guard",
+        ].join("\n");
+      },
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Ask AI" }));
+    const proposalPanel = await screen.findByLabelText("AI workflow proposal panel");
+    fireEvent.change(within(proposalPanel).getByLabelText("Change request"), {
+      target: { value: "Add a guard after triage" },
+    });
+    fireEvent.click(
+      within(proposalPanel).getByRole("button", { name: "Generate proposal" }),
+    );
+
+    await waitFor(() => {
+      expect(studioApi.authorWorkflow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentYaml: expect.stringContaining("id: triage"),
+          prompt: "Add a guard after triage",
+        }),
+        expect.objectContaining({
+          onReasoning: expect.any(Function),
+        }),
+      );
+    });
+    expect(await within(proposalPanel).findByText("Ready to review")).toBeTruthy();
+    expect(within(proposalPanel).getByText("Add a guard after triage.")).toBeTruthy();
+    expect(
+      (within(proposalPanel).getByLabelText(
+        "Proposed workflow YAML",
+      ) as HTMLTextAreaElement).value,
+    ).toContain("id: guard");
+    expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      within(proposalPanel).getByRole("button", { name: "Apply proposal" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:2");
+    });
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.bindMemberWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("blocks an AI proposal when the human draft changes during generation", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/new/workflow",
+    );
+    let resolveProposal: ((yaml: string) => void) | null = null;
+    (studioApi.authorWorkflow as jest.Mock).mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveProposal = resolve;
+        }),
+    );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add first step" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Insert LLM call node" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask AI" }));
+    const proposalPanel = await screen.findByLabelText("AI workflow proposal panel");
+    fireEvent.change(within(proposalPanel).getByLabelText("Change request"), {
+      target: { value: "Add a guard after triage" },
+    });
+    fireEvent.click(
+      within(proposalPanel).getByRole("button", { name: "Generate proposal" }),
+    );
+    await waitFor(() => {
+      expect(studioApi.authorWorkflow).toHaveBeenCalled();
+    });
+
+    fireEvent.change(screen.getByLabelText("Workflow title"), {
+      target: { value: "Human edited title" },
+    });
+    await act(async () => {
+      resolveProposal?.(
+        [
+          "name: Proposed title",
+          "steps:",
+          "  - id: llm_step",
+          "    type: llm_call",
+          "  - id: guard",
+          "    type: guard",
+        ].join("\n"),
+      );
+    });
+
+    expect(await within(proposalPanel).findByText("Outdated proposal")).toBeTruthy();
+    expect(
+      within(proposalPanel).getByText(
+        "Draft changed after this proposal was generated. Generate a new proposal from the current draft.",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(proposalPanel).getByRole("button", { name: "Apply proposal" }),
+    ).toBeDisabled();
+    expect(screen.getByLabelText("Workflow title")).toHaveValue("Human edited title");
+    expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:1");
+    expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
+    expect(studioApi.createMember).not.toHaveBeenCalled();
+  });
+
+  it("preserves the AI change request and retries after generation fails", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/scopes/scope-1/teams/t-alpha/members/new/workflow",
+    );
+    (studioApi.authorWorkflow as jest.Mock)
+      .mockRejectedValueOnce(new Error("Generator unavailable"))
+      .mockResolvedValueOnce(
+        [
+          "name: Recovered workflow",
+          "steps:",
+          "  - id: triage",
+          "    type: llm_call",
+        ].join("\n"),
+      );
+
+    renderWithQueryClient(React.createElement(TeamMemberWorkflowStudioPage));
+
+    await screen.findByLabelText("Workflow title");
+    fireEvent.click(screen.getByRole("button", { name: "Ask AI" }));
+    const proposalPanel = await screen.findByLabelText("AI workflow proposal panel");
+    const changeRequest = within(proposalPanel).getByLabelText("Change request");
+    fireEvent.change(changeRequest, {
+      target: { value: "Create a triage workflow" },
+    });
+    fireEvent.click(
+      within(proposalPanel).getByRole("button", { name: "Generate proposal" }),
+    );
+
+    expect(await within(proposalPanel).findByText("Generator unavailable")).toBeTruthy();
+    expect(changeRequest).toHaveValue("Create a triage workflow");
+    fireEvent.click(
+      within(proposalPanel).getByRole("button", { name: "Retry proposal" }),
+    );
+
+    expect(await within(proposalPanel).findByText("Ready to review")).toBeTruthy();
+    expect(studioApi.authorWorkflow).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("graph-canvas")).toHaveTextContent("nodes:0");
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
   });
 
   it("freezes YAML editing while Apply is in flight", async () => {

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -2,6 +2,7 @@ import { Alert, Spin } from "antd";
 import React from "react";
 import { t } from "@/shared/i18n/messages";
 import WorkflowStudioCanvas from "./components/WorkflowStudioCanvas";
+import WorkflowStudioAiProposalPanel from "./components/WorkflowStudioAiProposalPanel";
 import WorkflowStudioDraftRunPanel from "./components/WorkflowStudioDraftRunPanel";
 import WorkflowStudioExecutionPanel from "./components/WorkflowStudioExecutionPanel";
 import WorkflowStudioHeader from "./components/WorkflowStudioHeader";
@@ -56,7 +57,8 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
   const [executionPanelHeight, setExecutionPanelHeight] = React.useState(
     EXECUTION_PANEL_DEFAULT_HEIGHT,
   );
-  const sidePanelOpen = studio.draftRunPanelOpen || studio.yamlPanelOpen;
+  const sidePanelOpen =
+    studio.aiProposalOpen || studio.draftRunPanelOpen || studio.yamlPanelOpen;
   const executionPanelOpen = Boolean(studio.executionDetail || studio.executionError);
 
   React.useEffect(
@@ -229,6 +231,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         automationsHref={studio.automationsHref}
         automationsPlaceholderReason={studio.automationsPlaceholderReason}
         canOpenAutomations={studio.canOpenAutomations}
+        canAskAi={studio.canAskAi}
         canOpenInvoke={studio.canOpenInvoke}
         canOpenPublishedRuns={studio.canOpenPublishedRuns}
         invokeHref={studio.invokeHref}
@@ -249,6 +252,7 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
         dirty={studio.dirty}
         currentDraftRunPlaceholderReason={studio.currentDraftRunPlaceholderReason}
         onOpenAutomations={studio.navigateToAutomations}
+        onOpenAiProposal={studio.openAiProposalPanel}
         onOpenInvoke={studio.navigateToInvoke}
         onOpenPublishedRuns={studio.navigateToPublishedRuns}
         onPublishMember={studio.publishMember}
@@ -392,6 +396,20 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
           runMessage={studio.executionRunMessage}
           width={sidePanelWidth}
         />
+        <WorkflowStudioAiProposalPanel
+          error={studio.aiProposalError}
+          hasConflict={studio.aiProposalHasConflict}
+          onApply={studio.applyAiProposal}
+          onClose={studio.closeAiProposalPanel}
+          onGenerate={studio.generateAiProposal}
+          onPromptChange={studio.setAiProposalPrompt}
+          open={studio.aiProposalOpen}
+          pending={studio.aiProposalPending}
+          prompt={studio.aiProposalPrompt}
+          proposalYaml={studio.aiProposalYaml}
+          reasoning={studio.aiProposalReasoning}
+          width={sidePanelWidth}
+        />
         <WorkflowStudioYamlPanel
           applying={studio.yamlEditApplying}
           buffer={studio.yamlEditBuffer}
@@ -408,7 +426,8 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
           open={studio.yamlPanelOpen}
           width={sidePanelWidth}
         />
-        {studio.draftRunPanelOpen ||
+        {studio.aiProposalOpen ||
+        studio.draftRunPanelOpen ||
         studio.yamlPanelOpen ? null : (
           <WorkflowStudioNodeDetailPanel
             error={studio.selectedStepConfigurationError}


### PR DESCRIPTION
## Summary

- Add an Ask AI authoring panel to the canonical Team Member Workflow Studio using the existing contract-backed workflow authoring API.
- Keep generated YAML review-only until explicit application, block stale proposals after human edits, and preserve change requests across retryable failures.
- Preserve separate member, workflow, and published-service identities; this change does not save, publish, bind, or create members implicitly.

## Affected paths

- `apps/aevatar-console-web/src/pages/team-member-workflow-studio/`
- `apps/aevatar-console-web/src/locales/`

## Verification

- `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/team-member-workflow-studio/index.test.tsx`: passed, 87 tests
- `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/locales/catalog.test.ts src/locales/hardcodedCopyAudit.test.ts`: passed
- `pnpm --dir apps/aevatar-console-web tsc`: passed
- `pnpm --dir apps/aevatar-console-web exec biome check <seven affected files>`: passed
- `bash tools/ci/test_stability_guards.sh`: passed, including subordinate guards
- `pnpm --dir apps/aevatar-console-web build`: passed
- Full frontend and repository test suites were not run under the incremental unit-test policy.

## Risks

- `bash tools/ci/architecture_guards.sh` passed all checks reached before proto lint, then stopped because `buf` is not installed in the local environment. CI installs `buf` before running this guard.
- No documentation update was required because this is a localized authoring interaction using existing contracts.

Closes #3116