### PR TITLE
Verify invocation accepted receipts

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -185,6 +185,8 @@ internal sealed class StartWorkflowTool : IAevatarInvocationTool
             Status = AgentToolReceiptStatus.Success,
             ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
             SideEffectKind = SideEffectKind,
+            SubjectKind = AevatarInvocationReceiptJson.InvocationRunSubjectKind,
+            SubjectId = invocation.RunId,
             ResultJson = resultJson ?? string.Empty,
         };
         if (workflowRuntime.HasManagedParent && IsAcceptedManagedWorkflowStart(invocation))

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 
@@ -19,7 +20,13 @@ public interface IAevatarInvocationTool : IAgentTool
         string resultJson)
     {
         if (!AevatarInvocationJson.TryReadError(resultJson, out var error) || error is null)
-            return CreateSuccessReceipt(callId, toolName, resultJson);
+            return CreateSuccessReceipt(callId, toolName, resultJson) ??
+                   AevatarInvocationReceiptJson.CreateAcceptedInvocationReceipt(
+                       Name,
+                       SideEffectKind,
+                       callId,
+                       toolName,
+                       resultJson);
 
         return new AgentToolReceipt
         {
@@ -33,4 +40,62 @@ public interface IAevatarInvocationTool : IAgentTool
             ResultJson = resultJson ?? string.Empty,
         };
     }
+}
+
+internal static class AevatarInvocationReceiptJson
+{
+    public const string InvocationRunSubjectKind = "aevatar.invocation_run";
+
+    public static AgentToolReceipt? CreateAcceptedInvocationReceipt(
+        string defaultToolName,
+        string sideEffectKind,
+        string callId,
+        string toolName,
+        string resultJson)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(resultJson);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object || root.TryGetProperty("error", out _))
+                return null;
+
+            var runId = ReadString(root, "run_id");
+            var status = ReadString(root, "status");
+            var actorId = ReadString(root, "actor_id");
+            var commandId = ReadString(root, "command_id");
+            if (string.IsNullOrWhiteSpace(runId) ||
+                string.IsNullOrWhiteSpace(actorId) ||
+                string.IsNullOrWhiteSpace(commandId) ||
+                !IsAcceptedStatus(status))
+            {
+                return null;
+            }
+
+            return new AgentToolReceipt
+            {
+                CallId = callId ?? string.Empty,
+                ToolName = string.IsNullOrWhiteSpace(toolName) ? defaultToolName : toolName,
+                Status = AgentToolReceiptStatus.Success,
+                ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
+                SideEffectKind = sideEffectKind ?? string.Empty,
+                SubjectKind = InvocationRunSubjectKind,
+                SubjectId = runId.Trim(),
+                ResultJson = resultJson ?? string.Empty,
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsAcceptedStatus(string status) =>
+        string.Equals(status, "accepted", StringComparison.Ordinal) ||
+        string.Equals(status, "streaming", StringComparison.Ordinal);
+
+    private static string ReadString(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? string.Empty
+            : string.Empty;
 }

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Aevatar.AI.ToolProviders.AevatarInvocation.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.AevatarInvocation\Aevatar.AI.ToolProviders.AevatarInvocation.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Governance.Abstractions\Aevatar.GAgentService.Governance.Abstractions.csproj" />
   </ItemGroup>

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Core.Tools;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
@@ -1504,6 +1505,102 @@ public sealed class AevatarInvocationToolSourceTests
         result.GetProperty("run_id").GetString().Should().Be("call-workflow");
         result.GetProperty("actor_id").GetString().Should().Be("workflow-actor");
         result.GetProperty("stream_topic").GetString().Should().Be("aevatar://actors/workflow-actor/runs/call-workflow");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_CreateResultReceipt_WithAcceptedStreamAck_ShouldReturnVerifiedReceipt()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        var receipt = tool.CreateResultReceipt(
+            "call-workflow",
+            "aevatar_start_workflow",
+            "{}",
+            """{"run_id":"call-workflow","status":"streaming","stream_topic":"aevatar://actors/workflow-actor/runs/call-workflow","actor_id":"workflow-actor","command_id":"call-workflow","correlation_id":"call-workflow","wait":"stream"}""");
+
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.SideEffectKind.Should().Be("workflow.managed-child-start");
+        receipt.SubjectKind.Should().Be("aevatar.invocation_run");
+        receipt.SubjectId.Should().Be("call-workflow");
+        receipt.ResultJson.Should().Contain("workflow-actor");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_ThroughStreamingExecutor_ShouldKeepVerifiedAcceptedStreamAck()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow-executor");
+        var result = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "call-workflow-executor",
+            "aevatar_start_workflow",
+            """
+            {
+              "workflow_id": "wf-main",
+              "inputs": { "prompt": "run workflow" },
+              "wait": "stream"
+            }
+            """);
+
+        result.Result.Should().Contain("\"run_id\":\"call-workflow-executor\"");
+        result.Result.Should().Contain("\"status\":\"streaming\"");
+        result.Result.Should().NotContain("tool outcome could not be verified");
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        result.Receipt.SubjectId.Should().Be("call-workflow-executor");
+    }
+
+    [Fact]
+    public async Task InvokeMemberWorkflowService_ThroughStreamingExecutor_ShouldKeepVerifiedAcceptedAck()
+    {
+        var harness = new Harness();
+        harness.MemberResolver.Resolution = new MemberPublishedServiceResolution(
+            "scope-1",
+            "member-workflow",
+            "workflow-service");
+        harness.ConfigureServiceTarget(
+            ServiceImplementationKind.Workflow,
+            serviceId: "workflow-service",
+            endpointId: "chat",
+            primaryActorId: "workflow-definition-actor");
+        harness.ServiceInvocationDispatcher.Receipt = new ServiceInvocationAcceptedReceipt
+        {
+            RequestId = "call-member-workflow",
+            ServiceKey = "tenant:aevatar-service:default:workflow-service",
+            DeploymentId = "deployment-workflow-service",
+            RunId = "workflow-service-run",
+            CommandId = "workflow-command",
+            CorrelationId = "workflow-correlation",
+            TargetActorId = "workflow-actor",
+            EndpointId = "chat",
+        };
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_member");
+
+        using var _ = PushContext(callId: "call-member-workflow");
+        var result = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "call-member-workflow",
+            "aevatar_invoke_member",
+            """
+            {
+              "member_id": "member-workflow",
+              "payload": { "prompt": "process pdf" },
+              "wait": "stream"
+            }
+            """);
+
+        result.Result.Should().Contain("\"run_id\":\"workflow-service-run\"");
+        result.Result.Should().Contain("\"service_id\":\"workflow-service\"");
+        result.Result.Should().NotContain("tool outcome could not be verified");
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        result.Receipt.SubjectId.Should().Be("workflow-service-run");
     }
 
     [Fact]
@@ -3519,6 +3616,30 @@ public sealed class AevatarInvocationToolSourceTests
     {
         var tools = await source.DiscoverToolsAsync();
         return tools.Should().ContainSingle().Subject;
+    }
+
+    private static async Task<ToolExecutionResult> ExecuteToolThroughExecutorAsync(
+        IAgentTool tool,
+        string toolCallId,
+        string toolName,
+        string argumentsJson)
+    {
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var executor = new StreamingToolExecutor(tools);
+        using var executionState = executor.CreateExecutionState();
+        executor.AddTool(executionState, new ToolCall
+        {
+            Id = toolCallId,
+            Name = toolName,
+            ArgumentsJson = argumentsJson,
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+            results.Add(result);
+
+        return results.Should().ContainSingle().Subject;
     }
 
     private static JsonElement Read(string json)


### PR DESCRIPTION
## Summary
- Add provider-owned receipts for accepted/streaming Aevatar invocation results when run identity fields are present.
- Preserve raw workflow/member invocation ACK output through StreamingToolExecutor instead of replacing it with tool_outcome_unknown.
- Add executor-level coverage for aevatar_start_workflow and member workflow service invocation ACKs.

## Test plan
- [x] dotnet test /private/tmp/aevatar-3098-fix/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo
- [x] bash tools/ci/test_stability_guards.sh partially ran: polling and coverage guards passed; local Python pyexpat/libexpat link error blocks project_reference_layer_guard on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)