### PR TITLE
Verify invocation and Studio tool receipts

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -283,7 +283,7 @@ internal sealed class StartWorkflowTool : IAevatarInvocationTool
         WorkflowRunBackgroundDeliveryReceipt? WorkflowRunDelivery);
 }
 
-internal sealed class ObserveRunTool : IAevatarInvocationTool
+internal sealed class ObserveRunTool : IAevatarInvocationReadOnlyTool
 {
     private readonly AevatarInvocationDispatcher _dispatcher;
 
@@ -301,11 +301,19 @@ internal sealed class ObserveRunTool : IAevatarInvocationTool
 
     public bool IsReadOnly => true;
 
+    public string ReadOnlySubjectIdPropertyName => "run_id";
+
+    public IReadOnlyList<AevatarInvocationReceiptJson.ResultPropertyRequirement> ReadOnlyResultRequirements { get; } = new[]
+    {
+        AevatarInvocationReceiptJson.StringProperty("run_id"),
+        AevatarInvocationReceiptJson.StringProperty("status"),
+    };
+
     public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
         _dispatcher.ObserveRunAsync(argumentsJson, ct);
 }
 
-internal sealed class ReadWorkflowRunArtifactTool : IAevatarInvocationTool
+internal sealed class ReadWorkflowRunArtifactTool : IAevatarInvocationReadOnlyTool
 {
     private const int DefaultTimelineTake = 50;
     private const int DefaultGraphTake = 200;
@@ -376,6 +384,14 @@ internal sealed class ReadWorkflowRunArtifactTool : IAevatarInvocationTool
         """;
 
     public bool IsReadOnly => true;
+
+    public string ReadOnlySubjectIdPropertyName => "workflow_run_id";
+
+    public IReadOnlyList<AevatarInvocationReceiptJson.ResultPropertyRequirement> ReadOnlyResultRequirements { get; } = new[]
+    {
+        AevatarInvocationReceiptJson.StringProperty("workflow_run_id"),
+        AevatarInvocationReceiptJson.StringProperty("artifact"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
@@ -21,6 +21,7 @@ public interface IAevatarInvocationTool : IAgentTool
     {
         if (!AevatarInvocationJson.TryReadError(resultJson, out var error) || error is null)
             return CreateSuccessReceipt(callId, toolName, resultJson) ??
+                   CreateReadOnlySuccessReceipt(this, callId, toolName, resultJson) ??
                    AevatarInvocationReceiptJson.CreateAcceptedInvocationReceipt(
                        Name,
                        SideEffectKind,
@@ -40,11 +41,75 @@ public interface IAevatarInvocationTool : IAgentTool
             ResultJson = resultJson ?? string.Empty,
         };
     }
+
+    private static AgentToolReceipt? CreateReadOnlySuccessReceipt(
+        IAevatarInvocationTool tool,
+        string callId,
+        string toolName,
+        string resultJson) =>
+        tool is IAevatarInvocationReadOnlyTool readOnlyTool
+            ? AevatarInvocationReceiptJson.CreateReadOnlyInvocationReceipt(
+                tool.Name,
+                callId,
+                toolName,
+                resultJson,
+                readOnlyTool.ReadOnlySubjectIdPropertyName,
+                readOnlyTool.ReadOnlyResultRequirements)
+            : null;
+}
+
+internal interface IAevatarInvocationReadOnlyTool : IAevatarInvocationTool
+{
+    string? ReadOnlySubjectIdPropertyName { get; }
+
+    IReadOnlyList<AevatarInvocationReceiptJson.ResultPropertyRequirement> ReadOnlyResultRequirements { get; }
 }
 
 internal static class AevatarInvocationReceiptJson
 {
     public const string InvocationRunSubjectKind = "aevatar.invocation_run";
+
+    public static ResultPropertyRequirement StringProperty(params string[] path) =>
+        new(path, JsonValueKind.String);
+
+    public static AgentToolReceipt? CreateReadOnlyInvocationReceipt(
+        string defaultToolName,
+        string callId,
+        string toolName,
+        string resultJson,
+        string? subjectIdPropertyName,
+        IReadOnlyList<ResultPropertyRequirement> resultRequirements)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(resultJson);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object || root.TryGetProperty("error", out _))
+                return null;
+
+            foreach (var requirement in resultRequirements)
+            {
+                if (!TryGetProperty(root, requirement.Path, out var value) || value.ValueKind != requirement.ValueKind)
+                    return null;
+            }
+
+            return new AgentToolReceipt
+            {
+                CallId = callId ?? string.Empty,
+                ToolName = string.IsNullOrWhiteSpace(toolName) ? defaultToolName : toolName,
+                Status = AgentToolReceiptStatus.Success,
+                ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
+                SubjectId = string.IsNullOrWhiteSpace(subjectIdPropertyName)
+                    ? string.Empty
+                    : ReadString(root, subjectIdPropertyName),
+                ResultJson = resultJson ?? string.Empty,
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     public static AgentToolReceipt? CreateAcceptedInvocationReceipt(
         string defaultToolName,
@@ -98,4 +163,26 @@ internal static class AevatarInvocationReceiptJson
         root.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString() ?? string.Empty
             : string.Empty;
+
+    private static bool TryGetProperty(
+        JsonElement root,
+        IReadOnlyList<string> path,
+        out JsonElement value)
+    {
+        value = root;
+        foreach (var propertyName in path)
+        {
+            if (value.ValueKind != JsonValueKind.Object ||
+                !value.TryGetProperty(propertyName, out value))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public sealed record ResultPropertyRequirement(
+        IReadOnlyList<string> Path,
+        JsonValueKind ValueKind);
 }

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/BindStudioMemberWorkflowTool.cs
@@ -7,7 +7,7 @@ using Aevatar.Workflow.Abstractions;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class BindStudioMemberWorkflowTool : IAgentTool
+internal sealed class BindStudioMemberWorkflowTool : IStudioMutationReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -57,26 +57,16 @@ internal sealed class BindStudioMemberWorkflowTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.workflow.bind";
+    public string SubjectKind => "studio_member_workflow_binding";
+    public string SubjectIdPropertyName => "member_id";
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateMutationResultReceipt(
-            Name,
-            SideEffectKind,
-            "studio_member_workflow_binding",
-            callId,
-            toolName,
-            resultJson,
-            null,
-            null,
-            "member_id",
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("operation"),
-            StudioQueryToolJson.StringProperty("status"),
-            StudioQueryToolJson.StringProperty("member_workflow_url"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("operation"),
+        StudioQueryToolJson.StringProperty("status"),
+        StudioQueryToolJson.StringProperty("member_workflow_url"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberTool.cs
@@ -6,7 +6,7 @@ using Aevatar.Studio.Application.Provisioning;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class CreateStudioMemberTool : IAgentTool
+internal sealed class CreateStudioMemberTool : IStudioMutationReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -65,28 +65,18 @@ internal sealed class CreateStudioMemberTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.create";
+    public string SubjectKind => "studio_member";
+    public string SubjectIdPropertyName => "member_id";
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateMutationResultReceipt(
-            Name,
-            SideEffectKind,
-            "studio_member",
-            callId,
-            toolName,
-            resultJson,
-            null,
-            null,
-            "member_id",
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("display_name"),
-            StudioQueryToolJson.StringProperty("implementation_kind"),
-            StudioQueryToolJson.StringProperty("lifecycle_stage"),
-            StudioQueryToolJson.StringProperty("published_service_id"),
-            StudioQueryToolJson.StringProperty("member_url"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("display_name"),
+        StudioQueryToolJson.StringProperty("implementation_kind"),
+        StudioQueryToolJson.StringProperty("lifecycle_stage"),
+        StudioQueryToolJson.StringProperty("published_service_id"),
+        StudioQueryToolJson.StringProperty("member_url"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberWorkflowDraftTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioMemberWorkflowDraftTool.cs
@@ -6,7 +6,7 @@ using Aevatar.Studio.Application.Provisioning;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class CreateStudioMemberWorkflowDraftTool : IAgentTool
+internal sealed class CreateStudioMemberWorkflowDraftTool : IStudioMutationErrorReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -66,18 +66,6 @@ internal sealed class CreateStudioMemberWorkflowDraftTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.workflow_draft.create";
-
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateMutationErrorResultReceipt(
-            Name,
-            SideEffectKind,
-            callId,
-            toolName,
-            resultJson);
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioTeamTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/CreateStudioTeamTool.cs
@@ -10,7 +10,7 @@ namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 /// Local, typed Studio team creation tool. Scope authority comes from
 /// AgentToolRequestContext, not from LLM arguments.
 /// </summary>
-internal sealed class CreateStudioTeamTool : IAgentTool
+internal sealed class CreateStudioTeamTool : IStudioMutationReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -59,26 +59,16 @@ internal sealed class CreateStudioTeamTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.team.create";
+    public string SubjectKind => "studio_team";
+    public string SubjectIdPropertyName => "team_id";
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateMutationResultReceipt(
-            Name,
-            SideEffectKind,
-            "studio_team",
-            callId,
-            toolName,
-            resultJson,
-            null,
-            null,
-            "team_id",
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("display_name"),
-            StudioQueryToolJson.StringProperty("lifecycle_stage"),
-            StudioQueryToolJson.StringProperty("team_url"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("display_name"),
+        StudioQueryToolJson.StringProperty("lifecycle_stage"),
+        StudioQueryToolJson.StringProperty("team_url"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/ScheduleStudioMemberWorkflowTool.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
+internal sealed class ScheduleStudioMemberWorkflowTool : IStudioMutationReceiptTool
 {
     private const string CredentialProvisioningKind = "dedicated_scheduled_invocation_agent_key";
 
@@ -75,27 +75,17 @@ internal sealed class ScheduleStudioMemberWorkflowTool : IAgentTool
     public bool IsReadOnly => false;
     public bool IsDestructive => false;
     public string SideEffectKind => "studio.member.workflow.schedule";
+    public string SubjectKind => "studio_member_workflow_schedule";
+    public string SubjectIdPropertyName => "schedule_id";
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateMutationResultReceipt(
-            Name,
-            SideEffectKind,
-            "studio_member_workflow_schedule",
-            callId,
-            toolName,
-            resultJson,
-            null,
-            null,
-            "schedule_id",
-            StudioQueryToolJson.StringProperty("status"),
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("member_id"),
-            StudioQueryToolJson.StringProperty("published_service_id"),
-            StudioQueryToolJson.StringProperty("observatory_url"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("status"),
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("member_id"),
+        StudioQueryToolJson.StringProperty("published_service_id"),
+        StudioQueryToolJson.StringProperty("observatory_url"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioQueryTools.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioQueryTools.cs
@@ -9,7 +9,65 @@ using Aevatar.Studio.Application.Studio.Contracts;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class ListStudioTeamsTool : IAgentTool
+internal interface IStudioReceiptTool : IAgentTool
+{
+    AgentToolReceipt? IAgentTool.CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        this switch
+        {
+            IStudioReadOnlyReceiptTool readOnlyTool => StudioQueryToolJson.CreateReadOnlyResultReceipt(
+                Name,
+                callId,
+                toolName,
+                resultJson,
+                readOnlyTool.ResultRequirements),
+            IStudioMutationReceiptTool mutationTool => StudioQueryToolJson.CreateMutationResultReceipt(
+                Name,
+                SideEffectKind,
+                mutationTool.SubjectKind,
+                callId,
+                toolName,
+                resultJson,
+                mutationTool.SuccessStatusPropertyName,
+                mutationTool.SuccessStatusValue,
+                mutationTool.SubjectIdPropertyName,
+                mutationTool.ResultRequirements),
+            IStudioMutationErrorReceiptTool => StudioQueryToolJson.CreateMutationErrorResultReceipt(
+                Name,
+                SideEffectKind,
+                callId,
+                toolName,
+                resultJson),
+            _ => null,
+        };
+}
+
+internal interface IStudioReadOnlyReceiptTool : IStudioReceiptTool
+{
+    IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; }
+}
+
+internal interface IStudioMutationReceiptTool : IStudioReceiptTool
+{
+    string SubjectKind { get; }
+
+    string? SuccessStatusPropertyName => null;
+
+    string? SuccessStatusValue => null;
+
+    string SubjectIdPropertyName { get; }
+
+    IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; }
+}
+
+internal interface IStudioMutationErrorReceiptTool : IStudioReceiptTool
+{
+}
+
+internal sealed class ListStudioTeamsTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioTeamQueryPort _teamQueryPort;
@@ -45,18 +103,11 @@ internal sealed class ListStudioTeamsTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.ArrayProperty("teams"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.ArrayProperty("teams"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -119,7 +170,7 @@ internal sealed class ListStudioTeamsTool : IAgentTool
         string? NextPageToken);
 }
 
-internal sealed class GetStudioTeamTool : IAgentTool
+internal sealed class GetStudioTeamTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioTeamQueryPort _teamQueryPort;
@@ -152,21 +203,14 @@ internal sealed class GetStudioTeamTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("team_id"),
-            StudioQueryToolJson.StringProperty("display_name"),
-            StudioQueryToolJson.StringProperty("lifecycle_stage"),
-            StudioQueryToolJson.StringProperty("team_url"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("team_id"),
+        StudioQueryToolJson.StringProperty("display_name"),
+        StudioQueryToolJson.StringProperty("lifecycle_stage"),
+        StudioQueryToolJson.StringProperty("team_url"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -222,7 +266,7 @@ internal sealed class GetStudioTeamTool : IAgentTool
         [property: JsonPropertyName("team_id")] string? TeamId);
 }
 
-internal sealed class ListStudioMembersTool : IAgentTool
+internal sealed class ListStudioMembersTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioMemberQueryPort _memberQueryPort;
@@ -262,18 +306,11 @@ internal sealed class ListStudioMembersTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.ArrayProperty("members"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.ArrayProperty("members"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -343,7 +380,7 @@ internal sealed class ListStudioMembersTool : IAgentTool
         string? NextPageToken);
 }
 
-internal sealed class GetStudioMemberTool : IAgentTool
+internal sealed class GetStudioMemberTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioMemberQueryPort _memberQueryPort;
@@ -377,22 +414,15 @@ internal sealed class GetStudioMemberTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.ObjectProperty("summary"),
-            StudioQueryToolJson.StringProperty("summary", "scope_id"),
-            StudioQueryToolJson.StringProperty("summary", "member_id"),
-            StudioQueryToolJson.StringProperty("summary", "display_name"),
-            StudioQueryToolJson.StringProperty("summary", "implementation_kind"),
-            StudioQueryToolJson.StringProperty("summary", "member_url"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.ObjectProperty("summary"),
+        StudioQueryToolJson.StringProperty("summary", "scope_id"),
+        StudioQueryToolJson.StringProperty("summary", "member_id"),
+        StudioQueryToolJson.StringProperty("summary", "display_name"),
+        StudioQueryToolJson.StringProperty("summary", "implementation_kind"),
+        StudioQueryToolJson.StringProperty("summary", "member_url"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -448,7 +478,7 @@ internal sealed class GetStudioMemberTool : IAgentTool
         [property: JsonPropertyName("member_id")] string? MemberId);
 }
 
-internal sealed class ListStudioSchedulesTool : IAgentTool
+internal sealed class ListStudioSchedulesTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioMemberAutomationQueryPort _schedules;
@@ -497,19 +527,12 @@ internal sealed class ListStudioSchedulesTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("team_id"),
-            StudioQueryToolJson.ArrayProperty("schedules"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("team_id"),
+        StudioQueryToolJson.ArrayProperty("schedules"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -597,7 +620,7 @@ internal sealed class ListStudioSchedulesTool : IAgentTool
         long? TotalCount);
 }
 
-internal sealed class GetStudioScheduleTool : IAgentTool
+internal sealed class GetStudioScheduleTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioMemberAutomationQueryPort _schedules;
@@ -638,23 +661,16 @@ internal sealed class GetStudioScheduleTool : IAgentTool
     public bool IsReadOnly => true;
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.StringProperty("team_id"),
-            StudioQueryToolJson.StringProperty("member_id"),
-            StudioQueryToolJson.StringProperty("schedule_id"),
-            StudioQueryToolJson.StringProperty("published_service_id"),
-            StudioQueryToolJson.StringProperty("schedule_cron"),
-            StudioQueryToolJson.StringProperty("schedule_timezone"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.StringProperty("team_id"),
+        StudioQueryToolJson.StringProperty("member_id"),
+        StudioQueryToolJson.StringProperty("schedule_id"),
+        StudioQueryToolJson.StringProperty("published_service_id"),
+        StudioQueryToolJson.StringProperty("schedule_cron"),
+        StudioQueryToolJson.StringProperty("schedule_timezone"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
@@ -768,7 +784,7 @@ internal static class StudioQueryToolJson
         string callId,
         string toolName,
         string resultJson,
-        params ResultPropertyRequirement[] resultRequirements)
+        IReadOnlyCollection<ResultPropertyRequirement> resultRequirements)
     {
         if (!TryParseObject(resultJson, out var document))
             return null;
@@ -843,7 +859,7 @@ internal static class StudioQueryToolJson
         string? successStatusPropertyName,
         string? successStatusValue,
         string subjectIdPropertyName,
-        params ResultPropertyRequirement[] resultRequirements) =>
+        IReadOnlyCollection<ResultPropertyRequirement> resultRequirements) =>
         CreateSuccessfulMutationResultReceipt(
             defaultToolName,
             sideEffectKind,

--- a/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioWorkflowQueryTools.cs
+++ b/src/Aevatar.AI.ToolProviders.StudioProvisioning/StudioWorkflowQueryTools.cs
@@ -7,7 +7,7 @@ using Aevatar.Studio.Application.Studio.Contracts;
 
 namespace Aevatar.AI.ToolProviders.StudioProvisioning;
 
-internal sealed class ListStudioWorkflowsTool : IAgentTool
+internal sealed class ListStudioWorkflowsTool : IStudioReadOnlyReceiptTool
 {
     private static readonly JsonSerializerOptions s_jsonOptions = StudioQueryToolJson.Options;
     private readonly IStudioMemberQueryPort _memberQueryPort;
@@ -48,18 +48,11 @@ internal sealed class ListStudioWorkflowsTool : IAgentTool
 
     public bool IsDestructive => false;
 
-    public AgentToolReceipt? CreateResultReceipt(
-        string callId,
-        string toolName,
-        string argumentsJson,
-        string resultJson) =>
-        StudioQueryToolJson.CreateReadOnlyResultReceipt(
-            Name,
-            callId,
-            toolName,
-            resultJson,
-            StudioQueryToolJson.StringProperty("scope_id"),
-            StudioQueryToolJson.ArrayProperty("workflows"));
+    public IReadOnlyList<StudioQueryToolJson.ResultPropertyRequirement> ResultRequirements { get; } = new[]
+    {
+        StudioQueryToolJson.StringProperty("scope_id"),
+        StudioQueryToolJson.ArrayProperty("workflows"),
+    };
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -3197,6 +3197,42 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
+    public async Task ObserveRun_WorkflowCurrentState_ThroughStreamingExecutor_ShouldKeepVerifiedReadResult()
+    {
+        var harness = new Harness();
+        harness.WorkflowQuery.Snapshot = new WorkflowActorSnapshot
+        {
+            ActorId = "workflow-actor",
+            LastCommandId = "workflow-command",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+            StateVersion = 9,
+            LastOutput = "done",
+        };
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-workflow-executor");
+        var result = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "call-observe-workflow-executor",
+            "aevatar_observe_run",
+            """
+            {
+              "workflow_current_state": {
+                "actor_id": "workflow-actor",
+                "command_id": "workflow-command"
+              }
+            }
+            """);
+
+        result.Result.Should().Contain("\"run_id\":\"workflow-command\"");
+        result.Result.Should().Contain("\"status\":\"Completed\"");
+        result.Result.Should().NotContain("tool outcome could not be verified");
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        result.Receipt.SubjectId.Should().Be("workflow-command");
+    }
+
+    [Fact]
     public async Task ObserveRun_WorkflowCurrentState_WhenCommandIdIsOmitted_ShouldReturnSnapshotCommandId()
     {
         var harness = new Harness();
@@ -3372,6 +3408,37 @@ public sealed class AevatarInvocationToolSourceTests
         result.GetProperty("status").GetString().Should().Be(nameof(WorkflowRunCompletionStatus.Completed));
         result.GetProperty("final_output").GetString().Should().Be("Dinner is ready.");
         result.GetProperty("summary").GetProperty("completed_steps").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ReadWorkflowRunArtifact_Report_ThroughStreamingExecutor_ShouldKeepVerifiedReadResult()
+    {
+        var harness = new Harness();
+        harness.WorkflowQuery.Report = new WorkflowRunReport
+        {
+            RootActorId = "workflow-run-actor",
+            WorkflowName = "invoice-pdf-extraction-workflow",
+            CommandId = "run-1",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+            StateVersion = 17,
+            Success = true,
+            FinalOutput = "{\"document_type\":\"receipt\"}",
+        };
+        var tool = await harness.DiscoverToolAsync("aevatar_read_workflow_run_artifact");
+
+        var result = await ExecuteToolThroughExecutorAsync(
+            tool,
+            "call-read-workflow-artifact-executor",
+            "aevatar_read_workflow_run_artifact",
+            """{"workflow_run_id":"run-1"}""");
+
+        result.Result.Should().Contain("\"workflow_run_id\":\"run-1\"");
+        result.Result.Should().Contain("\"artifact\":\"report\"");
+        result.Result.Should().Contain("document_type");
+        result.Result.Should().NotContain("tool outcome could not be verified");
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        result.Receipt.SubjectId.Should().Be("run-1");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Verify accepted/streaming Aevatar invocation ACKs so the executor preserves workflow start/member invocation output.
- Add verified read receipts for workflow run observation and artifact reads so second-hop workflow status/result reads are not replaced with unknown.
- Centralize Studio provisioning receipt creation behind read-only/mutation/error-only receipt contracts while keeping draft-save ACKs non-terminal.

## Test plan
- [x] dotnet test /private/tmp/aevatar-3098-fix/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo
- [x] dotnet test /private/tmp/aevatar-3098-fix/test/Aevatar.AI.ToolProviders.StudioProvisioning.Tests/Aevatar.AI.ToolProviders.StudioProvisioning.Tests.csproj --nologo
- [x] git diff --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)