### PR TITLE
[Security][P0] Enforce workflow scope and member ownership

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Services/StudioAwareMemberPublishedServiceResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioAwareMemberPublishedServiceResolver.cs
@@ -19,9 +19,8 @@ namespace Aevatar.Studio.Application.Studio.Services;
 /// Resolution rule:
 ///   1. If the StudioMember authority knows about (scope, member), return its
 ///      stable <c>publishedServiceId</c> — this is the Studio-bound case.
-///   2. Otherwise fall through to the deterministic legacy mapping
-///      (<c>publishedServiceId == memberId</c>) so direct platform binds
-///      keep working unchanged.
+///   2. Missing member authority or a blank published service identity is an
+///      invalid normal-business state and fails closed.
 ///
 /// Registered with <c>Replace</c> in Studio's capability so Studio-enabled
 /// hosts use the member authority instead of the platform's deterministic
@@ -55,17 +54,24 @@ public sealed class StudioAwareMemberPublishedServiceResolver : IMemberPublished
         var normalizedMemberId = NormalizeMemberId(request.MemberId);
 
         var detail = await _memberQueryPort.GetAsync(normalizedScopeId, normalizedMemberId, ct);
+        if (detail == null)
+        {
+            throw new InvalidOperationException(
+                $"Member '{normalizedMemberId}' was not found in scope '{normalizedScopeId}'.");
+        }
+
         var publishedServiceId = detail?.Summary.PublishedServiceId;
-        var hasAuthorityBackedServiceId = !string.IsNullOrWhiteSpace(publishedServiceId);
-        var resolvedServiceId = hasAuthorityBackedServiceId
-            ? publishedServiceId!
-            : normalizedMemberId;  // legacy deterministic mapping for direct platform binds
+        if (string.IsNullOrWhiteSpace(publishedServiceId))
+        {
+            throw new InvalidOperationException(
+                $"Member '{normalizedMemberId}' has no published service in scope '{normalizedScopeId}'.");
+        }
 
         return new MemberPublishedServiceResolution(
             normalizedScopeId,
             normalizedMemberId,
-            resolvedServiceId,
-            hasAuthorityBackedServiceId);
+            publishedServiceId.Trim(),
+            IsMemberAuthorityBacked: true);
     }
 
     private static string NormalizeRequired(string? value, string fieldName)

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1,7 +1,10 @@
+using System.Text.Json;
+using Aevatar.AGUI.Contracts;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Audit;
 using Aevatar.Audit.Hosting.EndpointAudit;
+using Aevatar.Capabilities;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
@@ -19,24 +22,21 @@ using Aevatar.GAgentService.Application.Workflows;
 using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
-using Aevatar.Capabilities;
+using Aevatar.GAgentService.Hosting.Serialization;
+using Aevatar.GAgentService.Hosting.Sse;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
-using Aevatar.GAgentService.Hosting.Serialization;
-using Aevatar.AGUI.Contracts;
-using Aevatar.GAgentService.Hosting.Sse;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Text.Json;
 using WorkflowSagaStatus = Aevatar.Workflow.Abstractions.WorkflowSagaStatus;
 
 namespace Aevatar.GAgentService.Hosting.Endpoints;
@@ -488,7 +488,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -834,7 +834,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+            if (await TryWriteMemberRouteAccessDeniedAsync(http, scopeId, memberId, ct))
                 return;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -886,7 +886,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1246,7 +1246,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1325,7 +1325,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1380,7 +1380,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1447,7 +1447,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1490,7 +1490,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1533,7 +1533,7 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
@@ -1576,11 +1576,8 @@ public static class ScopeServiceEndpoints
     {
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (TryCreateMemberRouteAccessDeniedResult(http, scopeId, memberId, out var denied))
                 return denied;
-
-            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
-                return memberDenied;
 
             var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
                 new MemberPublishedServiceResolveRequest(scopeId, memberId),
@@ -4265,6 +4262,30 @@ const response = await fetch("{{invokePath}}", {
 
     private static string BuildScopeServiceRunNotFoundMessage(string scopeId, string serviceId, string runId) =>
         $"Run '{runId}' was not found on service '{serviceId}' in scope '{scopeId}'.";
+
+    private static bool TryCreateMemberRouteAccessDeniedResult(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        out IResult denied)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out denied))
+            return true;
+
+        return AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out denied);
+    }
+
+    private static async Task<bool> TryWriteMemberRouteAccessDeniedAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        CancellationToken ct)
+    {
+        if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+            return true;
+
+        return await AevatarMemberAccessGuard.TryWriteMemberAccessDeniedAsync(http, memberId, ct);
+    }
 
     private static async Task WriteJsonErrorResponseAsync(
         HttpContext http,

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/IWorkflowExecutionScopeQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/IWorkflowExecutionScopeQueryApplicationService.cs
@@ -1,0 +1,32 @@
+using Aevatar.Workflow.Application.Abstractions.Projections;
+
+namespace Aevatar.Workflow.Application.Abstractions.Queries;
+
+public interface IWorkflowExecutionScopeQueryApplicationService
+{
+    Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
+        string scopeId,
+        string actorId,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<WorkflowRunTimelineExportItem>?> ListWorkflowRunTimelineExportAsync(
+        string scopeId,
+        string workflowRunId,
+        int take = 200,
+        CancellationToken ct = default);
+
+    Task<IReadOnlyList<WorkflowRunGraphExportEdge>?> ListWorkflowRunGraphExportEdgesAsync(
+        string scopeId,
+        string workflowRunId,
+        int take = 200,
+        WorkflowRunGraphExportQueryOptions? options = null,
+        CancellationToken ct = default);
+
+    Task<WorkflowRunGraphExportSubgraph?> GetWorkflowRunGraphExportSubgraphAsync(
+        string scopeId,
+        string workflowRunId,
+        int depth = 2,
+        int take = 200,
+        WorkflowRunGraphExportQueryOptions? options = null,
+        CancellationToken ct = default);
+}

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
@@ -130,7 +130,8 @@ public sealed record WorkflowActorBinding(
 public sealed record WorkflowRunBindingQuery(
     string ScopeId,
     IReadOnlyList<string> DefinitionActorIds,
-    int Take = 50);
+    int Take = 50,
+    IReadOnlyList<string>? RunIds = null);
 
 public sealed record WorkflowRunForkSeedView(
     string SourceRunId,
@@ -212,6 +213,7 @@ public interface IWorkflowRunBindingReader
 public interface IWorkflowRunForkSeedQueryPort
 {
     Task<WorkflowRunForkSeedView?> GetForkSeedAsync(
+        string scopeId,
         string runId,
         CancellationToken ct = default);
 }

--- a/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,15 +4,16 @@ using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Core.Commands;
 using Aevatar.CQRS.Core.Interactions;
 using Aevatar.CQRS.Core.Streaming;
+using Aevatar.Foundation.Abstractions.EventSourcing;
+using Aevatar.Workflow.Application.Abstractions.ExternalCapabilities;
 using Aevatar.Workflow.Application.Abstractions.Observatory;
-using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Projections;
+using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.RunForks;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Abstractions.Schedules;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
-using Aevatar.Workflow.Application.Abstractions.ExternalCapabilities;
 using Aevatar.Workflow.Application.ExternalCapabilities;
 using Aevatar.Workflow.Application.Observatory;
 using Aevatar.Workflow.Application.Queries;
@@ -21,7 +22,6 @@ using Aevatar.Workflow.Application.RunForks;
 using Aevatar.Workflow.Application.Runs;
 using Aevatar.Workflow.Application.Schedules;
 using Aevatar.Workflow.Application.Workflows;
-using Aevatar.Foundation.Abstractions.EventSourcing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -168,7 +168,11 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<RegistryBackedWorkflowCatalogPort>());
         services.TryAddSingleton<IWorkflowCapabilitiesPort>(sp =>
             sp.GetRequiredService<RegistryBackedWorkflowCatalogPort>());
-        services.AddSingleton<IWorkflowExecutionQueryApplicationService, WorkflowExecutionQueryApplicationService>();
+        services.AddSingleton<WorkflowExecutionQueryApplicationService>();
+        services.AddSingleton<IWorkflowExecutionQueryApplicationService>(sp =>
+            sp.GetRequiredService<WorkflowExecutionQueryApplicationService>());
+        services.AddSingleton<IWorkflowExecutionScopeQueryApplicationService>(sp =>
+            sp.GetRequiredService<WorkflowExecutionQueryApplicationService>());
         // 06-19-workflow-run-observatory (C2): scope-enforcement seam for the read-only run viewer.
         // 06-20-observatory-admin-cross-scope (G3): one instance backs both the scope-bound reads and the
         // separate cross-scope admin query contract.

--- a/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
@@ -4,7 +4,9 @@ using Aevatar.Workflow.Application.Abstractions.Workflows;
 
 namespace Aevatar.Workflow.Application.Queries;
 
-public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutionQueryApplicationService
+public sealed class WorkflowExecutionQueryApplicationService :
+    IWorkflowExecutionQueryApplicationService,
+    IWorkflowExecutionScopeQueryApplicationService
 {
     private readonly IWorkflowDefinitionCatalog _workflowRegistry;
     private readonly IWorkflowExecutionCurrentStateQueryPort _currentStateQueryPort;
@@ -131,5 +133,80 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
             };
 
         return await _artifactQueryPort.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, options, ct);
+    }
+
+    public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
+        string scopeId,
+        string actorId,
+        CancellationToken ct = default) =>
+        ResolveOwnedCurrentStateAsync(scopeId, actorId, ct);
+
+    public async Task<IReadOnlyList<WorkflowRunTimelineExportItem>?> ListWorkflowRunTimelineExportAsync(
+        string scopeId,
+        string workflowRunId,
+        int take = 200,
+        CancellationToken ct = default)
+    {
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled ||
+            await ResolveOwnedCurrentStateAsync(scopeId, workflowRunId, ct) == null)
+        {
+            return null;
+        }
+
+        return await _artifactQueryPort.ListWorkflowRunTimelineExportAsync(workflowRunId, take, ct);
+    }
+
+    public async Task<IReadOnlyList<WorkflowRunGraphExportEdge>?> ListWorkflowRunGraphExportEdgesAsync(
+        string scopeId,
+        string workflowRunId,
+        int take = 200,
+        WorkflowRunGraphExportQueryOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled ||
+            await ResolveOwnedCurrentStateAsync(scopeId, workflowRunId, ct) == null)
+        {
+            return null;
+        }
+
+        return await _artifactQueryPort.GetWorkflowRunGraphExportEdgesAsync(workflowRunId, take, options, ct);
+    }
+
+    public async Task<WorkflowRunGraphExportSubgraph?> GetWorkflowRunGraphExportSubgraphAsync(
+        string scopeId,
+        string workflowRunId,
+        int depth = 2,
+        int take = 200,
+        WorkflowRunGraphExportQueryOptions? options = null,
+        CancellationToken ct = default)
+    {
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled ||
+            await ResolveOwnedCurrentStateAsync(scopeId, workflowRunId, ct) == null)
+        {
+            return null;
+        }
+
+        return await _artifactQueryPort.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, options, ct);
+    }
+
+    private async Task<WorkflowActorSnapshot?> ResolveOwnedCurrentStateAsync(
+        string scopeId,
+        string actorId,
+        CancellationToken ct)
+    {
+        if (!WorkflowActorCurrentStateQueryEnabled ||
+            string.IsNullOrWhiteSpace(scopeId) ||
+            string.IsNullOrWhiteSpace(actorId))
+        {
+            return null;
+        }
+
+        var snapshot = await _currentStateQueryPort.GetWorkflowActorCurrentStateAsync(actorId, ct);
+        return snapshot != null && string.Equals(
+            snapshot.ScopeId?.Trim(),
+            scopeId.Trim(),
+            StringComparison.Ordinal)
+            ? snapshot
+            : null;
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowForkRunCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowForkRunCommandTargetResolver.cs
@@ -39,6 +39,7 @@ internal sealed class WorkflowForkRunCommandTargetResolver
 
         var sourceRunId = Normalize(command.SourceRunId);
         var startAtStepId = Normalize(command.StartAtStepId);
+        var scopeId = Normalize(command.ScopeId);
         if (WorkflowCallerCredentialTokens.IsInvalidCredentialSet(
                 command.CallerCredential?.BearerToken,
                 command.CallerCredential?.Kind ?? NyxIdCallerCredentialKind.Unspecified,
@@ -48,7 +49,7 @@ internal sealed class WorkflowForkRunCommandTargetResolver
                 WorkflowForkRunStartError.InvalidCallerCredential(sourceRunId, startAtStepId));
         }
 
-        var seedView = await _seedQueryPort.GetForkSeedAsync(sourceRunId, ct).ConfigureAwait(false);
+        var seedView = await _seedQueryPort.GetForkSeedAsync(scopeId, sourceRunId, ct).ConfigureAwait(false);
         if (seedView == null)
         {
             return CommandTargetResolution<WorkflowForkRunCommandTarget, WorkflowForkRunStartError>.Failure(
@@ -73,7 +74,6 @@ internal sealed class WorkflowForkRunCommandTargetResolver
         }
 
         WorkflowRunCreationReceipt creationReceipt;
-        var scopeId = ResolveScopeId(command.ScopeId, seedView.ScopeId);
         try
         {
             creationReceipt = await _runProvisioningPort.CreateRunAsync(
@@ -243,11 +243,6 @@ internal sealed class WorkflowForkRunCommandTargetResolver
         variables.TryGetValue("input", out var seedInput)
             ? seedInput ?? string.Empty
             : commandInput ?? string.Empty;
-
-    private static string ResolveScopeId(string? commandScopeId, string? sourceScopeId) =>
-        !string.IsNullOrWhiteSpace(commandScopeId)
-            ? commandScopeId.Trim()
-            : sourceScopeId?.Trim() ?? string.Empty;
 
     private static WorkflowStepIdempotencyView? ResolveStartStepIdempotency(
         WorkflowRunForkSeedView seedView,

--- a/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowForkRunCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/RunForks/WorkflowForkRunCommandTargetResolver.cs
@@ -56,6 +56,13 @@ internal sealed class WorkflowForkRunCommandTargetResolver
                 WorkflowForkRunStartError.SourceRunNotFound(sourceRunId));
         }
 
+        if (!string.IsNullOrWhiteSpace(scopeId) &&
+            !string.Equals(scopeId, Normalize(seedView.ScopeId), StringComparison.Ordinal))
+        {
+            return CommandTargetResolution<WorkflowForkRunCommandTarget, WorkflowForkRunStartError>.Failure(
+                WorkflowForkRunStartError.SourceRunNotFound(sourceRunId));
+        }
+
         if (!IsTerminal(seedView.Status))
         {
             return CommandTargetResolution<WorkflowForkRunCommandTarget, WorkflowForkRunStartError>.Failure(

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatCapabilityModels.cs
@@ -1,6 +1,6 @@
-using Aevatar.AI.Abstractions.ToolProviders;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
 
@@ -284,7 +284,6 @@ public sealed record WorkflowForkRunInput
     public IDictionary<string, string>? InlineSubYamls { get; init; }
     public IDictionary<string, string>? VariableOverrides { get; init; }
     public string? Input { get; init; }
-    public string? ScopeId { get; init; }
     public string? CommandId { get; init; }
     public string? CorrelationId { get; init; }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -1,12 +1,12 @@
 using System.Net.WebSockets;
 using System.Text.Json;
-using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.RunForks;
 using Aevatar.Workflow.Application.Abstractions.Runs;
-using Aevatar.Workflow.Abstractions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
@@ -719,6 +719,13 @@ public static class WorkflowCapabilityEndpoints
                 return Results.BadRequest(new { error = "sourceRunId and startAtStepId are required." });
             }
 
+            if (http == null ||
+                !Aevatar.Capabilities.AevatarScopeAccessGuard.TryGetCallerScopeId(http, out var trustedScopeId))
+            {
+                scope.MarkResult(StatusCodes.Status401Unauthorized);
+                return Results.Unauthorized();
+            }
+
             var callerCredential = WorkflowCallerCredentialExtractor.Extract(http);
             if (!callerCredential.Succeeded)
             {
@@ -738,7 +745,7 @@ public static class WorkflowCapabilityEndpoints
                     input.Input,
                     NormalizeOptional(input.CommandId),
                     NormalizeOptional(input.CorrelationId),
-                    ScopeId: NormalizeOptional(input.ScopeId),
+                    ScopeId: trustedScopeId,
                     CallerCredential: callerCredential.Credential),
                 ct);
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
@@ -129,10 +129,14 @@ public static class ChatQueryEndpoints
     //   New principle: HTTP query exposes /workflow-actors/{actorId}/current-state as a readmodel resource.
     internal static async Task<IResult> GetWorkflowActorCurrentState(
         string actorId,
-        IWorkflowExecutionQueryApplicationService queryService,
+        HttpContext http,
+        IWorkflowExecutionScopeQueryApplicationService queryService,
         CancellationToken ct = default)
     {
-        var currentState = await queryService.GetWorkflowActorCurrentStateAsync(actorId, ct);
+        if (!Aevatar.Capabilities.AevatarScopeAccessGuard.TryGetCallerScopeId(http, out var scopeId))
+            return Results.Unauthorized();
+
+        var currentState = await queryService.GetWorkflowActorCurrentStateAsync(scopeId, actorId, ct);
         return currentState == null ? Results.NotFound() : Results.Ok(MapCurrentState(currentState));
     }
 
@@ -142,52 +146,97 @@ public static class ChatQueryEndpoints
     //   New pattern: workflow history/report/graph are artifacts or aggregate-owned views, not current-state readmodels.
     internal static async Task<IResult> ListWorkflowRunTimelineExport(
         string workflowRunId,
-        IWorkflowExecutionQueryApplicationService queryService,
+        HttpContext http,
+        IWorkflowExecutionScopeQueryApplicationService queryService,
         int take = 200,
         CancellationToken ct = default)
     {
-        var timeline = await queryService.ListWorkflowRunTimelineExportAsync(workflowRunId, take, ct);
+        if (!Aevatar.Capabilities.AevatarScopeAccessGuard.TryGetCallerScopeId(http, out var scopeId))
+            return Results.Unauthorized();
+
+        var timeline = await queryService.ListWorkflowRunTimelineExportAsync(scopeId, workflowRunId, take, ct);
+        if (timeline == null)
+            return Results.NotFound();
+
         return Results.Ok(timeline.Select(MapTimelineItem));
     }
 
     internal static async Task<IResult> ListWorkflowRunGraphExportEdges(
         string workflowRunId,
-        IWorkflowExecutionQueryApplicationService queryService,
+        HttpContext http,
+        IWorkflowExecutionScopeQueryApplicationService queryService,
         int take = 200,
         string? direction = null,
         string[]? edgeTypes = null,
         CancellationToken ct = default)
     {
+        if (!Aevatar.Capabilities.AevatarScopeAccessGuard.TryGetCallerScopeId(http, out var scopeId))
+            return Results.Unauthorized();
+
         var graphOptions = BuildGraphQueryOptions(direction, edgeTypes);
-        var edges = await queryService.ListWorkflowRunGraphExportEdgesAsync(workflowRunId, take, graphOptions, ct);
+        var edges = await queryService.ListWorkflowRunGraphExportEdgesAsync(
+            scopeId,
+            workflowRunId,
+            take,
+            graphOptions,
+            ct);
+        if (edges == null)
+            return Results.NotFound();
+
         return Results.Ok(edges.Select(MapGraphEdge));
     }
 
     internal static async Task<IResult> GetWorkflowRunGraphExportEnriched(
         string workflowRunId,
-        IWorkflowExecutionQueryApplicationService queryService,
+        HttpContext http,
+        IWorkflowExecutionScopeQueryApplicationService queryService,
         int depth = 2,
         int take = 200,
         string? direction = null,
         string[]? edgeTypes = null,
         CancellationToken ct = default)
     {
+        if (!Aevatar.Capabilities.AevatarScopeAccessGuard.TryGetCallerScopeId(http, out var scopeId))
+            return Results.Unauthorized();
+
         var graphOptions = BuildGraphQueryOptions(direction, edgeTypes);
-        var subgraph = await queryService.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, graphOptions, ct);
+        var subgraph = await queryService.GetWorkflowRunGraphExportSubgraphAsync(
+            scopeId,
+            workflowRunId,
+            depth,
+            take,
+            graphOptions,
+            ct);
+        if (subgraph == null)
+            return Results.NotFound();
+
         return Results.Ok(MapGraphSubgraph(subgraph));
     }
 
     internal static async Task<IResult> GetWorkflowRunGraphExportSubgraph(
         string workflowRunId,
-        IWorkflowExecutionQueryApplicationService queryService,
+        HttpContext http,
+        IWorkflowExecutionScopeQueryApplicationService queryService,
         int depth = 2,
         int take = 200,
         string? direction = null,
         string[]? edgeTypes = null,
         CancellationToken ct = default)
     {
+        if (!Aevatar.Capabilities.AevatarScopeAccessGuard.TryGetCallerScopeId(http, out var scopeId))
+            return Results.Unauthorized();
+
         var graphOptions = BuildGraphQueryOptions(direction, edgeTypes);
-        var subgraph = await queryService.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, graphOptions, ct);
+        var subgraph = await queryService.GetWorkflowRunGraphExportSubgraphAsync(
+            scopeId,
+            workflowRunId,
+            depth,
+            take,
+            graphOptions,
+            ct);
+        if (subgraph == null)
+            return Results.NotFound();
+
         return Results.Ok(MapGraphSubgraph(subgraph));
     }
 

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/ProjectionWorkflowActorBindingReader.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/ProjectionWorkflowActorBindingReader.cs
@@ -102,7 +102,12 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
             .Where(x => x.Length > 0)
             .Distinct(StringComparer.Ordinal)
             .ToArray();
-        if (definitionActorIds.Length == 0)
+        var runIds = (query.RunIds ?? [])
+            .Select(x => x?.Trim() ?? string.Empty)
+            .Where(x => x.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (definitionActorIds.Length == 0 && runIds.Length == 0)
             return [];
 
         var boundedTake = Math.Clamp(query.Take, 1, 200);
@@ -125,16 +130,29 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
             });
         }
 
-        filters.Add(new ProjectionDocumentFilter
+        if (definitionActorIds.Length > 0)
         {
-            FieldPath = nameof(WorkflowActorBindingDocument.DefinitionActorId),
-            Operator = definitionActorIds.Length == 1
-                ? ProjectionDocumentFilterOperator.Eq
-                : ProjectionDocumentFilterOperator.In,
-            Value = definitionActorIds.Length == 1
-                ? ProjectionDocumentValue.FromString(definitionActorIds[0])
-                : ProjectionDocumentValue.FromStrings(definitionActorIds),
-        });
+            filters.Add(new ProjectionDocumentFilter
+            {
+                FieldPath = nameof(WorkflowActorBindingDocument.DefinitionActorId),
+                Operator = definitionActorIds.Length == 1
+                    ? ProjectionDocumentFilterOperator.Eq
+                    : ProjectionDocumentFilterOperator.In,
+                Value = definitionActorIds.Length == 1
+                    ? ProjectionDocumentValue.FromString(definitionActorIds[0])
+                    : ProjectionDocumentValue.FromStrings(definitionActorIds),
+            });
+        }
+
+        if (runIds.Length > 0)
+        {
+            filters.Add(new ProjectionDocumentFilter
+            {
+                FieldPath = nameof(WorkflowActorBindingDocument.RunId),
+                Operator = ProjectionDocumentFilterOperator.In,
+                Value = ProjectionDocumentValue.FromStrings(runIds),
+            });
+        }
 
         var result = await _queryDocumentsAsync(
             new ProjectionDocumentQuery

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowRunForkSeedQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowRunForkSeedQueryPort.cs
@@ -26,21 +26,32 @@ public sealed class WorkflowRunForkSeedQueryPort : IWorkflowRunForkSeedQueryPort
     }
 
     public async Task<WorkflowRunForkSeedView?> GetForkSeedAsync(
+        string scopeId,
         string runId,
         CancellationToken ct = default)
     {
-        if (!_queryEnabled || string.IsNullOrWhiteSpace(runId))
+        if (!_queryEnabled || string.IsNullOrWhiteSpace(scopeId) || string.IsNullOrWhiteSpace(runId))
             return null;
 
+        var normalizedScopeId = scopeId.Trim();
         var normalizedRunId = WorkflowRunIdNormalizer.Normalize(runId);
-        var bindings = await _runBindingReader.ListByRunIdAsync(normalizedRunId, take: 20, ct);
+        var bindings = await _runBindingReader.QueryAsync(
+            new WorkflowRunBindingQuery(
+                normalizedScopeId,
+                [],
+                Take: 20,
+                RunIds: [normalizedRunId]),
+            ct);
         foreach (var binding in bindings)
         {
-            if (binding.ActorKind != WorkflowActorKind.Run || string.IsNullOrWhiteSpace(binding.ActorId))
+            if (binding.ActorKind != WorkflowActorKind.Run ||
+                string.IsNullOrWhiteSpace(binding.ActorId) ||
+                !string.Equals(binding.ScopeId?.Trim(), normalizedScopeId, StringComparison.Ordinal))
                 continue;
 
             var currentState = await _currentStateReader.GetAsync(binding.ActorId, ct);
-            if (currentState == null)
+            if (currentState == null ||
+                !string.Equals(currentState.ScopeId?.Trim(), normalizedScopeId, StringComparison.Ordinal))
                 continue;
 
             return _mapper.ToSeedView(currentState);

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceCatalogEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceCatalogEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text.Json;
+using Aevatar.AGUI.Contracts;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -10,23 +11,22 @@ using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
-using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.ScopeScripts;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Application.Workflows;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Scripting.Abstractions.Queries;
-using Aevatar.AGUI.Contracts;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -35,10 +35,10 @@ using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -396,12 +396,12 @@ public sealed class ScopeServiceCatalogEndpointTests : ScopeServiceEndpointTestK
     }
 
     [Fact]
-    public async Task GetMemberPublishedServiceEndpoint_ShouldAllowDifferentAuthenticatedMemberInSameScope()
+    public async Task GetMemberPublishedServiceEndpoint_ShouldAllowMatchingAuthenticatedMember()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/published-service");
         request.Headers.Add("X-Test-Scope-Id", "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var response = await host.Client.SendAsync(request);
         var body = await response.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberPublishedServiceHttpResponse>();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceInvocationEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceInvocationEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text.Json;
+using Aevatar.AGUI.Contracts;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -10,23 +11,22 @@ using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
-using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.ScopeScripts;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Application.Workflows;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Scripting.Abstractions.Queries;
-using Aevatar.AGUI.Contracts;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -35,10 +35,10 @@ using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -168,7 +168,7 @@ public sealed class ScopeServiceInvocationEndpointTests : ScopeServiceEndpointTe
                 payloadBase64 = "",
             },
             "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var response = await host.Client.SendAsync(request);
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceMemberAccessEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceMemberAccessEndpointTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Integration.Tests;
+
+[Collection(ScopeServiceEndpointCollection.Name)]
+public sealed class ScopeServiceMemberAccessEndpointTests : ScopeServiceEndpointTestKit
+{
+    [Theory]
+    [InlineData("GET", "/api/scopes/scope-alpha/members/m-alpha/published-service")]
+    [InlineData("POST", "/api/scopes/scope-alpha/members/m-alpha/invoke/chat")]
+    [InlineData("POST", "/api/scopes/scope-alpha/members/m-alpha/invoke/chat:stream")]
+    [InlineData("GET", "/api/scopes/scope-alpha/members/m-alpha/runs?take=5")]
+    [InlineData("GET", "/api/scopes/scope-alpha/members/m-alpha/runs/run-alpha")]
+    [InlineData("GET", "/api/scopes/scope-alpha/members/m-alpha/runs/run-alpha/audit")]
+    [InlineData("POST", "/api/scopes/scope-alpha/members/m-alpha/runs/run-alpha:resume")]
+    [InlineData("POST", "/api/scopes/scope-alpha/members/m-alpha/runs/run-alpha:signal")]
+    [InlineData("POST", "/api/scopes/scope-alpha/members/m-alpha/runs/run-alpha:stop")]
+    [InlineData("POST", "/api/scopes/scope-alpha/members/m-alpha/runs/run-alpha:retry-compensation")]
+    public async Task MemberFirstRoutes_ShouldRejectDifferentAuthenticatedMember(
+        string method,
+        string requestUri)
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var request = new HttpRequestMessage(new HttpMethod(method), requestUri);
+        if (string.Equals(method, "POST", StringComparison.Ordinal))
+            request.Content = JsonContent.Create(new { });
+        request.Headers.Add("X-Test-Scope-Id", "scope-alpha");
+        request.Headers.Add("X-Test-Member-Id", "m-attacker");
+
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        body.Should().Contain("MEMBER_ACCESS_DENIED");
+        host.MemberPublishedServiceResolver.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MemberFirstRoute_ShouldAllowScopeOwner()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            "/api/scopes/scope-alpha/members/m-alpha/published-service");
+        request.Headers.Add("X-Test-Scope-Id", "scope-alpha");
+        request.Headers.Add("X-Test-Member-Id", "m-attacker");
+        request.Headers.Add("X-Test-Role", "owner");
+
+        var response = await host.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.MemberPublishedServiceResolver.Calls.Should().ContainSingle();
+    }
+}

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceRunQueryEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
+using Aevatar.AGUI.Contracts;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -9,23 +10,22 @@ using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
-using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.ScopeScripts;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Application.Workflows;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Scripting.Abstractions.Queries;
-using Aevatar.AGUI.Contracts;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
@@ -35,10 +35,10 @@ using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -207,7 +207,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/runs?take=5");
         request.Headers.Add("X-Test-Scope-Id", "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var httpResponse = await host.Client.SendAsync(request);
         var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunCatalogHttpResponse>();
@@ -271,7 +271,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/runs/run-member-detail-1");
         request.Headers.Add("X-Test-Scope-Id", "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var httpResponse = await host.Client.SendAsync(request);
         var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunSummaryHttpResponse>();
@@ -353,7 +353,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
 
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/runs/run-member-audit-1/audit");
         request.Headers.Add("X-Test-Scope-Id", "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var httpResponse = await host.Client.SendAsync(request);
         var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunAuditHttpResponse>();
@@ -401,7 +401,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
                 },
             },
             "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var response = await host.Client.SendAsync(request);
 
@@ -444,7 +444,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
                 stepId = "wait-1",
             },
             "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var response = await host.Client.SendAsync(request);
 
@@ -482,7 +482,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
                 reason = "manual",
             },
             "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var response = await host.Client.SendAsync(request);
 
@@ -661,7 +661,7 @@ public sealed class ScopeServiceRunQueryEndpointTests : ScopeServiceEndpointTest
             HttpMethod.Get,
             "/api/scopes/scope-a/members/member-a/runs?take=1&scheduleId=schedule-member&status=Completed&updatedFrom=2026-04-27T00:30:00Z&updatedTo=2026-04-27T01:30:00Z");
         request.Headers.Add("X-Test-Scope-Id", "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "other-member");
+        request.Headers.Add("X-Test-Member-Id", "member-a");
 
         var httpResponse = await host.Client.SendAsync(request);
         var response = await httpResponse.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunCatalogHttpResponse>();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text.Json;
+using Aevatar.AGUI.Contracts;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
@@ -10,23 +11,22 @@ using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
-using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Abstractions.ScopeScripts;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Application.Workflows;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Scripting.Abstractions.Queries;
-using Aevatar.AGUI.Contracts;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -35,10 +35,10 @@ using Google.Protobuf;
 using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -928,7 +928,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
                 headers = new Dictionary<string, string> { ["channel"] = "member-tests" },
             },
             "scope-a");
-        request.Headers.Add("X-Test-Member-Id", "member-b");
+        request.Headers.Add("X-Test-Member-Id", "m-alpha");
 
         var response = await host.Client.SendAsync(request);
         var body = await response.Content.ReadAsStringAsync();
@@ -1018,6 +1018,7 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
                 prompt = "   ",
             },
             "scope-a");
+        request.Headers.Add("X-Test-Member-Id", "m-alpha");
 
         var response = await host.Client.SendAsync(request);
         var body = await response.Content.ReadAsStringAsync();

--- a/test/Aevatar.Studio.Tests/StudioAwareMemberPublishedServiceResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioAwareMemberPublishedServiceResolverTests.cs
@@ -12,9 +12,8 @@ namespace Aevatar.Studio.Tests;
 ///   - Studio members → return the actor-stored <c>publishedServiceId</c>
 ///     (e.g. <c>"member-{memberId}"</c>) so platform invoke / runs / binding
 ///     routes target the same service Studio's bind path wrote.
-///   - Non-Studio members → fall through to the legacy deterministic
-///     mapping (<c>publishedServiceId == memberId</c>) so direct platform
-///     binds keep working unchanged.
+///   - Missing or incomplete member authority → fail closed instead of
+///     treating <c>memberId</c> as <c>publishedServiceId</c>.
 ///   - Malformed input (empty / contains separator chars) → fail fast with
 ///     the legacy validation rules.
 /// </summary>
@@ -44,20 +43,17 @@ public sealed class StudioAwareMemberPublishedServiceResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldFallBackToMemberId_WhenStudioMemberMissing()
+    public async Task ResolveAsync_ShouldFailClosed_WhenStudioMemberMissing()
     {
         var port = new InMemoryQueryPort(new Dictionary<(string, string), string>());
         var resolver = new StudioAwareMemberPublishedServiceResolver(port);
 
-        var result = await resolver.ResolveAsync(
-            new MemberPublishedServiceResolveRequest("scope-1", "legacy-member"),
+        var act = () => resolver.ResolveAsync(
+            new MemberPublishedServiceResolveRequest("scope-1", "m-alpha"),
             CancellationToken.None);
 
-        // Direct platform binds (no StudioMember actor) must preserve the
-        // legacy deterministic mapping; otherwise existing platform-only
-        // member-first calls would silently break under this resolver.
-        result.PublishedServiceId.Should().Be("legacy-member");
-        result.IsMemberAuthorityBacked.Should().BeFalse();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*m-alpha*not found*");
     }
 
     [Fact]
@@ -117,25 +113,20 @@ public sealed class StudioAwareMemberPublishedServiceResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_ShouldFallBack_WhenStudioMemberHasEmptyPublishedServiceId()
+    public async Task ResolveAsync_ShouldFailClosed_WhenStudioMemberHasEmptyPublishedServiceId()
     {
-        // Defensive: an authority record with a blank publishedServiceId is
-        // a backend invariant violation, but resolver shouldn't crash —
-        // it should degrade to the legacy mapping so the rest of the host
-        // keeps serving. The right place to surface the invariant violation
-        // is StudioMemberService, which the test there asserts.
         var port = new InMemoryQueryPort(new Dictionary<(string, string), string>
         {
-            [("scope-1", "m-abc")] = string.Empty,
+            [("scope-1", "m-alpha")] = string.Empty,
         });
         var resolver = new StudioAwareMemberPublishedServiceResolver(port);
 
-        var result = await resolver.ResolveAsync(
-            new MemberPublishedServiceResolveRequest("scope-1", "m-abc"),
+        var act = () => resolver.ResolveAsync(
+            new MemberPublishedServiceResolveRequest("scope-1", "m-alpha"),
             CancellationToken.None);
 
-        result.PublishedServiceId.Should().Be("m-abc");
-        result.IsMemberAuthorityBacked.Should().BeFalse();
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*m-alpha*published service*");
     }
 
     private sealed class InMemoryQueryPort : IStudioMemberQueryPort

--- a/test/Aevatar.Studio.Tests/StudioAwareMemberPublishedServiceResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioAwareMemberPublishedServiceResolverTests.cs
@@ -24,21 +24,18 @@ public sealed class StudioAwareMemberPublishedServiceResolverTests
     {
         var port = new InMemoryQueryPort(new Dictionary<(string, string), string>
         {
-            [("scope-1", "m-abc")] = "member-m-abc",
+            [("scope-1", "m-alpha")] = "svc-alpha",
         });
         var resolver = new StudioAwareMemberPublishedServiceResolver(port);
 
         var result = await resolver.ResolveAsync(
-            new MemberPublishedServiceResolveRequest("scope-1", "m-abc"),
+            new MemberPublishedServiceResolveRequest("scope-1", "m-alpha"),
             CancellationToken.None);
 
         result.ScopeId.Should().Be("scope-1");
-        result.MemberId.Should().Be("m-abc");
-        // The fix the inline review flagged: contract / activate / retire
-        // resolved at "member-m-abc"; if invoke kept resolving at "m-abc"
-        // the URL contract handed back to the frontend would 404 against
-        // its own binding.
-        result.PublishedServiceId.Should().Be("member-m-abc");
+        result.MemberId.Should().Be("m-alpha");
+        // Member, workflow, and published-service identities are intentionally distinct.
+        result.PublishedServiceId.Should().Be("svc-alpha");
         result.IsMemberAuthorityBacked.Should().BeTrue();
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
@@ -1,7 +1,7 @@
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
-using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Queries;
 using Aevatar.Workflow.Application.Workflows;
 using FluentAssertions;
@@ -126,6 +126,47 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
             "ListWorkflowRunTimelineExport:run-1:5",
             "GetWorkflowRunGraphExportEdges:run-1:7:Outbound:child",
             "GetWorkflowRunGraphExportSubgraph:run-1:3:9:Outbound:child");
+    }
+
+    [Fact]
+    public async Task ScopeBoundQueries_ShouldRejectMismatchedOwnerBeforeReadingArtifacts()
+    {
+        var calls = new List<string>();
+        var currentStatePort = new FakeCurrentStateQueryPort(calls)
+        {
+            WorkflowActorCurrentStateQueryEnabled = true,
+            SingleSnapshot = new WorkflowActorSnapshot
+            {
+                ActorId = "run-victim",
+                ScopeId = "victim-scope",
+            },
+        };
+        var service = new WorkflowExecutionQueryApplicationService(
+            new StaticWorkflowDefinitionCatalog([]),
+            currentStatePort,
+            new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = true },
+            new StaticWorkflowCatalogPort(),
+            new StaticWorkflowCapabilitiesPort());
+        IWorkflowExecutionScopeQueryApplicationService scopedService = service;
+
+        var currentState = await scopedService.GetWorkflowActorCurrentStateAsync(
+            "attacker-scope",
+            "run-victim");
+        var timeline = await scopedService.ListWorkflowRunTimelineExportAsync(
+            "attacker-scope",
+            "run-victim");
+        var edges = await scopedService.ListWorkflowRunGraphExportEdgesAsync(
+            "attacker-scope",
+            "run-victim");
+        var subgraph = await scopedService.GetWorkflowRunGraphExportSubgraphAsync(
+            "attacker-scope",
+            "run-victim");
+
+        currentState.Should().BeNull();
+        timeline.Should().BeNull();
+        edges.Should().BeNull();
+        subgraph.Should().BeNull();
+        calls.Should().OnlyContain(call => call == "GetWorkflowActorCurrentState:run-victim");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowForkRunCommandDispatchTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowForkRunCommandDispatchTests.cs
@@ -175,7 +175,8 @@ public sealed class WorkflowForkRunCommandDispatchTests
                     ["input"] = "seed-input",
                     ["topic"] = "seed-topic",
                     ["step-a"] = "alpha",
-                }),
+                },
+                scopeId: "scope-1"),
         };
         var runPort = new RecordingRunProvisioningPort();
         var dispatchPort = new RecordingActorDispatchPort();
@@ -226,7 +227,8 @@ public sealed class WorkflowForkRunCommandDispatchTests
                 idempotencyByStepId: new Dictionary<string, WorkflowStepIdempotencyView>(StringComparer.Ordinal)
                 {
                     ["step-b"] = new("source-run", "step-b", 2, "source-run:step-b:2"),
-                }),
+                },
+                scopeId: "scope-1"),
         };
         var runPort = new RecordingRunProvisioningPort();
         var dispatchPort = new RecordingActorDispatchPort();
@@ -293,7 +295,7 @@ public sealed class WorkflowForkRunCommandDispatchTests
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldNotReplaceTrustedCommandScopeWithSeedScope()
+    public async Task DispatchAsync_WhenSeedScopeDiffersFromTrustedCommandScope_ShouldFailClosed()
     {
         var seedPort = new RecordingSeedQueryPort
         {
@@ -308,10 +310,11 @@ public sealed class WorkflowForkRunCommandDispatchTests
             StartAtStepId: "step-b",
             ScopeId: "attacker-scope"));
 
-        result.Succeeded.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
+        result.Error.Code.Should().Be(WorkflowForkRunStartErrorCode.SourceRunNotFound);
         seedPort.RequestedScopeIds.Should().Equal("attacker-scope");
-        runPort.CreateRunBindings.Should().ContainSingle().Which.ScopeId.Should().Be("attacker-scope");
-        dispatchPort.DispatchedRequest().ScopeId.Should().Be("attacker-scope");
+        runPort.CreateRunBindings.Should().BeEmpty();
+        dispatchPort.Dispatches.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowForkRunCommandDispatchTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowForkRunCommandDispatchTests.cs
@@ -35,6 +35,7 @@ public sealed class WorkflowForkRunCommandDispatchTests
         result.Succeeded.Should().BeFalse();
         result.Error.Code.Should().Be(expectedCode);
         seedPort.RequestedRunIds.Should().Equal("source-run");
+        seedPort.RequestedScopeIds.Should().Equal(string.Empty);
         runPort.CreateRunBindings.Should().BeEmpty();
     }
 
@@ -190,9 +191,11 @@ public sealed class WorkflowForkRunCommandDispatchTests
             },
             Input: "command-input",
             CommandId: "cmd-fork",
-            CorrelationId: "corr-fork"));
+            CorrelationId: "corr-fork",
+            ScopeId: "scope-1"));
 
         result.Succeeded.Should().BeTrue();
+        seedPort.RequestedScopeIds.Should().Equal("scope-1");
         var request = dispatchPort.DispatchedRequest();
         request.ForkSeed.Variables["topic"].Should().Be("override-topic");
         request.ForkSeed.Variables["extra"].Should().Be("override-extra");
@@ -248,6 +251,7 @@ public sealed class WorkflowForkRunCommandDispatchTests
             CallerCredential: new WorkflowApplicationCallerCredential("typed-token")));
 
         result.Succeeded.Should().BeTrue();
+        seedPort.RequestedScopeIds.Should().Equal("scope-1");
         result.Receipt.Should().BeEquivalentTo(new
         {
             SourceRunId = "source-run",
@@ -289,7 +293,7 @@ public sealed class WorkflowForkRunCommandDispatchTests
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenCommandScopeMissing_ShouldInheritSourceScopeFromSeedReadModel()
+    public async Task DispatchAsync_ShouldNotReplaceTrustedCommandScopeWithSeedScope()
     {
         var seedPort = new RecordingSeedQueryPort
         {
@@ -301,11 +305,13 @@ public sealed class WorkflowForkRunCommandDispatchTests
 
         var result = await service.DispatchAsync(new WorkflowForkRunCommand(
             SourceRunId: "source-run",
-            StartAtStepId: "step-b"));
+            StartAtStepId: "step-b",
+            ScopeId: "attacker-scope"));
 
         result.Succeeded.Should().BeTrue();
-        runPort.CreateRunBindings.Should().ContainSingle().Which.ScopeId.Should().Be("source-scope-1");
-        dispatchPort.DispatchedRequest().ScopeId.Should().Be("source-scope-1");
+        seedPort.RequestedScopeIds.Should().Equal("attacker-scope");
+        runPort.CreateRunBindings.Should().ContainSingle().Which.ScopeId.Should().Be("attacker-scope");
+        dispatchPort.DispatchedRequest().ScopeId.Should().Be("attacker-scope");
     }
 
     [Fact]
@@ -416,13 +422,16 @@ public sealed class WorkflowForkRunCommandDispatchTests
     private sealed class RecordingSeedQueryPort : IWorkflowRunForkSeedQueryPort
     {
         public WorkflowRunForkSeedView? View { get; set; }
+        public List<string> RequestedScopeIds { get; } = [];
         public List<string> RequestedRunIds { get; } = [];
 
         public Task<WorkflowRunForkSeedView?> GetForkSeedAsync(
+            string scopeId,
             string runId,
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            RequestedScopeIds.Add(scopeId);
             RequestedRunIds.Add(runId);
             return Task.FromResult(View);
         }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunForkSeedQueryPortTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunForkSeedQueryPortTests.cs
@@ -89,13 +89,14 @@ public sealed class WorkflowRunForkSeedQueryPortTests
                 "run-failed",
                 "demo",
                 "name: demo\nsteps: []",
-                new Dictionary<string, string>(StringComparer.Ordinal)));
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-1"));
         var port = new WorkflowRunForkSeedQueryPort(
             currentStateReader,
             bindingReader,
             mapper);
 
-        var view = await port.GetForkSeedAsync("run-failed", CancellationToken.None);
+        var view = await port.GetForkSeedAsync("scope-1", "run-failed", CancellationToken.None);
 
         view.Should().NotBeNull();
         view!.Status.Should().Be("failed");
@@ -106,7 +107,9 @@ public sealed class WorkflowRunForkSeedQueryPortTests
         view.LastFailedStepId.Should().Be("step-failed");
         view.FinalError.Should().Be("step boom");
         view.ScopeId.Should().Be("scope-1");
-        bindingReader.RequestedRunIds.Should().ContainSingle().Which.Should().Be("run-failed");
+        bindingReader.LastQuery.Should().NotBeNull();
+        bindingReader.LastQuery!.ScopeId.Should().Be("scope-1");
+        bindingReader.LastQuery.RunIds.Should().Equal("run-failed");
         currentStateReader.GetKeys.Should().ContainSingle().Which.Should().Be("actor-run-failed");
     }
 
@@ -165,25 +168,23 @@ public sealed class WorkflowRunForkSeedQueryPortTests
     {
         private readonly IReadOnlyList<WorkflowActorBinding> _bindings = bindings;
 
-        public List<string> RequestedRunIds { get; } = [];
+        public WorkflowRunBindingQuery? LastQuery { get; private set; }
 
         public Task<IReadOnlyList<WorkflowActorBinding>> ListByRunIdAsync(
             string runId,
             int take = 20,
             CancellationToken ct = default)
         {
-            ct.ThrowIfCancellationRequested();
-            RequestedRunIds.Add(runId);
-            return Task.FromResult(_bindings);
+            throw new InvalidOperationException("Fork seed lookup must not use the global run-id query.");
         }
 
         public Task<IReadOnlyList<WorkflowActorBinding>> QueryAsync(
             WorkflowRunBindingQuery query,
             CancellationToken ct = default)
         {
-            _ = query;
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult<IReadOnlyList<WorkflowActorBinding>>([]);
+            LastQuery = query;
+            return Task.FromResult(_bindings);
         }
     }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunForkSeedQueryPortTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunForkSeedQueryPortTests.cs
@@ -113,6 +113,62 @@ public sealed class WorkflowRunForkSeedQueryPortTests
         currentStateReader.GetKeys.Should().ContainSingle().Which.Should().Be("actor-run-failed");
     }
 
+    [Fact]
+    public async Task GetForkSeedAsync_WhenBindingBelongsToVictimScope_ShouldReturnNullWithoutReadingCurrentState()
+    {
+        var currentStateReader = new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>();
+        var bindingReader = new FakeWorkflowRunBindingReader(
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "actor-victim-run",
+                "wf-alpha",
+                "victim-run",
+                "demo",
+                "name: demo\nsteps: []",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "victim-scope"));
+        var port = new WorkflowRunForkSeedQueryPort(
+            currentStateReader,
+            bindingReader,
+            new WorkflowRunForkSeedReadModelMapper());
+
+        var view = await port.GetForkSeedAsync("attacker-scope", "victim-run", CancellationToken.None);
+
+        view.Should().BeNull();
+        bindingReader.LastQuery.Should().NotBeNull();
+        bindingReader.LastQuery!.ScopeId.Should().Be("attacker-scope");
+        bindingReader.LastQuery.RunIds.Should().Equal("victim-run");
+        currentStateReader.GetKeys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetForkSeedAsync_WhenCurrentStateBelongsToVictimScope_ShouldReturnNull()
+    {
+        var victimState = BuildWorkflowRunState("victim-run", "failed", "step boom");
+        victimState.ScopeId = "victim-scope";
+        var mapper = new WorkflowRunForkSeedReadModelMapper();
+        var currentStateReader = new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>
+        {
+            Item = BuildDocument(victimState, mapper.ToProjectionSnapshot(victimState)),
+        };
+        var bindingReader = new FakeWorkflowRunBindingReader(
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "actor-victim-run",
+                "wf-alpha",
+                "victim-run",
+                "demo",
+                "name: demo\nsteps: []",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "attacker-scope"));
+        var port = new WorkflowRunForkSeedQueryPort(currentStateReader, bindingReader, mapper);
+
+        var view = await port.GetForkSeedAsync("attacker-scope", "victim-run", CancellationToken.None);
+
+        view.Should().BeNull();
+        currentStateReader.GetKeys.Should().ContainSingle().Which.Should().Be("actor-victim-run");
+    }
+
     private static WorkflowRunState BuildWorkflowRunState(
         string runId,
         string status,

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
 using Aevatar.Workflow.Abstractions;
@@ -12,7 +13,6 @@ using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
-using Aevatar.Foundation.Abstractions.Connectors;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
@@ -20,11 +20,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using ApplicationFileArtifactRef = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactRef;
 using ApplicationFileArtifactSourceKind = Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactSourceKind;
@@ -76,6 +76,8 @@ public sealed class ChatEndpointsInternalTests
                     new DateTimeOffset(2026, 6, 8, 0, 0, 0, TimeSpan.Zero))),
         };
 
+        var requestHttp = CreateHttpContext();
+        requestHttp.User = AuthenticatedScopePrincipal("attacker-scope");
         var result = await WorkflowCapabilityEndpoints.HandleForkRun(
             new WorkflowForkRunInput
             {
@@ -84,13 +86,13 @@ public sealed class ChatEndpointsInternalTests
                 Input = "resume input",
                 CommandId = " cmd-1 ",
                 CorrelationId = " corr-1 ",
-                ScopeId = " scope-1 ",
                 VariableOverrides = new Dictionary<string, string>
                 {
                     [" topic "] = "override",
                 },
             },
             service,
+            requestHttp,
             ct: CancellationToken.None);
 
         var http = CreateHttpContext();
@@ -101,12 +103,18 @@ public sealed class ChatEndpointsInternalTests
         var command = service.Commands[0];
         command.SourceRunId.Should().Be("source-run");
         command.StartAtStepId.Should().Be("step-b");
-        command.ScopeId.Should().Be("scope-1");
+        command.ScopeId.Should().Be("attacker-scope");
         command.VariableOverrides.Should().Contain("topic", "override");
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         body.Should().Contain("new-run-actor");
         body.Should().Contain("cmd-1");
         body.Should().Contain("corr-1");
+    }
+
+    [Fact]
+    public void WorkflowForkRunInput_ShouldNotExposeScopeId()
+    {
+        typeof(WorkflowForkRunInput).GetProperty("ScopeId").Should().BeNull();
     }
 
     [Fact]
@@ -125,6 +133,7 @@ public sealed class ChatEndpointsInternalTests
                 StartAtStepId = "step-b",
             },
             service,
+            CreateAuthenticatedScopeHttpContext("scope-1"),
             ct: CancellationToken.None);
 
         var http = CreateHttpContext();
@@ -2418,12 +2427,11 @@ public sealed class ChatEndpointsInternalTests
                     [" topic "] = "recovered",
                 },
                 Input = "resume input",
-                ScopeId = " scope-1 ",
                 CommandId = " cmd-1 ",
                 CorrelationId = " corr-1 ",
             },
             service,
-            CreateHttpContext("Bearer trusted-token"),
+            CreateAuthenticatedScopeHttpContext("scope-1", "Bearer trusted-token"),
             CancellationToken.None);
 
         var http = CreateHttpContext();
@@ -2460,7 +2468,7 @@ public sealed class ChatEndpointsInternalTests
                 StartAtStepId = "step-b",
             },
             service,
-            CreateHttpContext("Bearer token 123"),
+            CreateAuthenticatedScopeHttpContext("scope-1", "Bearer token 123"),
             CancellationToken.None);
 
         var http = CreateHttpContext();
@@ -2485,7 +2493,7 @@ public sealed class ChatEndpointsInternalTests
                 StartAtStepId = startAtStepId,
             },
             service,
-            null,
+            CreateAuthenticatedScopeHttpContext("scope-1"),
             CancellationToken.None);
 
         var http = CreateHttpContext();
@@ -2513,7 +2521,7 @@ public sealed class ChatEndpointsInternalTests
                 StartAtStepId = "missing-step",
             },
             service,
-            null,
+            CreateAuthenticatedScopeHttpContext("scope-1"),
             CancellationToken.None);
 
         var http = CreateHttpContext();
@@ -2523,6 +2531,28 @@ public sealed class ChatEndpointsInternalTests
         http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         body.Should().Contain("Start step 'missing-step' was not found");
         service.Commands.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleForkRun_ShouldRejectMissingTrustedScopeBeforeDispatch()
+    {
+        var service = new RecordingDispatchService<WorkflowForkRunCommand, WorkflowForkRunAcceptedReceipt, WorkflowForkRunStartError>();
+
+        var result = await WorkflowCapabilityEndpoints.HandleForkRun(
+            new WorkflowForkRunInput
+            {
+                SourceRunId = "source-run",
+                StartAtStepId = "step-b",
+            },
+            service,
+            CreateHttpContext(),
+            CancellationToken.None);
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        service.Commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -2606,6 +2636,15 @@ public sealed class ChatEndpointsInternalTests
         if (!string.IsNullOrWhiteSpace(authorization))
             http.Request.Headers.Authorization = authorization;
         http.Response.Body = new MemoryStream();
+        return http;
+    }
+
+    private static DefaultHttpContext CreateAuthenticatedScopeHttpContext(
+        string scopeId,
+        string? authorization = null)
+    {
+        var http = CreateHttpContext(authorization);
+        http.User = AuthenticatedScopePrincipal(scopeId);
         return http;
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatQueryEndpointsTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Aevatar.Capabilities;
@@ -8,15 +9,16 @@ using Aevatar.Workflow.Infrastructure.CapabilityApi;
 using Aevatar.Workflow.Projection.ReadModels;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
@@ -245,11 +247,31 @@ public sealed class ChatQueryEndpointsTests
     {
         var service = new FakeWorkflowExecutionQueryApplicationService();
 
-        var result = await ChatQueryEndpoints.GetWorkflowActorCurrentState("actor-1", service, CancellationToken.None);
+        var result = await ChatQueryEndpoints.GetWorkflowActorCurrentState(
+            "actor-1",
+            CreateAuthenticatedQueryContext(),
+            service,
+            CancellationToken.None);
 
         var http = await ExecuteWithContextAsync(result);
         http.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         service.Calls.Should().ContainSingle().Which.Should().Be("GetWorkflowActorCurrentState:actor-1");
+    }
+
+    [Fact]
+    public async Task GetWorkflowActorCurrentState_ShouldReturnUnauthorized_WhenCallerScopeMissing()
+    {
+        var service = new FakeWorkflowExecutionQueryApplicationService();
+
+        var result = await ChatQueryEndpoints.GetWorkflowActorCurrentState(
+            "actor-1",
+            CreateQueryContext(),
+            service,
+            CancellationToken.None);
+
+        var http = await ExecuteWithContextAsync(result);
+        http.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        service.Calls.Should().BeEmpty();
     }
 
     [Fact]
@@ -407,6 +429,7 @@ public sealed class ChatQueryEndpointsTests
 
         var edgesResult = await ChatQueryEndpoints.ListWorkflowRunGraphExportEdges(
             "actor-1",
+            CreateAuthenticatedQueryContext(),
             service,
             take: 12,
             direction: " outbound ",
@@ -414,6 +437,7 @@ public sealed class ChatQueryEndpointsTests
             ct: CancellationToken.None);
         var subgraphResult = await ChatQueryEndpoints.GetWorkflowRunGraphExportSubgraph(
             "actor-1",
+            CreateAuthenticatedQueryContext(),
             service,
             depth: 3,
             take: 8,
@@ -441,6 +465,7 @@ public sealed class ChatQueryEndpointsTests
 
         var result = await ChatQueryEndpoints.GetWorkflowRunGraphExportEnriched(
             "run-1",
+            CreateAuthenticatedQueryContext(),
             service,
             depth: 4,
             take: 9,
@@ -469,7 +494,12 @@ public sealed class ChatQueryEndpointsTests
             ],
         };
 
-        var timelineResult = await ChatQueryEndpoints.ListWorkflowRunTimelineExport("actor-1", service, 15, CancellationToken.None);
+        var timelineResult = await ChatQueryEndpoints.ListWorkflowRunTimelineExport(
+            "actor-1",
+            CreateAuthenticatedQueryContext(),
+            service,
+            15,
+            CancellationToken.None);
 
         (await ExecuteAsync(timelineResult)).Should().Contain("step-1");
         service.Calls.Should().Contain("ListWorkflowRunTimelineExport:actor-1:15");
@@ -571,6 +601,25 @@ public sealed class ChatQueryEndpointsTests
         return http;
     }
 
+    private static DefaultHttpContext CreateAuthenticatedQueryContext()
+    {
+        var http = CreateQueryContext();
+        http.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim("scope_id", "scope-alpha")],
+            authenticationType: "test"));
+        return http;
+    }
+
+    private static DefaultHttpContext CreateQueryContext() =>
+        new()
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .AddOptions()
+                .AddSingleton<IHostEnvironment>(new TestHostEnvironment())
+                .BuildServiceProvider(),
+        };
+
     private static async Task<string> ReadBodyAsync(HttpResponse response)
     {
         response.Body.Seek(0, SeekOrigin.Begin);
@@ -586,7 +635,15 @@ public sealed class ChatQueryEndpointsTests
         });
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         builder.Services.AddSingleton(service);
+        builder.Services.AddSingleton((IWorkflowExecutionScopeQueryApplicationService)service);
         var app = builder.Build();
+        app.Use(async (http, next) =>
+        {
+            http.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim("scope_id", "scope-alpha")],
+                authenticationType: "test"));
+            await next();
+        });
         ChatQueryEndpoints.Map(app.MapGroup("/api"));
         await app.StartAsync();
         return app;
@@ -652,7 +709,9 @@ public sealed class ChatQueryEndpointsTests
             "aevatar-mainnet-workflow-execution-current-states-v6c660705",
             "aevatar-mainnet-workflow-execution-current-states-vddd647dc");
 
-    private sealed class FakeWorkflowExecutionQueryApplicationService : IWorkflowExecutionQueryApplicationService
+    private sealed class FakeWorkflowExecutionQueryApplicationService :
+        IWorkflowExecutionQueryApplicationService,
+        IWorkflowExecutionScopeQueryApplicationService
     {
         public bool WorkflowActorCurrentStateQueryEnabled => true;
         public IReadOnlyList<WorkflowAgentSummary> Agents { get; init; } = [];
@@ -745,6 +804,45 @@ public sealed class ChatQueryEndpointsTests
             Calls.Add($"GetWorkflowRunGraphExportSubgraph:{actorId}:{depth}:{take}:{options?.Direction}:{string.Join(",", options?.EdgeTypes ?? [])}");
             return Task.FromResult(GraphSubgraph);
         }
+
+        public Task<WorkflowActorSnapshot?> GetWorkflowActorCurrentStateAsync(
+            string scopeId,
+            string actorId,
+            CancellationToken ct = default) =>
+            GetWorkflowActorCurrentStateAsync(actorId, ct);
+
+        public async Task<IReadOnlyList<WorkflowRunTimelineExportItem>?> ListWorkflowRunTimelineExportAsync(
+            string scopeId,
+            string workflowRunId,
+            int take = 200,
+            CancellationToken ct = default) =>
+            await ListWorkflowRunTimelineExportAsync(workflowRunId, take, ct);
+
+        public async Task<IReadOnlyList<WorkflowRunGraphExportEdge>?> ListWorkflowRunGraphExportEdgesAsync(
+            string scopeId,
+            string workflowRunId,
+            int take = 200,
+            WorkflowRunGraphExportQueryOptions? options = null,
+            CancellationToken ct = default) =>
+            await ListWorkflowRunGraphExportEdgesAsync(workflowRunId, take, options, ct);
+
+        public async Task<WorkflowRunGraphExportSubgraph?> GetWorkflowRunGraphExportSubgraphAsync(
+            string scopeId,
+            string workflowRunId,
+            int depth = 2,
+            int take = 200,
+            WorkflowRunGraphExportQueryOptions? options = null,
+            CancellationToken ct = default) =>
+            await GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, options, ct);
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = nameof(ChatQueryEndpointsTests);
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
     }
 
     private sealed class FakeWorkflowExecutionCurrentStateIndexProbe

--- a/test/Aevatar.Workflow.Host.Api.Tests/RuntimeWorkflowActorBindingReaderTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/RuntimeWorkflowActorBindingReaderTests.cs
@@ -157,6 +157,9 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
                 query.Filters.Should().Contain(filter =>
                     filter.FieldPath == nameof(WorkflowActorBindingDocument.DefinitionActorId) &&
                     filter.Operator == ProjectionDocumentFilterOperator.In);
+                query.Filters.Should().Contain(filter =>
+                    filter.FieldPath == nameof(WorkflowActorBindingDocument.RunId) &&
+                    filter.Operator == ProjectionDocumentFilterOperator.In);
 
                 return Task.FromResult(new ProjectionDocumentQueryResult<WorkflowActorBindingDocument>
                 {
@@ -178,7 +181,8 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
             new WorkflowRunBindingQuery(
                 " scope-1 ",
                 ["definition-1", "definition-2", "definition-1", " "],
-                Take: 500),
+                Take: 500,
+                RunIds: ["run-2", "run-2", " "]),
             CancellationToken.None);
 
         result.Should().ContainSingle();


### PR DESCRIPTION
## 问题与方案

Workflow legacy run 查询与 fork 仅认证调用方，未校验目标资源 scope；同 scope 的 member-first 路由也缺少统一 member authority 校验，Studio resolver 还会把未解析的 memberId 当作 publishedServiceId。

本 PR：
- legacy current-state/timeline/graph/fork 只使用 principal 派生的可信 scope，并在 Application query、binding、current-state 和 fork resolver 边界 fail closed；
- 删除 fork body 的 scope 输入以及全局 runId seed lookup，禁止跨 scope re-home；
- 10 条 member-first read/invoke/control 路由统一执行 scope guard + member guard，保留 owner/admin 权限；
- 删除 Studio memberId 到 publishedServiceId 的正常业务 fallback；
- 使用 m-alpha、wf-alpha、svc-alpha 及 attacker/victim scopes 补齐回归测试。

Closes #3040

## 影响路径

- Workflow Application / Projection：legacy query 与 fork seed ownership
- Workflow Host API：principal scope 提取与 legacy endpoint 授权
- GAgentService Hosting：member-first route authorization
- Studio Application：published service identity resolution
- 对应 unit/integration tests 与 DI registration tests

## 验证

- `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --no-restore --nologo --verbosity minimal`：544/544
- Studio resolver tests：13/13
- member-first route integration tests：11/11
- `bash tools/ci/test_stability_guards.sh`：通过
- `bash tools/ci/workflow_binding_boundary_guard.sh`：通过
- `bash tools/ci/query_projection_priming_guard.sh`：通过
- projection version/mirror guards：通过
- `bash tools/ci/architecture_guards.sh`：通过
- `dotnet build aevatar.slnx --no-restore --nologo --verbosity minimal`：0 errors
- `dotnet test aevatar.slnx --no-restore --no-build --nologo --verbosity minimal`：通过
- 独立 review：Critical 0 / Important 0 / Minor 0，Ready to merge
