### PR TITLE
Carry admitted streaming tool identity

### DIFF
--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -1066,6 +1066,7 @@ public sealed class ChatRuntime
                 ? new StreamingToolCallAccumulator(toolCall => completedToolCalls.Enqueue(toolCall))
                 : new StreamingToolCallAccumulator();
 
+            using var toolContextScope = AgentToolContextScope.Push(authorizedToolContext);
             await using var providerEnumerator = provider.ChatStreamAsync(llmCallContext.Request, ct)
                 .GetAsyncEnumerator(ct);
             while (true)

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -1073,7 +1073,10 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
             : null;
         var streamCt = timeoutCts?.Token ?? CancellationToken.None;
         var llmControl = LLMControlContextMapper.FromPayload(request.LlmControl);
-        var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext));
+        var toolContext = ResolveTurnToolContext(
+            request,
+            llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext)),
+            Id);
         var committedAuthority = await EstablishTurnAuthorityAsync(
             request,
             trackedSession,
@@ -1196,6 +1199,26 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
 
     private static string SanitizeFailureMessage(string? message) =>
         string.IsNullOrWhiteSpace(message) ? "LLM request failed." : message.Trim();
+
+    private static AgentToolExecutionContext ResolveTurnToolContext(
+        ChatRequestEvent request,
+        AgentToolExecutionContext context,
+        string? actorId)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return context with
+        {
+            Request = context.Request with
+            {
+                RequestId = NormalizeToolContextValue(request.SessionId) ?? context.Request.RequestId,
+            },
+            ExecutionOwner = string.IsNullOrWhiteSpace(actorId)
+                ? context.ExecutionOwner
+                : AgentToolExecutionOwners.Actor(actorId),
+        };
+    }
 
     private async Task<AgentProfileTurnAuthorityState?> EstablishTurnAuthorityAsync(
         ChatRequestEvent request,

--- a/src/Aevatar.AI.LLMProviders.MEAI/AgentToolAIFunction.cs
+++ b/src/Aevatar.AI.LLMProviders.MEAI/AgentToolAIFunction.cs
@@ -49,14 +49,19 @@ internal sealed class AgentToolAIFunction : AIFunction
         var ambientContext = AgentToolRequestContext.Current
             ?? throw new InvalidOperationException(
                 "MEAI function invocation requires a stable tool execution context.");
-        if (string.IsNullOrWhiteSpace(ambientContext.Request.RequestId) ||
-            string.IsNullOrWhiteSpace(ambientContext.Request.CallId))
+        var invocationCallId = Normalize(FunctionInvokingChatClient.CurrentContext?.CallContent?.CallId);
+        var effectiveCallId = invocationCallId ?? ambientContext.Request.CallId;
+        var executionContext = string.Equals(effectiveCallId, ambientContext.Request.CallId, StringComparison.Ordinal)
+            ? ambientContext
+            : ambientContext.WithCallId(effectiveCallId);
+        if (string.IsNullOrWhiteSpace(executionContext.Request.RequestId) ||
+            string.IsNullOrWhiteSpace(executionContext.Request.CallId))
         {
             throw new InvalidOperationException(
                 "MEAI function invocation requires stable request and function-call identities.");
         }
-        if (ambientContext.ExecutionOwner.Kind == AgentToolExecutionOwnerKind.Unspecified ||
-            string.IsNullOrWhiteSpace(ambientContext.ExecutionOwner.OwnerId))
+        if (executionContext.ExecutionOwner.Kind == AgentToolExecutionOwnerKind.Unspecified ||
+            string.IsNullOrWhiteSpace(executionContext.ExecutionOwner.OwnerId))
         {
             throw new InvalidOperationException(
                 "MEAI function invocation requires a stable execution owner.");
@@ -66,12 +71,15 @@ internal sealed class AgentToolAIFunction : AIFunction
             new AgentToolExecutionRequest(
                 _tool,
                 argsJson,
-                ambientContext,
+                executionContext,
                 AgentToolApprovalContinuationMode.None,
                 null),
             cancellationToken).ConfigureAwait(false);
         return outcome.ResultJson;
     }
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static JsonElement ParseSchema(string? schema)
     {

--- a/src/Aevatar.AI.LLMProviders.MEAI/AgentToolAIFunction.cs
+++ b/src/Aevatar.AI.LLMProviders.MEAI/AgentToolAIFunction.cs
@@ -49,8 +49,8 @@ internal sealed class AgentToolAIFunction : AIFunction
         var ambientContext = AgentToolRequestContext.Current
             ?? throw new InvalidOperationException(
                 "MEAI function invocation requires a stable tool execution context.");
-        var invocationCallId = Normalize(FunctionInvokingChatClient.CurrentContext?.CallContent?.CallId);
-        var effectiveCallId = invocationCallId ?? ambientContext.Request.CallId;
+        var invocationContext = FunctionInvokingChatClient.CurrentContext;
+        var effectiveCallId = ResolveEffectiveCallId(ambientContext, invocationContext);
         var executionContext = string.Equals(effectiveCallId, ambientContext.Request.CallId, StringComparison.Ordinal)
             ? ambientContext
             : ambientContext.WithCallId(effectiveCallId);
@@ -76,6 +76,23 @@ internal sealed class AgentToolAIFunction : AIFunction
                 null),
             cancellationToken).ConfigureAwait(false);
         return outcome.ResultJson;
+    }
+
+    private static string? ResolveEffectiveCallId(
+        AgentToolExecutionContext ambientContext,
+        FunctionInvocationContext? invocationContext)
+    {
+        if (invocationContext is null)
+            return ambientContext.Request.CallId;
+
+        var invocationCallId = Normalize(invocationContext.CallContent?.CallId);
+        if (invocationCallId is not null)
+            return invocationCallId;
+
+        var requestId = Normalize(ambientContext.Request.RequestId)
+            ?? throw new InvalidOperationException(
+                "MEAI function invocation requires stable request and function-call identities.");
+        return $"meai-{requestId}-iteration-{invocationContext.Iteration}-function-{invocationContext.FunctionCallIndex}";
     }
 
     private static string? Normalize(string? value) =>

--- a/test/Aevatar.AI.Core.Tests/RoleGAgentTests.cs
+++ b/test/Aevatar.AI.Core.Tests/RoleGAgentTests.cs
@@ -62,6 +62,27 @@ public class RoleGAgentTests
     }
 
     [Fact]
+    public void TurnToolContext_ShouldCarryStableRequestAndActorExecutionOwner()
+    {
+        var request = new ChatRequestEvent
+        {
+            SessionId = "session-1",
+        };
+        var context = ResolveTurnToolContext(
+            request,
+            AgentToolExecutionContext.Empty with
+            {
+                Request = new AgentToolRequestIdentity(null, null),
+            },
+            "role-agent-1");
+
+        context.Request.RequestId.Should().Be("session-1");
+        context.Request.CallId.Should().BeNull();
+        context.ExecutionOwner.Kind.Should().Be(AgentToolExecutionOwnerKind.Actor);
+        context.ExecutionOwner.OwnerId.Should().Be("role-agent-1");
+    }
+
+    [Fact]
     public void ProductionSources_ShouldNotCallAgentToolExecutionContextMapperFromMetadata()
     {
         var root = FindRepoRoot();
@@ -91,6 +112,21 @@ public class RoleGAgentTests
 
         method.Should().NotBeNull();
         var result = (AgentToolExecutionContext?)method!.Invoke(null, [pending]);
+        result.Should().NotBeNull();
+        return result!;
+    }
+
+    private static AgentToolExecutionContext ResolveTurnToolContext(
+        ChatRequestEvent request,
+        AgentToolExecutionContext context,
+        string actorId)
+    {
+        var method = typeof(RoleGAgent).GetMethod(
+            "ResolveTurnToolContext",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        method.Should().NotBeNull();
+        var result = (AgentToolExecutionContext?)method!.Invoke(null, [request, context, actorId]);
         result.Should().NotBeNull();
         return result!;
     }

--- a/test/Aevatar.AI.Core.Tests/Tools/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Tools/StreamingToolExecutorTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.Tools;
@@ -8,6 +9,42 @@ namespace Aevatar.AI.Core.Tests.Tools;
 
 public sealed class StreamingToolExecutorTests
 {
+    [Fact]
+    public async Task GetRemainingResultsAsync_ShouldPassStableExecutionIdentitiesToExecutionPort()
+    {
+        var tools = new ToolManager();
+        tools.Register(new FakeAgentTool("echo"));
+        var executionPort = new RecordingExecutionPort();
+        var executor = new StreamingToolExecutor(
+            tools,
+            toolContext: AgentToolExecutionContext.Empty with
+            {
+                Request = new AgentToolRequestIdentity("session-1", null),
+                ExecutionOwner = AgentToolExecutionOwners.Actor("role-agent-1"),
+            },
+            toolExecutionPort: executionPort);
+        using var state = executor.CreateExecutionState();
+
+        executor.AddTool(state, new ToolCall
+        {
+            Id = "call-1",
+            Name = "echo",
+            ArgumentsJson = "{}",
+        });
+
+        var results = new List<ToolExecutionResult>();
+        await foreach (var toolResult in executor.GetRemainingResultsAsync(state, CancellationToken.None))
+            results.Add(toolResult);
+
+        results.Should().ContainSingle().Which.IsError.Should().BeFalse();
+        var request = executionPort.Requests.Should().ContainSingle().Subject;
+        request.Tool.Name.Should().Be("echo");
+        request.ExecutionContext.Request.RequestId.Should().Be("session-1");
+        request.ExecutionContext.Request.CallId.Should().Be("call-1");
+        request.ExecutionOwner.Kind.Should().Be(AgentToolExecutionOwnerKind.Actor);
+        request.ExecutionOwner.OwnerId.Should().Be("role-agent-1");
+    }
+
     [Fact]
     public async Task GetRemainingResultsAsync_WhenExecutionPortThrows_LogsOriginalFailureAndReturnsSafeError()
     {
@@ -43,6 +80,36 @@ public sealed class StreamingToolExecutorTests
             entry.Exception is InvalidOperationException &&
             entry.Exception.Message == "execution port failed" &&
             entry.Message.Contains("Tool execution failed before receipt finalization for tool echo and call call-failed-finalization"));
+    }
+
+    private sealed class RecordingExecutionPort : IAgentToolExecutionPort
+    {
+        public List<AgentToolExecutionRequest> Requests { get; } = [];
+
+        public Task<AgentToolExecutionOutcome> ExecuteAsync(
+            AgentToolExecutionRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            var resultJson = "{\"ok\":true}";
+            return Task.FromResult(new AgentToolExecutionOutcome(
+                AgentToolExecutionOutcomeKind.Executed,
+                resultJson,
+                new AgentToolReceipt
+                {
+                    CallId = request.ExecutionContext.Request.CallId ?? string.Empty,
+                    ToolName = request.Tool.Name,
+                    Status = AgentToolReceiptStatus.Success,
+                    ResultJson = resultJson,
+                },
+                IsMutation: false,
+                FailureCode: string.Empty,
+                SafeMessage: string.Empty,
+                AgentToolExecutionFailureStage.None,
+                TerminalInvoked: true,
+                Retryable: false,
+                AuditCompleted: true));
+        }
     }
 
     private sealed class ThrowingExecutionPort : IAgentToolExecutionPort

--- a/test/Aevatar.AI.Tests/AgentToolAIFunctionSchemaSanitizationTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolAIFunctionSchemaSanitizationTests.cs
@@ -244,6 +244,55 @@ public sealed class AgentToolAIFunctionSchemaSanitizationTests
         }
     }
 
+    [Fact]
+    public async Task InvokeAsync_WithProviderInvocationContextWithoutCallId_ShouldSynthesizeDistinctCallIds()
+    {
+        const string safeResult = "{\"ok\":true}";
+        var tool = new SchemaStubTool("test_tool", "{}");
+        var executionPort = new RecordingExecutionPort(CreateOutcome(
+            AgentToolExecutionOutcomeKind.Executed,
+            AgentToolReceiptStatus.Success,
+            safeResult));
+        var function = CreateFunction(tool, executionPort);
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity("request-alpha", "ambient-round-call"),
+            ExecutionOwner = AgentToolExecutionOwners.Actor("actor-alpha"),
+        });
+        var previousContext = FunctionInvokingChatClient.CurrentContext;
+        try
+        {
+            SetFunctionInvocationContext(new FunctionInvocationContext
+            {
+                CallContent = new FunctionCallContent("", "test_tool", new Dictionary<string, object>()),
+                Iteration = 2,
+                FunctionCallIndex = 0,
+                FunctionCount = 2,
+            });
+            await function.InvokeAsync(new AIFunctionArguments());
+
+            SetFunctionInvocationContext(new FunctionInvocationContext
+            {
+                CallContent = new FunctionCallContent("", "test_tool", new Dictionary<string, object>()),
+                Iteration = 2,
+                FunctionCallIndex = 1,
+                FunctionCount = 2,
+            });
+            await function.InvokeAsync(new AIFunctionArguments());
+
+            executionPort.Requests.Select(request => request.ExecutionContext.Request.CallId)
+                .Should().Equal(
+                    "meai-request-alpha-iteration-2-function-0",
+                    "meai-request-alpha-iteration-2-function-1");
+            executionPort.Requests.Select(request => request.ExecutionContext.Request.CallId)
+                .Should().NotContain("ambient-round-call");
+        }
+        finally
+        {
+            SetFunctionInvocationContext(previousContext);
+        }
+    }
+
     [Theory]
     [InlineData(AgentToolExecutionOutcomeKind.Denied, AgentToolReceiptStatus.Denied)]
     [InlineData(AgentToolExecutionOutcomeKind.Failed, AgentToolReceiptStatus.Error)]

--- a/test/Aevatar.AI.Tests/AgentToolAIFunctionSchemaSanitizationTests.cs
+++ b/test/Aevatar.AI.Tests/AgentToolAIFunctionSchemaSanitizationTests.cs
@@ -207,6 +207,43 @@ public sealed class AgentToolAIFunctionSchemaSanitizationTests
         tool.ExecutionCalls.Should().Be(0);
     }
 
+    [Fact]
+    public async Task InvokeAsync_WithFunctionInvocationContext_ShouldUseProviderFunctionCallId()
+    {
+        const string safeResult = "{\"ok\":true}";
+        var tool = new SchemaStubTool("test_tool", "{}");
+        var executionPort = new RecordingExecutionPort(CreateOutcome(
+            AgentToolExecutionOutcomeKind.Executed,
+            AgentToolReceiptStatus.Success,
+            safeResult));
+        var function = CreateFunction(tool, executionPort);
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity("request-alpha", "ambient-call"),
+            ExecutionOwner = AgentToolExecutionOwners.Actor("actor-alpha"),
+        });
+        var previousContext = FunctionInvokingChatClient.CurrentContext;
+        try
+        {
+            SetFunctionInvocationContext(new FunctionInvocationContext
+            {
+                CallContent = new FunctionCallContent("provider-call", "test_tool", new Dictionary<string, object>()),
+            });
+
+            var result = await function.InvokeAsync(new AIFunctionArguments());
+
+            result.Should().Be(safeResult);
+            var request = executionPort.Requests.Should().ContainSingle().Subject;
+            request.ExecutionContext.Request.RequestId.Should().Be("request-alpha");
+            request.ExecutionContext.Request.CallId.Should().Be("provider-call");
+            request.ExecutionOwner.OwnerId.Should().Be("actor-alpha");
+        }
+        finally
+        {
+            SetFunctionInvocationContext(previousContext);
+        }
+    }
+
     [Theory]
     [InlineData(AgentToolExecutionOutcomeKind.Denied, AgentToolReceiptStatus.Denied)]
     [InlineData(AgentToolExecutionOutcomeKind.Failed, AgentToolReceiptStatus.Error)]
@@ -229,6 +266,15 @@ public sealed class AgentToolAIFunctionSchemaSanitizationTests
         result.Should().Be(safeResult);
         executionPort.Requests.Should().ContainSingle();
         tool.ExecutionCalls.Should().Be(0);
+    }
+
+    private static void SetFunctionInvocationContext(FunctionInvocationContext? context)
+    {
+        var setter = typeof(FunctionInvokingChatClient)
+            .GetProperty(nameof(FunctionInvokingChatClient.CurrentContext))!
+            .GetSetMethod(nonPublic: true);
+        setter.Should().NotBeNull();
+        setter!.Invoke(null, [context]);
     }
 
     private static AIFunction CreateFunction(

--- a/test/Aevatar.AI.Tests/MEAILLMProviderUsageTests.cs
+++ b/test/Aevatar.AI.Tests/MEAILLMProviderUsageTests.cs
@@ -1,5 +1,7 @@
 using System.ClientModel.Primitives;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.LLMProviders.MEAI;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
@@ -68,6 +70,44 @@ public sealed class MEAILLMProviderUsageTests
         last.Usage.Should().BeNull();
         string.Concat(chunks.Where(chunk => chunk.DeltaContent != null).Select(chunk => chunk.DeltaContent))
             .Should().Be("only text");
+    }
+
+    [Fact]
+    public async Task ChatStreamAsync_WhenStreamingFallbackInvokesTool_ShouldCarryStableToolIdentity()
+    {
+        var innerClient = new FallbackFunctionCallChatClient();
+        var executionPort = new RecordingExecutionPort();
+        var provider = new MEAILLMProvider(
+            "meai-usage",
+            new FunctionInvokingChatClient(innerClient),
+            toolExecutionPort: executionPort);
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Request = new AgentToolRequestIdentity("request-alpha", "ambient-round-call"),
+            ExecutionOwner = AgentToolExecutionOwners.Actor("actor-alpha"),
+        });
+        var request = new LLMRequest
+        {
+            Messages = [new AevatarChatMessage { Role = "user", Content = "hi" }],
+            Model = "gpt-test",
+            Tools = [new FakeAgentTool("test_tool")],
+        };
+
+        var chunks = new List<LLMStreamChunk>();
+        await foreach (var chunk in provider.ChatStreamAsync(request))
+            chunks.Add(chunk);
+
+        innerClient.StreamingCalls.Should().Be(1);
+        innerClient.ResponseCalls.Should().Be(2);
+        chunks.Where(chunk => chunk.DeltaContent != null).Select(chunk => chunk.DeltaContent)
+            .Should().ContainSingle().Which.Should().Be("done");
+        var executionRequest = executionPort.Requests.Should().ContainSingle().Subject;
+        executionRequest.ExecutionContext.Request.RequestId.Should().Be("request-alpha");
+        executionRequest.ExecutionContext.Request.CallId.Should().Be("meai-request-alpha-iteration-0-function-0");
+        executionRequest.ExecutionContext.Request.CallId.Should().NotBe("ambient-round-call");
+        executionRequest.ExecutionOwner.Kind.Should().Be(AgentToolExecutionOwnerKind.Actor);
+        executionRequest.ExecutionOwner.OwnerId.Should().Be("actor-alpha");
+        executionRequest.ArgumentsJson.Should().Be("{\"city\":\"Paris\"}");
     }
 
     [Fact]
@@ -151,6 +191,91 @@ public sealed class MEAILLMProviderUsageTests
     {
         await Task.CompletedTask;
         yield break;
+    }
+
+    private sealed class FallbackFunctionCallChatClient : IChatClient
+    {
+        public int StreamingCalls { get; private set; }
+        public int ResponseCalls { get; private set; }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<MeaiChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            ResponseCalls++;
+            if (ResponseCalls == 1)
+            {
+                return Task.FromResult(new ChatResponse(new MeaiChatMessage(
+                    ChatRole.Assistant,
+                    [new FunctionCallContent("", "test_tool", new Dictionary<string, object?>
+                    {
+                        ["city"] = "Paris",
+                    })])));
+            }
+
+            return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "done")));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<MeaiChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            StreamingCalls++;
+            return EmptyStream();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class FakeAgentTool(string name) : IAgentTool
+    {
+        public string Name { get; } = name;
+        public string Description => "fake";
+        public string ParametersSchema =>
+            """{"type":"object","properties":{"city":{"type":"string"}},"required":["city"],"additionalProperties":false}""";
+        public int ExecutionCalls { get; private set; }
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecutionCalls++;
+            return Task.FromResult("{}");
+        }
+    }
+
+    private sealed class RecordingExecutionPort : IAgentToolExecutionPort
+    {
+        public List<AgentToolExecutionRequest> Requests { get; } = [];
+
+        public Task<AgentToolExecutionOutcome> ExecuteAsync(
+            AgentToolExecutionRequest request,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            const string resultJson = "{\"ok\":true}";
+            return Task.FromResult(new AgentToolExecutionOutcome(
+                AgentToolExecutionOutcomeKind.Executed,
+                resultJson,
+                new AgentToolReceipt
+                {
+                    CallId = request.ExecutionContext.Request.CallId ?? string.Empty,
+                    ToolName = request.Tool.Name,
+                    Status = AgentToolReceiptStatus.Success,
+                    ResultJson = resultJson,
+                },
+                IsMutation: false,
+                FailureCode: string.Empty,
+                SafeMessage: string.Empty,
+                AgentToolExecutionFailureStage.None,
+                TerminalInvoked: true,
+                Retryable: false,
+                AuditCompleted: true));
+        }
     }
 
     private sealed class UsageCapturingChatClient : IChatClient


### PR DESCRIPTION
## Summary
- Set RoleGAgent streaming turns to carry the stable session request id and actor execution owner before admitted tool execution.
- Push the authorized tool context through provider streaming so MEAI function calls see the same request/owner context.
- Add regression coverage for RoleGAgent turn identity and StreamingToolExecutor admitted request identities.

## Test plan
- [x] dotnet test test/Aevatar.AI.Core.Tests/Aevatar.AI.Core.Tests.csproj --nologo --filter "FullyQualifiedName~RoleGAgentTests|FullyQualifiedName~StreamingToolExecutorTests"
- [x] dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter "FullyQualifiedName~NyxIdLLMProviderRoutingTests|FullyQualifiedName~AgentToolAIFunctionSchemaSanitizationTests"
- [x] dotnet test test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj --nologo --filter "FullyQualifiedName~AIFeatureBootstrapCoverageTests"

Generated with [Claude Code](https://claude.com/claude-code)