### PR TITLE
Block external raw envelope schedules

### DIFF
--- a/docs/canon/scheduled-skill-runners.md
+++ b/docs/canon/scheduled-skill-runners.md
@@ -104,8 +104,8 @@ actor address, an `EventEnvelope`, or an equivalent raw dispatch payload.
 The authenticated request scope must equal the resolved target tenant. A
 target in another tenant is rejected before Application admission, even when
 the caller can name that service. `actorId` is an opaque runtime address and
-raw `EventEnvelope` is an internal transport shape; neither is exposed by a
-public schedule request, response, or lifecycle operation.
+raw `EventEnvelope` is an internal transport shape; the public schedule target
+input does not accept either as a caller-supplied value.
 
 Legacy persisted envelope schedules remain readable only by the actor and
 projection paths needed to retire them. Application hides those rows from

--- a/docs/canon/scheduled-skill-runners.md
+++ b/docs/canon/scheduled-skill-runners.md
@@ -94,6 +94,29 @@ Generic schedules and Team automations are isolated in both directions:
 - Team automations use `ScheduledDispatchScheduleKind.Workflow` and a server-derived workflow service target;
 - `ScheduledDispatchScheduleKind.Generic` is not a fallback for Team automation, and the retired SkillRunner kind is not recreated.
 
+## Public Schedule Target Boundary
+
+The public `/api/schedules` contract accepts only a catalog-resolved typed
+`serviceInvocation` target. The server resolves that target from the service
+and revision catalogs; a browser or other external caller cannot supply an
+actor address, an `EventEnvelope`, or an equivalent raw dispatch payload.
+
+The authenticated request scope must equal the resolved target tenant. A
+target in another tenant is rejected before Application admission, even when
+the caller can name that service. `actorId` is an opaque runtime address and
+raw `EventEnvelope` is an internal transport shape; neither is exposed by a
+public schedule request, response, or lifecycle operation.
+
+Legacy persisted envelope schedules remain readable only by the actor and
+projection paths needed to retire them. Application hides those rows from
+public get/list results and treats public lifecycle mutations as not found.
+When activation encounters an envelope schedule without the required marker,
+the actor durably disables it and purges its scheduled callbacks before it can
+fire. The Protobuf `TrustedInternal` marker is a strongly typed, actor-only
+contract for the narrow internal envelope protocol. Hosting and Application do
+not expose it, and it does not create an administrator or public
+raw-envelope-scheduling escape hatch.
+
 ## Admission Receipts And Projected State
 
 Mutation endpoints return `202 Accepted` with a typed receipt containing `accepted`, `status`, `scheduleId`, `operationId`, and `commandId`. Receipt status `accepted` or `pending` describes command/effect admission only. It does not prove that credential provisioning or revocation finished, that the schedule is active, or that the read model has observed the new authoritative version.

--- a/docs/superpowers/plans/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement.md
+++ b/docs/superpowers/plans/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement.md
@@ -1,0 +1,311 @@
+# Issue 3044 Scheduled Dispatch Envelope Retirement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent external callers and legacy public schedules from dispatching caller-supplied envelopes to arbitrary actors while preserving typed service invocation and an explicitly marked internal actor protocol.
+
+**Architecture:** Hosting exposes only catalog-resolved service invocation targets and checks target tenant authority. Application admits and returns only service-invocation schedules. Core stores a typed Protobuf envelope authority so legacy unmarked schedules fail closed while trusted internal actor commands remain explicit.
+
+**Tech Stack:** .NET 10, C#, ASP.NET Core minimal APIs, Google Protobuf, xUnit, FluentAssertions
+
+## Global Constraints
+
+- Keep `scopeId`, `memberId`, `workflowId`, `publishedServiceId`, and `actorId` distinct.
+- Public HTTP and Application contracts must not expose a raw-envelope scheduling capability.
+- Stable actor control semantics must be represented by Protobuf fields, not metadata bags.
+- Existing Workflow service invocation and Studio member automation behavior must remain functional.
+- Every production behavior change starts with a test that fails for the expected reason.
+
+---
+
+### Task 1: Retire the HTTP Envelope Contract and Enforce Target Scope
+
+**Files:**
+- Modify: `test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs`
+- Modify: `src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs`
+
+**Interfaces:**
+- Consumes: `AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(HttpContext, string, out IResult)`
+- Produces: `ScheduledDispatchConfigurationHttpRequest` with only `ServiceInvocation` as a target
+
+- [ ] **Step 1: Write failing HTTP contract tests**
+
+Add an actual host request containing distinct identities and a workflow control payload:
+
+```csharp
+var response = await host.Client.PostAsJsonAsync("/api/schedules", new
+{
+    scheduleId = "schedule-alpha",
+    cronExpression = "0 9 * * *",
+    envelope = new
+    {
+        actorId = "actor-cross-owner",
+        envelope = new
+        {
+            payload = new
+            {
+                typeUrl = "type.googleapis.com/aevatar.workflow.WorkflowStoppedEvent",
+                value = Convert.ToBase64String(Array.Empty<byte>()),
+            },
+        },
+    },
+});
+
+response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+host.Schedules.Created.Should().BeEmpty();
+```
+
+Add direct create/update tests proving `scope-alpha` cannot target a service in
+`scope-beta`, while a `scope-alpha` target still reaches the recording service.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --no-restore --filter "FullyQualifiedName~ScheduledDispatchEndpointsTests"
+```
+
+Expected: the raw envelope request is accepted and the cross-scope service request reaches the application service.
+
+- [ ] **Step 3: Remove the raw HTTP target and add scope admission**
+
+Delete `ScheduledDispatchEnvelopeTargetHttpRequest` and the `Envelope` property.
+Resolve exactly one service invocation target:
+
+```csharp
+if (ServiceInvocation == null)
+    throw new ArgumentException("A service invocation scheduled dispatch target is required.");
+
+return await ServiceInvocation.ToResolvedTargetAsync(
+    catalogReader,
+    revisionCatalogReader,
+    authenticatedOwnerSubject,
+    ct);
+```
+
+After `ToConfigurationAsync`, enforce authority before mutation:
+
+```csharp
+var targetScopeId = configuration.Target.ServiceInvocation?.Identity.TenantId;
+if (TryCreateOwnerScopeAccessDeniedResult(http, targetScopeId, out denied))
+    return denied;
+```
+
+Apply this to both create and update and convert unrelated endpoint test helpers
+from envelope targets to typed service invocation targets.
+
+- [ ] **Step 4: Run the focused endpoint tests and verify GREEN**
+
+Run the command from Step 2. Expected: all `ScheduledDispatchEndpointsTests` pass.
+
+### Task 2: Close the Application Capability and Hide Legacy Rows
+
+**Files:**
+- Modify: `test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs`
+- Modify: `test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchServiceInvocationTests.cs`
+- Modify: `src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs`
+- Modify: `src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchTargetPreparationService.cs`
+
+**Interfaces:**
+- Consumes: `IScheduledDispatchQueryPort`
+- Produces: public Application behavior restricted to `ScheduledDispatchTargetKind.ServiceInvocation`
+
+- [ ] **Step 1: Write failing Application admission and visibility tests**
+
+Add tests that submit an envelope configuration and assert no actor dispatch:
+
+```csharp
+var act = () => service.CreateAsync(CreateRawEnvelopeConfiguration("schedule-alpha"));
+
+await act.Should().ThrowAsync<ArgumentException>()
+    .WithMessage("*raw envelope*not supported*");
+actorPort.Created.Should().BeEmpty();
+```
+
+Use one deliberately named raw fixture for the rejection cases:
+
+```csharp
+private static ScheduledDispatchConfiguration CreateRawEnvelopeConfiguration(string scheduleId) =>
+    new(
+        scheduleId,
+        string.Empty,
+        new ScheduledDispatchTargetDescriptor(
+            ScheduledDispatchTargetKind.Envelope,
+            ActorId: "actor-cross-owner",
+            Envelope: new EventEnvelope { Payload = Any.Pack(new Empty()) }),
+        "0 9 * * *",
+        "UTC",
+        true,
+        new Dictionary<string, string>());
+```
+
+Seed a query result with `TargetKind = Envelope` and prove `GetAsync`, list,
+enable, disable, delete, and run-now do not return or mutate it. Add a target
+preparation test proving direct envelope preparation is rejected.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --no-restore --filter "FullyQualifiedName~ScheduledDispatchApplicationServiceTests|FullyQualifiedName~ScheduledDispatchServiceInvocationTests"
+```
+
+Expected: envelope creation/preparation and legacy lifecycle tests fail because the current Application still accepts them.
+
+- [ ] **Step 3: Implement service-invocation-only Application behavior**
+
+Make target normalization reject envelopes:
+
+```csharp
+return target.Kind switch
+{
+    ScheduledDispatchTargetKind.ServiceInvocation => NormalizeServiceInvocationTarget(target),
+    ScheduledDispatchTargetKind.Envelope => throw new ArgumentException(
+        "Raw envelope scheduled dispatch targets are not supported by the Application contract.",
+        nameof(target)),
+    _ => throw new ArgumentException(
+        $"Unsupported scheduled dispatch target kind '{target.Kind}'.",
+        nameof(target)),
+};
+```
+
+Force `TargetKind = ServiceInvocation` on list queries, require service invocation
+for get/team get, and make `GetMutableScheduleAsync` treat every other target as
+not found. Make target preparation throw for envelope targets instead of building
+an arbitrary actor envelope. Convert general-purpose test fixtures to service
+invocation targets; retain one explicit raw fixture only for rejection tests.
+
+- [ ] **Step 4: Run the focused Application tests and verify GREEN**
+
+Run the command from Step 2. Expected: all selected tests pass.
+
+### Task 3: Fence the Internal Actor Protocol and Retire Unmarked State
+
+**Files:**
+- Modify: `src/platform/Aevatar.GAgentService.Core/Schedules/scheduled_dispatch_state.proto`
+- Modify: `src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs`
+- Modify: `test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs`
+
+**Interfaces:**
+- Produces: `ScheduledDispatchEnvelopeAuthorityState.TrustedInternal`
+- Consumes: `ScheduledDispatchTargetState.EnvelopeAuthority`
+
+- [ ] **Step 1: Write failing actor authority tests**
+
+Add a configuration test with an unmarked envelope target:
+
+```csharp
+var command = CreateConfigureCommand(target: new ScheduledDispatchTargetState
+{
+    Kind = ScheduledDispatchTargetKindState.Envelope,
+    ActorId = "actor-cross-owner",
+    Envelope = CreateTriggerEnvelope("actor-cross-owner", new Empty()),
+});
+
+var act = () => agent.HandleConfigureAsync(command);
+await act.Should().ThrowAsync<ArgumentException>()
+    .WithMessage("*trusted internal authority*");
+```
+
+Create a snapshot containing an enabled legacy envelope target with unspecified
+authority. On activation assert `Enabled == false`, callback purge occurred, and
+no dispatch occurred. A manual fire must throw the stable retirement error and
+leave both dispatch ports empty. Keep an explicit `TrustedInternal` fire test.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --no-restore --filter "FullyQualifiedName~ScheduledDispatchGAgentTests"
+```
+
+Expected: unmarked configuration and legacy activation/manual-fire tests fail because authority is not yet represented or checked.
+
+- [ ] **Step 3: Add the Protobuf authority and fail-closed actor logic**
+
+Add:
+
+```protobuf
+enum ScheduledDispatchEnvelopeAuthorityState
+{
+  SCHEDULED_DISPATCH_ENVELOPE_AUTHORITY_STATE_UNSPECIFIED = 0;
+  SCHEDULED_DISPATCH_ENVELOPE_AUTHORITY_STATE_TRUSTED_INTERNAL = 1;
+}
+
+message ScheduledDispatchTargetState
+{
+  // existing fields 1-6
+  ScheduledDispatchEnvelopeAuthorityState envelope_authority = 7;
+}
+```
+
+Preserve the field in envelope target normalization. Command validation accepts
+an envelope only when the authority is `TrustedInternal`. Activation calls a
+single helper that persists a disabled event for unmarked legacy envelope state,
+purges callbacks, and returns before scheduling. Fire calls the same predicate;
+manual fire throws and automatic fire disables/purges without dispatch.
+
+Update the common actor test helper to mark its intentional internal envelope
+targets as `TrustedInternal` so unrelated low-level runtime tests preserve their
+meaning.
+
+- [ ] **Step 4: Run the focused actor tests and verify GREEN**
+
+Run the command from Step 2. Expected: all `ScheduledDispatchGAgentTests` pass.
+
+### Task 4: Document the Public Boundary and Verify the Issue
+
+**Files:**
+- Modify: `docs/canon/scheduled-skill-runners.md`
+- Modify: `docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md`
+
+**Interfaces:**
+- Produces: canonical documented service-invocation-only public schedule contract
+
+- [ ] **Step 1: Update canonical documentation**
+
+State explicitly that `/api/schedules` accepts only catalog-resolved
+`serviceInvocation`, enforces authenticated scope versus target tenant, and
+does not expose actor IDs or raw envelopes. Document that legacy unmarked
+envelope schedules are hidden and disabled, while the Protobuf
+`TrustedInternal` marker is an actor-only contract.
+
+- [ ] **Step 2: Run affected project suites**
+
+```bash
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --no-restore
+dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --no-restore
+dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --no-restore
+```
+
+Expected: zero failed tests.
+
+- [ ] **Step 3: Run repository guards and full verification**
+
+```bash
+bash tools/ci/test_stability_guards.sh
+bash tools/ci/architecture_guards.sh
+bash tools/docs/lint.sh
+dotnet build aevatar.slnx --nologo --no-restore
+dotnet test aevatar.slnx --nologo --no-build --no-restore
+git diff --check
+```
+
+Expected: every command exits zero and the full test summary reports zero failures.
+
+- [ ] **Step 4: Commit the completed issue implementation**
+
+Stage only files listed in this plan and commit with:
+
+```bash
+git commit -m "Block external raw envelope schedules"
+```
+
+- [ ] **Step 5: Request independent review**
+
+Give a reviewer issue `#3044`, the design document, the branch diff against
+`origin/feature/integrate`, and all verification evidence. Resolve every Critical
+or Important finding with another RED/GREEN cycle, then repeat verification.

--- a/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
@@ -2,7 +2,8 @@
 
 ## Context
 
-`POST /api/schedules` and `PUT /api/schedules/{scheduleId}` currently accept
+Before this change, `POST /api/schedules` and
+`PUT /api/schedules/{scheduleId}` accepted
 an `envelope` target containing a caller-selected actor ID and arbitrary
 `EventEnvelope` payload. The target preparation path rewrites routing but
 preserves both authority-bearing inputs. An authenticated caller can therefore
@@ -20,8 +21,9 @@ Retire raw-envelope scheduling instead of adding a payload allowlist. Public
 scheduling accepts only a typed `serviceInvocation` target that is resolved
 through the service catalog and revision catalog. The HTTP boundary requires
 the resolved target tenant to equal the authenticated request scope before
-calling the Application service. It does not expose `actorId`, raw
-`EventEnvelope`, or the internal authority marker.
+calling the Application service. The public schedule target input does not
+accept a caller-supplied `actorId`, raw `EventEnvelope`, or internal authority
+marker.
 
 The retirement is enforced at three independent boundaries:
 
@@ -41,10 +43,12 @@ The retirement is enforced at three independent boundaries:
    tests. `TrustedInternal` is not surfaced by Hosting or Application and does
    not authorize a public or administrator raw-envelope API.
 
-Legacy Protobuf/state fields and enum values remain readable only so existing
-actors and projections can recognize the retired target and fail closed. The
-new Protobuf authority enum is not exposed through Hosting or Application, and
-no administrator/raw-envelope API is introduced.
+At the Hosting/Application boundary, legacy Protobuf/state fields and enum
+values are retired and read only: they remain available only to recognize and
+hide legacy rows. Core retains the legacy representation for retirement and
+fail-closed activation, and retains the typed Protobuf `TrustedInternal`
+actor-only write protocol. The authority marker is not surfaced through
+Hosting or Application, and no administrator/raw-envelope API is introduced.
 
 ## Alternatives
 
@@ -63,10 +67,11 @@ recognition is safer and more explicit.
 
 ### Payload Allowlist and Actor Ownership Lookup
 
-An allowlist still exposes actor addresses and creates a second authorization
-system beside typed service invocation. Every future message type would reopen
-the injection surface. The repository already has the correct typed,
-server-resolved path, so a second public path is unnecessary.
+An allowlist would retain caller control over actor addresses and create a
+second authorization system beside typed service invocation. Every future
+message type would reopen the injection surface. The repository already has
+the correct typed, server-resolved path, so a second public path is
+unnecessary.
 
 ## Data Flow
 

--- a/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
@@ -1,0 +1,134 @@
+# Issue 3044 Scheduled Dispatch Envelope Retirement Design
+
+## Context
+
+`POST /api/schedules` and `PUT /api/schedules/{scheduleId}` currently accept
+an `envelope` target containing a caller-selected actor ID and arbitrary
+`EventEnvelope` payload. The target preparation path rewrites routing but
+preserves both authority-bearing inputs. An authenticated caller can therefore
+persist control or domain messages for an actor outside the caller's scope and
+trigger them on a cron schedule or with `:run-now`.
+
+Production callers do not require raw-envelope scheduling. Workflow schedules,
+Studio member automations, and generic public schedules already use typed
+service invocation targets. The raw target remains only in legacy state and
+tests.
+
+## Decision
+
+Retire raw-envelope scheduling instead of adding a payload allowlist. Public
+scheduling accepts only a typed `serviceInvocation` target that is resolved
+through the service catalog and revision catalog. The HTTP boundary verifies
+that the resolved target tenant is accessible to the authenticated scope before
+calling the Application service.
+
+The retirement is enforced at three independent boundaries:
+
+1. **HTTP contract:** remove the `envelope` request property and its request
+   type. Unmapped-member rejection makes an external envelope payload a stable
+   `400 Bad Request`. Cross-scope service targets are rejected before mutation.
+2. **Application contract:** reject new envelope configurations even when an
+   internal caller constructs `ScheduledDispatchConfiguration` directly. Hide
+   legacy envelope rows from get/list and reject their lifecycle mutations as
+   not found.
+3. **Actor runtime:** reject new envelope configuration commands. On activation,
+   an existing enabled envelope schedule is durably disabled and its callbacks
+   are purged. Manual fire also fails before any target dispatch. This protects
+   persisted schedules created before the HTTP contract changes.
+
+Legacy Protobuf/state fields and enum values remain readable only so existing
+actors and projections can recognize the retired target and fail closed. They
+are not an extension point and no administrator/raw-envelope API is introduced.
+
+## Alternatives
+
+### Remove Only the HTTP Field
+
+This is the smallest source change, but existing malicious schedules could
+still fire automatically or through lifecycle endpoints. It does not isolate
+the raw capability and is rejected.
+
+### Delete Envelope State From Protobuf
+
+This removes the representation completely, but historical actor event replay
+would lose the target or fail activation before it can be disabled. That turns
+a security retirement into an unsafe state migration. Keeping read-only legacy
+recognition is safer and more explicit.
+
+### Payload Allowlist and Actor Ownership Lookup
+
+An allowlist still exposes actor addresses and creates a second authorization
+system beside typed service invocation. Every future message type would reopen
+the injection surface. The repository already has the correct typed,
+server-resolved path, so a second public path is unnecessary.
+
+## Data Flow
+
+For accepted public writes:
+
+```text
+HTTP serviceInvocation request
+  -> catalog/revision resolution
+  -> authenticated scope versus target tenant check
+  -> Application service-invocation-only admission
+  -> ScheduledDispatch actor configuration
+  -> typed service invocation adapter at fire time
+```
+
+For rejected raw writes:
+
+```text
+HTTP envelope member -> JSON unmapped-member rejection -> 400, no mutation
+direct envelope configuration -> Application/Core rejection, no actor dispatch
+```
+
+For historical raw schedules:
+
+```text
+projection row -> hidden from public get/list/lifecycle
+actor activation -> disable event + callback purge
+manual fire -> fail before FireStarted or target dispatch
+```
+
+## Authority Rules
+
+- `scopeId`, `memberId`, `workflowId`, `publishedServiceId`, and `actorId` remain
+  distinct identities in tests and code.
+- A caller with `scope-alpha` cannot create or update a target whose
+  `ServiceIdentity.TenantId` is `scope-beta`.
+- Studio member automation keeps its exact
+  `scope-alpha/team-alpha/m-alpha` owner checks and server-derived service
+  target.
+- A caller can never provide `actor-cross-owner` or a workflow control event as
+  a public schedule target.
+
+## Error Semantics
+
+- A JSON `envelope` member is an invalid public request and maps to the existing
+  `400` request-validation response.
+- A cross-scope typed service target uses the existing scope access guard and
+  returns the same non-leaking access-denied result as other scoped resources.
+- A legacy envelope schedule is not visible or mutable through public schedule
+  lifecycle APIs.
+- Actor-level manual fire of a legacy envelope schedule throws a stable
+  retirement error without dispatching an envelope.
+
+## Verification
+
+Tests must prove:
+
+- raw HTTP envelope payloads are rejected, including a workflow stop/control
+  payload addressed to a distinct actor ID;
+- cross-scope typed service targets are rejected and same-scope targets remain
+  accepted;
+- direct Application envelope create/update is rejected before actor dispatch;
+- legacy envelope rows are hidden from get/list and lifecycle mutation;
+- new actor envelope configuration is rejected;
+- activation disables a persisted envelope schedule and manual fire never
+  dispatches it;
+- existing service invocation, workflow schedule, and Studio member automation
+  tests remain green.
+
+Required validation includes focused Scheduled Dispatch tests, affected project
+test suites, architecture and stability guards, repository build/test, docs
+lint, independent review, and GitHub CI.

--- a/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
@@ -31,14 +31,17 @@ The retirement is enforced at three independent boundaries:
    internal caller constructs `ScheduledDispatchConfiguration` directly. Hide
    legacy envelope rows from get/list and reject their lifecycle mutations as
    not found.
-3. **Actor runtime:** reject new envelope configuration commands. On activation,
-   an existing enabled envelope schedule is durably disabled and its callbacks
-   are purged. Manual fire also fails before any target dispatch. This protects
-   persisted schedules created before the HTTP contract changes.
+3. **Actor runtime:** require a typed `TrustedInternal` authority on every new
+   envelope configuration command. On activation, an existing envelope schedule
+   without that authority is durably disabled and its callbacks are purged.
+   Manual fire also fails before any target dispatch. This protects persisted
+   schedules created before the HTTP contract changes while preserving the
+   explicit low-level internal actor protocol used by runtime tests.
 
 Legacy Protobuf/state fields and enum values remain readable only so existing
-actors and projections can recognize the retired target and fail closed. They
-are not an extension point and no administrator/raw-envelope API is introduced.
+actors and projections can recognize the retired target and fail closed. The
+new Protobuf authority enum is not exposed through Hosting or Application, and
+no administrator/raw-envelope API is introduced.
 
 ## Alternatives
 
@@ -79,14 +82,15 @@ For rejected raw writes:
 
 ```text
 HTTP envelope member -> JSON unmapped-member rejection -> 400, no mutation
-direct envelope configuration -> Application/Core rejection, no actor dispatch
+direct envelope configuration -> Application rejection, no actor dispatch
+internal actor envelope without TrustedInternal -> Core rejection
 ```
 
 For historical raw schedules:
 
 ```text
 projection row -> hidden from public get/list/lifecycle
-actor activation -> disable event + callback purge
+actor activation without TrustedInternal -> disable event + callback purge
 manual fire -> fail before FireStarted or target dispatch
 ```
 
@@ -123,9 +127,10 @@ Tests must prove:
   accepted;
 - direct Application envelope create/update is rejected before actor dispatch;
 - legacy envelope rows are hidden from get/list and lifecycle mutation;
-- new actor envelope configuration is rejected;
-- activation disables a persisted envelope schedule and manual fire never
-  dispatches it;
+- new actor envelope configuration without typed internal authority is
+  rejected, while the explicit trusted-internal protocol remains functional;
+- activation disables a persisted unauthorized envelope schedule and manual
+  fire never dispatches it;
 - existing service invocation, workflow schedule, and Studio member automation
   tests remain green.
 

--- a/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-02-issue-3044-scheduled-dispatch-envelope-retirement-design.md
@@ -18,9 +18,10 @@ tests.
 
 Retire raw-envelope scheduling instead of adding a payload allowlist. Public
 scheduling accepts only a typed `serviceInvocation` target that is resolved
-through the service catalog and revision catalog. The HTTP boundary verifies
-that the resolved target tenant is accessible to the authenticated scope before
-calling the Application service.
+through the service catalog and revision catalog. The HTTP boundary requires
+the resolved target tenant to equal the authenticated request scope before
+calling the Application service. It does not expose `actorId`, raw
+`EventEnvelope`, or the internal authority marker.
 
 The retirement is enforced at three independent boundaries:
 
@@ -31,12 +32,14 @@ The retirement is enforced at three independent boundaries:
    internal caller constructs `ScheduledDispatchConfiguration` directly. Hide
    legacy envelope rows from get/list and reject their lifecycle mutations as
    not found.
-3. **Actor runtime:** require a typed `TrustedInternal` authority on every new
-   envelope configuration command. On activation, an existing envelope schedule
-   without that authority is durably disabled and its callbacks are purged.
-   Manual fire also fails before any target dispatch. This protects persisted
-   schedules created before the HTTP contract changes while preserving the
-   explicit low-level internal actor protocol used by runtime tests.
+3. **Actor runtime:** require a typed Protobuf `TrustedInternal` authority on
+   every new envelope configuration command. On activation, an existing
+   envelope schedule without that authority is durably disabled and its
+   callbacks are purged. Manual fire also fails before any target dispatch.
+   This protects persisted schedules created before the HTTP contract changes
+   while preserving the explicit low-level actor-only protocol used by runtime
+   tests. `TrustedInternal` is not surfaced by Hosting or Application and does
+   not authorize a public or administrator raw-envelope API.
 
 Legacy Protobuf/state fields and enum values remain readable only so existing
 actors and projections can recognize the retired target and fail closed. The

--- a/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchApplicationService.cs
@@ -176,7 +176,14 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
     {
         var normalizedScheduleId = NormalizeScheduleId(scheduleId);
         var schedule = await _queryPort.GetAsync(normalizedScheduleId, ct);
-        return schedule?.Schedule is { Deleted: false, TeamOwned: false } ? schedule : null;
+        return schedule?.Schedule is
+        {
+            Deleted: false,
+            TeamOwned: false,
+            TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
+        }
+            ? schedule
+            : null;
     }
 
     public Task<ScheduledDispatchListResult> ListAsync(
@@ -196,6 +203,7 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
             return _queryPort.ListAsync(query with
             {
                 Take = Math.Clamp(query.Take, 1, 200),
+                TargetKind = ScheduledDispatchTargetKind.ServiceInvocation,
                 TeamAutomationOwner = NormalizeTeamOwner(query.TeamAutomationOwner),
                 TeamAutomationScopeId = null,
                 TeamAutomationTeamId = null,
@@ -212,6 +220,7 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
             return _queryPort.ListAsync(query with
             {
                 Take = Math.Clamp(query.Take, 1, 200),
+                TargetKind = ScheduledDispatchTargetKind.ServiceInvocation,
                 TeamAutomationOwner = null,
                 TeamAutomationScopeId = teamAutomationScopeId,
                 TeamAutomationTeamId = NormalizeNullable(query.TeamAutomationTeamId),
@@ -223,6 +232,7 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
         return _queryPort.ListAsync(query with
         {
             Take = Math.Clamp(query.Take, 1, 200),
+            TargetKind = ScheduledDispatchTargetKind.ServiceInvocation,
             TeamAutomationOwner = null,
             ExcludeTeamOwned = true,
             IncludeDeleted = false,
@@ -653,7 +663,11 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
         var normalizedTeamId = NormalizeNullable(teamId);
         var normalizedMemberId = NormalizeNullable(memberId);
         var detail = await _queryPort.GetAsync(normalizedScheduleId, ct);
-        return detail?.Schedule is { Deleted: false } &&
+        return detail?.Schedule is
+               {
+                   Deleted: false,
+                   TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
+               } &&
                TeamScopeEquals(detail.Schedule, normalizedScopeId) &&
                (normalizedTeamId is null || TeamEquals(detail.Schedule, normalizedTeamId)) &&
                (normalizedMemberId is null || TeamMemberEquals(detail.Schedule, normalizedMemberId))
@@ -669,7 +683,11 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
         var normalizedScheduleId = NormalizeScheduleId(scheduleId);
         var normalizedOwner = NormalizeTeamOwner(owner);
         var detail = await _queryPort.GetAsync(normalizedScheduleId, ct);
-        return detail?.Schedule is { TeamOwned: true } &&
+        return detail?.Schedule is
+               {
+                   TeamOwned: true,
+                   TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
+               } &&
                (!detail.Schedule.Deleted || detail.Schedule.RevocationPending) &&
                TeamOwnerEquals(detail.Schedule, normalizedOwner)
             ? detail
@@ -687,6 +705,7 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
             Take: Math.Clamp(take, 1, 200),
             Cursor: cursor,
             IncludeTotalCount: includeTotalCount,
+            TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
             TeamAutomationOwner: NormalizeTeamOwner(owner),
             ExcludeCompletedTeamAutomationDeletions: true), ct);
         return result;
@@ -1227,6 +1246,11 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
         CancellationToken ct)
     {
         var existing = await _queryPort.GetAsync(scheduleId, ct);
+        if (existing is not null &&
+            existing.Schedule.TargetKind != ScheduledDispatchTargetKind.ServiceInvocation)
+        {
+            throw new ScheduledDispatchNotFoundException(scheduleId);
+        }
         if (existing?.Schedule.Deleted == true)
             throw new ScheduledDispatchNotFoundException(scheduleId);
         if (existing?.Schedule.TeamOwned == true)
@@ -1248,8 +1272,14 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
         CancellationToken ct)
     {
         var existing = await _queryPort.GetAsync(scheduleId, ct);
-        if (existing?.Schedule.TeamOwned != true || !TeamOwnerEquals(existing.Schedule, owner))
+        if (existing?.Schedule is not
+            {
+                TeamOwned: true,
+                TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
+            } || !TeamOwnerEquals(existing.Schedule, owner))
+        {
             throw new ScheduledDispatchNotFoundException(scheduleId);
+        }
         return existing;
     }
 
@@ -1384,30 +1414,11 @@ public sealed class ScheduledDispatchApplicationService : IScheduledDispatchAppl
         ArgumentNullException.ThrowIfNull(target);
         return target.Kind switch
         {
-            ScheduledDispatchTargetKind.Envelope => NormalizeEnvelopeTarget(target),
             ScheduledDispatchTargetKind.ServiceInvocation => NormalizeServiceInvocationTarget(target),
+            ScheduledDispatchTargetKind.Envelope => throw new ArgumentException(
+                "Raw envelope scheduled dispatch targets are not supported by the Application contract.",
+                nameof(target)),
             _ => throw new ArgumentException($"Unsupported scheduled dispatch target kind '{target.Kind}'.", nameof(target)),
-        };
-    }
-
-    private static ScheduledDispatchTargetDescriptor NormalizeEnvelopeTarget(ScheduledDispatchTargetDescriptor target)
-    {
-        if (target.Envelope?.Payload == null)
-            throw new ArgumentException("Envelope scheduled dispatch target requires an envelope payload.", nameof(target));
-
-        var actorId = NormalizeNullable(target.ActorId);
-        if (string.IsNullOrWhiteSpace(actorId))
-        {
-            actorId = NormalizeNullable(target.Envelope.Route.GetTargetActorId());
-            if (string.IsNullOrWhiteSpace(actorId))
-                throw new ArgumentException("Envelope scheduled dispatch target requires an actor id.", nameof(target));
-        }
-
-        return target with
-        {
-            ActorId = actorId,
-            Envelope = target.Envelope.Clone(),
-            ServiceInvocation = null,
         };
     }
 

--- a/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchTargetPreparationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Schedules/ScheduledDispatchTargetPreparationService.cs
@@ -18,46 +18,14 @@ public sealed class ScheduledDispatchTargetPreparationService : IScheduledDispat
 
         return configuration.Target.Kind switch
         {
-            ScheduledDispatchTargetKind.Envelope => Task.FromResult(PrepareEnvelopeTarget(configuration, commandId, correlationId)),
             ScheduledDispatchTargetKind.ServiceInvocation => Task.FromResult(PrepareServiceInvocationTarget(configuration, commandId, correlationId)),
+            ScheduledDispatchTargetKind.Envelope => throw new ArgumentException(
+                "Raw envelope scheduled dispatch targets are not supported by target preparation.",
+                nameof(configuration)),
             _ => throw new ArgumentException(
                 $"Unsupported scheduled dispatch target kind '{configuration.Target.Kind}'.",
                 nameof(configuration)),
         };
-    }
-
-    private static PreparedScheduledDispatchTarget PrepareEnvelopeTarget(
-        ScheduledDispatchConfiguration configuration,
-        string commandId,
-        string correlationId)
-    {
-        var target = configuration.Target;
-        var envelope = target.Envelope?.Clone()
-            ?? throw new ArgumentException("Envelope scheduled dispatch target is required.", nameof(configuration));
-        if (envelope.Payload == null)
-            throw new ArgumentException("Envelope scheduled dispatch target requires a payload.", nameof(configuration));
-
-        envelope.Payload = ScheduledServiceInvocationPayloadPolicy.StripScheduleOwnedCredentialFields(envelope.Payload);
-        envelope.Id = string.IsNullOrWhiteSpace(envelope.Id) ? commandId : envelope.Id.Trim();
-        envelope.Timestamp ??= Timestamp.FromDateTime(DateTime.UtcNow);
-        var targetActorId = ResolveTargetActorId(target.ActorId, envelope);
-        envelope.Route = EnvelopeRouteSemantics.CreateDirect(
-            ResolvePublisherActorId(envelope, configuration.ScheduleId),
-            targetActorId);
-        var propagation = envelope.EnsurePropagation();
-        if (string.IsNullOrWhiteSpace(propagation.CorrelationId))
-            propagation.CorrelationId = correlationId;
-
-        var safeDescriptor = configuration.Target with
-        {
-            Envelope = envelope.Clone(),
-        };
-
-        return new PreparedScheduledDispatchTarget(
-            targetActorId,
-            envelope,
-            envelope.Payload.TypeUrl,
-            safeDescriptor);
     }
 
     private static PreparedScheduledDispatchTarget PrepareServiceInvocationTarget(
@@ -114,24 +82,4 @@ public sealed class ScheduledDispatchTargetPreparationService : IScheduledDispat
                 CorrelationId = correlationId,
             },
         };
-
-    private static string ResolveTargetActorId(string? configuredActorId, EventEnvelope envelope)
-    {
-        if (!string.IsNullOrWhiteSpace(configuredActorId))
-            return configuredActorId.Trim();
-        if (!string.IsNullOrWhiteSpace(envelope.Route.GetTargetActorId()))
-            return envelope.Route.GetTargetActorId().Trim();
-
-        throw new ArgumentException("Envelope scheduled dispatch target requires an actor id.", nameof(envelope));
-    }
-
-    private static string ResolvePublisherActorId(EventEnvelope envelope, string scheduleId)
-    {
-        if (!string.IsNullOrWhiteSpace(envelope.Route?.PublisherActorId))
-            return envelope.Route.PublisherActorId.Trim();
-
-        return string.IsNullOrWhiteSpace(scheduleId)
-            ? "scheduled.dispatch"
-            : scheduleId.Trim();
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -2925,6 +2925,8 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
     {
         if (triggerEnvelope == null || triggerEnvelope.Payload == null)
             throw new ArgumentException("Trigger envelope with payload is required.", nameof(triggerEnvelope));
+        if (target == null || target.Kind == ScheduledDispatchTargetKindState.Unspecified)
+            throw new ArgumentException("Scheduled dispatch typed target is required.", nameof(target));
         var normalizedTarget = NormalizeTarget(target, scheduleKind);
         if (normalizedTarget.Kind == ScheduledDispatchTargetKindState.Envelope &&
             !HasTrustedInternalEnvelopeAuthority(normalizedTarget))

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/ScheduledDispatchGAgent.cs
@@ -26,6 +26,10 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
     private static readonly TimeSpan OverdueFireGracePeriod = TimeSpan.FromMinutes(10);
     private const string LegacyDurableSenderBearerBlockedError =
         "Scheduled service invocation contains legacy durable bearer auth; reconfigure the schedule with senderNyxId or scopeOwnerNyxId.";
+    private const string LegacyUnmarkedEnvelopeRetiredError =
+        "Scheduled dispatch envelope target is retired because it lacks trusted internal authority.";
+    private const string LegacyUnmarkedEnvelopeRetiredReason =
+        "legacy_unmarked_envelope_target_retired";
     private static readonly TimeSpan MaxNextFireCallbackHop = TimeSpan.FromDays(7);
     internal static readonly TimeSpan TeamAutomationEffectAttemptLeaseDuration = TimeSpan.FromMinutes(5);
     private readonly IActorDispatchPort _dispatchPort;
@@ -55,6 +59,9 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
             await PurgeDurableCallbacksAsync(ct);
             return;
         }
+
+        if (await RetireUnmarkedEnvelopeTargetAsync(ct))
+            return;
 
         await RecoverTeamCredentialExpiryAsync(ct);
         if (CanScheduleAutomaticFire())
@@ -956,6 +963,9 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         }
 
         EnsureConfiguredForWrite(command.Manual ? "manual fire" : "fire");
+        if (await RetireUnmarkedEnvelopeTargetAsync(ct, rejectManualFire: command.Manual))
+            return;
+
         if (command.Manual)
             EnsureTeamAutomationOwnerAccess(command.TeamAutomationOwner, "manual fire");
 
@@ -1611,8 +1621,44 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
         !State.Completed &&
         !State.Deleted &&
         IsConfigured() &&
+        !HasEnvelopeTargetWithoutTrustedInternalAuthority() &&
         (!HasTeamCredentialLifecycle() ||
          HasUsableActiveTeamCredential(_timeProvider.GetUtcNow()));
+
+    private async Task<bool> RetireUnmarkedEnvelopeTargetAsync(
+        CancellationToken ct,
+        bool rejectManualFire = false)
+    {
+        if (!HasEnvelopeTargetWithoutTrustedInternalAuthority())
+            return false;
+        if (rejectManualFire)
+            throw new InvalidOperationException(LegacyUnmarkedEnvelopeRetiredError);
+
+        if (State.Enabled)
+        {
+            await PersistDomainEventAsync(new ScheduledDispatchDisabledEvent
+            {
+                Reason = LegacyUnmarkedEnvelopeRetiredReason,
+                DisabledAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            }, ct);
+        }
+
+        await PurgeDurableCallbacksAsync(ct);
+        Logger.LogWarning(
+            "Scheduled dispatch {ActorId} retired an envelope target without trusted internal authority. scheduleId={ScheduleId}",
+            Id,
+            ResolveScheduleId());
+        return true;
+    }
+
+    private bool HasEnvelopeTargetWithoutTrustedInternalAuthority() =>
+        IsConfigured() &&
+        ResolveTargetKind() == ScheduledDispatchTargetKindState.Envelope &&
+        !HasTrustedInternalEnvelopeAuthority(State.Target);
+
+    private static bool HasTrustedInternalEnvelopeAuthority(ScheduledDispatchTargetState? target) =>
+        target?.Kind == ScheduledDispatchTargetKindState.Envelope &&
+        target.EnvelopeAuthority == ScheduledDispatchEnvelopeAuthorityState.TrustedInternal;
 
     private async Task RecoverTeamCredentialExpiryAsync(CancellationToken ct)
     {
@@ -2879,7 +2925,14 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
     {
         if (triggerEnvelope == null || triggerEnvelope.Payload == null)
             throw new ArgumentException("Trigger envelope with payload is required.", nameof(triggerEnvelope));
-        _ = NormalizeTarget(target, scheduleKind);
+        var normalizedTarget = NormalizeTarget(target, scheduleKind);
+        if (normalizedTarget.Kind == ScheduledDispatchTargetKindState.Envelope &&
+            !HasTrustedInternalEnvelopeAuthority(normalizedTarget))
+        {
+            throw new ArgumentException(
+                "Scheduled dispatch envelope target requires trusted internal authority.",
+                nameof(target));
+        }
         _ = NormalizeRequired(targetActorId, nameof(targetActorId));
 
         var normalizedMode = NormalizeScheduleMode(scheduleMode);
@@ -2928,6 +2981,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
                 Kind = ScheduledDispatchTargetKindState.Envelope,
                 ActorId = NormalizeOptional(target.ActorId),
                 Envelope = target.Envelope == null ? null : NormalizeTriggerEnvelope(target.Envelope),
+                EnvelopeAuthority = target.EnvelopeAuthority,
                 CredentialRequirementTargetKind = ResolveCredentialRequirementTargetKind(
                     target.CredentialRequirementTargetKind,
                     ScheduledDispatchTargetKindState.Envelope,
@@ -2938,6 +2992,7 @@ public sealed class ScheduledDispatchGAgent : GAgentBase<ScheduledDispatchState>
                 Kind = ScheduledDispatchTargetKindState.Envelope,
                 ActorId = NormalizeOptional(target.ActorId),
                 Envelope = target.Envelope == null ? null : NormalizeTriggerEnvelope(target.Envelope),
+                EnvelopeAuthority = target.EnvelopeAuthority,
                 CredentialRequirementTargetKind = ResolveCredentialRequirementTargetKind(
                     target.CredentialRequirementTargetKind,
                     ScheduledDispatchTargetKindState.Envelope,

--- a/src/platform/Aevatar.GAgentService.Core/Schedules/scheduled_dispatch_state.proto
+++ b/src/platform/Aevatar.GAgentService.Core/Schedules/scheduled_dispatch_state.proto
@@ -154,6 +154,12 @@ message ScheduledDispatchRuntimeCallbackLeaseState
   int32 slot_epoch = 5;
 }
 
+enum ScheduledDispatchEnvelopeAuthorityState
+{
+  SCHEDULED_DISPATCH_ENVELOPE_AUTHORITY_STATE_UNSPECIFIED = 0;
+  SCHEDULED_DISPATCH_ENVELOPE_AUTHORITY_STATE_TRUSTED_INTERNAL = 1;
+}
+
 message ScheduledDispatchTargetState
 {
   ScheduledDispatchTargetKindState kind = 1;
@@ -162,6 +168,7 @@ message ScheduledDispatchTargetState
   ScheduledServiceInvocationTargetState service_invocation = 4;
   reserved 5;
   ScheduledDispatchCredentialRequirementTargetKindState credential_requirement_target_kind = 6;
+  ScheduledDispatchEnvelopeAuthorityState envelope_authority = 7;
 }
 
 enum ScheduledDispatchTargetKindState

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/Schedules/ScheduledDispatchEndpoints.cs
@@ -102,6 +102,9 @@ public static class ScheduledDispatchEndpoints
             {
                 TeamAutomationOwner = owner,
             };
+            var targetScopeId = configuration.Target.ServiceInvocation?.Identity.TenantId;
+            if (TryCreateOwnerScopeAccessDeniedResult(http, targetScopeId, out denied))
+                return denied;
         }
         catch (Exception ex) when (TryMapScheduleConfigurationError(ex, out var result))
         {
@@ -149,6 +152,9 @@ public static class ScheduledDispatchEndpoints
             {
                 TeamAutomationOwner = owner,
             };
+            var targetScopeId = configuration.Target.ServiceInvocation?.Identity.TenantId;
+            if (TryCreateOwnerScopeAccessDeniedResult(http, targetScopeId, out denied))
+                return denied;
         }
         catch (Exception ex) when (TryMapScheduleConfigurationError(ex, out var result))
         {
@@ -783,7 +789,6 @@ public sealed record ScheduledDispatchConfigurationHttpRequest
     public bool Enabled { get; init; } = true;
     public IReadOnlyDictionary<string, string>? Headers { get; init; }
     public ScheduledDispatchOwnerHttpRequest? Owner { get; init; }
-    public ScheduledDispatchEnvelopeTargetHttpRequest? Envelope { get; init; }
     public ScheduledDispatchServiceInvocationTargetHttpRequest? ServiceInvocation { get; init; }
 
     public async Task<ScheduledDispatchConfiguration> ToConfigurationAsync(
@@ -819,20 +824,14 @@ public sealed record ScheduledDispatchConfigurationHttpRequest
         ScheduledServiceInvocationNyxIdSubjectRef? authenticatedOwnerSubject,
         CancellationToken ct)
     {
-        var targetCount = (Envelope == null ? 0 : 1) +
-                          (ServiceInvocation == null ? 0 : 1);
-        if (targetCount != 1)
-            throw new ArgumentException("Exactly one scheduled dispatch target is required.");
+        if (ServiceInvocation == null)
+            throw new ArgumentException("A service invocation scheduled dispatch target is required.");
 
-        if (Envelope != null)
-        {
-            return new ResolvedScheduledDispatchTarget(
-                Envelope.ToTarget(),
-                IsWorkflowServiceTarget: false,
-                ScheduledDispatchCredentialRequirementTargetKind.Envelope);
-        }
-
-        return await ServiceInvocation!.ToResolvedTargetAsync(catalogReader, revisionCatalogReader, authenticatedOwnerSubject, ct);
+        return await ServiceInvocation.ToResolvedTargetAsync(
+            catalogReader,
+            revisionCatalogReader,
+            authenticatedOwnerSubject,
+            ct);
     }
 
     private ScheduledDispatchScheduleKind ResolveScheduleKind(ResolvedScheduledDispatchTarget resolvedTarget)
@@ -895,25 +894,6 @@ public sealed record ScheduledDispatchConfigurationHttpRequest
         ScheduledDispatchTargetDescriptor Target,
         bool IsWorkflowServiceTarget,
         ScheduledDispatchCredentialRequirementTargetKind CredentialRequirementTargetKind);
-}
-
-[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
-public sealed record ScheduledDispatchEnvelopeTargetHttpRequest
-{
-    public string? ActorId { get; init; }
-    public required EventEnvelope Envelope { get; init; }
-
-    public ScheduledDispatchTargetDescriptor ToTarget() =>
-        CreateTarget(Envelope);
-
-    private ScheduledDispatchTargetDescriptor CreateTarget(EventEnvelope envelope)
-    {
-        ScheduledDispatchEndpoints.RejectExternalCallerDurableCredential(envelope.Payload);
-        return new(
-            ScheduledDispatchTargetKind.Envelope,
-            ActorId: ActorId,
-            Envelope: envelope);
-    }
 }
 
 [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
@@ -74,10 +74,37 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
-    public async Task Create_ShouldAcceptEnvelopeTargetAndForwardConfiguration()
+    public async Task Create_HttpRoute_ShouldRejectRawEnvelopeTarget()
+    {
+        await using var host = await ScheduleEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PostAsJsonAsync("/api/schedules", new
+        {
+            scheduleId = "schedule-alpha",
+            cronExpression = "0 9 * * *",
+            envelope = new
+            {
+                actorId = "actor-cross-owner",
+                envelope = new
+                {
+                    payload = new
+                    {
+                        typeUrl = "type.googleapis.com/aevatar.workflow.WorkflowStoppedEvent",
+                        value = Convert.ToBase64String(Array.Empty<byte>()),
+                    },
+                },
+            },
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        host.Schedules.Created.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Create_ShouldAcceptServiceInvocationTargetAndForwardConfiguration()
     {
         var service = new RecordingScheduledDispatchApplicationService();
-        var request = CreateEnvelopeRequest(scheduleId: "schedule-1");
+        var request = CreateServiceInvocationRequest(scheduleId: "schedule-1");
 
         var result = await CreateAsync(request, service);
 
@@ -85,28 +112,18 @@ public sealed class ScheduledDispatchEndpointsTests
         await result.ExecuteAsync(http);
 
         http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        service.Created.Should().ContainSingle().Which.Should().BeEquivalentTo(
-            new ScheduledDispatchConfiguration(
-                "schedule-1",
-                "Daily",
-                new ScheduledDispatchTargetDescriptor(
-                    ScheduledDispatchTargetKind.Envelope,
-                    ActorId: "actor-1",
-                    Envelope: request.Envelope!.Envelope),
-                "0 9 * * *",
-                "UTC",
-                true,
-                new Dictionary<string, string> { ["trace"] = "1" })
-            {
-                CredentialRequirementTargetKind = ScheduledDispatchCredentialRequirementTargetKind.Envelope,
-            });
+        var configuration = service.Created.Should().ContainSingle().Which;
+        configuration.ScheduleId.Should().Be("schedule-1");
+        configuration.Target.Kind.Should().Be(ScheduledDispatchTargetKind.ServiceInvocation);
+        configuration.Target.ServiceInvocation!.Identity.TenantId.Should().Be("tenant");
+        configuration.Target.ServiceInvocation.EndpointId.Should().Be("run");
     }
 
     [Fact]
     public async Task Create_ShouldForwardTypedStudioMemberAutomationOwner()
     {
         var service = new RecordingScheduledDispatchApplicationService();
-        var request = CreateEnvelopeRequest(scheduleId: "sch-alpha") with
+        var request = CreateServiceInvocationRequest(scheduleId: "sch-alpha") with
         {
             Owner = StudioMemberAutomationOwnerRequest(),
         };
@@ -128,7 +145,7 @@ public sealed class ScheduledDispatchEndpointsTests
     public async Task Create_ShouldRejectTypedOwnerWhenAuthenticatedScopeDiffers()
     {
         var service = new RecordingScheduledDispatchApplicationService();
-        var request = CreateEnvelopeRequest(scheduleId: "sch-alpha") with
+        var request = CreateServiceInvocationRequest(scheduleId: "sch-alpha") with
         {
             Owner = StudioMemberAutomationOwnerRequest(),
         };
@@ -272,7 +289,7 @@ public sealed class ScheduledDispatchEndpointsTests
             CreateException = new ScheduledDispatchConflictException("schedule-1", "Schedule target cannot be prepared."),
         };
 
-        var result = await CreateAsync(CreateEnvelopeRequest(scheduleId: "schedule-1"), service);
+        var result = await CreateAsync(CreateServiceInvocationRequest(scheduleId: "schedule-1"), service);
 
         var http = CreateHttpContext();
         await result.ExecuteAsync(http);
@@ -288,7 +305,7 @@ public sealed class ScheduledDispatchEndpointsTests
             CreateException = new InvalidOperationException("dispatch runtime failure"),
         };
 
-        var act = () => CreateAsync(CreateEnvelopeRequest(scheduleId: "schedule-1"), service);
+        var act = () => CreateAsync(CreateServiceInvocationRequest(scheduleId: "schedule-1"), service);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("dispatch runtime failure");
@@ -301,7 +318,7 @@ public sealed class ScheduledDispatchEndpointsTests
 
         var result = await UpdateAsync(
             "route-schedule",
-            CreateEnvelopeRequest(scheduleId: null),
+            CreateServiceInvocationRequest(scheduleId: null),
             service);
 
         var http = CreateHttpContext();
@@ -360,6 +377,56 @@ public sealed class ScheduledDispatchEndpointsTests
         configuration.Target.ServiceInvocation.Payload.Should().Be(payload);
         configuration.Target.ServiceInvocation.RevisionId.Should().Be("rev-1");
         configuration.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Create_ShouldRejectServiceInvocationTargetOutsideAuthenticatedScope()
+    {
+        var service = new RecordingScheduledDispatchApplicationService();
+        var result = await CreateAsync(
+            CreateServiceInvocationRequest("schedule-alpha", "scope-beta"),
+            service,
+            CreateHttpContext(scopeId: "scope-alpha", authenticationEnabled: true));
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        service.Created.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Update_ShouldRejectServiceInvocationTargetOutsideAuthenticatedScope()
+    {
+        var service = new RecordingScheduledDispatchApplicationService();
+        var result = await UpdateAsync(
+            "schedule-alpha",
+            CreateServiceInvocationRequest("schedule-alpha", "scope-beta"),
+            service,
+            CreateHttpContext(scopeId: "scope-alpha", authenticationEnabled: true));
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        service.Updated.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Create_ShouldForwardServiceInvocationTargetWithinAuthenticatedScope()
+    {
+        var service = new RecordingScheduledDispatchApplicationService();
+        var result = await CreateAsync(
+            CreateServiceInvocationRequest("schedule-alpha", "scope-alpha"),
+            service,
+            CreateHttpContext(scopeId: "scope-alpha", authenticationEnabled: true));
+
+        var http = CreateHttpContext();
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        service.Created.Should().ContainSingle()
+            .Which.Target.ServiceInvocation!.Identity.TenantId.Should().Be("scope-alpha");
     }
 
     [Fact]
@@ -636,7 +703,7 @@ public sealed class ScheduledDispatchEndpointsTests
     {
         var service = new RecordingScheduledDispatchApplicationService();
 
-        var result = await CreateAsync(CreateEnvelopeRequest(scheduleId: "schedule-1"), service);
+        var result = await CreateAsync(CreateServiceInvocationRequest(scheduleId: "schedule-1"), service);
 
         var http = CreateHttpContext();
         await result.ExecuteAsync(http);
@@ -2031,24 +2098,6 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
-    public async Task Create_WithWorkflowScheduleKindAndEnvelopeTarget_ShouldReturnBadRequest()
-    {
-        var service = new RecordingScheduledDispatchApplicationService();
-        var request = CreateEnvelopeRequest(scheduleId: "schedule-1") with
-        {
-            ScheduleKind = ScheduledDispatchScheduleKind.Workflow,
-        };
-
-        var result = await CreateAsync(request, service);
-
-        var http = CreateHttpContext();
-        await result.ExecuteAsync(http);
-
-        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
-        service.Created.Should().BeEmpty();
-    }
-
-    [Fact]
     public async Task Create_WithStaticServiceInvocationAndOmittedAuth_ShouldNotDefaultAuth()
     {
         await using var host = await ScheduleEndpointTestHost.StartAsync();
@@ -2460,7 +2509,7 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
-    public async Task Create_WithNoOrMultipleTargets_ShouldKeepExactlyOneTargetValidation()
+    public async Task Create_WithNoTargetOrRawEnvelopeTarget_ShouldReturnBadRequest()
     {
         await using var host = await ScheduleEndpointTestHost.StartAsync();
 
@@ -2510,7 +2559,9 @@ public sealed class ScheduledDispatchEndpointsTests
         host.Schedules.Created.Should().BeEmpty();
     }
 
-    private static ScheduledDispatchConfigurationHttpRequest CreateEnvelopeRequest(string? scheduleId) =>
+    private static ScheduledDispatchConfigurationHttpRequest CreateServiceInvocationRequest(
+        string? scheduleId,
+        string scopeId = "tenant") =>
         new()
         {
             ScheduleId = scheduleId,
@@ -2519,14 +2570,18 @@ public sealed class ScheduledDispatchEndpointsTests
             Timezone = "UTC",
             Enabled = true,
             Headers = new Dictionary<string, string> { ["trace"] = "1" },
-            Envelope = new ScheduledDispatchEnvelopeTargetHttpRequest
+            ServiceInvocation = new ScheduledDispatchServiceInvocationTargetHttpRequest
             {
-                ActorId = "actor-1",
-                Envelope = new EventEnvelope
+                Identity = new ServiceIdentity
                 {
-                    Id = "template",
-                    Payload = Any.Pack(new StringValue { Value = "run" }),
+                    TenantId = scopeId,
+                    AppId = "app",
+                    Namespace = "default",
+                    ServiceId = "svc",
                 },
+                EndpointId = "run",
+                PayloadTypeUrl = Any.Pack(new StringValue()).TypeUrl,
+                PayloadBase64 = Convert.ToBase64String(new StringValue { Value = "run" }.ToByteArray()),
             },
         };
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
@@ -56,6 +56,14 @@ public sealed class ScheduledDispatchEndpointsTests
     }
 
     [Fact]
+    public void ConfigurationRequest_ShouldNotExposeRawEnvelopeTarget()
+    {
+        typeof(ScheduledDispatchConfigurationHttpRequest)
+            .GetProperty("Envelope")
+            .Should().BeNull();
+    }
+
+    [Fact]
     public void ServiceInvocationRequest_ShouldRejectForgedAuthorizationFact()
     {
         const string json = """

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
@@ -20,26 +20,20 @@ namespace Aevatar.GAgentService.Tests.Application;
 public sealed class ScheduledDispatchApplicationServiceTests
 {
     [Fact]
-    public async Task CreateAsync_ShouldNormalizeGeneratedEnvelopeScheduleAndDispatchCreate()
+    public async Task CreateAsync_ShouldNormalizeGeneratedServiceInvocationScheduleAndDispatchCreate()
     {
         var actorPort = new RecordingScheduledDispatchActorPort { ResolveUnknownAsMissing = true };
-        var queryPort = new RecordingScheduledDispatchQueryPort();
         var service = new ScheduledDispatchApplicationService(
             actorPort,
-            queryPort,
-            new ScheduledDispatchTargetPreparationService(), new NoopScheduledDispatchCredentialAdmissionPort());
-        var envelope = new EventEnvelope
-        {
-            Payload = Any.Pack(new StringValue { Value = "run" }),
-            Route = EnvelopeRouteSemantics.CreateDirect("publisher-1", "target-1"),
-        };
+            new RecordingScheduledDispatchQueryPort(),
+            new ScheduledDispatchTargetPreparationService(),
+            new NoopScheduledDispatchCredentialAdmissionPort());
+        var target = CreateDefaultServiceInvocationConfiguration("schedule-placeholder").Target;
 
         var receipt = await service.CreateAsync(new ScheduledDispatchConfiguration(
             string.Empty,
             " Daily ",
-            new ScheduledDispatchTargetDescriptor(
-                ScheduledDispatchTargetKind.Envelope,
-                Envelope: envelope),
+            target,
             " 0 9 * * * ",
             " UTC ",
             true,
@@ -56,12 +50,33 @@ public sealed class ScheduledDispatchApplicationServiceTests
         var created = actorPort.Created.Should().ContainSingle().Which;
         created.Configuration.ScheduleId.Should().Be(receipt.ScheduleId);
         created.Configuration.DisplayName.Should().Be("Daily");
-        created.Configuration.Target.ActorId.Should().Be("target-1");
+        created.Configuration.Target.Kind.Should().Be(ScheduledDispatchTargetKind.ServiceInvocation);
+        created.Configuration.Target.ActorId.Should().BeNull();
+        created.Configuration.Target.Envelope.Should().BeNull();
+        created.Configuration.Target.ServiceInvocation!.Identity.ServiceId.Should().Be("svc-alpha");
         created.Configuration.Headers.Should().Contain("trace", "enabled");
         created.Configuration.Headers.Should().NotContainKey("empty");
-        created.Dispatch.TargetActorId.Should().Be("target-1");
+        created.Dispatch.TargetActorId.Should().Be(ScheduledDispatchAdapterConventions.ServiceInvocationTargetActorId);
         created.Dispatch.TriggerEnvelope.Id.Should().Be($"schedule-{receipt.ScheduleId}-trigger");
         created.Dispatch.TriggerEnvelope.Propagation!.CorrelationId.Should().Be($"schedule-{receipt.ScheduleId}");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldRejectRawEnvelopeBeforeActorDispatch()
+    {
+        var actorPort = new RecordingScheduledDispatchActorPort { ResolveUnknownAsMissing = true };
+        var service = new ScheduledDispatchApplicationService(
+            actorPort,
+            new RecordingScheduledDispatchQueryPort(),
+            new ScheduledDispatchTargetPreparationService(), new NoopScheduledDispatchCredentialAdmissionPort());
+
+        var act = () => service.CreateAsync(CreateRawEnvelopeConfiguration("schedule-alpha"));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*raw envelope*not supported*");
+        actorPort.ResolvedScheduleIds.Should().BeEmpty();
+        actorPort.EnsuredScheduleIds.Should().BeEmpty();
+        actorPort.Created.Should().BeEmpty();
     }
 
     [Fact]
@@ -74,7 +89,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             queryPort,
             new ScheduledDispatchTargetPreparationService(), new NoopScheduledDispatchCredentialAdmissionPort());
 
-        await service.CreateAsync(CreateEnvelopeConfiguration("schedule-1"));
+        await service.CreateAsync(CreateDefaultServiceInvocationConfiguration("schedule-1"));
 
         actorPort.ResolvedScheduleIds.Should().ContainSingle().Which.Should().Be("schedule-1");
         actorPort.Created.Should().ContainSingle();
@@ -91,7 +106,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new RecordingScheduledDispatchQueryPort(),
             new ScheduledDispatchTargetPreparationService(), new NoopScheduledDispatchCredentialAdmissionPort());
 
-        var act = () => service.CreateAsync(CreateEnvelopeConfiguration("schedule-1"));
+        var act = () => service.CreateAsync(CreateDefaultServiceInvocationConfiguration("schedule-1"));
 
         await act.Should().ThrowAsync<ScheduledDispatchConflictException>()
             .WithMessage("*already exists*");
@@ -112,10 +127,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
         await service.CreateAsync(new ScheduledDispatchConfiguration(
             "one-shot-1",
             " Reminder ",
-            new ScheduledDispatchTargetDescriptor(
-                ScheduledDispatchTargetKind.Envelope,
-                ActorId: "actor-1",
-                Envelope: new EventEnvelope { Payload = Any.Pack(new Empty()) }),
+            CreateDefaultServiceInvocationConfiguration("one-shot-1").Target,
             "0 9 * * *",
             " Asia/Shanghai ",
             true,
@@ -134,12 +146,12 @@ public sealed class ScheduledDispatchApplicationServiceTests
     public async Task CreateAsync_ShouldRejectMissingOrPastOneShotFireTime()
     {
         var service = CreateService();
-        var missingFireAt = () => service.CreateAsync(CreateEnvelopeConfiguration("one-shot-missing") with
+        var missingFireAt = () => service.CreateAsync(CreateDefaultServiceInvocationConfiguration("one-shot-missing") with
         {
             ScheduleMode = ScheduledDispatchScheduleMode.OneShotAtUtc,
             OneShotFireAt = null,
         });
-        var pastFireAt = () => service.CreateAsync(CreateEnvelopeConfiguration("one-shot-past") with
+        var pastFireAt = () => service.CreateAsync(CreateDefaultServiceInvocationConfiguration("one-shot-past") with
         {
             ScheduleMode = ScheduledDispatchScheduleMode.OneShotAtUtc,
             OneShotFireAt = DateTimeOffset.UtcNow.AddMinutes(-1),
@@ -494,9 +506,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
                     SenderNyxIdAccessToken = "sender-token",
                 },
             })));
-        var headerCredential = () => service.CreateAsync(CreateEnvelopeConfiguration("schedule-header-credential") with
+        var headerCredential = () => service.CreateAsync(CreateDefaultServiceInvocationConfiguration("schedule-header-credential") with
         {
-            CredentialRequirementTargetKind = ScheduledDispatchCredentialRequirementTargetKind.Envelope,
             Headers = new Dictionary<string, string>
             {
                 [ScheduledDispatchCredentialRequirementRequests.LegacyConnectorHttpAuthorizationHeader] = "Bearer current-token",
@@ -522,9 +533,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new RecordingScheduledDispatchQueryPort(),
             new ScheduledDispatchTargetPreparationService(),
             new NoopScheduledDispatchCredentialAdmissionPort());
-        var configuration = CreateEnvelopeConfiguration("schedule-header-case-variant") with
+        var configuration = CreateDefaultServiceInvocationConfiguration("schedule-header-case-variant") with
         {
-            CredentialRequirementTargetKind = ScheduledDispatchCredentialRequirementTargetKind.Envelope,
             Headers = new Dictionary<string, string>
             {
                 [authorizationHeader] = "redacted",
@@ -658,7 +668,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             preparation,
             new NoopScheduledDispatchCredentialAdmissionPort());
 
-        var receipt = await service.EnsureAsync(CreateEnvelopeConfiguration(" schedule-1 "));
+        var receipt = await service.EnsureAsync(CreateDefaultServiceInvocationConfiguration(" schedule-1 "));
 
         receipt.ScheduleId.Should().Be("schedule-1");
         receipt.ScheduleActorId.Should().Be("actor:schedule-1");
@@ -695,7 +705,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             queryPort,
             preparation,
             admissionPort);
-        var configuration = CreateEnvelopeConfiguration("sch-alpha") with
+        var configuration = CreateDefaultServiceInvocationConfiguration("sch-alpha") with
         {
             TeamAutomationOwner = ownerOnConfiguration ? owner : null,
         };
@@ -721,7 +731,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
     [Theory]
     [InlineData(nameof(ScheduleMutationKind.Create))]
     [InlineData(nameof(ScheduleMutationKind.Ensure))]
-    public async Task GenericCreationMutations_WithoutTeamOwner_ShouldKeepLegacyBehavior(string mutationName)
+    public async Task GenericCreationMutations_WithoutTeamOwner_ShouldDispatchServiceInvocation(string mutationName)
     {
         var mutation = System.Enum.Parse<ScheduleMutationKind>(mutationName);
         var actorPort = new RecordingScheduledDispatchActorPort { ResolveUnknownAsMissing = true };
@@ -738,7 +748,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
                 string.Empty,
                 "owner-alpha"));
 
-        await ExecuteMutationAsync(service, mutation, CreateEnvelopeConfiguration("schedule-legacy"), context);
+        await ExecuteMutationAsync(service, mutation, CreateDefaultServiceInvocationConfiguration("schedule-generic"), context);
 
         preparation.Requests.Should().ContainSingle();
         if (mutation == ScheduleMutationKind.Create)
@@ -1009,7 +1019,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new RecordingScheduledDispatchQueryPort(),
             new ScheduledDispatchTargetPreparationService(), new NoopScheduledDispatchCredentialAdmissionPort());
 
-        var act = () => service.UpdateAsync(" missing ", CreateEnvelopeConfiguration("ignored"));
+        var act = () => service.UpdateAsync(" missing ", CreateDefaultServiceInvocationConfiguration("ignored"));
 
         await act.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
         actorPort.EnsuredScheduleIds.Should().BeEmpty();
@@ -1024,7 +1034,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
     {
         var service = CreateService();
 
-        var act = () => service.CreateAsync(CreateEnvelopeConfiguration(scheduleId));
+        var act = () => service.CreateAsync(CreateDefaultServiceInvocationConfiguration(scheduleId));
 
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*letters, digits, '.', '_', and '-'*");
@@ -1098,17 +1108,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
     {
         var service = CreateService();
 
-        var missingEnvelopePayload = () => service.CreateAsync(new ScheduledDispatchConfiguration(
-            "schedule-1",
-            string.Empty,
-            new ScheduledDispatchTargetDescriptor(
-                ScheduledDispatchTargetKind.Envelope,
-                ActorId: "actor-1",
-                Envelope: new EventEnvelope()),
-            "0 9 * * *",
-            "UTC",
-            true,
-            new Dictionary<string, string>()));
+        var rawEnvelope = () => service.CreateAsync(CreateRawEnvelopeConfiguration("schedule-1"));
         var missingServiceId = () => service.CreateAsync(new ScheduledDispatchConfiguration(
             "schedule-2",
             string.Empty,
@@ -1128,7 +1128,13 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.ServiceInvocation,
                 ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
-                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default", ServiceId = "svc" },
+                    new ServiceIdentity
+                    {
+                        TenantId = "tenant-alpha",
+                        AppId = "app-alpha",
+                        Namespace = "default",
+                        ServiceId = "svc-alpha",
+                    },
                     " ",
                     Any.Pack(new Empty()))),
             "0 9 * * *",
@@ -1136,8 +1142,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
             true,
             new Dictionary<string, string>()));
 
-        await missingEnvelopePayload.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*envelope payload*");
+        await rawEnvelope.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*raw envelope*not supported*");
         await missingServiceId.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*service id*");
         await missingEndpoint.Should().ThrowAsync<ArgumentException>()
@@ -1881,7 +1887,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
         var dispatchPort = new RecordingActorDispatchPort();
         var port = new ScheduledDispatchActorPort(new RecordingActorRuntime(), dispatchPort);
         var fireAt = new DateTimeOffset(2026, 7, 14, 1, 30, 0, TimeSpan.Zero);
-        var configuration = CreateEnvelopeConfiguration("one-shot-1") with
+        var configuration = CreateDefaultServiceInvocationConfiguration("one-shot-1") with
         {
             CronExpression = string.Empty,
             ScheduleMode = ScheduledDispatchScheduleMode.OneShotAtUtc,
@@ -1899,11 +1905,11 @@ public sealed class ScheduledDispatchApplicationServiceTests
     }
 
     [Fact]
-    public async Task ScheduledDispatchActorPort_ShouldMapEnvelopeUpdateAndRejectUnsupportedTarget()
+    public async Task ScheduledDispatchActorPort_ShouldMapServiceInvocationUpdateAndRejectUnsupportedTarget()
     {
         var dispatchPort = new RecordingActorDispatchPort();
         var port = new ScheduledDispatchActorPort(new RecordingActorRuntime(), dispatchPort);
-        var configuration = CreateEnvelopeConfiguration("schedule-1");
+        var configuration = CreateDefaultServiceInvocationConfiguration("schedule-1");
         var prepared = await new ScheduledDispatchTargetPreparationService()
             .PrepareAsync(configuration, "cmd-1", "corr-1");
 
@@ -1918,9 +1924,9 @@ public sealed class ScheduledDispatchApplicationServiceTests
                 new ScheduledDispatchTargetDescriptor((ScheduledDispatchTargetKind)99)));
 
         var command = dispatchPort.Envelopes.Should().ContainSingle().Which.Payload.Unpack<ScheduledDispatchUpdateCommand>();
-        command.Target.Kind.Should().Be(ScheduledDispatchTargetKindState.Envelope);
-        command.Target.ActorId.Should().Be("actor-1");
-        command.Target.Envelope.Payload.Unpack<Empty>().Should().NotBeNull();
+        command.Target.Kind.Should().Be(ScheduledDispatchTargetKindState.ServiceInvocation);
+        command.Target.ServiceInvocation.Identity.ServiceId.Should().Be("svc-alpha");
+        command.Target.ServiceInvocation.EndpointId.Should().Be("run");
         command.ScheduleKind.Should().Be(ScheduledDispatchScheduleKindState.Generic);
         await unsupported.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*Unsupported scheduled dispatch target kind*");
@@ -1934,9 +1940,9 @@ public sealed class ScheduledDispatchApplicationServiceTests
         {
             Detail = CreateSummaryDetail(
                 "schedule-1",
-                ScheduledDispatchTargetKind.Envelope,
+                ScheduledDispatchTargetKind.ServiceInvocation,
                 ScheduledDispatchScheduleKind.Generic,
-                ScheduledDispatchCredentialRequirementTargetKind.Envelope,
+                ScheduledDispatchCredentialRequirementTargetKind.StaticService,
                 ScheduledDispatchCredentialSourceKind.None),
         };
         var service = new ScheduledDispatchApplicationService(
@@ -2006,8 +2012,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
                 new ScheduledDispatchSummary(
                     "schedule-1",
                     string.Empty,
-                    ScheduledDispatchTargetKind.Envelope,
-                    "actor-1",
+                    ScheduledDispatchTargetKind.ServiceInvocation,
+                    string.Empty,
                     string.Empty,
                     string.Empty,
                     string.Empty,
@@ -2038,8 +2044,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetPreparationService(), new NoopScheduledDispatchCredentialAdmissionPort());
 
         var get = await service.GetAsync(" schedule-1 ");
-        var update = () => service.UpdateAsync("schedule-1", CreateEnvelopeConfiguration("schedule-1"));
-        var ensure = () => service.EnsureAsync(CreateEnvelopeConfiguration("schedule-1"));
+        var update = () => service.UpdateAsync("schedule-1", CreateDefaultServiceInvocationConfiguration("schedule-1"));
+        var ensure = () => service.EnsureAsync(CreateDefaultServiceInvocationConfiguration("schedule-1"));
         var enable = () => service.EnableAsync("schedule-1", string.Empty);
         var disable = () => service.DisableAsync("schedule-1", string.Empty);
         var delete = () => service.DeleteAsync("schedule-1", string.Empty);
@@ -2066,9 +2072,9 @@ public sealed class ScheduledDispatchApplicationServiceTests
         var actorPort = new RecordingScheduledDispatchActorPort();
         var detail = CreateSummaryDetail(
             "team-schedule",
-            ScheduledDispatchTargetKind.Envelope,
+            ScheduledDispatchTargetKind.ServiceInvocation,
             ScheduledDispatchScheduleKind.Generic,
-            ScheduledDispatchCredentialRequirementTargetKind.Envelope,
+            ScheduledDispatchCredentialRequirementTargetKind.StaticService,
             ScheduledDispatchCredentialSourceKind.None);
         var queryPort = new RecordingScheduledDispatchQueryPort
         {
@@ -2090,8 +2096,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
 
         (await service.GetAsync("team-schedule")).Should().BeNull();
         var update = () => service.UpdateAsync(
-            "team-schedule", CreateEnvelopeConfiguration("team-schedule"));
-        var ensure = () => service.EnsureAsync(CreateEnvelopeConfiguration("team-schedule"));
+            "team-schedule", CreateDefaultServiceInvocationConfiguration("team-schedule"));
+        var ensure = () => service.EnsureAsync(CreateDefaultServiceInvocationConfiguration("team-schedule"));
         var enable = () => service.EnableAsync("team-schedule", string.Empty);
         var disable = () => service.DisableAsync("team-schedule", string.Empty);
         var delete = () => service.DeleteAsync("team-schedule", string.Empty);
@@ -2111,6 +2117,95 @@ public sealed class ScheduledDispatchApplicationServiceTests
         actorPort.Disabled.Should().BeEmpty();
         actorPort.Deleted.Should().BeEmpty();
         actorPort.RunNow.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LegacyEnvelopeSchedule_ShouldBeHiddenFromGenericGetAndLifecycleBeforeActorDispatch()
+    {
+        var actorPort = new RecordingScheduledDispatchActorPort();
+        var queryPort = new RecordingScheduledDispatchQueryPort
+        {
+            Detail = CreateSummaryDetail(
+                "schedule-legacy-envelope",
+                ScheduledDispatchTargetKind.Envelope,
+                ScheduledDispatchScheduleKind.Generic,
+                ScheduledDispatchCredentialRequirementTargetKind.Envelope,
+                ScheduledDispatchCredentialSourceKind.None),
+        };
+        var service = new ScheduledDispatchApplicationService(
+            actorPort,
+            queryPort,
+            new ScheduledDispatchTargetPreparationService(),
+            new NoopScheduledDispatchCredentialAdmissionPort());
+
+        var get = await service.GetAsync("schedule-legacy-envelope");
+        var enable = () => service.EnableAsync("schedule-legacy-envelope", "resume");
+        var disable = () => service.DisableAsync("schedule-legacy-envelope", "pause");
+        var delete = () => service.DeleteAsync("schedule-legacy-envelope", "remove");
+        var runNow = () => service.RunNowAsync("schedule-legacy-envelope");
+
+        get.Should().BeNull();
+        await enable.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        await disable.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        await delete.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        await runNow.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        actorPort.ResolvedScheduleIds.Should().BeEmpty();
+        actorPort.Enabled.Should().BeEmpty();
+        actorPort.Disabled.Should().BeEmpty();
+        actorPort.Deleted.Should().BeEmpty();
+        actorPort.RunNow.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LegacyEnvelopeSchedule_ShouldBeHiddenFromTeamGetAndLifecycleBeforeActorDispatch()
+    {
+        var owner = new TeamMemberAutomationOwner("scope-alpha", "m-alpha", "team-alpha");
+        var legacy = CreateSummaryDetail(
+            "schedule-team-legacy-envelope",
+            ScheduledDispatchTargetKind.Envelope,
+            ScheduledDispatchScheduleKind.Workflow,
+            ScheduledDispatchCredentialRequirementTargetKind.Envelope,
+            ScheduledDispatchCredentialSourceKind.None);
+        var actorPort = new RecordingScheduledDispatchActorPort();
+        var queryPort = new RecordingScheduledDispatchQueryPort
+        {
+            Detail = legacy with
+            {
+                Schedule = legacy.Schedule with
+                {
+                    TeamOwned = true,
+                    TeamOwnerScopeId = owner.ScopeId,
+                    TeamId = owner.TeamId,
+                    TeamOwnerMemberId = owner.MemberId,
+                },
+            },
+        };
+        var service = new ScheduledDispatchApplicationService(
+            actorPort,
+            queryPort,
+            new ScheduledDispatchTargetPreparationService(),
+            new NoopScheduledDispatchCredentialAdmissionPort());
+
+        var getByScope = await service.GetTeamScheduleAsync(
+            "schedule-team-legacy-envelope",
+            owner.ScopeId,
+            owner.TeamId,
+            owner.MemberId);
+        var getByOwner = await service.GetTeamAutomationAsync("schedule-team-legacy-envelope", owner);
+        var enable = () => service.EnableTeamAutomationAsync("schedule-team-legacy-envelope", owner, "resume");
+        var disable = () => service.DisableTeamAutomationAsync("schedule-team-legacy-envelope", owner, "pause");
+        var delete = () => service.DeleteTeamAutomationAsync("schedule-team-legacy-envelope", owner, "remove");
+        var runNow = () => service.RunTeamAutomationNowAsync("schedule-team-legacy-envelope", owner);
+
+        getByScope.Should().BeNull();
+        getByOwner.Should().BeNull();
+        await enable.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        await disable.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        await delete.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        await runNow.Should().ThrowAsync<ScheduledDispatchNotFoundException>();
+        actorPort.ResolvedScheduleIds.Should().BeEmpty();
+        actorPort.TeamDeleted.Should().BeEmpty();
+        actorPort.TeamRunNow.Should().BeEmpty();
     }
 
     [Fact]
@@ -2168,9 +2263,15 @@ public sealed class ScheduledDispatchApplicationServiceTests
             ScheduledDispatchScheduleKind.Workflow));
         queryPort.FilteredListRequests.Should().HaveCount(3);
         queryPort.FilteredListRequests[0].Should().Be(new ScheduledDispatchListQuery(
-            1, "cursor-1", true, ExcludeTeamOwned: true));
+            1,
+            "cursor-1",
+            true,
+            ScheduledDispatchTargetKind.ServiceInvocation,
+            ExcludeTeamOwned: true));
         queryPort.FilteredListRequests[1].Should().Be(new ScheduledDispatchListQuery(
-            200, ExcludeTeamOwned: true));
+            200,
+            TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
+            ExcludeTeamOwned: true));
         queryPort.FilteredListRequests[2].Should().Be(new ScheduledDispatchListQuery(
             25,
             "cursor-2",
@@ -2193,7 +2294,8 @@ public sealed class ScheduledDispatchApplicationServiceTests
             IncludeTotalCount: true,
             TeamAutomationScopeId: "scope-alpha",
             TeamAutomationTeamId: "team-alpha",
-            TeamAutomationMemberId: "member-alpha"));
+            TeamAutomationMemberId: "member-alpha",
+            TargetKind: ScheduledDispatchTargetKind.ServiceInvocation));
         preview.Timezone.Should().Be("UTC");
         preview.NextFireTimes.Should().HaveCount(100);
         await invalidPreview.Should().ThrowAsync<ArgumentException>();
@@ -2220,6 +2322,7 @@ public sealed class ScheduledDispatchApplicationServiceTests
             Take: 25,
             Cursor: "cursor-owner",
             IncludeTotalCount: true,
+            TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
             TeamAutomationOwner: new TeamMemberAutomationOwner("scope-alpha", "m-alpha", "team-alpha"),
             ExcludeTeamOwned: false,
             ExcludeCompletedTeamAutomationDeletions: true));
@@ -2256,8 +2359,45 @@ public sealed class ScheduledDispatchApplicationServiceTests
                 Take: 25,
                 Cursor: "cursor-input",
                 IncludeTotalCount: true,
+                TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
                 TeamAutomationOwner: new TeamMemberAutomationOwner("scope-alpha", "member-alpha", "team-alpha"),
                 ExcludeCompletedTeamAutomationDeletions: true));
+    }
+
+    [Fact]
+    public async Task ListMethods_ShouldHideLegacyEnvelopeRowsBeforePaging()
+    {
+        var legacy = CreateSummaryDetail(
+            "schedule-legacy-envelope",
+            ScheduledDispatchTargetKind.Envelope,
+            ScheduledDispatchScheduleKind.Workflow,
+            ScheduledDispatchCredentialRequirementTargetKind.Envelope,
+            ScheduledDispatchCredentialSourceKind.None);
+        var queryPort = new RecordingScheduledDispatchQueryPort
+        {
+            ListResult = new ScheduledDispatchListResult([legacy.Schedule], "legacy-cursor", 1),
+        };
+        var service = new ScheduledDispatchApplicationService(
+            new RecordingScheduledDispatchActorPort(),
+            queryPort,
+            new ScheduledDispatchTargetPreparationService(),
+            new NoopScheduledDispatchCredentialAdmissionPort());
+        var owner = new TeamMemberAutomationOwner("scope-alpha", "m-alpha", "team-alpha");
+
+        var generic = await service.ListAsync();
+        var teamScope = await service.ListAsync(new ScheduledDispatchListQuery(
+            TeamAutomationScopeId: owner.ScopeId,
+            TeamAutomationTeamId: owner.TeamId,
+            TeamAutomationMemberId: owner.MemberId));
+        var teamOwner = await service.ListAsync(new ScheduledDispatchListQuery(TeamAutomationOwner: owner));
+        var teamAutomations = await service.ListTeamAutomationsAsync(owner);
+
+        generic.Items.Should().BeEmpty();
+        teamScope.Items.Should().BeEmpty();
+        teamOwner.Items.Should().BeEmpty();
+        teamAutomations.Items.Should().BeEmpty();
+        queryPort.FilteredListRequests.Should().HaveCount(4)
+            .And.OnlyContain(query => query.TargetKind == ScheduledDispatchTargetKind.ServiceInvocation);
     }
 
     [Fact]
@@ -2596,55 +2736,9 @@ public sealed class ScheduledDispatchApplicationServiceTests
     }
 
     [Fact]
-    public async Task TargetPreparation_ShouldPreserveExistingEnvelopeIdentityAndCorrelation()
+    public async Task TargetPreparation_ShouldRejectUnsupportedKind()
     {
         var service = new ScheduledDispatchTargetPreparationService();
-        var envelope = new EventEnvelope
-        {
-            Id = "existing-command",
-            Payload = Any.Pack(new StringValue { Value = "run" }),
-            Route = EnvelopeRouteSemantics.CreateDirect("publisher-1", "route-target"),
-            Propagation = new EnvelopePropagation { CorrelationId = "existing-correlation" },
-        };
-
-        var prepared = await service.PrepareAsync(
-            new ScheduledDispatchConfiguration(
-                "schedule-1",
-                string.Empty,
-                new ScheduledDispatchTargetDescriptor(
-                    ScheduledDispatchTargetKind.Envelope,
-                    Envelope: envelope),
-                "0 9 * * *",
-                "UTC",
-                true,
-                new Dictionary<string, string>()),
-            "cmd-1",
-            "corr-1");
-
-        prepared.TargetActorId.Should().Be("route-target");
-        prepared.TriggerEnvelope.Id.Should().Be("existing-command");
-        prepared.TriggerEnvelope.Route.PublisherActorId.Should().Be("publisher-1");
-        prepared.TriggerEnvelope.Propagation!.CorrelationId.Should().Be("existing-correlation");
-        envelope.Id.Should().Be("existing-command");
-    }
-
-    [Fact]
-    public async Task TargetPreparation_ShouldRejectMissingEnvelopeTargetActorAndUnsupportedKind()
-    {
-        var service = new ScheduledDispatchTargetPreparationService();
-        var missingActor = () => service.PrepareAsync(
-            new ScheduledDispatchConfiguration(
-                "schedule-1",
-                string.Empty,
-                new ScheduledDispatchTargetDescriptor(
-                    ScheduledDispatchTargetKind.Envelope,
-                    Envelope: new EventEnvelope { Payload = Any.Pack(new Empty()) }),
-                "0 9 * * *",
-                "UTC",
-                true,
-                new Dictionary<string, string>()),
-            "cmd-1",
-            "corr-1");
         var unsupported = () => service.PrepareAsync(
             new ScheduledDispatchConfiguration(
                 "schedule-1",
@@ -2657,8 +2751,6 @@ public sealed class ScheduledDispatchApplicationServiceTests
             "cmd-1",
             "corr-1");
 
-        await missingActor.Should().ThrowAsync<ArgumentException>()
-            .WithMessage("*actor id*");
         await unsupported.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*Unsupported scheduled dispatch target kind*");
     }
@@ -2696,13 +2788,19 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetPreparationService(),
             new NoopScheduledDispatchCredentialAdmissionPort());
 
-    private static ScheduledDispatchConfiguration CreateEnvelopeConfiguration(string scheduleId) =>
+    private static ScheduledDispatchConfiguration CreateDefaultServiceInvocationConfiguration(string scheduleId) =>
+        CreateServiceInvocationConfiguration(
+            scheduleId,
+            ScheduledDispatchScheduleKind.Generic,
+            ScheduledDispatchCredentialRequirementTargetKind.StaticService);
+
+    private static ScheduledDispatchConfiguration CreateRawEnvelopeConfiguration(string scheduleId) =>
         new(
             scheduleId,
             string.Empty,
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.Envelope,
-                ActorId: "actor-1",
+                ActorId: "actor-cross-owner",
                 Envelope: new EventEnvelope { Payload = Any.Pack(new Empty()) }),
             "0 9 * * *",
             "UTC",
@@ -2720,7 +2818,13 @@ public sealed class ScheduledDispatchApplicationServiceTests
             new ScheduledDispatchTargetDescriptor(
                 ScheduledDispatchTargetKind.ServiceInvocation,
                 ServiceInvocation: new ScheduledServiceInvocationTargetDescriptor(
-                    new ServiceIdentity { TenantId = "tenant", AppId = "app", Namespace = "default", ServiceId = "svc" },
+                    new ServiceIdentity
+                    {
+                        TenantId = "tenant-alpha",
+                        AppId = "app-alpha",
+                        Namespace = "default",
+                        ServiceId = "svc-alpha",
+                    },
                     "run",
                     payload ?? Any.Pack(new Empty()))),
             "0 9 * * *",
@@ -3263,6 +3367,16 @@ public sealed class ScheduledDispatchApplicationServiceTests
         {
             ct.ThrowIfCancellationRequested();
             FilteredListRequests.Add(query);
+            var visibleItems = query.TargetKind is { } targetKind
+                ? ListResult.Items.Where(item => item.TargetKind == targetKind).ToArray()
+                : ListResult.Items;
+            if (visibleItems.Count != ListResult.Items.Count)
+            {
+                return Task.FromResult(new ScheduledDispatchListResult(
+                    visibleItems,
+                    NextCursor: null,
+                    TotalCount: query.IncludeTotalCount ? visibleItems.Count : null));
+            }
             if (query.IncludeTotalCount && ListResult.TotalCount.HasValue)
                 return Task.FromResult(ListResult);
             return Task.FromResult(ListResult with

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchApplicationServiceTests.cs
@@ -80,6 +80,50 @@ public sealed class ScheduledDispatchApplicationServiceTests
     }
 
     [Fact]
+    public async Task UpdateAsync_ShouldRejectRawEnvelopeBeforeQueryReadActorResolutionAndDispatch()
+    {
+        var actorPort = new RecordingScheduledDispatchActorPort();
+        var queryPort = new RecordingScheduledDispatchQueryPort();
+        var service = new ScheduledDispatchApplicationService(
+            actorPort,
+            queryPort,
+            new ScheduledDispatchTargetPreparationService(),
+            new NoopScheduledDispatchCredentialAdmissionPort());
+
+        var act = () => service.UpdateAsync(
+            "schedule-update-raw",
+            CreateRawEnvelopeConfiguration("schedule-ignored"));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*raw envelope*not supported*");
+        queryPort.GetScheduleIds.Should().BeEmpty();
+        actorPort.ResolvedScheduleIds.Should().BeEmpty();
+        actorPort.EnsuredScheduleIds.Should().BeEmpty();
+        actorPort.Updated.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnsureAsync_ShouldRejectRawEnvelopeBeforeQueryReadActorResolutionAndDispatch()
+    {
+        var actorPort = new RecordingScheduledDispatchActorPort();
+        var queryPort = new RecordingScheduledDispatchQueryPort();
+        var service = new ScheduledDispatchApplicationService(
+            actorPort,
+            queryPort,
+            new ScheduledDispatchTargetPreparationService(),
+            new NoopScheduledDispatchCredentialAdmissionPort());
+
+        var act = () => service.EnsureAsync(CreateRawEnvelopeConfiguration("schedule-ensure-raw"));
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*raw envelope*not supported*");
+        queryPort.GetScheduleIds.Should().BeEmpty();
+        actorPort.ResolvedScheduleIds.Should().BeEmpty();
+        actorPort.EnsuredScheduleIds.Should().BeEmpty();
+        actorPort.Ensured.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task CreateAsync_ShouldCheckActorExistenceWithoutQueryingReadModel()
     {
         var actorPort = new RecordingScheduledDispatchActorPort { ResolveUnknownAsMissing = true };

--- a/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchServiceInvocationTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScheduledDispatchServiceInvocationTests.cs
@@ -70,6 +70,31 @@ public sealed class ScheduledDispatchServiceInvocationTests
     }
 
     [Fact]
+    public async Task PrepareAsync_ShouldRejectRawEnvelopeTarget()
+    {
+        var service = new ScheduledDispatchTargetPreparationService();
+        var rawEnvelopeConfiguration = new ScheduledDispatchConfiguration(
+            "schedule-raw-envelope",
+            string.Empty,
+            new ScheduledDispatchTargetDescriptor(
+                ScheduledDispatchTargetKind.Envelope,
+                ActorId: "actor-cross-owner",
+                Envelope: new EventEnvelope { Payload = Any.Pack(new Empty()) }),
+            "0 9 * * *",
+            "UTC",
+            true,
+            new Dictionary<string, string>());
+
+        var act = () => service.PrepareAsync(
+            rawEnvelopeConfiguration,
+            "cmd-raw-envelope",
+            "corr-raw-envelope");
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*raw envelope*not supported*");
+    }
+
+    [Fact]
     public async Task PrepareAsync_ShouldPreserveDurableLlmControlAndStripCredentials()
     {
         var service = new ScheduledDispatchTargetPreparationService();
@@ -258,20 +283,8 @@ public sealed class ScheduledDispatchServiceInvocationTests
     }
 
     [Fact]
-    public void ScheduledDispatchHttpRequest_ShouldRejectExternalCallerDurableCredential()
+    public void ScheduledDispatchServiceInvocationHttpRequest_ShouldRejectExternalCallerDurableCredential()
     {
-        var envelopeTarget = new ScheduledDispatchEnvelopeTargetHttpRequest
-        {
-            ActorId = "target",
-            Envelope = new EventEnvelope
-            {
-                Payload = Any.Pack(new ChatRequestEvent
-                {
-                    Prompt = "hello",
-                    CallerDurableCredential = CreateDurableCallerCredentialRef(),
-                }),
-            },
-        };
         var serviceTarget = new ScheduledDispatchServiceInvocationTargetHttpRequest
         {
             Identity = new ServiceIdentity { TenantId = "tenant", ServiceId = "svc" },
@@ -279,10 +292,6 @@ public sealed class ScheduledDispatchServiceInvocationTests
             PayloadTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
         };
 
-        FluentActions.Invoking(() => envelopeTarget.ToTarget())
-            .Should()
-            .Throw<ArgumentException>()
-            .WithMessage("*caller_durable_credential*trusted-only*");
         FluentActions.Invoking(() => serviceTarget.ToTarget(
                 Any.Pack(new ChatRequestEvent
                 {

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowScheduleApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowScheduleApplicationServiceTests.cs
@@ -892,6 +892,7 @@ public sealed class WorkflowScheduleApplicationServiceTests
             "cursor",
             true,
             ScheduleKind: ScheduledDispatchScheduleKind.Workflow,
+            TargetKind: ScheduledDispatchTargetKind.ServiceInvocation,
             ExcludeTeamOwned: true));
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -94,6 +94,91 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
+    public async Task HandleConfigureAsync_WithUnknownEnvelopeAuthority_ShouldRejectBeforePersistingEvents()
+    {
+        var eventStore = new TestEventStore();
+        var agent = CreateAgent(eventStore, new RecordingActorDispatchPort());
+        await agent.ActivateAsync();
+        var command = CreateConfigureCommand(target: new ScheduledDispatchTargetState
+        {
+            Kind = ScheduledDispatchTargetKindState.Envelope,
+            ActorId = "actor-unknown-authority",
+            Envelope = CreateTriggerEnvelope("actor-unknown-authority", new Empty()),
+            EnvelopeAuthority = (ScheduledDispatchEnvelopeAuthorityState)99,
+        });
+
+        var act = () => agent.HandleConfigureAsync(command);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*trusted internal authority*");
+        eventStore.GetEvents(ScheduleActorId).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleConfigureAsync_WithUnspecifiedTargetKind_ShouldRequireTypedTargetBeforePersistingEvents()
+    {
+        var eventStore = new TestEventStore();
+        var agent = CreateAgent(eventStore, new RecordingActorDispatchPort());
+        await agent.ActivateAsync();
+        var command = CreateConfigureCommand(target: new ScheduledDispatchTargetState
+        {
+            Kind = ScheduledDispatchTargetKindState.Unspecified,
+        });
+
+        var act = () => agent.HandleConfigureAsync(command);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*typed target is required*");
+        eventStore.GetEvents(ScheduleActorId).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("create")]
+    [InlineData("update")]
+    [InlineData("ensure-create")]
+    [InlineData("ensure-update")]
+    public async Task ConfigureEntryPoints_WithMissingTypedTarget_ShouldRejectBeforePersistingEvents(
+        string operation)
+    {
+        var eventStore = new TestEventStore();
+        var agent = CreateAgent(eventStore, new RecordingActorDispatchPort());
+        await agent.ActivateAsync();
+        if (operation is "update" or "ensure-update")
+            await agent.HandleConfigureAsync(CreateConfigureCommand(enabled: false));
+
+        var create = CreateConfigureCommand(enabled: false);
+        create.Target = null;
+        var update = CreateUpdateCommand(enabled: false);
+        update.Target = null;
+        var ensure = CreateEnsureCommand(enabled: false);
+        ensure.Target = null;
+        var eventCountBefore = eventStore.GetEvents(ScheduleActorId).Count;
+        var configuredEventCountBefore = eventStore.GetEvents(ScheduleActorId)
+            .Count(x => string.Equals(
+                x.EventType,
+                ScheduledDispatchConfiguredEvent.Descriptor.FullName,
+                StringComparison.Ordinal));
+        Func<Task> act = operation switch
+        {
+            "create" => () => agent.HandleConfigureAsync(create),
+            "update" => () => agent.HandleConfigureAsync(update),
+            "ensure-create" or "ensure-update" => () => agent.HandleEnsureAsync(ensure),
+            _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, null),
+        };
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*typed target is required*");
+        eventStore.GetEvents(ScheduleActorId).Should().HaveCount(eventCountBefore);
+        eventStore.GetEvents(ScheduleActorId)
+            .Count(x => string.Equals(
+                x.EventType,
+                ScheduledDispatchConfiguredEvent.Descriptor.FullName,
+                StringComparison.Ordinal))
+            .Should()
+            .Be(configuredEventCountBefore);
+    }
+
+    [Fact]
     public async Task OnActivateAsync_WithEnabledLegacyUnmarkedEnvelopeSnapshot_ShouldRetireAndPurgeWithoutDispatch()
     {
         var eventStore = new TestEventStore();
@@ -123,6 +208,32 @@ public sealed class ScheduledDispatchGAgentTests
             .Should()
             .ContainSingle();
         scheduler.TimeoutRequests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_WithDisabledLegacyUnmarkedEnvelopeSnapshot_ShouldPurgeWithoutPersistingOrScheduling()
+    {
+        var eventStore = new TestEventStore();
+        var actorDispatch = new RecordingActorDispatchPort();
+        var serviceDispatch = new RecordingScheduledServiceInvocationDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(
+            eventStore,
+            actorDispatch,
+            scheduler,
+            serviceDispatch,
+            snapshotStore: new TestSnapshotStore(
+                CreateLegacyUnmarkedEnvelopeSnapshot(enabled: false),
+                version: 0));
+
+        await agent.ActivateAsync();
+
+        agent.State.Enabled.Should().BeFalse();
+        eventStore.GetEvents(ScheduleActorId).Should().BeEmpty();
+        scheduler.PurgedActors.Should().ContainSingle().Which.Should().Be(ScheduleActorId);
+        scheduler.TimeoutRequests.Should().BeEmpty();
+        actorDispatch.Dispatches.Should().BeEmpty();
+        serviceDispatch.Requests.Should().BeEmpty();
     }
 
     [Fact]
@@ -179,15 +290,19 @@ public sealed class ScheduledDispatchGAgentTests
         await agent.ActivateAsync();
         scheduler.PurgedActors.Clear();
 
-        await agent.HandleFireAsync(new ScheduledDispatchFireCommand
+        var command = new ScheduledDispatchFireCommand
         {
             ScheduledFireAt = Timestamp.FromDateTimeOffset(
                 new DateTimeOffset(2026, 5, 29, 9, 0, 0, TimeSpan.Zero)),
             Manual = false,
-        });
+        };
+
+        await agent.HandleFireAsync(command);
+        await agent.HandleFireAsync(command);
 
         agent.State.Enabled.Should().BeFalse();
-        scheduler.PurgedActors.Should().ContainSingle().Which.Should().Be(ScheduleActorId);
+        scheduler.PurgedActors.Should().HaveCount(2)
+            .And.OnlyContain(actorId => actorId == ScheduleActorId);
         actorDispatch.Dispatches.Should().BeEmpty();
         serviceDispatch.Requests.Should().BeEmpty();
         eventStore.GetEvents(ScheduleActorId)
@@ -197,6 +312,13 @@ public sealed class ScheduledDispatchGAgentTests
                 StringComparison.Ordinal))
             .Should()
             .BeEmpty();
+        eventStore.GetEvents(ScheduleActorId)
+            .Count(x => string.Equals(
+                x.EventType,
+                ScheduledDispatchDisabledEvent.Descriptor.FullName,
+                StringComparison.Ordinal))
+            .Should()
+            .Be(1);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/ScheduledDispatchGAgentTests.cs
@@ -27,6 +27,8 @@ public sealed class ScheduledDispatchGAgentTests
     private const string NextFireCallbackId = "scheduled-dispatch-next-fire";
     private const string TeamCredentialExpiryCallbackId = "scheduled-dispatch-team-credential-expiry";
     private const string ManualFireIdempotencyKey = "manual-fire";
+    private const string LegacyUnmarkedEnvelopeRetiredError =
+        "Scheduled dispatch envelope target is retired because it lacks trusted internal authority.";
 
     [Fact]
     public void AuthorizationFactState_ShouldReserveRemovedRuntimeNodeGrantTopology()
@@ -57,6 +59,144 @@ public sealed class ScheduledDispatchGAgentTests
             field.Number == 11 && field.Name == "catalog_policy_version");
         authority.Field.Should().Contain(field =>
             field.Number == 12 && field.Name == "catalog_evaluated_at");
+    }
+
+    [Fact]
+    public void EnvelopeAuthorityState_ShouldUseStableProtocolValuesAndFieldNumber()
+    {
+        ((int)ScheduledDispatchEnvelopeAuthorityState.Unspecified).Should().Be(0);
+        ((int)ScheduledDispatchEnvelopeAuthorityState.TrustedInternal).Should().Be(1);
+        ScheduledDispatchTargetState.Descriptor.Fields
+            .InFieldNumberOrder()
+            .Should()
+            .ContainSingle(field =>
+                field.FieldNumber == 7 && field.Name == "envelope_authority");
+    }
+
+    [Fact]
+    public async Task HandleConfigureAsync_WithUnmarkedEnvelopeTarget_ShouldRequireTrustedInternalAuthority()
+    {
+        var eventStore = new TestEventStore();
+        var agent = CreateAgent(eventStore, new RecordingActorDispatchPort());
+        await agent.ActivateAsync();
+        var command = CreateConfigureCommand(target: new ScheduledDispatchTargetState
+        {
+            Kind = ScheduledDispatchTargetKindState.Envelope,
+            ActorId = "actor-cross-owner",
+            Envelope = CreateTriggerEnvelope("actor-cross-owner", new Empty()),
+        });
+
+        var act = () => agent.HandleConfigureAsync(command);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*trusted internal authority*");
+        eventStore.GetEvents(ScheduleActorId).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OnActivateAsync_WithEnabledLegacyUnmarkedEnvelopeSnapshot_ShouldRetireAndPurgeWithoutDispatch()
+    {
+        var eventStore = new TestEventStore();
+        var actorDispatch = new RecordingActorDispatchPort();
+        var serviceDispatch = new RecordingScheduledServiceInvocationDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(
+            eventStore,
+            actorDispatch,
+            scheduler,
+            serviceDispatch,
+            snapshotStore: new TestSnapshotStore(
+                CreateLegacyUnmarkedEnvelopeSnapshot(enabled: true),
+                version: 0));
+
+        await agent.ActivateAsync();
+
+        agent.State.Enabled.Should().BeFalse();
+        scheduler.PurgedActors.Should().ContainSingle().Which.Should().Be(ScheduleActorId);
+        actorDispatch.Dispatches.Should().BeEmpty();
+        serviceDispatch.Requests.Should().BeEmpty();
+        eventStore.GetEvents(ScheduleActorId)
+            .Where(x => string.Equals(
+                x.EventType,
+                ScheduledDispatchDisabledEvent.Descriptor.FullName,
+                StringComparison.Ordinal))
+            .Should()
+            .ContainSingle();
+        scheduler.TimeoutRequests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleFireAsync_WithLegacyUnmarkedEnvelopeTarget_ShouldThrowRetirementErrorBeforeDispatch()
+    {
+        var eventStore = new TestEventStore();
+        var actorDispatch = new RecordingActorDispatchPort();
+        var serviceDispatch = new RecordingScheduledServiceInvocationDispatchPort();
+        var agent = CreateAgent(
+            eventStore,
+            actorDispatch,
+            serviceInvocationDispatch: serviceDispatch,
+            snapshotStore: new TestSnapshotStore(
+                CreateLegacyUnmarkedEnvelopeSnapshot(enabled: false),
+                version: 0));
+        await agent.ActivateAsync();
+
+        var act = () => agent.HandleFireAsync(new ScheduledDispatchFireCommand
+        {
+            ScheduledFireAt = Timestamp.FromDateTimeOffset(
+                new DateTimeOffset(2026, 5, 29, 9, 0, 0, TimeSpan.Zero)),
+            Manual = true,
+            IdempotencyKey = ManualFireIdempotencyKey,
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(LegacyUnmarkedEnvelopeRetiredError);
+        actorDispatch.Dispatches.Should().BeEmpty();
+        serviceDispatch.Requests.Should().BeEmpty();
+        eventStore.GetEvents(ScheduleActorId)
+            .Where(x => string.Equals(
+                x.EventType,
+                ScheduledDispatchFireStartedEvent.Descriptor.FullName,
+                StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleFireAsync_AutomaticWithLegacyUnmarkedEnvelopeTarget_ShouldDisableAndPurgeWithoutDispatch()
+    {
+        var eventStore = new TestEventStore();
+        var actorDispatch = new RecordingActorDispatchPort();
+        var serviceDispatch = new RecordingScheduledServiceInvocationDispatchPort();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var agent = CreateAgent(
+            eventStore,
+            actorDispatch,
+            scheduler,
+            serviceDispatch,
+            snapshotStore: new TestSnapshotStore(
+                CreateLegacyUnmarkedEnvelopeSnapshot(enabled: true),
+                version: 0));
+        await agent.ActivateAsync();
+        scheduler.PurgedActors.Clear();
+
+        await agent.HandleFireAsync(new ScheduledDispatchFireCommand
+        {
+            ScheduledFireAt = Timestamp.FromDateTimeOffset(
+                new DateTimeOffset(2026, 5, 29, 9, 0, 0, TimeSpan.Zero)),
+            Manual = false,
+        });
+
+        agent.State.Enabled.Should().BeFalse();
+        scheduler.PurgedActors.Should().ContainSingle().Which.Should().Be(ScheduleActorId);
+        actorDispatch.Dispatches.Should().BeEmpty();
+        serviceDispatch.Requests.Should().BeEmpty();
+        eventStore.GetEvents(ScheduleActorId)
+            .Where(x => string.Equals(
+                x.EventType,
+                ScheduledDispatchFireStartedEvent.Descriptor.FullName,
+                StringComparison.Ordinal))
+            .Should()
+            .BeEmpty();
     }
 
     [Fact]
@@ -1010,18 +1150,26 @@ public sealed class ScheduledDispatchGAgentTests
     }
 
     [Fact]
-    public async Task HandleFireAsync_ShouldDispatchStoredEnvelopeToConfiguredNonWorkflowTarget()
+    public async Task HandleFireAsync_WithTrustedInternalEnvelope_ShouldDispatchStoredEnvelopeToConfiguredNonWorkflowTarget()
     {
         var eventStore = new TestEventStore();
         var dispatch = new RecordingActorDispatchPort();
         var agent = CreateAgent(eventStore, dispatch);
         await agent.ActivateAsync();
+        var triggerEnvelope = CreateTriggerEnvelope("generic-agent-1", new ChatRequestEvent
+        {
+            Prompt = "generic scheduled prompt",
+        });
         await agent.HandleConfigureAsync(CreateConfigureCommand(
             targetActorId: "generic-agent-1",
-            triggerEnvelope: CreateTriggerEnvelope("generic-agent-1", new ChatRequestEvent
+            triggerEnvelope: triggerEnvelope,
+            target: new ScheduledDispatchTargetState
             {
-                Prompt = "generic scheduled prompt",
-            }),
+                Kind = ScheduledDispatchTargetKindState.Envelope,
+                ActorId = "generic-agent-1",
+                Envelope = triggerEnvelope.Clone(),
+                EnvelopeAuthority = ScheduledDispatchEnvelopeAuthorityState.TrustedInternal,
+            },
             enabled: false));
 
         var scheduledFireAt = new DateTimeOffset(2026, 5, 29, 10, 0, 0, TimeSpan.Zero);
@@ -1047,6 +1195,8 @@ public sealed class ScheduledDispatchGAgentTests
         chatRequest.Metadata.Should().NotContainKey("workflow.schedule_id");
         chatRequest.Metadata.Should().NotContainKey("workflow.scheduled_fire_at_utc");
         agent.State.FireRecords[idempotencyKey].TargetActorId.Should().Be("generic-agent-1");
+        agent.State.Target!.EnvelopeAuthority.Should().Be(
+            ScheduledDispatchEnvelopeAuthorityState.TrustedInternal);
     }
 
     [Fact]
@@ -5507,7 +5657,29 @@ public sealed class ScheduledDispatchGAgentTests
             Kind = ScheduledDispatchTargetKindState.Envelope,
             ActorId = targetActorId,
             Envelope = triggerEnvelope?.Clone(),
+            EnvelopeAuthority = ScheduledDispatchEnvelopeAuthorityState.TrustedInternal,
         };
+
+    private static ScheduledDispatchState CreateLegacyUnmarkedEnvelopeSnapshot(bool enabled)
+    {
+        var triggerEnvelope = CreateTriggerEnvelope("legacy-target-actor", new Empty());
+        return new ScheduledDispatchState
+        {
+            ScheduleId = "schedule-1",
+            DisplayName = "Legacy unmarked envelope schedule",
+            TargetActorId = "legacy-target-actor",
+            TriggerEnvelope = triggerEnvelope,
+            CronExpression = "*/15 * * * *",
+            Timezone = "UTC",
+            Enabled = enabled,
+            Target = new ScheduledDispatchTargetState
+            {
+                Kind = ScheduledDispatchTargetKindState.Envelope,
+                ActorId = "legacy-target-actor",
+                Envelope = triggerEnvelope.Clone(),
+            },
+        };
+    }
 
     private static ChatRequestEvent CreateCredentialBearingChatRequest(string prompt) =>
         new()


### PR DESCRIPTION
## Problem

The public schedule API accepted a caller-selected actor address and raw
`EventEnvelope`, allowing persistent cross-resource control-event injection.
Application callers could also create and operate the same raw target shape,
while legacy actor state had no explicit internal authority marker.

## Solution

- Restrict public schedule target input to catalog-resolved
  `serviceInvocation` and require the authenticated scope to match the target
  tenant before mutation.
- Reject raw envelope targets throughout the Application contract and hide
  legacy envelope rows from public queries and lifecycle operations.
- Add the typed Protobuf `TrustedInternal` actor-only authority; reject untyped
  new targets and durably disable/purge unmarked legacy schedules before any
  dispatch.
- Document the public input boundary and legacy retirement behavior.

## Impact

- `Aevatar.GAgentService.Hosting`: scheduled dispatch HTTP input and tenant
  admission.
- `Aevatar.GAgentService.Application`: target admission, query visibility, and
  lifecycle mutation.
- `Aevatar.GAgentService.Core`: typed actor authority and legacy state
  retirement.
- Workflow and platform test suites plus canonical schedule documentation.

## Verification

- Independent task reviews and final whole-branch review: no remaining
  Critical, Important, or Minor findings; ready to merge.
- `dotnet build aevatar.slnx --nologo --no-restore`
- `dotnet test aevatar.slnx --nologo --no-build --no-restore`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`
- `bash tools/docs/lint.sh`
- `git diff --check origin/feature/integrate..HEAD`

Closes #3044
