### PR TITLE
Require JWT audience outside Development

### DIFF
--- a/docker-compose.mainnet-cluster.yml
+++ b/docker-compose.mainnet-cluster.yml
@@ -53,6 +53,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Distributed
       ASPNETCORE_URLS: http://+:8080
+      AEVATAR_Aevatar__Authentication__Audience: urn:aevatar:api
       AEVATAR_ActorRuntime__Provider: Orleans
       AEVATAR_ActorRuntime__OrleansStreamBackend: KafkaProvider
       AEVATAR_ActorRuntime__OrleansPersistenceBackend: Garnet
@@ -100,6 +101,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Distributed
       ASPNETCORE_URLS: http://+:8080
+      AEVATAR_Aevatar__Authentication__Audience: urn:aevatar:api
       AEVATAR_ActorRuntime__Provider: Orleans
       AEVATAR_ActorRuntime__OrleansStreamBackend: KafkaProvider
       AEVATAR_ActorRuntime__OrleansPersistenceBackend: Garnet
@@ -147,6 +149,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Distributed
       ASPNETCORE_URLS: http://+:8080
+      AEVATAR_Aevatar__Authentication__Audience: urn:aevatar:api
       AEVATAR_ActorRuntime__Provider: Orleans
       AEVATAR_ActorRuntime__OrleansStreamBackend: KafkaProvider
       AEVATAR_ActorRuntime__OrleansPersistenceBackend: Garnet

--- a/docs/operations/2026-06-18-aevatar-mode-voice-presence-setup.md
+++ b/docs/operations/2026-06-18-aevatar-mode-voice-presence-setup.md
@@ -67,6 +67,7 @@ OpenAI realtime broker path:
 export AEVATAR_Aevatar__NyxId__Authority="$NYXID_OIDC_AUTHORITY"
 export AEVATAR_Aevatar__NyxId__ApiBaseUrl="$NYXID_API_BASE_URL"
 export AEVATAR_Aevatar__Authentication__Authority="$NYXID_OIDC_AUTHORITY"
+export AEVATAR_Aevatar__Authentication__Audience="urn:aevatar:api"
 
 export AEVATAR_Aevatar__VoicePresence__OpenAI__Nyxid__ServiceSlug="openai-realtime"
 export AEVATAR_Aevatar__VoicePresence__OpenAI__Nyxid__MintPath="v1/realtime/client_secrets"
@@ -76,6 +77,10 @@ export AEVATAR_Aevatar__VoicePresence__OpenAI__Model="gpt-realtime"
 export AEVATAR_Aevatar__VoicePresence__OpenAI__Voice="alloy"
 export AEVATAR_Aevatar__VoicePresence__OpenAI__Instructions="你是一个简短自然的语音助手。"
 ```
+
+Every non-Development host with authentication enabled must set the external
+JWT audience. Startup fails when this value is empty; the scope-service-token
+audience is a separate setting and does not satisfy this requirement.
 
 `ServiceSlug` defaults to `openai-realtime` in code, but set it explicitly in
 production so redeploys are easy to audit. The NyxID service endpoint for that

--- a/src/Aevatar.Authentication.Abstractions/AevatarAuthenticationOptions.cs
+++ b/src/Aevatar.Authentication.Abstractions/AevatarAuthenticationOptions.cs
@@ -18,7 +18,10 @@ public sealed class AevatarAuthenticationOptions
     /// <summary>OIDC discovery authority URL (e.g. "https://idp.example.com").</summary>
     public string Authority { get; set; } = string.Empty;
 
-    /// <summary>Expected JWT audience. Empty means audience validation is skipped.</summary>
+    /// <summary>
+    /// Expected external JWT audience. Required outside Development when authentication is enabled;
+    /// Development may leave it empty to opt out of audience validation.
+    /// </summary>
     public string Audience { get; set; } = string.Empty;
 
     /// <summary>Whether to require HTTPS for the authority metadata endpoint. Default: true.</summary>

--- a/src/Aevatar.Authentication.Hosting/AevatarAuthenticationHostExtensions.cs
+++ b/src/Aevatar.Authentication.Hosting/AevatarAuthenticationHostExtensions.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using System.Text.Encodings.Web;
 
 namespace Aevatar.Authentication.Hosting;
@@ -54,6 +55,13 @@ public static class AevatarAuthenticationHostExtensions
             return builder;
         }
 
+        var apiAudience = ResolveApiAudience(options.Audience, builder.Environment);
+        if (scopeTokenOptions.Enabled && string.IsNullOrWhiteSpace(scopeTokenOptions.Audience))
+        {
+            throw new InvalidOperationException(
+                "Aevatar:Authentication:ScopeServiceTokens:Audience is required when scope service tokens are enabled.");
+        }
+
         if (scopeTokenOptions.Enabled)
             builder.Services.AddScopeServiceTokens(builder.Configuration);
 
@@ -67,8 +75,8 @@ public static class AevatarAuthenticationHostExtensions
                 jwt.Authority = options.Authority;
                 jwt.RequireHttpsMetadata = options.RequireHttpsMetadata;
 
-                jwt.TokenValidationParameters.ValidAudience = options.Audience;
-                jwt.TokenValidationParameters.ValidateAudience = !string.IsNullOrWhiteSpace(options.Audience);
+                jwt.TokenValidationParameters.ValidAudience = apiAudience;
+                jwt.TokenValidationParameters.ValidateAudience = apiAudience != null;
 
                 // Pin the accepted signing algorithms to block alg=none and downgrade attacks.
                 // Default is a safe superset covering every algorithm actually accepted; when
@@ -130,7 +138,7 @@ public static class AevatarAuthenticationHostExtensions
         {
             builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
                 .Configure<IScopeServiceTokenKeyProvider>((jwt, keyProvider) =>
-                    ConfigureScopeServiceTokenValidation(jwt, options, keyProvider));
+                    ConfigureScopeServiceTokenValidation(jwt, options, apiAudience, keyProvider));
         }
 
         // DPoP (RFC 9449) sender-constraint validation. Hosts enabling it must replace the
@@ -139,12 +147,6 @@ public static class AevatarAuthenticationHostExtensions
         builder.Services.TryAddSingleton<IDPoPReplayGuard, NoOpDPoPReplayGuard>();
         builder.Services.TryAddSingleton<DPoPProofValidator>();
         builder.Services.AddHostedService<DPoPReplayGuardStartupValidator>();
-
-        // Audience defense: warn (never fail closed) when audience validation is silently off
-        // outside Development. Emitted once at startup via a hosted service so a real logger is
-        // available; ValidateAudience itself stays config-driven.
-        if (string.IsNullOrWhiteSpace(options.Audience) && !builder.Environment.IsDevelopment())
-            builder.Services.AddHostedService<AudienceValidationDisabledWarning>();
 
         // When authentication is enabled, endpoints default to requiring an authenticated caller.
         // Public endpoints must opt out with [AllowAnonymous] / .AllowAnonymous().
@@ -162,6 +164,7 @@ public static class AevatarAuthenticationHostExtensions
     private static void ConfigureScopeServiceTokenValidation(
         JwtBearerOptions jwt,
         AevatarAuthenticationOptions options,
+        string? apiAudience,
         IScopeServiceTokenKeyProvider keyProvider)
     {
         var issuers = new List<string>();
@@ -196,15 +199,39 @@ public static class AevatarAuthenticationHostExtensions
         jwt.TokenValidationParameters.IssuerValidatorUsingConfiguration = resolver.ValidateIssuer;
         jwt.TokenValidationParameters.ValidateIssuer = true;
 
-        if (!string.IsNullOrWhiteSpace(keyProvider.Audience))
-        {
-            jwt.TokenValidationParameters.ValidAudiences = string.IsNullOrWhiteSpace(options.Audience)
-                ? [keyProvider.Audience]
-                : [options.Audience, keyProvider.Audience];
-            jwt.TokenValidationParameters.ValidateAudience = true;
-        }
+        jwt.TokenValidationParameters.ValidAudience = null;
+        jwt.TokenValidationParameters.ValidAudiences = null;
+        jwt.TokenValidationParameters.AudienceValidator = (audiences, securityToken, _) =>
+            ValidateAudienceForIssuer(
+                audiences,
+                securityToken,
+                apiAudience,
+                keyProvider.Issuer,
+                keyProvider.Audience);
+        jwt.TokenValidationParameters.ValidateAudience = true;
 
         jwt.TokenValidationParameters.ClockSkew = keyProvider.ClockSkew;
+    }
+
+    private static bool ValidateAudienceForIssuer(
+        IEnumerable<string> audiences,
+        SecurityToken securityToken,
+        string? apiAudience,
+        string scopeIssuer,
+        string? scopeAudience)
+    {
+        var isScopeIssuer = string.Equals(
+            securityToken?.Issuer,
+            scopeIssuer,
+            StringComparison.Ordinal);
+        if (isScopeIssuer)
+        {
+            return scopeAudience != null &&
+                   audiences.Contains(scopeAudience, StringComparer.Ordinal);
+        }
+
+        return apiAudience == null ||
+               audiences.Contains(apiAudience, StringComparer.Ordinal);
     }
 
     // Asymmetric OIDC algorithms every legitimate NyxID/OIDC token may be signed with. Kept a
@@ -313,6 +340,21 @@ public static class AevatarAuthenticationHostExtensions
 
         return enabled;
     }
+
+    private static string? ResolveApiAudience(string? configuredAudience, IHostEnvironment environment)
+    {
+        var audience = string.IsNullOrWhiteSpace(configuredAudience)
+            ? null
+            : configuredAudience.Trim();
+        if (audience == null && !environment.IsDevelopment())
+        {
+            throw new InvalidOperationException(
+                $"{AevatarAuthenticationOptions.SectionName}:Audience is required when " +
+                "authentication is enabled outside Development.");
+        }
+
+        return audience;
+    }
 }
 
 internal sealed class DPoPReplayGuardStartupValidator : IHostedService
@@ -337,32 +379,6 @@ internal sealed class DPoPReplayGuardStartupValidator : IHostedService
                 "Configure an atomic TTL-backed replay guard before starting the host.");
         }
 
-        return Task.CompletedTask;
-    }
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-}
-
-/// <summary>
-/// Emits a single startup WARNING when JWT audience validation is disabled (empty
-/// <c>Audience</c>) outside Development. Advisory only — the host does not fail closed; it
-/// surfaces that any audience-scoped token is accepted so the operator can decide.
-/// </summary>
-internal sealed class AudienceValidationDisabledWarning : IHostedService
-{
-    private readonly ILogger<AudienceValidationDisabledWarning> _logger;
-
-    public AudienceValidationDisabledWarning(ILogger<AudienceValidationDisabledWarning> logger)
-    {
-        _logger = logger;
-    }
-
-    public Task StartAsync(CancellationToken cancellationToken)
-    {
-        _logger.LogWarning(
-            "JWT audience validation is disabled: {SectionName}:Audience is empty. Tokens minted " +
-            "for any audience will be accepted. Set an Audience to enforce audience binding.",
-            AevatarAuthenticationOptions.SectionName);
         return Task.CompletedTask;
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -3,6 +3,7 @@
     "Authentication": {
       "Enabled": true,
       "Authority": "https://nyx.chrono-ai.fun",
+      "Audience": "urn:aevatar:api",
       "RequireHttpsMetadata": true,
       "NyxIdIdentityAssertion": {
         "OidcDiscoveryUrl": "https://nyx-api.chrono-ai.fun/.well-known/openid-configuration",

--- a/test/Aevatar.Bootstrap.Tests/AuthenticationHostCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AuthenticationHostCoverageTests.cs
@@ -106,27 +106,6 @@ public class AuthenticationHostCoverageTests
     }
 
     [Fact]
-    public async Task AddAevatarAuthentication_WhenDisabledOutsideDevelopment_ShouldStillUseJwtBearerAuthentication()
-    {
-        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
-        {
-            EnvironmentName = Environments.Production,
-        });
-
-        builder.Configuration["Aevatar:Authentication:Enabled"] = "false";
-        builder.Configuration["Aevatar:Authentication:Authority"] = "https://id.example.com";
-
-        builder.AddAevatarAuthentication();
-
-        using var app = builder.Build();
-        using var scope = app.Services.CreateScope();
-        var schemeProvider = scope.ServiceProvider.GetRequiredService<IAuthenticationSchemeProvider>();
-
-        (await schemeProvider.GetDefaultAuthenticateSchemeAsync())!.Name.Should().Be("Bearer");
-        (await schemeProvider.GetDefaultChallengeSchemeAsync())!.Name.Should().Be("Bearer");
-    }
-
-    [Fact]
     public void AddAevatarAuthentication_WhenDisabled_ShouldNotSetFallbackPolicy()
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions

--- a/test/Aevatar.Bootstrap.Tests/AuthenticationHttpPipelineTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AuthenticationHttpPipelineTests.cs
@@ -23,6 +23,10 @@ public sealed class AuthenticationHttpPipelineTests
     private const string Authority = "https://nyxid.example.com";
     private const string DiscoveredIssuer = "https://nyx-api.example.com";
     private const string Audience = "aevatar-api";
+    private const string ScopeIssuer = "https://scope.example.com";
+    private const string ScopeAudience = "aevatar-scope-services";
+    private const string ScopeKeyId = "scope-key";
+    private const string ScopeSigningKey = "0123456789abcdef0123456789abcdef";
     private const string ResourceUri = "https://api.example.com/resource";
 
     [Fact]
@@ -89,6 +93,60 @@ public sealed class AuthenticationHttpPipelineTests
             .WithMessage("*shared IDPoPReplayGuard*");
     }
 
+    [Theory]
+    [InlineData(false, false, Audience, HttpStatusCode.OK)]
+    [InlineData(false, false, "another-api", HttpStatusCode.Unauthorized)]
+    [InlineData(true, false, Audience, HttpStatusCode.OK)]
+    [InlineData(true, false, ScopeAudience, HttpStatusCode.Unauthorized)]
+    [InlineData(true, true, ScopeAudience, HttpStatusCode.OK)]
+    [InlineData(true, true, Audience, HttpStatusCode.Unauthorized)]
+    public async Task BearerAuthorization_ShouldBindAudienceToTokenIssuer(
+        bool scopeTokensEnabled,
+        bool issueScopeToken,
+        string tokenAudience,
+        HttpStatusCode expectedStatusCode)
+    {
+        using var authorityKey = RSA.Create(2048);
+        var discovery = new DiscoveryDocumentHandler(authorityKey);
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+        builder.WebHost.UseTestServer();
+        ConfigureAuthentication(builder, dpopEnabled: false, scopeTokensEnabled);
+        builder.AddAevatarAuthentication();
+        builder.Services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, jwt =>
+        {
+            var retriever = new HttpDocumentRetriever(new HttpClient(discovery))
+            {
+                RequireHttps = true,
+            };
+            jwt.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                $"{Authority}/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever(),
+                retriever);
+        });
+
+        await using var app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.MapGet("/resource", () => "ok").RequireAuthorization();
+        await app.StartAsync();
+
+        var accessToken = issueScopeToken
+            ? CreateScopeAccessToken(tokenAudience)
+            : CreateAccessToken(
+                authorityKey,
+                confirmationThumbprint: null,
+                audience: tokenAudience);
+        using var request = new HttpRequestMessage(HttpMethod.Get, ResourceUri);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using var response = await app.GetTestClient().SendAsync(request);
+
+        response.StatusCode.Should().Be(expectedStatusCode);
+    }
+
     private static void ConfigureAuthentication(
         WebApplicationBuilder builder,
         bool dpopEnabled,
@@ -104,18 +162,21 @@ public sealed class AuthenticationHttpPipelineTests
             return;
 
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Issuer"] =
-            "https://scope.example.com";
+            ScopeIssuer;
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Audience"] =
-            "aevatar-scope-services";
+            ScopeAudience;
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Kid"] =
-            "scope-key";
+            ScopeKeyId;
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Algorithm"] =
             "HS256";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Key"] =
-            "0123456789abcdef0123456789abcdef";
+            ScopeSigningKey;
     }
 
-    private static string CreateAccessToken(RSA authorityKey, string jkt)
+    private static string CreateAccessToken(
+        RSA authorityKey,
+        string? confirmationThumbprint,
+        string audience = Audience)
     {
         var header = new JwtHeader(new SigningCredentials(
             new RsaSecurityKey(authorityKey) { KeyId = DiscoveryDocumentHandler.KeyId },
@@ -124,12 +185,32 @@ public sealed class AuthenticationHttpPipelineTests
         var payload = new JwtPayload
         {
             [JwtRegisteredClaimNames.Iss] = DiscoveredIssuer,
-            [JwtRegisteredClaimNames.Aud] = Audience,
+            [JwtRegisteredClaimNames.Aud] = audience,
             [JwtRegisteredClaimNames.Sub] = "user-alpha",
             [JwtRegisteredClaimNames.Iat] = now.ToUnixTimeSeconds(),
             [JwtRegisteredClaimNames.Exp] = now.AddMinutes(5).ToUnixTimeSeconds(),
-            ["cnf"] = new Dictionary<string, object> { ["jkt"] = jkt },
         };
+        if (!string.IsNullOrWhiteSpace(confirmationThumbprint))
+            payload["cnf"] = new Dictionary<string, object> { ["jkt"] = confirmationThumbprint };
+
+        return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
+    }
+
+    private static string CreateScopeAccessToken(string audience)
+    {
+        var header = new JwtHeader(new SigningCredentials(
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(ScopeSigningKey)) { KeyId = ScopeKeyId },
+            SecurityAlgorithms.HmacSha256));
+        var now = DateTimeOffset.UtcNow;
+        var payload = new JwtPayload
+        {
+            [JwtRegisteredClaimNames.Iss] = ScopeIssuer,
+            [JwtRegisteredClaimNames.Aud] = audience,
+            [JwtRegisteredClaimNames.Sub] = "scope-alpha",
+            [JwtRegisteredClaimNames.Iat] = now.ToUnixTimeSeconds(),
+            [JwtRegisteredClaimNames.Exp] = now.AddMinutes(5).ToUnixTimeSeconds(),
+        };
+
         return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(header, payload));
     }
 

--- a/test/Aevatar.Bootstrap.Tests/JwtAlgorithmPinningTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/JwtAlgorithmPinningTests.cs
@@ -80,6 +80,7 @@ public sealed class JwtAlgorithmPinningTests
         builder.Configuration["Aevatar:Authentication:Authority"] = "https://nyxid.example.com/";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Enabled"] = "true";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Issuer"] = "https://aevatar.example.com";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Audience"] = "aevatar-scope-services";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Kid"] = "scope-kid-1";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Algorithm"] = "HS256";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:SigningKeys:0:Key"] =

--- a/test/Aevatar.Bootstrap.Tests/JwtAudienceValidationTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/JwtAudienceValidationTests.cs
@@ -1,0 +1,74 @@
+using Aevatar.Authentication.Hosting;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Bootstrap.Tests;
+
+public sealed class JwtAudienceValidationTests
+{
+    [Fact]
+    public async Task AddAevatarAuthentication_WhenDisabledOutsideDevelopment_ShouldStillUseJwtBearerAuthentication()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+
+        builder.Configuration["Aevatar:Authentication:Enabled"] = "false";
+        builder.Configuration["Aevatar:Authentication:Authority"] = "https://id.example.com";
+        builder.Configuration["Aevatar:Authentication:Audience"] = "aevatar-api";
+
+        builder.AddAevatarAuthentication();
+
+        using var app = builder.Build();
+        using var scope = app.Services.CreateScope();
+        var schemeProvider = scope.ServiceProvider.GetRequiredService<IAuthenticationSchemeProvider>();
+
+        (await schemeProvider.GetDefaultAuthenticateSchemeAsync())!.Name.Should().Be("Bearer");
+        (await schemeProvider.GetDefaultChallengeSchemeAsync())!.Name.Should().Be("Bearer");
+    }
+
+    [Fact]
+    public void AddAevatarAuthentication_WhenAudienceIsMissingInDevelopment_ShouldAllowExplicitOptOut()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+        builder.Configuration["Aevatar:Authentication:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:Authority"] = "https://id.example.com";
+
+        builder.AddAevatarAuthentication();
+        using var app = builder.Build();
+
+        using var scope = app.Services.CreateScope();
+        var options = scope.ServiceProvider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(JwtBearerDefaults.AuthenticationScheme);
+
+        options.TokenValidationParameters.ValidateAudience.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddAevatarAuthentication_WhenAudienceIsMissingOutsideDevelopment_ShouldFailClosed()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+
+        builder.Configuration["Aevatar:Authentication:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:Authority"] = "https://id.example.com";
+
+        var act = () => builder.AddAevatarAuthentication();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "Aevatar:Authentication:Audience is required when authentication is enabled outside Development.");
+    }
+}

--- a/test/Aevatar.Bootstrap.Tests/ScopeServiceTokenAuthenticationTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/ScopeServiceTokenAuthenticationTests.cs
@@ -28,6 +28,7 @@ public sealed class ScopeServiceTokenAuthenticationTests
 
         builder.Configuration["Aevatar:Authentication:Enabled"] = "true";
         builder.Configuration["Aevatar:Authentication:Authority"] = "https://nyxid.example.com/";
+        builder.Configuration["Aevatar:Authentication:Audience"] = "aevatar-api";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Enabled"] = "true";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Issuer"] = "https://aevatar.example.com";
         builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Audience"] = "aevatar-scope-services";
@@ -50,7 +51,52 @@ public sealed class ScopeServiceTokenAuthenticationTests
             .Which.KeyId.Should().Be("scope-kid-1");
         jwtOptions.TokenValidationParameters.IssuerSigningKeyResolver.Should().BeNull();
         jwtOptions.TokenValidationParameters.IssuerSigningKeyResolverUsingConfiguration.Should().NotBeNull();
-        jwtOptions.TokenValidationParameters.ValidAudiences.Should().Contain("aevatar-scope-services");
+        jwtOptions.TokenValidationParameters.ValidAudience.Should().BeNull();
+        jwtOptions.TokenValidationParameters.ValidAudiences.Should().BeNull();
+        jwtOptions.TokenValidationParameters.AudienceValidator.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddAevatarAuthentication_WhenOnlyScopeAudienceIsConfiguredOutsideDevelopment_ShouldFailClosed()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+
+        builder.Configuration["Aevatar:Authentication:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:Authority"] = "https://nyxid.example.com/";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Issuer"] =
+            "https://aevatar.example.com";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Audience"] =
+            "aevatar-scope-services";
+
+        var act = () => builder.AddAevatarAuthentication();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "Aevatar:Authentication:Audience is required when authentication is enabled outside Development.");
+    }
+
+    [Fact]
+    public void AddAevatarAuthentication_WhenScopeAudienceIsMissing_ShouldFailClosed()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production,
+        });
+
+        builder.Configuration["Aevatar:Authentication:Enabled"] = "true";
+        builder.Configuration["Aevatar:Authentication:Authority"] = "https://nyxid.example.com/";
+        builder.Configuration["Aevatar:Authentication:Audience"] = "aevatar-api";
+        builder.Configuration["Aevatar:Authentication:ScopeServiceTokens:Enabled"] = "true";
+
+        var act = () => builder.AddAevatarAuthentication();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage(
+                "Aevatar:Authentication:ScopeServiceTokens:Audience is required when scope service tokens are enabled.");
     }
 
     [Fact]

--- a/test/Aevatar.Capabilities.Tests/MainnetChatCompletionsEndpointsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetChatCompletionsEndpointsTests.cs
@@ -394,6 +394,7 @@ public sealed class MainnetChatCompletionsEndpointsTests
         });
         builder.WebHost.UseTestServer();
         builder.Configuration["Aevatar:Authentication:Authority"] = "https://invalid.example";
+        builder.Configuration["Aevatar:Authentication:Audience"] = "aevatar-api";
         builder.AddAevatarAuthentication();
 
         builder.Services.AddSingleton<ILLMProviderFactory>(provider);

--- a/test/Aevatar.Capabilities.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetResponsesEndpointsTests.cs
@@ -1483,6 +1483,7 @@ public sealed class MainnetResponsesEndpointsTests
         // and JwtBearer scheme to be registered so an un-annotated endpoint would
         // be rejected. .AllowAnonymous() must short-circuit that.
         builder.Configuration["Aevatar:Authentication:Authority"] = "https://invalid.example";
+        builder.Configuration["Aevatar:Authentication:Audience"] = "aevatar-api";
         builder.AddAevatarAuthentication();
 
         builder.Services.AddSingleton(provider);
@@ -1573,6 +1574,7 @@ public sealed class MainnetResponsesEndpointsTests
         });
         builder.WebHost.UseTestServer();
         builder.Configuration["Aevatar:Authentication:Authority"] = "https://invalid.example";
+        builder.Configuration["Aevatar:Authentication:Audience"] = "aevatar-api";
         builder.AddAevatarAuthentication();
 
         builder.Services.AddSingleton(provider);


### PR DESCRIPTION
## Problem

Non-Development hosts could enable authentication without configuring an API audience, so tokens issued for another resource by the trusted issuer could be accepted. Scope-service-token audience configuration could also weaken issuer-to-audience binding.

## Solution

- Fail startup when authentication is enabled outside Development and the API audience is empty.
- Require an explicit audience whenever scope service tokens are enabled.
- Bind external and scope token audiences to their respective issuers instead of using a shared audience union.
- Configure the canonical urn:aevatar:api audience in Mainnet appsettings, all distributed compose nodes, and the production setup guide.
- Add HTTP and registration tests for Development opt-out, missing configuration, correct audience, wrong audience, and cross-issuer audience rejection.

## Impact

Non-Development hosts now fail closed on incomplete JWT audience configuration. Development retains its explicit empty-audience opt-out. Existing test hosts that enable authentication now declare their intended API audience.

## Validation

- dotnet build aevatar.slnx --nologo --no-restore (0 errors)
- dotnet test aevatar.slnx --nologo --no-build --no-restore (0 failures)
- bash tools/ci/architecture_guards.sh
- bash tools/ci/test_stability_guards.sh
- bash tools/docs/lint.sh
- git diff --check
- Independent review: Ready to merge, no findings after three rounds

Closes #3039