### PR TITLE
Recover stranded workflow draft runs

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -383,6 +383,7 @@ public sealed partial class ConversationGAgent :
             RestoreRuntimeTransportCredentials(runCopy.Activity, runtimeContext);
             if (!string.IsNullOrWhiteSpace(runtimeContext.NyxUserAccessToken))
                 runCopy.NyxUserAccessToken = runtimeContext.NyxUserAccessToken.Trim();
+            await AttachWorkflowRuntimeSecretReferencesAsync(runCopy, runtimeContext, CancellationToken.None);
 
             var persistedCopy = runCopy.Clone();
             persistedCopy.ReplyToken = string.Empty;
@@ -799,9 +800,32 @@ public sealed partial class ConversationGAgent :
             return;
         }
 
-        if (IsRelayActivity(request.Activity))
+        var dispatchRequest = request.Clone();
+        try
         {
-            if (string.IsNullOrWhiteSpace(request.ReplyToken))
+            await RestoreWorkflowRuntimeCredentialsAsync(dispatchRequest, ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(
+                ex,
+                "Failed to resolve workflow draft-run runtime credentials: correlation={CorrelationId}",
+                request.CorrelationId);
+            await PersistWorkflowDraftRunFailureAsync(
+                request,
+                "workflow_draft_run_runtime_credential_unavailable",
+                "Workflow draft-run runtime credentials could not be resolved.",
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            return;
+        }
+
+        if (IsRelayActivity(dispatchRequest.Activity))
+        {
+            if (string.IsNullOrWhiteSpace(dispatchRequest.ReplyToken))
             {
                 await PersistMissingRuntimeCredentialFailureAsync(
                     BuildWorkflowDraftRunCommandId(request.CorrelationId),
@@ -812,7 +836,7 @@ public sealed partial class ConversationGAgent :
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(request.NyxUserAccessToken))
+            if (string.IsNullOrWhiteSpace(dispatchRequest.NyxUserAccessToken))
             {
                 await PersistMissingRuntimeCredentialFailureAsync(
                     BuildWorkflowDraftRunCommandId(request.CorrelationId),
@@ -826,7 +850,7 @@ public sealed partial class ConversationGAgent :
 
         try
         {
-            await dispatcher.DispatchAsync(request.Clone(), ct);
+            await dispatcher.DispatchAsync(dispatchRequest, ct);
             Logger.LogInformation(
                 "Dispatched workflow draft-run request: runId={RunId} correlation={CorrelationId} conversation={Key}",
                 request.RunId,
@@ -943,7 +967,10 @@ public sealed partial class ConversationGAgent :
         }
 
         var referenceActivity = pendingRequest?.Activity ?? pendingWorkflowRequest?.Activity ?? evt.Activity;
-        var runtimeContext = BuildNyxRelayRuntimeContextForReply(evt, referenceActivity);
+        var runtimeContext = await BuildNyxRelayRuntimeContextForReplyAsync(
+            evt,
+            referenceActivity,
+            CancellationToken.None);
         Logger.LogInformation(
             "Received LLM reply ready: correlation={CorrelationId} terminal={TerminalState} replyTokenSource={Source}",
             evt.CorrelationId,
@@ -2537,18 +2564,53 @@ public sealed partial class ConversationGAgent :
             accessToken);
     }
 
-    private ConversationTurnRuntimeContext BuildNyxRelayRuntimeContextForReply(
+    private async Task<ConversationTurnRuntimeContext> BuildNyxRelayRuntimeContextForReplyAsync(
         LlmReplyReadyEvent evt,
-        ChatActivity? pendingActivity)
+        ChatActivity? pendingActivity,
+        CancellationToken ct)
     {
         var activity = pendingActivity ?? evt.Activity;
+        var replyToken = NormalizeOptional(evt.ReplyToken);
+        var replyTokenExpiresAtUnixMs = evt.ReplyTokenExpiresAtUnixMs;
+        var userAccessToken = NormalizeOptional(evt.Activity?.TransportExtras?.NyxUserAccessToken);
+
+        if (Services.GetService<IRuntimeSecretStore>() is { } secretStore)
+        {
+            if (replyToken is null && evt.RelayReplyTokenRef is { Ref.Length: > 0 } replyTokenRef)
+            {
+                var resolved = await secretStore.ResolveAsync(
+                    new ResolveRuntimeSecretRequest(
+                        replyTokenRef.Ref,
+                        RelayReplyTokenSecretPurpose,
+                        evt.RunId,
+                        evt.CorrelationId,
+                        "Resolve durable terminal outbox reply credential."),
+                    ct);
+                replyToken = NormalizeOptional(resolved.Secret);
+                replyTokenExpiresAtUnixMs = replyTokenRef.ExpiresAtUnixMs;
+            }
+
+            if (userAccessToken is null &&
+                evt.RelayUserAccessTokenRef is { Ref.Length: > 0 } userAccessTokenRef)
+            {
+                var resolved = await secretStore.ResolveAsync(
+                    new ResolveRuntimeSecretRequest(
+                        userAccessTokenRef.Ref,
+                        RelayUserAccessTokenSecretPurpose,
+                        evt.RunId,
+                        evt.CorrelationId,
+                        "Resolve durable terminal outbox user credential."),
+                    ct);
+                userAccessToken = NormalizeOptional(resolved.Secret);
+            }
+        }
 
         return BuildNyxRelayRuntimeContext(
             evt.CorrelationId,
             activity,
-            evt.ReplyToken,
-            evt.ReplyTokenExpiresAtUnixMs,
-            evt.Activity?.TransportExtras?.NyxUserAccessToken);
+            replyToken,
+            replyTokenExpiresAtUnixMs,
+            userAccessToken);
     }
 
     private DeliveryProducedEvent BuildDeliveryProducedEvent(
@@ -2708,6 +2770,68 @@ public sealed partial class ConversationGAgent :
         }
     }
 
+    private async Task AttachWorkflowRuntimeSecretReferencesAsync(
+        NeedsWorkflowDraftRunEvent request,
+        ConversationTurnRuntimeContext runtimeContext,
+        CancellationToken ct)
+    {
+        if (!IsRelayActivity(request.Activity) ||
+            runtimeContext.NyxRelayReplyToken is not { } replyContext ||
+            Services.GetService<IRuntimeSecretStore>() is not { } secretStore)
+        {
+            return;
+        }
+
+        var timeToLive = replyContext.ExpiresAtUtc - DateTimeOffset.UtcNow;
+        if (timeToLive <= TimeSpan.Zero)
+            return;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.RelayReplyTokenRef?.Ref) &&
+                NormalizeOptional(replyContext.ReplyToken) is { } replyToken)
+            {
+                request.RelayReplyTokenRef = (await secretStore.PutAsync(
+                    new StoreRuntimeSecretRequest(
+                        RelayReplyTokenSecretPurpose,
+                        request.RunId,
+                        request.CorrelationId,
+                        replyToken,
+                        timeToLive,
+                        ConsumeOnce: false,
+                        AuditReason: "Preserve workflow draft-run reply credential for durable recovery."),
+                    ct)).Reference;
+            }
+
+            if (string.IsNullOrWhiteSpace(request.RelayUserAccessTokenRef?.Ref) &&
+                NormalizeOptional(runtimeContext.NyxUserAccessToken) is { } userAccessToken)
+            {
+                request.RelayUserAccessTokenRef = (await secretStore.PutAsync(
+                    new StoreRuntimeSecretRequest(
+                        RelayUserAccessTokenSecretPurpose,
+                        request.RunId,
+                        request.CorrelationId,
+                        userAccessToken,
+                        timeToLive,
+                        ConsumeOnce: false,
+                        AuditReason: "Preserve workflow draft-run user credential for durable recovery."),
+                    ct)).Reference;
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(
+                ex,
+                "Failed to preserve workflow draft-run runtime credentials: runId={RunId} correlation={CorrelationId}",
+                request.RunId,
+                request.CorrelationId);
+        }
+    }
+
     private async Task RestoreRelayRuntimeCredentialsAsync(
         NeedsLlmReplyEvent request,
         CancellationToken ct)
@@ -2749,6 +2873,53 @@ public sealed partial class ConversationGAgent :
                 ct);
             if (NormalizeOptional(resolved.Secret) is { } userAccessToken)
                 RestoreRuntimeTransportCredentials(request.Activity, userAccessToken);
+        }
+    }
+
+    private async Task RestoreWorkflowRuntimeCredentialsAsync(
+        NeedsWorkflowDraftRunEvent request,
+        CancellationToken ct)
+    {
+        if (!IsRelayActivity(request.Activity) ||
+            Services.GetService<IRuntimeSecretStore>() is not { } secretStore)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ReplyToken) &&
+            request.RelayReplyTokenRef is { Ref.Length: > 0 } replyTokenRef)
+        {
+            var resolved = await secretStore.ResolveAsync(
+                new ResolveRuntimeSecretRequest(
+                    replyTokenRef.Ref,
+                    RelayReplyTokenSecretPurpose,
+                    request.RunId,
+                    request.CorrelationId,
+                    "Recover workflow draft-run reply credential."),
+                ct);
+            if (NormalizeOptional(resolved.Secret) is { } replyToken)
+            {
+                request.ReplyToken = replyToken;
+                request.ReplyTokenExpiresAtUnixMs = replyTokenRef.ExpiresAtUnixMs;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(request.NyxUserAccessToken) &&
+            request.RelayUserAccessTokenRef is { Ref.Length: > 0 } userAccessTokenRef)
+        {
+            var resolved = await secretStore.ResolveAsync(
+                new ResolveRuntimeSecretRequest(
+                    userAccessTokenRef.Ref,
+                    RelayUserAccessTokenSecretPurpose,
+                    request.RunId,
+                    request.CorrelationId,
+                    "Recover workflow draft-run user credential."),
+                ct);
+            if (NormalizeOptional(resolved.Secret) is { } userAccessToken)
+            {
+                request.NyxUserAccessToken = userAccessToken;
+                RestoreRuntimeTransportCredentials(request.Activity, userAccessToken);
+            }
         }
     }
 

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -120,6 +120,10 @@ message NeedsWorkflowDraftRunEvent {
   string reply_token = 10;
   int64 reply_token_expires_at_unix_ms = 11;
   string nyx_user_access_token = 12;
+  // Durable encrypted handles for workflow-run recovery. Raw credentials stay
+  // command-only and are cleared before this request enters actor state.
+  aevatar.credentials.RuntimeSecretReference relay_reply_token_ref = 13;
+  aevatar.credentials.RuntimeSecretReference relay_user_access_token_ref = 14;
 }
 
 message ConversationHistoryEntry {
@@ -206,6 +210,11 @@ message LlmReplyReadyEvent {
   // History entries produced by this LLM turn. ConversationGAgent persists
   // them only after the reply reaches a terminal user-visible outcome.
   repeated ConversationHistoryEntry appended_history = 13;
+  // Optional encrypted handles used by durable output outboxes. ConversationGAgent
+  // resolves them only for the outbound operation; raw credentials never enter
+  // the producer actor's committed state.
+  aevatar.credentials.RuntimeSecretReference relay_reply_token_ref = 14;
+  aevatar.credentials.RuntimeSecretReference relay_user_access_token_ref = 15;
 }
 
 enum ConversationReplyLifecycleMode {

--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunGAgent.cs
@@ -1,5 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
@@ -8,6 +10,7 @@ using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat.WorkflowDraftRun;
@@ -18,6 +21,14 @@ namespace Aevatar.GAgents.NyxidChat.WorkflowDraftRun;
 [GAgent("nyxid.chat.workflow-draft-run")]
 public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDraftRunGAgentState>
 {
+    private const string RecoveryTimeoutErrorCode = "workflow_draft_run_recovery_timeout";
+    private const string RecoveryContextMissingErrorCode = "workflow_draft_run_recovery_context_missing";
+    private const string RelayReplyTokenSecretPurpose = "channel-relay-reply-token";
+    private const string RelayUserAccessTokenSecretPurpose = "channel-relay-user-access-token";
+    private static readonly TimeSpan RecoveryTimeout = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan TerminalHandoffSafetyWindow = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan TerminalHandoffRetryDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ImmediateCallbackDelay = TimeSpan.FromMilliseconds(1);
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly WorkflowDraftRunReplyRenderer _renderer;
     private readonly IChannelWorkflowDraftRunInteractionPort? _workflowInteractionPort;
@@ -45,9 +56,25 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
             .Match(current, evt)
             .On<ChannelWorkflowDraftRunStartedEvent>(ApplyStarted)
             .On<ChannelWorkflowDraftRunFrameRenderedEvent>(ApplyFrameRendered)
+            .On<ChannelWorkflowDraftRunTerminalProducedEvent>(ApplyTerminalProduced)
             .On<ChannelWorkflowDraftRunReplyHandedOffEvent>(ApplyReplyHandedOff)
             .On<ChannelWorkflowDraftRunFailedEvent>(ApplyFailed)
             .OrCurrent();
+
+    protected override async Task OnActivateAsync(CancellationToken ct)
+    {
+        await base.OnActivateAsync(ct);
+        if (State.Status is ChannelWorkflowDraftRunStatus.ReplyHandedOff or ChannelWorkflowDraftRunStatus.Failed)
+        {
+            await PurgeDurableCallbacksBestEffortAsync();
+            return;
+        }
+
+        if (State.Status == ChannelWorkflowDraftRunStatus.Started)
+            await EnsureRecoveryTimeoutAsync(ct);
+        else if (State.Status == ChannelWorkflowDraftRunStatus.TerminalProduced)
+            await EnsureTerminalHandoffRetryAsync(ct);
+    }
 
     [EventHandler]
     public async Task HandleStartAsync(ChannelWorkflowDraftRunStartRequested command)
@@ -77,12 +104,24 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
             return;
         }
 
+        if (State.Status == ChannelWorkflowDraftRunStatus.TerminalProduced)
+        {
+            _logger.LogInformation(
+                "Reconciling duplicate workflow draft-run start from durable terminal outbox: runId={RunId} correlation={CorrelationId}",
+                State.RunId,
+                State.CorrelationId);
+            await EnsureTerminalHandoffRetryAsync(CancellationToken.None);
+            await TryHandoffProducedTerminalAsync(CancellationToken.None);
+            return;
+        }
+
         if (State.Status == ChannelWorkflowDraftRunStatus.Started)
         {
             _logger.LogInformation(
-                "Ignoring duplicate in-flight workflow draft-run start: runId={RunId} correlation={CorrelationId}",
+                "Reconciling duplicate in-flight workflow draft-run start without redispatch: runId={RunId} correlation={CorrelationId}",
                 State.RunId,
                 State.CorrelationId);
+            await EnsureRecoveryTimeoutAsync(CancellationToken.None);
             return;
         }
 
@@ -99,13 +138,18 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         }
 
         request.RunId = typedCommandRunId.Value;
+        await EnsureRuntimeSecretReferencesAsync(request, CancellationToken.None);
+        var startedAt = _timeProvider.GetUtcNow();
         await PersistDomainEventAsync(new ChannelWorkflowDraftRunStartedEvent
         {
             RunId = request.RunId,
             CorrelationId = request.CorrelationId,
             TargetActorId = request.TargetActorId,
-            StartedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+            StartedAtUnixMs = startedAt.ToUnixTimeMilliseconds(),
+            RecoveryRequest = BuildRecoveryRequest(request),
+            RecoveryDeadlineUnixMs = ResolveRecoveryDeadline(request, startedAt).ToUnixTimeMilliseconds(),
         });
+        await EnsureRecoveryTimeoutAsync(CancellationToken.None);
 
         if (_workflowInteractionPort is null)
         {
@@ -117,6 +161,76 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         }
 
         await _workflowInteractionPort.StartWorkflowInteractionAsync(Id, request, CancellationToken.None);
+    }
+
+    private static DateTimeOffset ResolveRecoveryDeadline(
+        NeedsWorkflowDraftRunEvent request,
+        DateTimeOffset startedAt)
+    {
+        var deadline = startedAt.Add(RecoveryTimeout);
+        if (request.ReplyTokenExpiresAtUnixMs <= 0)
+            return deadline;
+
+        var credentialDeadline = DateTimeOffset
+            .FromUnixTimeMilliseconds(request.ReplyTokenExpiresAtUnixMs)
+            .Subtract(TerminalHandoffSafetyWindow);
+        if (credentialDeadline <= startedAt)
+            return startedAt;
+
+        return credentialDeadline < deadline ? credentialDeadline : deadline;
+    }
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleRecoveryTimeoutAsync(ChannelWorkflowDraftRunRecoveryTimeoutElapsed signal)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        if (State.Status != ChannelWorkflowDraftRunStatus.Started ||
+            !string.Equals(State.RunId, signal.RunId, StringComparison.Ordinal) ||
+            !string.Equals(State.CorrelationId, signal.CorrelationId, StringComparison.Ordinal) ||
+            State.RecoveryDeadlineUnixMs != signal.RecoveryDeadlineUnixMs)
+        {
+            return;
+        }
+
+        if (State.RecoveryRequest is null || State.RecoveryDeadlineUnixMs <= 0)
+        {
+            await DispatchReadyAndPersistTerminalAsync(
+                BuildLegacyRecoveryRequest(),
+                BuildFailure(
+                    RecoveryContextMissingErrorCode,
+                    "Workflow draft-run recovery context is unavailable after restart."),
+                CancellationToken.None);
+            return;
+        }
+
+        if (_timeProvider.GetUtcNow().ToUnixTimeMilliseconds() < State.RecoveryDeadlineUnixMs)
+        {
+            await EnsureRecoveryTimeoutAsync(CancellationToken.None);
+            return;
+        }
+
+        await DispatchReadyAndPersistTerminalAsync(
+            State.RecoveryRequest.Clone(),
+            BuildFailure(
+                RecoveryTimeoutErrorCode,
+                "Workflow draft-run did not complete before its durable recovery deadline."),
+            CancellationToken.None);
+    }
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleTerminalHandoffRetryAsync(ChannelWorkflowDraftRunTerminalHandoffRetryElapsed signal)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        if (State.Status != ChannelWorkflowDraftRunStatus.TerminalProduced ||
+            !string.Equals(State.RunId, signal.RunId, StringComparison.Ordinal) ||
+            !string.Equals(State.CorrelationId, signal.CorrelationId, StringComparison.Ordinal) ||
+            !string.Equals(State.TerminalOperationId, signal.OperationId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await EnsureTerminalHandoffRetryAsync(CancellationToken.None);
+        await TryHandoffProducedTerminalAsync(CancellationToken.None);
     }
 
     [EventHandler]
@@ -214,19 +328,24 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         WorkflowDraftRunRenderedFrame rendered,
         CancellationToken ct)
     {
+        await EnsureRuntimeSecretReferencesAsync(request, ct);
+        var activity = request.Activity?.Clone() ?? new ChatActivity();
+        if (activity.TransportExtras is not null)
+            activity.TransportExtras.NyxUserAccessToken = string.Empty;
         var ready = new LlmReplyReadyEvent
         {
             CorrelationId = request.CorrelationId,
             RunId = request.RunId,
             RegistrationId = request.RegistrationId,
-            Activity = request.Activity?.Clone() ?? new ChatActivity(),
+            SourceActorId = Id,
+            Activity = activity,
             Outbound = new MessageContent { Text = rendered.Text },
             TerminalState = rendered.IsFailure ? LlmReplyTerminalState.Failed : LlmReplyTerminalState.Completed,
             ErrorCode = rendered.ErrorCode,
             ErrorSummary = rendered.IsFailure ? rendered.Text : string.Empty,
             ReadyAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-            ReplyToken = request.ReplyToken,
-            ReplyTokenExpiresAtUnixMs = request.ReplyTokenExpiresAtUnixMs,
+            RelayReplyTokenRef = request.RelayReplyTokenRef?.Clone(),
+            RelayUserAccessTokenRef = request.RelayUserAccessTokenRef?.Clone(),
         };
 
         if (!rendered.IsFailure)
@@ -238,50 +357,265 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
             });
         }
 
-        await DispatchToConversationAsync(request, ready, ct);
-        await PersistTerminalAsync(request, rendered);
+        var operationId = BuildTerminalOperationId(request.RunId);
+        await PersistDomainEventAsync(new ChannelWorkflowDraftRunTerminalProducedEvent
+        {
+            RunId = request.RunId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            TerminalReply = ready,
+            OperationId = operationId,
+            ProducedAtUnixMs = ready.ReadyAtUnixMs,
+        });
+        await EnsureTerminalHandoffRetryAsync(ct);
+        await TryHandoffProducedTerminalAsync(ct);
+    }
+
+    private async Task TryHandoffProducedTerminalAsync(CancellationToken ct)
+    {
+        if (State.Status != ChannelWorkflowDraftRunStatus.TerminalProduced ||
+            State.ProducedTerminalReply is null ||
+            string.IsNullOrWhiteSpace(State.TerminalOperationId))
+        {
+            return;
+        }
+
+        try
+        {
+            await DispatchEnvelopeAsync(
+                State.TargetActorId,
+                State.CorrelationId,
+                State.ProducedTerminalReply,
+                ct,
+                State.TerminalOperationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Workflow draft-run terminal admission failed; durable outbox remains pending: runId={RunId} correlation={CorrelationId}",
+                State.RunId,
+                State.CorrelationId);
+            return;
+        }
+
+        try
+        {
+            await PersistTerminalAsync(State.ProducedTerminalReply);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Workflow draft-run terminal admission succeeded but final state append failed; durable outbox will replay: runId={RunId} correlation={CorrelationId}",
+                State.RunId,
+                State.CorrelationId);
+            return;
+        }
+
+        await PurgeDurableCallbacksBestEffortAsync();
     }
 
     private async Task DispatchToConversationAsync(
         NeedsWorkflowDraftRunEvent request,
         IMessage payload,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? operationId = null)
     {
-        var targetActorId = request.TargetActorId;
+        await DispatchEnvelopeAsync(request.TargetActorId, request.CorrelationId, payload, ct, operationId);
+    }
+
+    private async Task DispatchEnvelopeAsync(
+        string targetActorId,
+        string correlationId,
+        IMessage payload,
+        CancellationToken ct,
+        string? operationId = null)
+    {
         if (string.IsNullOrWhiteSpace(targetActorId))
             throw new InvalidOperationException("Workflow draft-run request target actor id is required.");
 
-        await _actorDispatchPort.DispatchAsync(
-            targetActorId,
-            new EventEnvelope
+        var envelopeId = string.IsNullOrWhiteSpace(operationId)
+            ? Guid.NewGuid().ToString("N")
+            : operationId;
+        var envelope = new EventEnvelope
+        {
+            Id = envelopeId,
+            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateDirect(
+                "channel-workflow-draft-run-runner",
+                targetActorId),
+            Propagation = new EnvelopePropagation
             {
-                Id = Guid.NewGuid().ToString("N"),
-                Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-                Payload = Any.Pack(payload),
-                Route = EnvelopeRouteSemantics.CreateDirect(
-                    "channel-workflow-draft-run-runner",
-                    targetActorId),
-                Propagation = new EnvelopePropagation
-                {
-                    CorrelationId = request.CorrelationId,
-                },
+                CorrelationId = correlationId,
             },
+        };
+        if (!string.IsNullOrWhiteSpace(operationId))
+        {
+            envelope.Runtime = new EnvelopeRuntime
+            {
+                DeliveryIdentity = new DeliveryIdentity
+                {
+                    OperationId = operationId,
+                },
+            };
+        }
+
+        var admission = await _actorDispatchPort.DispatchAsync(
+            targetActorId,
+            envelope,
             ct);
+        if (!admission.Accepted)
+            throw new InvalidOperationException($"Workflow draft-run terminal envelope '{envelopeId}' was not accepted.");
     }
 
-    private async Task PersistTerminalAsync(
-        NeedsWorkflowDraftRunEvent request,
-        WorkflowDraftRunRenderedFrame rendered)
+    private async Task EnsureRecoveryTimeoutAsync(CancellationToken ct)
     {
-        if (rendered.IsFailure)
+        if (State.Status != ChannelWorkflowDraftRunStatus.Started)
+            return;
+
+        var remaining = State.RecoveryDeadlineUnixMs <= 0
+            ? ImmediateCallbackDelay
+            : DateTimeOffset.FromUnixTimeMilliseconds(State.RecoveryDeadlineUnixMs) - _timeProvider.GetUtcNow();
+        if (remaining <= TimeSpan.Zero)
+            remaining = ImmediateCallbackDelay;
+
+        await ScheduleSelfDurableTimeoutAsync(
+            BuildRecoveryCallbackId(State.RunId),
+            remaining,
+            new ChannelWorkflowDraftRunRecoveryTimeoutElapsed
+            {
+                RunId = State.RunId,
+                CorrelationId = State.CorrelationId,
+                RecoveryDeadlineUnixMs = State.RecoveryDeadlineUnixMs,
+            },
+            ct: ct);
+    }
+
+    private async Task EnsureTerminalHandoffRetryAsync(CancellationToken ct)
+    {
+        if (State.Status != ChannelWorkflowDraftRunStatus.TerminalProduced ||
+            string.IsNullOrWhiteSpace(State.TerminalOperationId))
+        {
+            return;
+        }
+
+        await ScheduleSelfDurableTimeoutAsync(
+            BuildTerminalHandoffRetryCallbackId(State.RunId),
+            TerminalHandoffRetryDelay,
+            new ChannelWorkflowDraftRunTerminalHandoffRetryElapsed
+            {
+                RunId = State.RunId,
+                CorrelationId = State.CorrelationId,
+                OperationId = State.TerminalOperationId,
+            },
+            ct: ct);
+    }
+
+    private async Task EnsureRuntimeSecretReferencesAsync(
+        NeedsWorkflowDraftRunEvent request,
+        CancellationToken ct)
+    {
+        var secretStore = Services.GetService<IRuntimeSecretStore>();
+        if (secretStore is null)
+            return;
+
+        var expiresAt = request.ReplyTokenExpiresAtUnixMs > 0
+            ? DateTimeOffset.FromUnixTimeMilliseconds(request.ReplyTokenExpiresAtUnixMs)
+            : _timeProvider.GetUtcNow().Add(RecoveryTimeout);
+        var timeToLive = expiresAt - _timeProvider.GetUtcNow();
+        if (timeToLive <= TimeSpan.Zero)
+            return;
+
+        if (string.IsNullOrWhiteSpace(request.RelayReplyTokenRef?.Ref) &&
+            !string.IsNullOrWhiteSpace(request.ReplyToken))
+        {
+            request.RelayReplyTokenRef = (await secretStore.PutAsync(
+                new StoreRuntimeSecretRequest(
+                    RelayReplyTokenSecretPurpose,
+                    request.RunId,
+                    request.CorrelationId,
+                    request.ReplyToken,
+                    timeToLive,
+                    ConsumeOnce: false,
+                    AuditReason: "Preserve workflow draft-run reply credential for durable terminal handoff."),
+                ct)).Reference;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.RelayUserAccessTokenRef?.Ref) &&
+            !string.IsNullOrWhiteSpace(request.NyxUserAccessToken))
+        {
+            request.RelayUserAccessTokenRef = (await secretStore.PutAsync(
+                new StoreRuntimeSecretRequest(
+                    RelayUserAccessTokenSecretPurpose,
+                    request.RunId,
+                    request.CorrelationId,
+                    request.NyxUserAccessToken,
+                    timeToLive,
+                    ConsumeOnce: false,
+                    AuditReason: "Preserve workflow draft-run user credential for durable recovery."),
+                ct)).Reference;
+        }
+    }
+
+    private async Task PurgeDurableCallbacksBestEffortAsync()
+    {
+        try
+        {
+            await Services.GetRequiredService<IActorRuntimeCallbackScheduler>()
+                .PurgeActorAsync(Id, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Workflow draft-run callback cleanup failed: actorId={ActorId} runId={RunId} status={Status}",
+                Id,
+                State.RunId,
+                State.Status);
+        }
+    }
+
+    private static NeedsWorkflowDraftRunEvent BuildRecoveryRequest(NeedsWorkflowDraftRunEvent request)
+    {
+        var recovery = request.Clone();
+        recovery.ReplyToken = string.Empty;
+        recovery.ReplyTokenExpiresAtUnixMs = 0;
+        recovery.NyxUserAccessToken = string.Empty;
+        if (recovery.Activity?.TransportExtras is not null)
+            recovery.Activity.TransportExtras.NyxUserAccessToken = string.Empty;
+        return recovery;
+    }
+
+    private NeedsWorkflowDraftRunEvent BuildLegacyRecoveryRequest() =>
+        new()
+        {
+            RunId = State.RunId,
+            CorrelationId = State.CorrelationId,
+            TargetActorId = State.TargetActorId,
+        };
+
+    private static string BuildRecoveryCallbackId(string runId) =>
+        $"workflow-draft-run-recovery:{runId}";
+
+    private static string BuildTerminalHandoffRetryCallbackId(string runId) =>
+        $"workflow-draft-run-terminal-handoff:{runId}";
+
+    private static string BuildTerminalOperationId(string runId) =>
+        $"workflow-draft-run-terminal:{runId}";
+
+    private async Task PersistTerminalAsync(LlmReplyReadyEvent ready)
+    {
+        if (ready.TerminalState == LlmReplyTerminalState.Failed)
         {
             await PersistDomainEventAsync(new ChannelWorkflowDraftRunFailedEvent
             {
-                RunId = request.RunId,
-                CorrelationId = request.CorrelationId,
-                TargetActorId = request.TargetActorId,
-                ErrorCode = rendered.ErrorCode,
-                ErrorSummary = rendered.Text,
+                RunId = ready.RunId,
+                CorrelationId = ready.CorrelationId,
+                TargetActorId = State.TargetActorId,
+                ErrorCode = ready.ErrorCode,
+                ErrorSummary = ready.ErrorSummary,
                 FailedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
             });
             return;
@@ -289,9 +623,9 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
 
         await PersistDomainEventAsync(new ChannelWorkflowDraftRunReplyHandedOffEvent
         {
-            RunId = request.RunId,
-            CorrelationId = request.CorrelationId,
-            TargetActorId = request.TargetActorId,
+            RunId = ready.RunId,
+            CorrelationId = ready.CorrelationId,
+            TargetActorId = State.TargetActorId,
             HandedOffAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
         });
     }
@@ -309,6 +643,8 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         next.TargetActorId = evt.TargetActorId;
         next.Status = ChannelWorkflowDraftRunStatus.Started;
         next.StartedAtUnixMs = evt.StartedAtUnixMs;
+        next.RecoveryRequest = evt.RecoveryRequest?.Clone();
+        next.RecoveryDeadlineUnixMs = evt.RecoveryDeadlineUnixMs;
         next.AccumulatedText = string.Empty;
         next.CompletedAtUnixMs = 0;
         next.ErrorCode = string.Empty;
@@ -328,6 +664,20 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         return next;
     }
 
+    private static ChannelWorkflowDraftRunGAgentState ApplyTerminalProduced(
+        ChannelWorkflowDraftRunGAgentState current,
+        ChannelWorkflowDraftRunTerminalProducedEvent evt)
+    {
+        var next = current.Clone();
+        next.RunId = evt.RunId;
+        next.CorrelationId = evt.CorrelationId;
+        next.TargetActorId = evt.TargetActorId;
+        next.Status = ChannelWorkflowDraftRunStatus.TerminalProduced;
+        next.ProducedTerminalReply = evt.TerminalReply?.Clone();
+        next.TerminalOperationId = evt.OperationId;
+        return next;
+    }
+
     private static ChannelWorkflowDraftRunGAgentState ApplyReplyHandedOff(
         ChannelWorkflowDraftRunGAgentState current,
         ChannelWorkflowDraftRunReplyHandedOffEvent evt)
@@ -340,6 +690,10 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         next.CompletedAtUnixMs = evt.HandedOffAtUnixMs;
         next.ErrorCode = string.Empty;
         next.ErrorSummary = string.Empty;
+        next.RecoveryRequest = null;
+        next.RecoveryDeadlineUnixMs = 0;
+        next.ProducedTerminalReply = null;
+        next.TerminalOperationId = string.Empty;
         return next;
     }
 
@@ -355,6 +709,10 @@ public sealed class ChannelWorkflowDraftRunGAgent : GAgentBase<ChannelWorkflowDr
         next.CompletedAtUnixMs = evt.FailedAtUnixMs;
         next.ErrorCode = evt.ErrorCode;
         next.ErrorSummary = evt.ErrorSummary;
+        next.RecoveryRequest = null;
+        next.RecoveryDeadlineUnixMs = 0;
+        next.ProducedTerminalReply = null;
+        next.TerminalOperationId = string.Empty;
         return next;
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs
@@ -112,6 +112,8 @@ public sealed class ChannelWorkflowDraftRunInteractionPort : IChannelWorkflowDra
                 ct);
         }
 
+        // This observer is transient by design. It only publishes typed frames/completion
+        // back to the run actor; the actor-owned durable deadline guarantees termination.
         _ = Task.Run(
             () => ExecuteWorkflowInteractionAsync(runActorId, request.Clone(), CancellationToken.None),
             CancellationToken.None);

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -468,6 +468,9 @@ enum ChannelWorkflowDraftRunStatus {
   CHANNEL_WORKFLOW_DRAFT_RUN_STATUS_STARTED = 1;
   CHANNEL_WORKFLOW_DRAFT_RUN_STATUS_REPLY_HANDED_OFF = 2;
   CHANNEL_WORKFLOW_DRAFT_RUN_STATUS_FAILED = 3;
+  // An immutable terminal reply has been committed, but actor-inbox admission
+  // and the corresponding final state event have not both completed yet.
+  CHANNEL_WORKFLOW_DRAFT_RUN_STATUS_TERMINAL_PRODUCED = 4;
 }
 
 message ChannelWorkflowDraftRunGAgentState {
@@ -480,6 +483,10 @@ message ChannelWorkflowDraftRunGAgentState {
   string error_code = 7;
   string error_summary = 8;
   string accumulated_text = 9;
+  aevatar.gagents.channel.runtime.NeedsWorkflowDraftRunEvent recovery_request = 10;
+  int64 recovery_deadline_unix_ms = 11;
+  aevatar.gagents.channel.runtime.LlmReplyReadyEvent produced_terminal_reply = 12;
+  string terminal_operation_id = 13;
 }
 
 message ChannelWorkflowDraftRunStartRequested {
@@ -492,6 +499,35 @@ message ChannelWorkflowDraftRunStartedEvent {
   string correlation_id = 2;
   string target_actor_id = 3;
   int64 started_at_unix_ms = 4;
+  aevatar.gagents.channel.runtime.NeedsWorkflowDraftRunEvent recovery_request = 5;
+  int64 recovery_deadline_unix_ms = 6;
+}
+
+// Durable self-timeout payload. The actor rehydrates the recovery request from
+// committed state so callback storage never contains runtime credentials.
+message ChannelWorkflowDraftRunRecoveryTimeoutElapsed {
+  string run_id = 1;
+  string correlation_id = 2;
+  int64 recovery_deadline_unix_ms = 3;
+}
+
+// Durable outbox fact. This is committed before actor-inbox admission is
+// attempted, so activation and retries only replay this immutable payload.
+message ChannelWorkflowDraftRunTerminalProducedEvent {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  aevatar.gagents.channel.runtime.LlmReplyReadyEvent terminal_reply = 4;
+  string operation_id = 5;
+  int64 produced_at_unix_ms = 6;
+}
+
+// Signal-only durable callback. The terminal payload is rehydrated from actor
+// state so callback storage contains no reply body or credential material.
+message ChannelWorkflowDraftRunTerminalHandoffRetryElapsed {
+  string run_id = 1;
+  string correlation_id = 2;
+  string operation_id = 3;
 }
 
 message ChannelWorkflowDraftRunFrame {

--- a/docs/superpowers/plans/2026-08-02-workflow-draft-run-recovery.md
+++ b/docs/superpowers/plans/2026-08-02-workflow-draft-run-recovery.md
@@ -1,0 +1,142 @@
+# Workflow Draft-Run Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee that a persisted channel workflow draft-run reaches one terminal state after process restart without persisting credentials or replaying workflow side effects.
+
+**Architecture:** The draft-run actor persists a scrubbed recovery continuation and absolute deadline with `Started`. Timeout and normal completion first commit one immutable terminal outbox payload, then retry actor-inbox admission with a stable operation ID, and only then commit the final state.
+
+**Tech Stack:** .NET 10, C#, protobuf, event-sourced GAgents, `IActorRuntimeCallbackScheduler`, xUnit, FluentAssertions.
+
+## Global Constraints
+
+- Raw relay reply tokens and NyxID user access tokens remain runtime-only.
+- Recovery never redispatches the workflow command.
+- Recovery reserves a one-minute terminal-handoff window before an explicit relay reply-token expiry.
+- Background interaction code only publishes typed messages to the actor.
+- Every behavior change follows RED, GREEN, REFACTOR.
+
+---
+
+### Task 1: Prove the restart failure boundary
+
+**Files:**
+- Modify: `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs`
+
+**Interfaces:**
+- Consumes: `ChannelWorkflowDraftRunGAgent.ActivateAsync`, shared `IEventStore`, `IActorRuntimeCallbackScheduler`.
+- Produces: deterministic restart, credential-scrubbing, duplicate-repair, and terminal-race tests.
+
+- [ ] **Step 1: Add a shared-event-store actor factory and recording callback scheduler**
+
+Extend `CreateWorkflowDraftRunAgentAsync` with optional `IEventStore`, `IActorRuntimeCallbackScheduler`, and `TimeProvider` arguments. Register the chosen scheduler in the service provider. The scheduler records `RuntimeCallbackTimeoutRequest` objects and returns monotonically increasing in-memory leases.
+
+- [ ] **Step 2: Write the restart-boundary test**
+
+Start an actor with a recording interaction port, assert `Started`, then create a second actor with the same ID and event store. Assert activation schedules a typed recovery timeout without starting another interaction. Advance a `FakeTimeProvider`, invoke the recorded timeout signal, and assert exactly one failed `LlmReplyReadyEvent` plus `Failed` actor state.
+
+- [ ] **Step 3: Add credential and race assertions**
+
+Assert the persisted recovery request and callback payload contain no reply or NyxID credentials. Deliver a late interaction completion after timeout and assert the dispatch count remains one.
+
+- [ ] **Step 4: Run the focused test and verify RED**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter 'FullyQualifiedName~ChannelWorkflowDraftRunTests'
+```
+
+Expected: compile or assertion failure because recovery state, timeout message, activation scheduling, and timeout handler do not exist.
+
+### Task 2: Add the durable recovery contract and actor behavior
+
+**Files:**
+- Modify: `agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto`
+- Modify: `agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunGAgent.cs`
+- Modify: `agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs`
+
+**Interfaces:**
+- Consumes: `ScheduleSelfDurableTimeoutAsync`, `IActorRuntimeCallbackScheduler.PurgeActorAsync`, `NeedsWorkflowDraftRunEvent`.
+- Produces: `ChannelWorkflowDraftRunRecoveryTimeoutElapsed`, persisted `RecoveryRequest`, and `RecoveryDeadlineUnixMs`.
+
+- [ ] **Step 1: Extend the protobuf contract**
+
+Add `recovery_request` and `recovery_deadline_unix_ms` to the started event and actor state. Add the typed timeout signal with stable identity fields only.
+
+- [ ] **Step 2: Persist a scrubbed recovery continuation**
+
+Clone the request, clear all raw credential fields including nested transport credentials, compute the deadline once, and include both values in `ChannelWorkflowDraftRunStartedEvent`. Use the earlier of the 30-minute recovery limit and one minute before reply-token expiry; clamp an already elapsed credential bound to the start time so the durable callback fires immediately.
+
+- [ ] **Step 3: Reconcile the durable callback**
+
+After the `Started` commit, on duplicate active start, and from `OnActivateAsync`, schedule the deterministic self-timeout for the remaining duration. If the deadline already elapsed, enqueue it with the minimum supported delay so the normal actor handler performs the transition.
+
+- [ ] **Step 4: Implement the serialized timeout transition**
+
+Validate status and stable identity against actor state. Dispatch `workflow_draft_run_recovery_timeout`, commit `Failed`, and purge callbacks best effort. Make normal terminal paths purge callbacks too.
+
+- [ ] **Step 5: Stabilize the terminal envelope identity**
+
+Use one operation ID derived from the run ID for terminal `LlmReplyReadyEvent` dispatch. Keep stream chunks independently identified.
+
+- [ ] **Step 6: Run the focused tests and verify GREEN**
+
+Run the Task 1 test command. Expected: all `ChannelWorkflowDraftRunTests` pass with zero failures.
+
+### Task 3: Verify the change and prepare review
+
+Before verification, close the independent-review blocker with a durable terminal outbox:
+
+- [ ] Add `TerminalProduced`, a persisted scrubbed `LlmReplyReadyEvent`, stable operation ID, and typed terminal-handoff retry signal.
+- [ ] Persist the terminal payload before dispatch and arm the retry before admission.
+- [ ] On dispatch failure or post-admission final append failure, remain pending and replay the same payload after activation.
+- [ ] Store relay credentials only as encrypted `RuntimeSecretReference` values and resolve them in `ConversationGAgent` at delivery time.
+- [ ] Add deterministic fault-injection tests for both failure windows and credential-reference tests for the Conversation boundary.
+- [ ] Add a fake-clock test that reaches the credential-bounded timeout, produces the terminal reply before token expiry, and resolves its runtime-secret reference at the handoff boundary.
+
+**Files:**
+- Verify: all files changed since `origin/feature/integrate`.
+
+**Interfaces:**
+- Consumes: repository build/test/guard scripts.
+- Produces: reviewable commit with fresh verification evidence.
+
+- [ ] **Step 1: Run mandatory focused guards**
+
+```bash
+bash tools/ci/test_stability_guards.sh
+bash tools/ci/workflow_binding_boundary_guard.sh
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 2: Run architecture and full solution verification**
+
+```bash
+bash tools/ci/architecture_guards.sh
+dotnet build aevatar.slnx --nologo
+dotnet test aevatar.slnx --nologo
+```
+
+Expected: all commands exit 0 and tests report zero failures.
+
+- [ ] **Step 3: Commit the scoped change**
+
+```bash
+git add docs/superpowers/specs/2026-08-02-workflow-draft-run-recovery-design.md \
+  docs/superpowers/plans/2026-08-02-workflow-draft-run-recovery.md \
+  agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto \
+  agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunGAgent.cs \
+  agents/Aevatar.GAgents.NyxidChat/WorkflowDraftRun/ChannelWorkflowDraftRunInteractionPort.cs \
+  test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+git commit -m 'Recover stranded workflow draft runs'
+```
+
+- [ ] **Step 4: Request independent review**
+
+Review the commit range from the original `origin/feature/integrate` baseline to `HEAD` against issue #3043 and the design spec. Fix all Critical and Important findings, then rerun affected checks.
+
+- [ ] **Step 5: Push, open the PR, and wait for CI**
+
+Push `fix/2026-08-02_resume-workflow-draft-runs`, open a ready PR targeting `feature/integrate`, wait for every required GitHub check, and merge only after all checks succeed.

--- a/docs/superpowers/specs/2026-08-02-workflow-draft-run-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-02-workflow-draft-run-recovery-design.md
@@ -1,0 +1,89 @@
+# Workflow Draft-Run Recovery Design
+
+## Context
+
+`ChannelWorkflowDraftRunGAgent` currently commits `ChannelWorkflowDraftRunStartedEvent` and then starts a transient interaction observer. The observer runs in process memory and reports frames and completion back to the run actor. A process restart after the `Started` commit loses that observer. The actor rehydrates as `Started`, ignores the deterministic start command as a duplicate, and has no durable continuation or terminal deadline.
+
+The durable workflow run actor remains the authority for workflow execution. The missing authority is the channel draft-run handoff: no durable owner decides how a stranded `Started` draft-run reaches a terminal state.
+
+## Constraints
+
+- Raw relay reply tokens and NyxID user access tokens remain runtime-only and must not enter event store, actor state, or durable callback payloads.
+- Restart recovery must not redispatch the workflow command. A deterministic command ID alone does not prove that every downstream effect is safe to repeat.
+- All state transitions occur in the draft-run actor turn. Background interaction code may only publish typed observations back to the actor.
+- Timeout recovery must use the runtime's durable callback scheduler and a typed protobuf signal.
+- A recovery deadline that depends on a relay reply token must leave time to hand the terminal reply off before that token expires.
+- Terminal output must be committed before actor-inbox admission. A stable operation ID preserves delivery lineage across retries; it neither suppresses retransmission nor replaces a durable outbox.
+- Normal completion and timeout recovery must produce one immutable terminal payload and may retry its idempotent handoff.
+
+## Considered Approaches
+
+### 1. Durable recovery deadline with fail-closed timeout
+
+Persist a scrubbed recovery request and an absolute recovery deadline in the `Started` event/state. Schedule a deterministic durable self-timeout after the commit. On activation and duplicate start, reconcile the same deadline and schedule it again if necessary. When the timeout fires, the actor emits the existing typed terminal failure carrier and commits `Failed`. Normal completion and timeout are serialized by actor state, so only the first terminal path performs a handoff.
+
+This is the selected approach. It closes the restart hole without replaying a workflow or persisting credentials. The transient observer is no longer the sole terminal owner: it can only publish frames/completion, while the actor-owned durable deadline guarantees a terminal decision.
+
+### 2. Resume observation from a persisted workflow receipt
+
+Persist the accepted workflow actor ID and command receipt, then add an observe-only application port that can attach to an existing workflow run or read its terminal current-state model. This can recover a successful result after restart, but it requires a new cross-layer observation contract and careful projection freshness semantics. It is a valid future enhancement, but it is larger than the blocker and unnecessary for guaranteed termination.
+
+### 3. Re-run the deterministic start command
+
+Persist or recover the original request and call `ExecuteAsync` again. This would require durable secret references for both relay credentials and still cannot prove that every workflow side effect is idempotent. This approach is rejected.
+
+## State And Messages
+
+`ChannelWorkflowDraftRunStartedEvent` and `ChannelWorkflowDraftRunGAgentState` gain:
+
+- `recovery_request`: a cloned `NeedsWorkflowDraftRunEvent` with `reply_token`, `reply_token_expires_at_unix_ms`, `nyx_user_access_token`, and `activity.transport_extras.nyx_user_access_token` cleared.
+- `recovery_deadline_unix_ms`: an absolute UTC deadline derived once when `Started` is committed. It is the earlier of the 30-minute recovery limit and one minute before reply-token expiry; an already elapsed credential bound is clamped to the start time for immediate durable timeout handling.
+- encrypted runtime-secret references for reply and user credentials; raw credentials remain cleared.
+
+Terminal delivery adds a second durable phase:
+
+- `ChannelWorkflowDraftRunTerminalProducedEvent` commits the complete scrubbed `LlmReplyReadyEvent` and stable operation ID before dispatch.
+- `ChannelWorkflowDraftRunStatus.TerminalProduced` means that the immutable terminal payload is pending handoff or final-state persistence.
+- `ChannelWorkflowDraftRunTerminalHandoffRetryElapsed` carries only run, correlation, and operation IDs. Activation and duplicate starts re-arm this callback and replay the committed payload.
+- `ReplyHandedOff` or `Failed` is committed only after the target actor inbox accepts the terminal envelope.
+
+Raw relay credentials are stored in `IRuntimeSecretStore`. The persisted workflow request and terminal reply carry typed `RuntimeSecretReference` fields. `ConversationGAgent` resolves those references only while performing outbound delivery.
+
+The new `ChannelWorkflowDraftRunRecoveryTimeoutElapsed` self-signal carries only `run_id`, `correlation_id`, and `recovery_deadline_unix_ms`. It contains no content or credential fields.
+
+The callback ID is deterministic per run. Rescheduling is safe: an early or duplicate callback rechecks the persisted deadline, and a callback after terminal state is a no-op.
+
+## Runtime Flow
+
+1. Validate the start request and commit `Started` together with the scrubbed recovery request and deadline.
+2. Schedule the durable recovery timeout. For relay requests, the deadline reserves a one-minute terminal-handoff window before reply-token expiry; requests without an explicit expiry retain the 30-minute recovery limit.
+3. Start the transient workflow interaction observer. It may only dispatch typed frame/completion messages to the run actor.
+4. On duplicate start for the same active run, do not start another interaction; reconcile the durable timeout.
+5. On activation in `Started`, reconcile the durable timeout. If the deadline is already elapsed, enqueue the typed durable self-timeout with the minimum supported delay so the normal actor handler performs the transition.
+6. On timeout, verify status, run ID, correlation ID, and deadline against actor state. If still active, produce `LlmReplyReadyEvent` with error code `workflow_draft_run_recovery_timeout`.
+7. Commit the immutable scrubbed terminal reply and operation ID as `TerminalProduced`.
+8. Arm the deterministic terminal-handoff retry before attempting actor-inbox admission.
+9. Dispatch the committed payload. If admission fails, remain `TerminalProduced`; activation or the typed retry replays the same payload and operation ID.
+10. If admission succeeds, commit `ChannelWorkflowDraftRunReplyHandedOffEvent` or `ChannelWorkflowDraftRunFailedEvent`. If this append fails, remain `TerminalProduced` and safely replay the already admitted payload.
+11. Only after the final event commits, best-effort purge the actor's durable callbacks.
+
+Terminal conversation envelopes use a stable operation ID derived from the run ID. The durable outbox supplies restart recovery, while the operation ID preserves delivery lineage across retries. The transport may redeliver; `ConversationGAgent` absorbs a replay through its persisted terminal correlation state.
+
+## Error Handling
+
+- Missing recovery context in a legacy `Started` state is treated as an already-stranded run and fails closed with `workflow_draft_run_recovery_context_missing`.
+- Durable callback scheduling errors are not hidden. The actor remains `Started`; activation or duplicate start can repair scheduling later.
+- Terminal admission failures and post-admission final-append failures leave the committed outbox pending and do not purge callbacks.
+- Callback purge is best effort and logged. Persisted final state remains authoritative if cleanup fails.
+- Late frames, completion messages, and timeout signals after a terminal transition are ignored.
+
+## Verification
+
+- A deterministic test commits `Started`, recreates the actor from the same event store before interaction completion, fires the re-established durable timeout, and verifies one terminal failure handoff with no second interaction start.
+- Tests verify persisted recovery state and durable callback payloads contain no raw credentials.
+- Tests verify duplicate active start repairs the timeout without redispatching workflow execution.
+- Tests verify a late completion after recovery timeout does not produce a second terminal handoff.
+- Fault-injection tests verify dispatch admission failure and post-admission final append failure both rehydrate as `TerminalProduced`, replay byte-identical payloads with the same operation ID, and never restart workflow execution.
+- Tests verify terminal outbox state contains secret references rather than raw reply or NyxID credentials, and `ConversationGAgent` resolves those references only at delivery time.
+- A fake-clock test advances to the credential-bounded recovery deadline, verifies the timeout fires one minute before reply-token expiry, and resolves the persisted secret reference at the terminal handoff boundary.
+- Run the channel runtime test project, test stability guard, workflow binding boundary guard, architecture guards, full solution build, and full solution test.

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -1806,6 +1806,76 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleLlmReplyReadyAsync_ResolvesDurableTerminalCredentialReferences()
+    {
+        const string runId = "workflow-draft-run-secret-ref";
+        const string correlationId = "corr-workflow-secret-ref";
+        const string replyToken = "durable-terminal-reply-token";
+        const string userAccessToken = "durable-terminal-user-token";
+        var runtimeSecretStore = new InMemoryRuntimeSecretStore();
+        var replyReference = (await runtimeSecretStore.PutAsync(new StoreRuntimeSecretRequest(
+            "channel-relay-reply-token",
+            runId,
+            correlationId,
+            replyToken,
+            TimeSpan.FromMinutes(10),
+            ConsumeOnce: false,
+            AuditReason: "test durable terminal reply credential"))).Reference;
+        var userReference = (await runtimeSecretStore.PutAsync(new StoreRuntimeSecretRequest(
+            "channel-relay-user-access-token",
+            runId,
+            correlationId,
+            userAccessToken,
+            TimeSpan.FromMinutes(10),
+            ConsumeOnce: false,
+            AuditReason: "test durable terminal user credential"))).Reference;
+        ConversationTurnRuntimeContext? observedContext = null;
+        var runner = new RecordingTurnRunner
+        {
+            LlmReplyResultFactory = reply => ConversationTurnResult.Sent(
+                "sent:" + reply.CorrelationId,
+                new MessageContent { Text = "ack" },
+                "bot",
+                new OutboundDeliveryContext
+                {
+                    ReplyMessageId = reply.Activity?.OutboundDelivery?.ReplyMessageId ?? string.Empty,
+                    CorrelationId = reply.CorrelationId,
+                }),
+            LlmReplyContextObserver = context => observedContext = context,
+        };
+        var (agent, _) = await CreateAgentAsync(
+            runner,
+            "conv-workflow-secret-ref",
+            runtimeSecretStore: runtimeSecretStore);
+        var activity = CreateActivity("act-workflow-secret-ref", "conv:slack:C1");
+        activity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-msg-workflow-secret-ref",
+            CorrelationId = correlationId,
+        };
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = correlationId,
+            RegistrationId = "reg-1",
+            RunId = runId,
+            SourceActorId = "workflow-draft-run-actor-1",
+            Activity = activity,
+            Outbound = new MessageContent { Text = "workflow complete" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            RelayReplyTokenRef = replyReference,
+            RelayUserAccessTokenRef = userReference,
+        });
+
+        observedContext.ShouldNotBeNull();
+        observedContext!.NyxRelayReplyToken.ShouldNotBeNull();
+        observedContext.NyxRelayReplyToken!.ReplyToken.ShouldBe(replyToken);
+        observedContext.NyxRelayReplyToken.CorrelationId.ShouldBe(correlationId);
+        observedContext.NyxUserAccessToken.ShouldBe(userAccessToken);
+    }
+
+    [Fact]
     public async Task HandleDeferredLlmReplyDroppedAsync_RetiresPendingRequestWithNotRetryableFailure()
     {
         // Run actor gates (stale-age, missing relay credential, malformed payload) need

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelWorkflowDraftRunTests.cs
@@ -1,5 +1,8 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Credentials.Testing;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.AI.ToolProviders.Lark;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
@@ -15,12 +18,16 @@ using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
 public sealed class ChannelWorkflowDraftRunTests
 {
+    private static readonly DateTimeOffset WorkflowDraftRunNow =
+        DateTimeOffset.Parse("2026-08-02T00:00:00Z");
+
     [Theory]
     [InlineData("/workflow run daily-greeting", "daily-greeting")]
     [InlineData("/run-workflow daily.greeting", "daily.greeting")]
@@ -711,7 +718,8 @@ public sealed class ChannelWorkflowDraftRunTests
         ready.RunId.Should().Be("workflow-draft-run-1");
         ready.TerminalState.Should().Be(LlmReplyTerminalState.Completed);
         ready.Outbound.Text.Should().Be("hello world");
-        ready.ReplyToken.Should().Be("reply-token-1");
+        ready.ReplyToken.Should().BeEmpty();
+        ready.RelayReplyTokenRef.Ref.Should().NotBeNullOrWhiteSpace();
 
         agent.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.ReplyHandedOff);
         agent.State.RunId.Should().Be("workflow-draft-run-1");
@@ -719,14 +727,16 @@ public sealed class ChannelWorkflowDraftRunTests
     }
 
     [Fact]
-    public async Task WorkflowDraftRunGAgent_ShouldIgnoreDuplicateInFlightStartWithoutDispatchingAgain()
+    public async Task WorkflowDraftRunGAgent_ShouldRepairTimeoutWithoutDispatchingDuplicateInFlightStart()
     {
         var workflow = new RecordingWorkflowDraftRunInteractionPort();
         var dispatch = new RecordingActorDispatchPort();
-        var agent = await CreateWorkflowDraftRunAgentAsync(dispatch, workflow);
-        agent.State.Status = ChannelWorkflowDraftRunStatus.Started;
-        agent.State.RunId = "workflow-draft-run-1";
-        agent.State.CorrelationId = "msg-1";
+        var scheduler = new RecordingCallbackScheduler();
+        var agent = await CreateWorkflowDraftRunAgentAsync(
+            dispatch,
+            workflow,
+            callbackScheduler: scheduler,
+            timeProvider: new FakeTimeProvider(WorkflowDraftRunNow));
         var request = BuildWorkflowRequest();
 
         await agent.HandleStartAsync(new ChannelWorkflowDraftRunStartRequested
@@ -734,12 +744,334 @@ public sealed class ChannelWorkflowDraftRunTests
             Request = request.Clone(),
             RunId = request.RunId,
         });
+        await agent.HandleStartAsync(new ChannelWorkflowDraftRunStartRequested
+        {
+            Request = request.Clone(),
+            RunId = request.RunId,
+        });
 
-        workflow.Started.Should().BeEmpty();
+        workflow.Started.Should().ContainSingle();
+        scheduler.Timeouts.Should().HaveCount(2);
+        scheduler.Timeouts.Select(x => x.CallbackId).Distinct().Should().ContainSingle();
         dispatch.Envelopes.Should().BeEmpty();
         agent.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.Started);
         agent.State.RunId.Should().Be("workflow-draft-run-1");
         agent.State.CorrelationId.Should().Be("msg-1");
+    }
+
+    [Fact]
+    public async Task WorkflowDraftRunGAgent_ShouldFailRehydratedStartedRunAfterDurableRecoveryTimeout()
+    {
+        var eventStore = new InMemoryEventStore();
+        var timeProvider = new FakeTimeProvider(WorkflowDraftRunNow);
+        var firstScheduler = new RecordingCallbackScheduler();
+        var firstWorkflow = new RecordingWorkflowDraftRunInteractionPort();
+        var firstDispatch = new RecordingActorDispatchPort();
+        var firstAgent = await CreateWorkflowDraftRunAgentAsync(
+            firstDispatch,
+            firstWorkflow,
+            eventStore,
+            firstScheduler,
+            timeProvider);
+        var request = BuildWorkflowRequest();
+        request.Activity.TransportExtras = new TransportExtras
+        {
+            NyxUserAccessToken = "activity-user-token",
+        };
+
+        await firstAgent.HandleStartAsync(new ChannelWorkflowDraftRunStartRequested
+        {
+            Request = request.Clone(),
+            RunId = request.RunId,
+        });
+
+        firstAgent.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.Started);
+        firstWorkflow.Started.Should().ContainSingle();
+        firstScheduler.Timeouts.Should().ContainSingle();
+        firstAgent.State.RecoveryRequest.ReplyToken.Should().BeEmpty();
+        firstAgent.State.RecoveryRequest.ReplyTokenExpiresAtUnixMs.Should().Be(0);
+        firstAgent.State.RecoveryRequest.NyxUserAccessToken.Should().BeEmpty();
+        firstAgent.State.RecoveryRequest.Activity.TransportExtras.NyxUserAccessToken.Should().BeEmpty();
+
+        var startedEvents = (await eventStore.GetEventsAsync(firstAgent.Id))
+            .Where(x => x.EventData.Is(ChannelWorkflowDraftRunStartedEvent.Descriptor))
+            .Select(x => x.EventData.Unpack<ChannelWorkflowDraftRunStartedEvent>())
+            .ToArray();
+        startedEvents.Should().ContainSingle();
+        startedEvents[0].RecoveryRequest.ReplyToken.Should().BeEmpty();
+        startedEvents[0].RecoveryRequest.NyxUserAccessToken.Should().BeEmpty();
+
+        var rehydratedScheduler = new RecordingCallbackScheduler();
+        var rehydratedWorkflow = new RecordingWorkflowDraftRunInteractionPort();
+        var rehydratedDispatch = new RecordingActorDispatchPort();
+        var rehydrated = await CreateWorkflowDraftRunAgentAsync(
+            rehydratedDispatch,
+            rehydratedWorkflow,
+            eventStore,
+            rehydratedScheduler,
+            timeProvider);
+
+        rehydrated.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.Started);
+        rehydratedWorkflow.Started.Should().BeEmpty();
+        rehydratedScheduler.Timeouts.Should().ContainSingle();
+        rehydratedScheduler.Timeouts[0].CallbackId.Should().Be(firstScheduler.Timeouts[0].CallbackId);
+        var timeout = rehydratedScheduler.Timeouts[0]
+            .TriggerEnvelope.Payload.Unpack<ChannelWorkflowDraftRunRecoveryTimeoutElapsed>();
+        timeout.RunId.Should().Be(request.RunId);
+        timeout.CorrelationId.Should().Be(request.CorrelationId);
+        timeout.RecoveryDeadlineUnixMs.Should().Be(rehydrated.State.RecoveryDeadlineUnixMs);
+
+        timeProvider.Advance(
+            DateTimeOffset.FromUnixTimeMilliseconds(rehydrated.State.RecoveryDeadlineUnixMs) -
+            timeProvider.GetUtcNow() +
+            TimeSpan.FromMilliseconds(1));
+        await rehydrated.HandleRecoveryTimeoutAsync(timeout);
+
+        rehydratedDispatch.Envelopes.Should().ContainSingle();
+        var terminalEnvelope = rehydratedDispatch.Envelopes[0].Envelope;
+        terminalEnvelope.Id.Should().Be("workflow-draft-run-terminal:workflow-draft-run-1");
+        terminalEnvelope.Runtime.DeliveryIdentity.OperationId.Should()
+            .Be("workflow-draft-run-terminal:workflow-draft-run-1");
+        var failure = terminalEnvelope.Payload.Unpack<LlmReplyReadyEvent>();
+        failure.RunId.Should().Be(request.RunId);
+        failure.TerminalState.Should().Be(LlmReplyTerminalState.Failed);
+        failure.ErrorCode.Should().Be("workflow_draft_run_recovery_timeout");
+        failure.ReplyToken.Should().BeEmpty();
+        rehydrated.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.Failed);
+        rehydratedScheduler.PurgedActorIds.Should().Contain(rehydrated.Id);
+
+        await rehydrated.HandleWorkflowInteractionCompletedAsync(new ChannelWorkflowDraftRunInteractionCompleted
+        {
+            Request = request.Clone(),
+            Succeeded = true,
+            Completed = true,
+        });
+
+        rehydratedDispatch.Envelopes.Should().ContainSingle();
+        rehydratedWorkflow.Started.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WorkflowDraftRunGAgent_ShouldReserveTerminalHandoffWindowBeforeReplyTokenExpires()
+    {
+        var eventStore = new InMemoryEventStore();
+        var timeProvider = new FakeTimeProvider(WorkflowDraftRunNow);
+        var secretClock = new ManualRuntimeSecretClock(WorkflowDraftRunNow.ToUnixTimeMilliseconds());
+        var secretStore = new InMemoryRuntimeSecretStore(secretClock);
+        var scheduler = new RecordingCallbackScheduler();
+        var dispatch = new RecordingActorDispatchPort();
+        var agent = await CreateWorkflowDraftRunAgentAsync(
+            dispatch,
+            new RecordingWorkflowDraftRunInteractionPort(),
+            eventStore,
+            scheduler,
+            timeProvider,
+            secretStore);
+        var request = BuildWorkflowRequest();
+        var replyTokenExpiresAt = WorkflowDraftRunNow.AddMinutes(30);
+        request.ReplyTokenExpiresAtUnixMs = replyTokenExpiresAt.ToUnixTimeMilliseconds();
+
+        await agent.HandleStartAsync(new ChannelWorkflowDraftRunStartRequested
+        {
+            Request = request.Clone(),
+            RunId = request.RunId,
+        });
+
+        var expectedDeadline = replyTokenExpiresAt.AddMinutes(-1);
+        DateTimeOffset.FromUnixTimeMilliseconds(agent.State.RecoveryDeadlineUnixMs)
+            .Should().Be(expectedDeadline);
+        scheduler.Timeouts.Should().ContainSingle();
+        scheduler.Timeouts[0].DueTime.Should().Be(TimeSpan.FromMinutes(29));
+
+        var timeout = scheduler.Timeouts[0]
+            .TriggerEnvelope.Payload.Unpack<ChannelWorkflowDraftRunRecoveryTimeoutElapsed>();
+        var elapsed = expectedDeadline - WorkflowDraftRunNow + TimeSpan.FromMilliseconds(1);
+        timeProvider.Advance(elapsed);
+        secretClock.Advance(elapsed);
+
+        await agent.HandleRecoveryTimeoutAsync(timeout);
+
+        var terminal = dispatch.Envelopes.Should().ContainSingle().Subject.Envelope.Payload
+            .Unpack<LlmReplyReadyEvent>();
+        terminal.RelayReplyTokenRef.ExpiresAtUnixMs.Should().Be(replyTokenExpiresAt.ToUnixTimeMilliseconds());
+        var resolved = await secretStore.ResolveAsync(new ResolveRuntimeSecretRequest(
+            terminal.RelayReplyTokenRef.Ref,
+            "channel-relay-reply-token",
+            request.RunId,
+            request.CorrelationId,
+            "Verify recovery terminal credential remains available at handoff."));
+        resolved.Secret.Should().Be(request.ReplyToken);
+    }
+
+    [Fact]
+    public async Task WorkflowDraftRunGAgent_ShouldReplayPersistedTerminalAfterDispatchAdmissionFailure()
+    {
+        var eventStore = new InMemoryEventStore();
+        var timeProvider = new FakeTimeProvider(WorkflowDraftRunNow);
+        var firstScheduler = new RecordingCallbackScheduler();
+        var firstDispatch = new RecordingActorDispatchPort(failuresRemaining: 1);
+        var firstAgent = await CreateWorkflowDraftRunAgentAsync(
+            firstDispatch,
+            new RecordingWorkflowDraftRunInteractionPort(),
+            eventStore,
+            firstScheduler,
+            timeProvider);
+        var request = BuildWorkflowRequest();
+
+        await firstAgent.HandleStartAsync(new ChannelWorkflowDraftRunStartRequested
+        {
+            Request = request.Clone(),
+            RunId = request.RunId,
+        });
+        await firstAgent.HandleWorkflowInteractionCompletedAsync(new ChannelWorkflowDraftRunInteractionCompleted
+        {
+            Request = request.Clone(),
+            Succeeded = true,
+            Completed = true,
+        });
+
+        firstAgent.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.TerminalProduced);
+        firstAgent.State.ProducedTerminalReply.Should().NotBeNull();
+        firstAgent.State.ProducedTerminalReply.ReplyToken.Should().BeEmpty();
+        firstAgent.State.TerminalOperationId.Should().Be("workflow-draft-run-terminal:workflow-draft-run-1");
+        firstScheduler.PurgedActorIds.Should().BeEmpty();
+        var attemptedEnvelope = firstDispatch.Envelopes.Should().ContainSingle().Subject.Envelope;
+        var persistedPayload = firstAgent.State.ProducedTerminalReply.ToByteArray();
+
+        var rehydratedScheduler = new RecordingCallbackScheduler();
+        var rehydratedDispatch = new RecordingActorDispatchPort();
+        var rehydratedWorkflow = new RecordingWorkflowDraftRunInteractionPort();
+        var rehydrated = await CreateWorkflowDraftRunAgentAsync(
+            rehydratedDispatch,
+            rehydratedWorkflow,
+            eventStore,
+            rehydratedScheduler,
+            timeProvider);
+
+        rehydrated.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.TerminalProduced);
+        rehydrated.State.ProducedTerminalReply.ToByteArray().Should().Equal(persistedPayload);
+        rehydratedWorkflow.Started.Should().BeEmpty();
+        var retryRequest = rehydratedScheduler.Timeouts
+            .Select(x => x.TriggerEnvelope.Payload)
+            .Single(x => x.Is(ChannelWorkflowDraftRunTerminalHandoffRetryElapsed.Descriptor))
+            .Unpack<ChannelWorkflowDraftRunTerminalHandoffRetryElapsed>();
+
+        await rehydrated.HandleTerminalHandoffRetryAsync(retryRequest);
+
+        rehydratedDispatch.Envelopes.Should().ContainSingle();
+        var replayedEnvelope = rehydratedDispatch.Envelopes[0].Envelope;
+        replayedEnvelope.Id.Should().Be(attemptedEnvelope.Id);
+        replayedEnvelope.Runtime.DeliveryIdentity.OperationId.Should()
+            .Be(attemptedEnvelope.Runtime.DeliveryIdentity.OperationId);
+        replayedEnvelope.Payload.Value.ToByteArray().Should().Equal(attemptedEnvelope.Payload.Value.ToByteArray());
+        rehydrated.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.ReplyHandedOff);
+        rehydratedScheduler.PurgedActorIds.Should().Contain(rehydrated.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowDraftRunGAgent_ShouldReplayPersistedTerminalWhenFinalAppendFailsAfterAdmission()
+    {
+        var eventStore = new InMemoryEventStore();
+        var timeProvider = new FakeTimeProvider(WorkflowDraftRunNow);
+        var firstScheduler = new RecordingCallbackScheduler();
+        var firstDispatch = new RecordingActorDispatchPort();
+        var firstAgent = await CreateWorkflowDraftRunAgentAsync(
+            firstDispatch,
+            new RecordingWorkflowDraftRunInteractionPort(),
+            eventStore,
+            firstScheduler,
+            timeProvider);
+        var request = BuildWorkflowRequest();
+
+        await firstAgent.HandleStartAsync(new ChannelWorkflowDraftRunStartRequested
+        {
+            Request = request.Clone(),
+            RunId = request.RunId,
+        });
+        eventStore.FailNextAppend<ChannelWorkflowDraftRunReplyHandedOffEvent>();
+
+        await firstAgent.HandleWorkflowInteractionCompletedAsync(new ChannelWorkflowDraftRunInteractionCompleted
+        {
+            Request = request.Clone(),
+            Succeeded = true,
+            Completed = true,
+        });
+
+        firstAgent.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.TerminalProduced);
+        firstScheduler.PurgedActorIds.Should().BeEmpty();
+        var admittedEnvelope = firstDispatch.Envelopes.Should().ContainSingle().Subject.Envelope;
+
+        var rehydratedScheduler = new RecordingCallbackScheduler();
+        var rehydratedDispatch = new RecordingActorDispatchPort();
+        var rehydrated = await CreateWorkflowDraftRunAgentAsync(
+            rehydratedDispatch,
+            new RecordingWorkflowDraftRunInteractionPort(),
+            eventStore,
+            rehydratedScheduler,
+            timeProvider);
+        var retryRequest = rehydratedScheduler.Timeouts
+            .Select(x => x.TriggerEnvelope.Payload)
+            .Single(x => x.Is(ChannelWorkflowDraftRunTerminalHandoffRetryElapsed.Descriptor))
+            .Unpack<ChannelWorkflowDraftRunTerminalHandoffRetryElapsed>();
+
+        await rehydrated.HandleTerminalHandoffRetryAsync(retryRequest);
+
+        rehydratedDispatch.Envelopes.Should().ContainSingle();
+        var replayedEnvelope = rehydratedDispatch.Envelopes[0].Envelope;
+        replayedEnvelope.Id.Should().Be(admittedEnvelope.Id);
+        replayedEnvelope.Payload.Value.ToByteArray().Should().Equal(admittedEnvelope.Payload.Value.ToByteArray());
+        rehydrated.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.ReplyHandedOff);
+        rehydratedScheduler.PurgedActorIds.Should().Contain(rehydrated.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowDraftRunGAgent_ShouldFailClosedWhenLegacyStartedStateHasNoRecoveryContext()
+    {
+        const string actorId = "channel-workflow-draft-run:workflow-draft-run-1";
+        var eventStore = new InMemoryEventStore();
+        var now = new FakeTimeProvider(WorkflowDraftRunNow);
+        await eventStore.AppendAsync(
+            actorId,
+            [new StateEvent
+            {
+                EventId = "legacy-workflow-draft-run-started",
+                Timestamp = Timestamp.FromDateTimeOffset(now.GetUtcNow()),
+                Version = 1,
+                EventType = ChannelWorkflowDraftRunStartedEvent.Descriptor.FullName,
+                EventData = Any.Pack(new ChannelWorkflowDraftRunStartedEvent
+                {
+                    RunId = "workflow-draft-run-1",
+                    CorrelationId = "msg-1",
+                    TargetActorId = "conversation-1",
+                    StartedAtUnixMs = now.GetUtcNow().ToUnixTimeMilliseconds(),
+                }),
+                AgentId = actorId,
+            }],
+            expectedVersion: 0);
+        var scheduler = new RecordingCallbackScheduler();
+        var workflow = new RecordingWorkflowDraftRunInteractionPort();
+        var dispatch = new RecordingActorDispatchPort();
+
+        var agent = await CreateWorkflowDraftRunAgentAsync(
+            dispatch,
+            workflow,
+            eventStore,
+            scheduler,
+            now);
+
+        workflow.Started.Should().BeEmpty();
+        scheduler.Timeouts.Should().ContainSingle();
+        var timeout = scheduler.Timeouts[0]
+            .TriggerEnvelope.Payload.Unpack<ChannelWorkflowDraftRunRecoveryTimeoutElapsed>();
+        timeout.RecoveryDeadlineUnixMs.Should().Be(0);
+
+        await agent.HandleRecoveryTimeoutAsync(timeout);
+
+        dispatch.Envelopes.Should().ContainSingle();
+        var failure = dispatch.Envelopes[0].Envelope.Payload.Unpack<LlmReplyReadyEvent>();
+        failure.ErrorCode.Should().Be("workflow_draft_run_recovery_context_missing");
+        agent.State.Status.Should().Be(ChannelWorkflowDraftRunStatus.Failed);
+        scheduler.PurgedActorIds.Should().Contain(actorId);
     }
 
     [Fact]
@@ -1073,10 +1405,19 @@ public sealed class ChannelWorkflowDraftRunTests
 
     private static async Task<ChannelWorkflowDraftRunGAgent> CreateWorkflowDraftRunAgentAsync(
         IActorDispatchPort dispatchPort,
-        IChannelWorkflowDraftRunInteractionPort? workflowInteractionPort)
+        IChannelWorkflowDraftRunInteractionPort? workflowInteractionPort,
+        IEventStore? eventStore = null,
+        IActorRuntimeCallbackScheduler? callbackScheduler = null,
+        TimeProvider? timeProvider = null,
+        IRuntimeSecretStore? runtimeSecretStore = null)
     {
+        eventStore ??= new InMemoryEventStore();
+        callbackScheduler ??= new RecordingCallbackScheduler();
+        runtimeSecretStore ??= new InMemoryRuntimeSecretStore();
         var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection()
-            .AddSingleton<IEventStore, InMemoryEventStore>()
+            .AddSingleton(eventStore)
+            .AddSingleton(callbackScheduler)
+            .AddSingleton(runtimeSecretStore)
             .AddSingleton<EventSourcingRuntimeOptions>()
             .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
             .BuildServiceProvider();
@@ -1086,7 +1427,7 @@ public sealed class ChannelWorkflowDraftRunTests
             new WorkflowDraftRunReplyRenderer(),
             NullLogger<ChannelWorkflowDraftRunGAgent>.Instance,
             workflowInteractionPort,
-            TimeProvider.System)
+            timeProvider ?? TimeProvider.System)
         {
             Services = services,
             EventSourcingBehaviorFactory =
@@ -1270,10 +1611,45 @@ public sealed class ChannelWorkflowDraftRunTests
         public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
     }
 
-    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+        public List<string> PurgedActorIds { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Timeouts.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            PurgedActorIds.Add(actorId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingActorDispatchPort(int failuresRemaining = 0) : IActorDispatchPort
     {
         private readonly object _gate = new();
         private readonly Dictionary<int, TaskCompletionSource<IReadOnlyList<(string ActorId, EventEnvelope Envelope)>>> _countWaiters = [];
+        private int _failuresRemaining = failuresRemaining;
 
         public List<(string ActorId, EventEnvelope Envelope)> Envelopes { get; } = [];
 
@@ -1289,6 +1665,9 @@ public sealed class ChannelWorkflowDraftRunTests
                     waiter.Value.TrySetResult(Envelopes.Select(CloneDispatch).ToList());
                 }
             }
+
+            if (Interlocked.Decrement(ref _failuresRemaining) >= 0)
+                throw new InvalidOperationException("Simulated actor dispatch admission failure.");
 
             return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
         }
@@ -1327,6 +1706,11 @@ public sealed class ChannelWorkflowDraftRunTests
     private sealed class InMemoryEventStore : IEventStore
     {
         private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+        private string? _failNextEventType;
+
+        public void FailNextAppend<TEvent>()
+            where TEvent : IMessage<TEvent>, new() =>
+            _failNextEventType = new TEvent().Descriptor.FullName;
 
         public Task<EventStoreCommitResult> AppendAsync(
             string agentId,
@@ -1346,6 +1730,12 @@ public sealed class ChannelWorkflowDraftRunTests
                 throw new EventStoreOptimisticConcurrencyException(agentId, expectedVersion, currentVersion);
 
             var appended = events.Select(x => x.Clone()).ToList();
+            if (_failNextEventType is { } failedType && appended.Any(x => x.EventType == failedType))
+            {
+                _failNextEventType = null;
+                throw new InvalidOperationException($"Simulated event-store append failure for '{failedType}'.");
+            }
+
             stream.AddRange(appended);
             return Task.FromResult(new EventStoreCommitResult
             {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Credentials.Testing;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core.EventSourcing;
@@ -68,7 +70,14 @@ public sealed class ConversationGAgentTargetActorIdTests
         var eventStore = new InMemoryEventStore();
         var runner = new DeferredWorkflowDraftRunTurnRunner();
         var dispatcher = new RecordingWorkflowDraftRunInteractionPort();
-        var agent = await CreateAgentAsync(actorId, runner, new RecordingLlmReplyRunDispatcher(), dispatcher, eventStore);
+        var runtimeSecretStore = new InMemoryRuntimeSecretStore();
+        var agent = await CreateAgentAsync(
+            actorId,
+            runner,
+            new RecordingLlmReplyRunDispatcher(),
+            dispatcher,
+            eventStore,
+            runtimeSecretStore: runtimeSecretStore);
         var activity = BuildInboundActivity("msg-workflow-1");
         activity.OutboundDelivery = new OutboundDeliveryContext
         {
@@ -101,6 +110,8 @@ public sealed class ConversationGAgentTargetActorIdTests
         persisted.ReplyTokenExpiresAtUnixMs.Should().Be(0);
         persisted.NyxUserAccessToken.Should().BeEmpty();
         persisted.Activity.TransportExtras.NyxUserAccessToken.Should().BeEmpty();
+        persisted.RelayReplyTokenRef.Ref.Should().NotBeNullOrWhiteSpace();
+        persisted.RelayUserAccessTokenRef.Ref.Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]
@@ -408,7 +419,8 @@ public sealed class ConversationGAgentTargetActorIdTests
         IChannelLlmReplyRunDispatcher dispatcher,
         IChannelWorkflowDraftRunInteractionPort? workflowDispatcher = null,
         InMemoryEventStore? eventStore = null,
-        RecordingEventPublisher? eventPublisher = null)
+        RecordingEventPublisher? eventPublisher = null,
+        IRuntimeSecretStore? runtimeSecretStore = null)
     {
         eventStore ??= new InMemoryEventStore();
         var servicesCollection = new ServiceCollection()
@@ -421,6 +433,8 @@ public sealed class ConversationGAgentTargetActorIdTests
             .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
         if (workflowDispatcher is not null)
             servicesCollection.AddSingleton(workflowDispatcher);
+        if (runtimeSecretStore is not null)
+            servicesCollection.AddSingleton(runtimeSecretStore);
 
         var services = servicesCollection.BuildServiceProvider();
 


### PR DESCRIPTION
## Problem

A channel workflow draft-run could persist `Started`, lose its transient observer during a process restart, and remain non-terminal forever. Terminal handoff also lacked a durable outbox, while the default recovery timeout coincided with relay reply-token expiry.

## Solution

- Persist a scrubbed recovery request and absolute actor-owned deadline, then reconcile a typed durable self-timeout on activation and duplicate starts without replaying workflow execution.
- Persist one immutable terminal reply and stable operation ID before actor-inbox admission, with typed durable retry across admission and final-append failure windows.
- Keep raw relay credentials out of events, actor state, and callbacks; persist runtime-secret references and resolve them only at the Conversation delivery boundary.
- Bound recovery to one minute before explicit reply-token expiry so timeout failures can still be delivered.

## Impacted paths

- Channel workflow draft-run and Conversation actors
- Channel and NyxIdChat protobuf contracts
- Channel runtime/protocol tests
- Recovery design and implementation documentation

## Validation

- `Aevatar.GAgents.ChannelRuntime.Tests`: 1866 passed
- `Aevatar.GAgents.Channel.Protocol.Tests`: 162 passed
- `test_stability_guards.sh`: passed
- `workflow_binding_boundary_guard.sh`: passed
- `architecture_guards.sh` with `DIFF_RANGE=origin/feature/integrate...HEAD`: passed
- `dotnet build aevatar.slnx --no-restore --nologo`: 0 errors
- Full solution tests: every project passed except the pre-existing `AgentToolExecutionBoundaryTests.ServerOwnedAgentTools_ShouldHaveOneAdmittedTerminalAndAllKnownSurfaces` baseline failure, independently reproduced on `origin/feature/integrate`; this change does not touch that surface.
- Independent review: Critical 0, Important 0, ready to merge

Fixes #3043