### PR TITLE
Align AgentRun pending tool execution with admitted auth

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -591,20 +591,39 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
     private async Task DispatchToolStepExecutorAsync(NeedsLlmReplyEvent request, AgentRunReplyStepState stepState)
     {
+        var authorizedToolStep = _authorizedToolStep;
+        _authorizedToolStep = null;
+        var durableAuthorizationAvailable = !stepState.PendingToolAuthorizationConsumed &&
+                                            stepState.PendingToolAuthorizations.Count > 0;
+        var matchedTransientAuthorization = authorizedToolStep?.Matches(
+            new AgentRunReplyStepExecutionRequest(
+                stepState.RunId,
+                Id,
+                stepState.Attempt,
+                stepState.NextStepIndex,
+                request.Clone(),
+                stepState.Clone())) == true;
+        var allowDurableAuthorization = authorizedToolStep is null && durableAuthorizationAvailable;
+        if (matchedTransientAuthorization || allowDurableAuthorization)
+        {
+            stepState = MarkPendingToolAuthorizationConsumed(stepState);
+            await PersistStepStateAsync(stepState);
+        }
+
         var executionRequest = new AgentRunReplyStepExecutionRequest(
             stepState.RunId,
             Id,
             stepState.Attempt,
             stepState.NextStepIndex,
             request.Clone(),
-            stepState.Clone());
-        var authorizedToolStep = _authorizedToolStep;
-        _authorizedToolStep = null;
+            stepState.Clone(),
+            AllowDurableToolAuthorization: allowDurableAuthorization);
+
         try
         {
             var continuation = await _generationExecutor.BuildToolStepContinuationAsync(
                 executionRequest,
-                authorizedToolStep,
+                matchedTransientAuthorization ? authorizedToolStep : null,
                 CancellationToken.None);
             await PublishAsync(
                 continuation,
@@ -1108,6 +1127,10 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         next.PendingToolCalls.Clear();
         if (result.ToolCalls.Count > 0)
             next.PendingToolCalls.AddRange(result.ToolCalls.Select(call => call.Clone()));
+        next.PendingToolAuthorizations.Clear();
+        if (result.PendingToolAuthorizations.Count > 0)
+            next.PendingToolAuthorizations.AddRange(result.PendingToolAuthorizations.Select(authorization => authorization.Clone()));
+        next.PendingToolAuthorizationConsumed = false;
 
         if (!string.IsNullOrEmpty(result.Content) ||
             !string.IsNullOrEmpty(result.ReasoningContent) ||
@@ -1148,6 +1171,13 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         _authorizedToolStep = null;
     }
 
+    private static AgentRunReplyStepState MarkPendingToolAuthorizationConsumed(AgentRunReplyStepState current)
+    {
+        var next = current.Clone();
+        next.PendingToolAuthorizationConsumed = true;
+        return next;
+    }
+
     // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
     //   Old pattern: AgentRunReplyGenerationExecutor cloned/mutated AgentRunReplyStepState and the actor persisted that full state.
     //   New principle: Executor returns typed IO facts; actor applies deterministic step-state transition inside event handling.
@@ -1159,6 +1189,8 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         var next = current.Clone();
         next.NextStepIndex = completedStepIndex;
         next.PendingToolCalls.Clear();
+        next.PendingToolAuthorizations.Clear();
+        next.PendingToolAuthorizationConsumed = false;
         next.Messages.AddRange(result.ResultMessages.Select(message => message.Clone()));
         next.AppendedHistory.AddRange(
             result.ResultMessages.Select(AgentRunReplyStepMappers.ToConversationHistoryEntry));
@@ -1178,6 +1210,7 @@ public sealed partial class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         next.NextStepIndex = nextStepIndex;
         next.FinalNoToolsStep = true;
         next.PendingToolCalls.Clear();
+        next.PendingToolAuthorizations.Clear();
         next.AccumulatedText = string.Empty;
         next.LastFinishReason = string.Empty;
         next.HasStreamedTextContent = false;

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -330,12 +331,15 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             if (tool is null)
                 continue;
 
+            var argumentsJson = call.ArgumentsJson ?? string.Empty;
+            var callSafety = tool.GetCallSafety(argumentsJson);
             snapshots.Add(new AgentRunAuthorizedToolCallSafety(
                 call.Id ?? string.Empty,
                 call.Name ?? string.Empty,
-                call.ArgumentsJson ?? string.Empty,
-                tool.GetCallSafety(call.ArgumentsJson ?? string.Empty),
-                tool.SideEffectKind ?? string.Empty));
+                argumentsJson,
+                callSafety,
+                tool.SideEffectKind ?? string.Empty,
+                BuildToolDefinitionFingerprint(tool, callSafety)));
         }
 
         return snapshots;
@@ -356,6 +360,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             IsReadOnly = source.CallSafety.IsReadOnly,
             IsDestructive = source.CallSafety.IsDestructive,
             SideEffectKind = source.SideEffectKind ?? string.Empty,
+            ToolDefinitionFingerprint = source.ToolDefinitionFingerprint ?? string.Empty,
         };
 
     private async Task<LLMRequest> MaterializeFileRefMessagesAsync(LLMRequest request, CancellationToken ct)
@@ -578,7 +583,25 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                authorization.RequiresApproval == (currentSafety.RequiresApproval ?? false) &&
                authorization.IsReadOnly == currentSafety.IsReadOnly &&
                authorization.IsDestructive == currentSafety.IsDestructive &&
-               string.Equals(authorization.SideEffectKind, tool.SideEffectKind ?? string.Empty, StringComparison.Ordinal);
+               string.Equals(authorization.SideEffectKind, tool.SideEffectKind ?? string.Empty, StringComparison.Ordinal) &&
+               string.Equals(
+                   authorization.ToolDefinitionFingerprint,
+                   BuildToolDefinitionFingerprint(tool, currentSafety),
+                   StringComparison.Ordinal);
+    }
+
+    private static string BuildToolDefinitionFingerprint(IAgentTool tool, AgentToolCallSafety callSafety)
+    {
+        var canonical = string.Join('\n',
+            tool.Name ?? string.Empty,
+            tool.Description ?? string.Empty,
+            tool.ParametersSchema ?? string.Empty,
+            tool.SideEffectKind ?? string.Empty,
+            callSafety.RequiresApproval.HasValue ? "1" : "0",
+            callSafety.RequiresApproval == true ? "1" : "0",
+            callSafety.IsReadOnly ? "1" : "0",
+            callSafety.IsDestructive ? "1" : "0");
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical))).ToLowerInvariant();
     }
 
     private static AgentRunToolStepResult BuildUnauthorizedToolStepResult(IReadOnlyList<ToolCall> toolCalls)

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -283,7 +283,10 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             var capturedToolContext = llmResult.AuthorizedToolContext;
             authorizedToolCallSafeties = BuildAuthorizedToolCallSafeties(
                 capturedToolCalls,
-                capturedTools);
+                capturedTools,
+                capturedToolContext);
+            result.PendingToolAuthorizations.AddRange(
+                authorizedToolCallSafeties.Select(BuildPendingToolAuthorization));
             authorizedToolStep = new AgentRunAuthorizedToolStep(
                 workItem.RunId,
                 request.CorrelationId,
@@ -315,8 +318,10 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
 
     private static IReadOnlyList<AgentRunAuthorizedToolCallSafety> BuildAuthorizedToolCallSafeties(
         IReadOnlyList<ToolCall> toolCalls,
-        IReadOnlyList<IAgentTool> authorizedTools)
+        IReadOnlyList<IAgentTool> authorizedTools,
+        AgentToolExecutionContext authorizedToolContext)
     {
+        using var toolContextScope = AgentToolContextScope.Push(authorizedToolContext);
         var snapshots = new List<AgentRunAuthorizedToolCallSafety>(toolCalls.Count);
         foreach (var call in toolCalls)
         {
@@ -335,6 +340,23 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
 
         return snapshots;
     }
+
+    private static AgentRunPendingToolAuthorization BuildPendingToolAuthorization(
+        AgentRunAuthorizedToolCallSafety source) =>
+        new()
+        {
+            Call = new AgentRunToolCall
+            {
+                Id = source.CallId,
+                Name = source.ToolName,
+                ArgumentsJson = source.ArgumentsJson,
+            },
+            HasRequiresApproval = source.CallSafety.RequiresApproval.HasValue,
+            RequiresApproval = source.CallSafety.RequiresApproval ?? false,
+            IsReadOnly = source.CallSafety.IsReadOnly,
+            IsDestructive = source.CallSafety.IsDestructive,
+            SideEffectKind = source.SideEffectKind ?? string.Empty,
+        };
 
     private async Task<LLMRequest> MaterializeFileRefMessagesAsync(LLMRequest request, CancellationToken ct)
     {
@@ -395,25 +417,21 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         var request = workItem.Request.Clone();
         var toolCalls = workItem.StepState.PendingToolCalls.Select(AgentRunReplyStepMappers.FromProto).ToArray();
         AgentRunToolStepResult toolStepResult;
-        if (authorizedToolStep?.Matches(workItem) == true)
+        if (authorizedToolStep is not null)
         {
-            toolStepResult = await authorizedToolStep.ExecuteAsync(ct).ConfigureAwait(false);
+            toolStepResult = authorizedToolStep.Matches(workItem)
+                ? await authorizedToolStep.ExecuteAsync(ct).ConfigureAwait(false)
+                : BuildUnauthorizedToolStepResult(toolCalls);
+        }
+        else if (workItem.AllowDurableToolAuthorization &&
+                 await TryExecuteDurablyAuthorizedToolStepAsync(workItem, request, toolCalls, ct)
+                     .ConfigureAwait(false) is { } durableToolStepResult)
+        {
+            toolStepResult = durableToolStepResult;
         }
         else
         {
-            var deniedResults = new List<ToolExecutionResult>(toolCalls.Length);
-            foreach (var toolCall in toolCalls)
-            {
-                deniedResults.Add(new ToolExecutionResult(
-                    toolCall.Id,
-                    toolCall.Name,
-                    JsonSerializer.Serialize(new
-                    {
-                        error = $"Tool '{toolCall.Name}' is not authorized for this actor-owned step.",
-                    }),
-                    IsError: true));
-            }
-            toolStepResult = BuildToolStepResult(deniedResults);
+            toolStepResult = BuildUnauthorizedToolStepResult(toolCalls);
         }
 
         return new AgentRunNextToolStepRequestedEvent
@@ -426,6 +444,159 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             Request = request.Clone(),
             ToolStepResult = toolStepResult,
         };
+    }
+
+    private async Task<AgentRunToolStepResult?> TryExecuteDurablyAuthorizedToolStepAsync(
+        AgentRunReplyStepExecutionRequest workItem,
+        NeedsLlmReplyEvent request,
+        IReadOnlyList<ToolCall> toolCalls,
+        CancellationToken ct)
+    {
+        if (!TryMatchDurablePendingToolAuthorizations(workItem.StepState, toolCalls, out var authorizations))
+            return null;
+        if (request.Activity is null)
+            return null;
+
+        var generator = RequireStepGenerator();
+        var stepMetadata = AgentRunReplyStepMappers.ToDictionary(workItem.StepState.ExternalMetadata);
+        var stepControl = AgentRunReplyStepMappers.LlmControlFromProto(workItem.StepState);
+        var planToolContext = AgentRunReplyStepMappers.ToolContextFromProto(workItem.StepState);
+        if (workItem.StepState.FinalNoToolsStep)
+            return null;
+
+        (stepControl, planToolContext) = await ReSupplyRuntimeCredentialsAsync(request, stepControl, planToolContext, ct)
+            .ConfigureAwait(false);
+        var plan = await generator.BuildStepPlanAsync(
+                request.Activity,
+                stepMetadata,
+                stepControl,
+                planToolContext,
+                priorHistory: null,
+                attachmentContext: null,
+                forceDisableTools: false,
+                ct: ct,
+                turnCatalog: workItem.TurnCatalog)
+            .ConfigureAwait(false);
+        var messages = workItem.StepState.Messages.Select(AgentRunReplyStepMappers.FromProto).ToList();
+        var llmRequest = plan.StepExecutor.BuildLlmStepRequest(
+            messages,
+            request.Activity.Id,
+            plan.Metadata,
+            plan.ToolContext,
+            plan.LlmControl,
+            workItem.StepState.Round,
+            finalNoTools: false,
+            toolReceipts: workItem.StepState.ToolReceipts);
+        var executionToolContext = llmRequest.ToolContext ?? plan.ToolContext ?? AgentToolExecutionContext.Empty;
+        var currentCatalog = llmRequest.Tools ?? [];
+        if (!TryMatchCurrentCatalog(toolCalls, authorizations, currentCatalog, executionToolContext, out var admittedTools))
+            return null;
+
+        using var toolScope = TryBeginInteractiveScope(request);
+        var toolResults = await plan.StepExecutor.ExecuteAuthorizedToolStepAsync(
+                toolCalls,
+                admittedTools,
+                executionToolContext,
+                ct)
+            .ConfigureAwait(false);
+        var toolStepResult = BuildToolStepResult(toolResults);
+        if (TryTakeOutboundIntent(generator) is { } toolOutboundIntent)
+            toolStepResult.OutboundIntent = toolOutboundIntent.Clone();
+        return toolStepResult;
+    }
+
+    private static bool TryMatchDurablePendingToolAuthorizations(
+        AgentRunReplyStepState stepState,
+        IReadOnlyList<ToolCall> toolCalls,
+        out IReadOnlyList<AgentRunPendingToolAuthorization> authorizations)
+    {
+        authorizations = [];
+        if (toolCalls.Count == 0 ||
+            !stepState.PendingToolAuthorizationConsumed ||
+            stepState.PendingToolAuthorizations.Count != toolCalls.Count)
+        {
+            return false;
+        }
+
+        var matched = new List<AgentRunPendingToolAuthorization>(toolCalls.Count);
+        foreach (var toolCall in toolCalls)
+        {
+            var snapshot = stepState.PendingToolAuthorizations.FirstOrDefault(candidate =>
+                ToolCallMatches(candidate.Call, toolCall));
+            if (snapshot is null)
+                return false;
+
+            matched.Add(snapshot);
+        }
+
+        authorizations = matched;
+        return true;
+    }
+
+    private static bool TryMatchCurrentCatalog(
+        IReadOnlyList<ToolCall> toolCalls,
+        IReadOnlyList<AgentRunPendingToolAuthorization> authorizations,
+        IReadOnlyList<IAgentTool> currentCatalog,
+        AgentToolExecutionContext executionToolContext,
+        out IReadOnlyList<IAgentTool> admittedTools)
+    {
+        using var toolContextScope = AgentToolContextScope.Push(executionToolContext);
+        admittedTools = [];
+        var matchedTools = new List<IAgentTool>(toolCalls.Count);
+        for (var i = 0; i < toolCalls.Count; i++)
+        {
+            var toolCall = toolCalls[i];
+            var authorization = authorizations[i];
+            var tool = currentCatalog.FirstOrDefault(candidate =>
+                string.Equals(candidate.Name, toolCall.Name, StringComparison.OrdinalIgnoreCase));
+            if (tool is null || !ToolSafetyMatches(authorization, tool, toolCall.ArgumentsJson ?? string.Empty))
+                return false;
+
+            matchedTools.Add(tool);
+        }
+
+        admittedTools = matchedTools
+            .GroupBy(static tool => tool.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
+        return true;
+    }
+
+    private static bool ToolCallMatches(AgentRunToolCall? snapshot, ToolCall toolCall) =>
+        snapshot is not null &&
+        string.Equals(snapshot.Id, toolCall.Id, StringComparison.Ordinal) &&
+        string.Equals(snapshot.Name, toolCall.Name, StringComparison.Ordinal) &&
+        string.Equals(snapshot.ArgumentsJson, toolCall.ArgumentsJson, StringComparison.Ordinal);
+
+    private static bool ToolSafetyMatches(
+        AgentRunPendingToolAuthorization authorization,
+        IAgentTool tool,
+        string argumentsJson)
+    {
+        var currentSafety = tool.GetCallSafety(argumentsJson);
+        return authorization.HasRequiresApproval == currentSafety.RequiresApproval.HasValue &&
+               authorization.RequiresApproval == (currentSafety.RequiresApproval ?? false) &&
+               authorization.IsReadOnly == currentSafety.IsReadOnly &&
+               authorization.IsDestructive == currentSafety.IsDestructive &&
+               string.Equals(authorization.SideEffectKind, tool.SideEffectKind ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    private static AgentRunToolStepResult BuildUnauthorizedToolStepResult(IReadOnlyList<ToolCall> toolCalls)
+    {
+        var deniedResults = new List<ToolExecutionResult>(toolCalls.Count);
+        foreach (var toolCall in toolCalls)
+        {
+            deniedResults.Add(new ToolExecutionResult(
+                toolCall.Id,
+                toolCall.Name,
+                JsonSerializer.Serialize(new
+                {
+                    error = $"Tool '{toolCall.Name}' is not authorized for this actor-owned step.",
+                }),
+                IsError: true));
+        }
+
+        return BuildToolStepResult(deniedResults);
     }
 
     private static AgentRunToolStepResult BuildToolStepResult(

--- a/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
@@ -145,4 +145,5 @@ public sealed record AgentRunReplyStepExecutionRequest(
     NeedsLlmReplyEvent Request,
     AgentRunReplyStepState StepState,
     Func<LLMStreamChunk, CancellationToken, Task>? ReportChunkAsync = null,
-    AgentProfileTurnCatalog? TurnCatalog = null);
+    AgentProfileTurnCatalog? TurnCatalog = null,
+    bool AllowDurableToolAuthorization = false);

--- a/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
@@ -34,7 +34,8 @@ public sealed record AgentRunAuthorizedToolCallSafety(
     string ToolName,
     string ArgumentsJson,
     AgentToolCallSafety CallSafety,
-    string SideEffectKind);
+    string SideEffectKind,
+    string ToolDefinitionFingerprint = "");
 
 public sealed class AgentRunAuthorizedToolStep
 {

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -199,6 +199,7 @@ message AgentRunPendingToolAuthorization {
   bool is_read_only = 4;
   bool is_destructive = 5;
   string side_effect_kind = 6;
+  string tool_definition_fingerprint = 7;
 }
 
 message AgentRunChatMessage {

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -192,6 +192,15 @@ message AgentRunToolCall {
   string arguments_json = 3;
 }
 
+message AgentRunPendingToolAuthorization {
+  AgentRunToolCall call = 1;
+  bool has_requires_approval = 2;
+  bool requires_approval = 3;
+  bool is_read_only = 4;
+  bool is_destructive = 5;
+  string side_effect_kind = 6;
+}
+
 message AgentRunChatMessage {
   string role = 1;
   string content = 2;
@@ -230,6 +239,8 @@ message AgentRunReplyStepState {
   // tool-stripping / server-default-routing semantics of final_no_tools_step: the recovery retry
   // keeps tools + the user's routing + channel-context and only trims history to the recent floor.
   bool empty_reply_retry = 25;
+  repeated AgentRunPendingToolAuthorization pending_tool_authorizations = 26;
+  bool pending_tool_authorization_consumed = 27;
 }
 
 // Typed LLM IO facts returned by the executor. The run actor reconciles these
@@ -246,6 +257,7 @@ message AgentRunLlmStepResult {
   string finish_reason = 6;
   aevatar.gagents.channel.abstractions.MessageContent outbound_intent = 7;
   bool has_streamed_text_content = 8;
+  repeated AgentRunPendingToolAuthorization pending_tool_authorizations = 10;
 }
 
 // Typed tool IO facts returned after the run actor has reconciled and persisted

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1103,7 +1103,7 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
-    public async Task HandleNextLlmStepAsync_WhenLlmContinuationIsReplayed_ShouldClearMatchingCapability()
+    public async Task HandleNextLlmStepAsync_WhenLlmContinuationIsReplayed_ShouldExecuteFromDurableAuthorization()
     {
         var executor = new CapabilityTrackingReplyGenerationExecutor();
         var publisher = new RecordingSelfEventPublisher();
@@ -1120,11 +1120,11 @@ public sealed class AgentRunGAgentTests
         await runtime.HandleNextToolStepAsync(toolRequest);
 
         executor.ToolStepAuthorizationPresence.Should().Equal(false);
-        executor.ToolExecutionCount.Should().Be(0);
+        executor.ToolExecutionCount.Should().Be(1);
     }
 
     [Fact]
-    public async Task HandleNextToolStepAsync_WhenToolRequestArrivesBeforeLlmResult_ShouldClearMatchingCapability()
+    public async Task HandleNextToolStepAsync_WhenToolRequestArrivesBeforeLlmResult_ShouldExecuteFromDurableAuthorization()
     {
         var executor = new CapabilityTrackingReplyGenerationExecutor();
         var publisher = new RecordingSelfEventPublisher();
@@ -1142,17 +1142,60 @@ public sealed class AgentRunGAgentTests
         await runtime.HandleNextToolStepAsync(reconciledToolRequest);
 
         executor.ToolStepAuthorizationPresence.Should().Equal(false);
-        executor.ToolExecutionCount.Should().Be(0);
+        executor.ToolExecutionCount.Should().Be(1);
     }
 
     [Fact]
-    public async Task HandleNextToolStepAsync_AfterActorRestart_ShouldRejectWhenCapabilityIsMissing()
+    public async Task HandleNextToolStepAsync_AfterActorRestart_ShouldExecuteWhenDurableAuthorizationExists()
     {
         var executor = new CapabilityTrackingReplyGenerationExecutor();
         var publisher = new RecordingSelfEventPublisher();
         var restartedRuntime = CreateCapabilityTestAgent(executor, publisher, nextStepIndex: 2);
         restartedRuntime.State.GenerationStep!.PendingToolCalls.Add(
             CapabilityTrackingReplyGenerationExecutor.ToolCall.Clone());
+        restartedRuntime.State.GenerationStep.PendingToolAuthorizations.Add(
+            CapabilityTrackingReplyGenerationExecutor.Authorization.Clone());
+        var toolRequest = BuildCapabilityToolStepRequest(
+            runId: restartedRuntime.State.RunId,
+            correlationId: restartedRuntime.State.CorrelationId,
+            stepIndex: 2);
+
+        await restartedRuntime.HandleNextToolStepAsync(toolRequest);
+
+        executor.ToolStepAuthorizationPresence.Should().Equal(false);
+        executor.ToolExecutionCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleNextToolStepAsync_AfterActorRestart_ShouldRejectWhenDurableAuthorizationIsMissing()
+    {
+        var executor = new CapabilityTrackingReplyGenerationExecutor();
+        var publisher = new RecordingSelfEventPublisher();
+        var restartedRuntime = CreateCapabilityTestAgent(executor, publisher, nextStepIndex: 2);
+        restartedRuntime.State.GenerationStep!.PendingToolCalls.Add(
+            CapabilityTrackingReplyGenerationExecutor.ToolCall.Clone());
+        var toolRequest = BuildCapabilityToolStepRequest(
+            runId: restartedRuntime.State.RunId,
+            correlationId: restartedRuntime.State.CorrelationId,
+            stepIndex: 2);
+
+        await restartedRuntime.HandleNextToolStepAsync(toolRequest);
+
+        executor.ToolStepAuthorizationPresence.Should().Equal(false);
+        executor.ToolExecutionCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task HandleNextToolStepAsync_AfterActorRestart_ShouldRejectWhenDurableAuthorizationWasConsumed()
+    {
+        var executor = new CapabilityTrackingReplyGenerationExecutor();
+        var publisher = new RecordingSelfEventPublisher();
+        var restartedRuntime = CreateCapabilityTestAgent(executor, publisher, nextStepIndex: 2);
+        restartedRuntime.State.GenerationStep!.PendingToolCalls.Add(
+            CapabilityTrackingReplyGenerationExecutor.ToolCall.Clone());
+        restartedRuntime.State.GenerationStep.PendingToolAuthorizations.Add(
+            CapabilityTrackingReplyGenerationExecutor.Authorization.Clone());
+        restartedRuntime.State.GenerationStep.PendingToolAuthorizationConsumed = true;
         var toolRequest = BuildCapabilityToolStepRequest(
             runId: restartedRuntime.State.RunId,
             correlationId: restartedRuntime.State.CorrelationId,
@@ -4030,6 +4073,16 @@ public sealed class AgentRunGAgentTests
             ArgumentsJson = "{}",
         };
 
+        public static AgentRunPendingToolAuthorization Authorization { get; } = new()
+        {
+            Call = ToolCall.Clone(),
+            HasRequiresApproval = true,
+            RequiresApproval = false,
+            IsReadOnly = true,
+            IsDestructive = false,
+            SideEffectKind = "use.skill",
+        };
+
         public int ToolExecutionCount { get; private set; }
 
         public List<bool> ToolStepAuthorizationPresence { get; } = [];
@@ -4045,6 +4098,7 @@ public sealed class AgentRunGAgentTests
         {
             var result = new AgentRunLlmStepResult();
             result.ToolCalls.Add(ToolCall.Clone());
+            result.PendingToolAuthorizations.Add(Authorization.Clone());
             var continuation = new AgentRunNextLlmStepRequestedEvent
             {
                 RunId = request.RunId,
@@ -4077,7 +4131,7 @@ public sealed class AgentRunGAgentTests
             ToolStepAuthorizationPresence.Add(authorizedToolStep is not null);
             var result = authorizedToolStep?.Matches(request) == true
                 ? await authorizedToolStep.ExecuteAsync(ct)
-                : new AgentRunToolStepResult { AdvanceRound = true };
+                : ExecuteDurableAuthorizationIfMatched(request);
             return new AgentRunNextToolStepRequestedEvent
             {
                 RunId = request.RunId,
@@ -4089,6 +4143,26 @@ public sealed class AgentRunGAgentTests
                 ToolStepResult = result,
             };
         }
+
+        private AgentRunToolStepResult ExecuteDurableAuthorizationIfMatched(AgentRunReplyStepExecutionRequest request)
+        {
+            if (request.AllowDurableToolAuthorization &&
+                request.StepState.PendingToolAuthorizationConsumed &&
+                request.StepState.PendingToolCalls.Count == 1 &&
+                request.StepState.PendingToolAuthorizations.Count == 1 &&
+                ToolCallMatches(request.StepState.PendingToolCalls[0]) &&
+                ToolCallMatches(request.StepState.PendingToolAuthorizations[0].Call))
+            {
+                ToolExecutionCount++;
+            }
+
+            return new AgentRunToolStepResult { AdvanceRound = true };
+        }
+
+        private static bool ToolCallMatches(AgentRunToolCall call) =>
+            string.Equals(call.Id, ToolCall.Id, StringComparison.Ordinal) &&
+            string.Equals(call.Name, ToolCall.Name, StringComparison.Ordinal) &&
+            string.Equals(call.ArgumentsJson, ToolCall.ArgumentsJson, StringComparison.Ordinal);
     }
 
     private sealed class RecordingSelfEventPublisher : IEventPublisher

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1167,6 +1167,29 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleNextToolStepAsync_AfterActorRestart_ShouldExecuteWhenDurableAuthorizationSurvivesProtobufRoundTrip()
+    {
+        var executor = new CapabilityTrackingReplyGenerationExecutor();
+        var publisher = new RecordingSelfEventPublisher();
+        var restartedRuntime = CreateCapabilityTestAgent(executor, publisher, nextStepIndex: 2);
+        restartedRuntime.State.GenerationStep!.PendingToolCalls.Add(
+            CapabilityTrackingReplyGenerationExecutor.ToolCall.Clone());
+        restartedRuntime.State.GenerationStep.PendingToolAuthorizations.Add(
+            CapabilityTrackingReplyGenerationExecutor.Authorization.Clone());
+        SetState(restartedRuntime, RoundTrip(restartedRuntime.State));
+        var toolRequest = BuildCapabilityToolStepRequest(
+            runId: restartedRuntime.State.RunId,
+            correlationId: restartedRuntime.State.CorrelationId,
+            stepIndex: 2);
+
+        await restartedRuntime.HandleNextToolStepAsync(toolRequest);
+
+        executor.ToolStepAuthorizationPresence.Should().Equal(false);
+        executor.DurableAuthorizationAllowed.Should().Equal(true);
+        executor.ToolExecutionCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task HandleNextToolStepAsync_AfterActorRestart_ShouldRejectWhenDurableAuthorizationIsMissing()
     {
         var executor = new CapabilityTrackingReplyGenerationExecutor();
@@ -1204,6 +1227,7 @@ public sealed class AgentRunGAgentTests
         await restartedRuntime.HandleNextToolStepAsync(toolRequest);
 
         executor.ToolStepAuthorizationPresence.Should().Equal(false);
+        executor.DurableAuthorizationAllowed.Should().Equal(false);
         executor.ToolExecutionCount.Should().Be(0);
     }
 
@@ -3786,6 +3810,9 @@ public sealed class AgentRunGAgentTests
         throw new InvalidOperationException("Unable to set agent id via reflection.");
     }
 
+    private static AgentRunGAgentState RoundTrip(AgentRunGAgentState state) =>
+        AgentRunGAgentState.Parser.ParseFrom(state.ToByteArray());
+
     private static void SetState(AgentRunGAgent agent, AgentRunGAgentState state)
     {
         var stateField = typeof(Aevatar.Foundation.Core.GAgentBase<AgentRunGAgentState>).GetField(
@@ -4086,6 +4113,7 @@ public sealed class AgentRunGAgentTests
         public int ToolExecutionCount { get; private set; }
 
         public List<bool> ToolStepAuthorizationPresence { get; } = [];
+        public List<bool> DurableAuthorizationAllowed { get; } = [];
 
         public Task<AgentRunReplyStepState> BuildInitialStepStateAsync(
             AgentRunReplyGenerationExecutionRequest request,
@@ -4129,6 +4157,7 @@ public sealed class AgentRunGAgentTests
             CancellationToken ct)
         {
             ToolStepAuthorizationPresence.Add(authorizedToolStep is not null);
+            DurableAuthorizationAllowed.Add(request.AllowDurableToolAuthorization);
             var result = authorizedToolStep?.Matches(request) == true
                 ? await authorizedToolStep.ExecuteAsync(ct)
                 : ExecuteDurableAuthorizationIfMatched(request);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
@@ -537,6 +537,89 @@ public sealed class AgentRunReplyGenerationExecutorTests
         registeredTool.ExecuteCount.Should().Be(0);
     }
 
+    [Fact]
+    public async Task BuildToolStepContinuation_WithDurableAuthorization_ShouldExecuteWhenCatalogStillAdmitsTool()
+    {
+        var registeredTool = new CountingTool("use_skill");
+        var executor = CreateToolEnabledExecutor(
+            registeredTool,
+            new ToolCallProvider(registeredTool.Name));
+        var llmWorkItem = BuildToolEnabledWorkItem();
+        var execution = await executor.BuildLlmStepExecutionAsync(
+            llmWorkItem,
+            CancellationToken.None);
+        var toolWorkItem = BuildDurablyAuthorizedToolStepWorkItem(llmWorkItem, execution.Continuation);
+
+        var continuation = await executor.BuildToolStepContinuationAsync(
+            toolWorkItem,
+            authorizedToolStep: null,
+            CancellationToken.None);
+
+        continuation.ToolStepResult.Should().NotBeNull();
+        continuation.ToolStepResult.ResultMessages.Should().ContainSingle();
+        registeredTool.ExecuteCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BuildToolStepContinuation_WithDurableAuthorization_ShouldMatchSafetyInsideToolContextScope()
+    {
+        var registeredTool = new ContextClassifiedTool("use_skill");
+        var executor = CreateToolEnabledExecutor(
+            registeredTool,
+            new ToolCallProvider(registeredTool.Name),
+            toolContext: AgentToolExecutionContext.Empty with
+            {
+                ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["tool_safety_mode"] = "read",
+                },
+            });
+        var llmWorkItem = BuildToolEnabledWorkItem();
+        var execution = await executor.BuildLlmStepExecutionAsync(
+            llmWorkItem,
+            CancellationToken.None);
+        var toolWorkItem = BuildDurablyAuthorizedToolStepWorkItem(llmWorkItem, execution.Continuation);
+
+        var continuation = await executor.BuildToolStepContinuationAsync(
+            toolWorkItem,
+            authorizedToolStep: null,
+            CancellationToken.None);
+
+        continuation.ToolStepResult.Should().NotBeNull();
+        continuation.ToolStepResult.ResultMessages.Should().ContainSingle();
+        registeredTool.ExecuteCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(AuthorizedToolStepMutation.ToolCallId)]
+    [InlineData(AuthorizedToolStepMutation.ToolName)]
+    [InlineData(AuthorizedToolStepMutation.Arguments)]
+    public async Task BuildToolStepContinuation_WhenDurableAuthorizationIsMismatched_ShouldRejectBeforeToolExecution(
+        AuthorizedToolStepMutation mutation)
+    {
+        var registeredTool = new CountingTool("use_skill");
+        var executor = CreateToolEnabledExecutor(
+            registeredTool,
+            new ToolCallProvider(registeredTool.Name));
+        var llmWorkItem = BuildToolEnabledWorkItem();
+        var execution = await executor.BuildLlmStepExecutionAsync(
+            llmWorkItem,
+            CancellationToken.None);
+        var toolWorkItem = MutateToolStepWorkItem(
+            BuildDurablyAuthorizedToolStepWorkItem(llmWorkItem, execution.Continuation),
+            mutation);
+
+        var continuation = await executor.BuildToolStepContinuationAsync(
+            toolWorkItem,
+            authorizedToolStep: null,
+            CancellationToken.None);
+
+        continuation.ToolStepResult.Should().NotBeNull();
+        continuation.ToolStepResult.ResultMessages.Should().OnlyContain(static message =>
+            message.Content.Contains("not authorized", StringComparison.Ordinal));
+        registeredTool.ExecuteCount.Should().Be(0);
+    }
+
     [Theory]
     [InlineData(AuthorizedToolStepMutation.RunId)]
     [InlineData(AuthorizedToolStepMutation.CorrelationId)]
@@ -723,11 +806,23 @@ public sealed class AgentRunReplyGenerationExecutorTests
         stepState.NextStepIndex = continuation.StepIndex;
         stepState.PendingToolCalls.Clear();
         stepState.PendingToolCalls.AddRange(continuation.LlmStepResult.ToolCalls.Select(static call => call.Clone()));
+        stepState.PendingToolAuthorizations.Clear();
+        stepState.PendingToolAuthorizations.AddRange(
+            continuation.LlmStepResult.PendingToolAuthorizations.Select(static authorization => authorization.Clone()));
         return llmWorkItem with
         {
             StepIndex = continuation.StepIndex,
             StepState = stepState,
         };
+    }
+
+    private static AgentRunReplyStepExecutionRequest BuildDurablyAuthorizedToolStepWorkItem(
+        AgentRunReplyStepExecutionRequest llmWorkItem,
+        AgentRunNextLlmStepRequestedEvent continuation)
+    {
+        var workItem = BuildToolStepWorkItem(llmWorkItem, continuation);
+        workItem.StepState.PendingToolAuthorizationConsumed = true;
+        return workItem with { AllowDurableToolAuthorization = true };
     }
 
     private static AgentRunReplyStepExecutionRequest MutateToolStepWorkItem(
@@ -894,6 +989,33 @@ public sealed class AgentRunReplyGenerationExecutorTests
         public string Name => name;
         public string Description => name;
         public string ParametersSchema => "{}";
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCount++;
+            return Task.FromResult("{}");
+        }
+    }
+
+    private sealed class ContextClassifiedTool(string name) : IAgentTool
+    {
+        public int ExecuteCount { get; private set; }
+        public string Name => name;
+        public string Description => name;
+        public string ParametersSchema => "{}";
+        public string SideEffectKind => "context.classified";
+
+        public AgentToolCallSafety GetCallSafety(string argumentsJson)
+        {
+            var isReadMode = AgentToolRequestContext.Current?.ExternalMetadata.TryGetValue(
+                "tool_safety_mode",
+                out var mode) == true &&
+                string.Equals(mode, "read", StringComparison.Ordinal);
+            return new AgentToolCallSafety(
+                RequiresApproval: false,
+                IsReadOnly: isReadMode,
+                IsDestructive: !isReadMode);
+        }
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunReplyGenerationExecutorTests.cs
@@ -567,13 +567,7 @@ public sealed class AgentRunReplyGenerationExecutorTests
         var executor = CreateToolEnabledExecutor(
             registeredTool,
             new ToolCallProvider(registeredTool.Name),
-            toolContext: AgentToolExecutionContext.Empty with
-            {
-                ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
-                {
-                    ["tool_safety_mode"] = "read",
-                },
-            });
+            toolContext: BuildSafetyModeToolContext(SafetyMode.ReadOnly));
         var llmWorkItem = BuildToolEnabledWorkItem();
         var execution = await executor.BuildLlmStepExecutionAsync(
             llmWorkItem,
@@ -588,6 +582,93 @@ public sealed class AgentRunReplyGenerationExecutorTests
         continuation.ToolStepResult.Should().NotBeNull();
         continuation.ToolStepResult.ResultMessages.Should().ContainSingle();
         registeredTool.ExecuteCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(DefinitionDrift.Description)]
+    [InlineData(DefinitionDrift.ParametersSchema)]
+    public async Task BuildToolStepContinuation_WhenToolDefinitionDrifts_ShouldRejectBeforeToolExecution(
+        DefinitionDrift drift)
+    {
+        var registeredTool = new DriftableDefinitionTool("use_skill");
+        var executor = CreateToolEnabledExecutor(
+            registeredTool,
+            new ToolCallProvider(registeredTool.Name));
+        var llmWorkItem = BuildToolEnabledWorkItem();
+        var execution = await executor.BuildLlmStepExecutionAsync(
+            llmWorkItem,
+            CancellationToken.None);
+        var toolWorkItem = BuildDurablyAuthorizedToolStepWorkItem(llmWorkItem, execution.Continuation);
+        registeredTool.Apply(drift);
+
+        var continuation = await executor.BuildToolStepContinuationAsync(
+            toolWorkItem,
+            authorizedToolStep: null,
+            CancellationToken.None);
+
+        continuation.ToolStepResult.Should().NotBeNull();
+        continuation.ToolStepResult.ResultMessages.Should().OnlyContain(static message =>
+            message.Content.Contains("not authorized", StringComparison.Ordinal));
+        registeredTool.ExecuteCount.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(SafetyMode.ApprovalUnspecified)]
+    [InlineData(SafetyMode.ApprovalRequired)]
+    [InlineData(SafetyMode.Destructive)]
+    [InlineData(SafetyMode.ReadOnlyChanged)]
+    [InlineData(SafetyMode.SideEffectChanged)]
+    public async Task BuildToolStepContinuation_WhenCurrentSafetyDrifts_ShouldRejectBeforeToolExecution(
+        SafetyMode currentSafety)
+    {
+        var registeredTool = new ContextClassifiedTool("use_skill");
+        var executor = CreateToolEnabledExecutor(
+            registeredTool,
+            new ToolCallProvider(registeredTool.Name),
+            toolContext: BuildSafetyModeToolContext(SafetyMode.ReadOnly));
+        var llmWorkItem = BuildToolEnabledWorkItem();
+        var execution = await executor.BuildLlmStepExecutionAsync(
+            llmWorkItem,
+            CancellationToken.None);
+        var toolWorkItem = BuildDurablyAuthorizedToolStepWorkItem(llmWorkItem, execution.Continuation);
+        registeredTool.SafetyOverride = currentSafety;
+
+        var continuation = await executor.BuildToolStepContinuationAsync(
+            toolWorkItem,
+            authorizedToolStep: null,
+            CancellationToken.None);
+
+        continuation.ToolStepResult.Should().NotBeNull();
+        continuation.ToolStepResult.ResultMessages.Should().OnlyContain(static message =>
+            message.Content.Contains("not authorized", StringComparison.Ordinal));
+        registeredTool.ExecuteCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BuildToolStepContinuation_WhenDurableAuthorizationWasConsumed_ShouldRejectBeforeToolExecution()
+    {
+        var registeredTool = new CountingTool("use_skill");
+        var executor = CreateToolEnabledExecutor(
+            registeredTool,
+            new ToolCallProvider(registeredTool.Name));
+        var llmWorkItem = BuildToolEnabledWorkItem();
+        var execution = await executor.BuildLlmStepExecutionAsync(
+            llmWorkItem,
+            CancellationToken.None);
+        var toolWorkItem = BuildToolStepWorkItem(llmWorkItem, execution.Continuation);
+        var consumedStepState = toolWorkItem.StepState.Clone();
+        consumedStepState.PendingToolAuthorizationConsumed = true;
+        toolWorkItem = toolWorkItem with { StepState = consumedStepState };
+
+        var continuation = await executor.BuildToolStepContinuationAsync(
+            toolWorkItem,
+            authorizedToolStep: null,
+            CancellationToken.None);
+
+        continuation.ToolStepResult.Should().NotBeNull();
+        continuation.ToolStepResult.ResultMessages.Should().OnlyContain(static message =>
+            message.Content.Contains("not authorized", StringComparison.Ordinal));
+        registeredTool.ExecuteCount.Should().Be(0);
     }
 
     [Theory]
@@ -786,6 +867,15 @@ public sealed class AgentRunReplyGenerationExecutorTests
             request,
             stepState);
     }
+
+    private static AgentToolExecutionContext BuildSafetyModeToolContext(SafetyMode mode) =>
+        AgentToolExecutionContext.Empty with
+        {
+            ExternalMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["tool_safety_mode"] = mode.ToString(),
+            },
+        };
 
     private static NyxIdChatOperationKey BuildOperationKey(string stepId, string operationId) =>
         new()
@@ -997,30 +1087,116 @@ public sealed class AgentRunReplyGenerationExecutorTests
         }
     }
 
+    public enum DefinitionDrift
+    {
+        Description,
+        ParametersSchema,
+    }
+
+    private sealed class DriftableDefinitionTool : IAgentTool
+    {
+        private readonly string _name;
+
+        public DriftableDefinitionTool(string name)
+        {
+            _name = name;
+            Description = name;
+        }
+
+        public int ExecuteCount { get; private set; }
+        public string Name => _name;
+        public string Description { get; private set; }
+        public string ParametersSchema { get; private set; } = "{}";
+
+        public AgentToolCallSafety GetCallSafety(string argumentsJson) => new(
+            RequiresApproval: false,
+            IsReadOnly: true,
+            IsDestructive: false);
+
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            ExecuteCount++;
+            return Task.FromResult("{}");
+        }
+
+        public void Apply(DefinitionDrift drift)
+        {
+            if (drift == DefinitionDrift.Description)
+            {
+                Description = "changed definition";
+                return;
+            }
+
+            ParametersSchema = "{\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}}}";
+        }
+    }
+
+    public enum SafetyMode
+    {
+        ReadOnly,
+        ApprovalUnspecified,
+        ApprovalRequired,
+        Destructive,
+        ReadOnlyChanged,
+        SideEffectChanged,
+    }
+
     private sealed class ContextClassifiedTool(string name) : IAgentTool
     {
         public int ExecuteCount { get; private set; }
+        public SafetyMode? SafetyOverride { get; set; }
         public string Name => name;
         public string Description => name;
         public string ParametersSchema => "{}";
-        public string SideEffectKind => "context.classified";
+        public string SideEffectKind => ResolveSafetyMode() == SafetyMode.SideEffectChanged
+            ? "context.changed"
+            : "context.classified";
 
         public AgentToolCallSafety GetCallSafety(string argumentsJson)
         {
-            var isReadMode = AgentToolRequestContext.Current?.ExternalMetadata.TryGetValue(
-                "tool_safety_mode",
-                out var mode) == true &&
-                string.Equals(mode, "read", StringComparison.Ordinal);
-            return new AgentToolCallSafety(
-                RequiresApproval: false,
-                IsReadOnly: isReadMode,
-                IsDestructive: !isReadMode);
+            return ResolveSafetyMode() switch
+            {
+                SafetyMode.ApprovalUnspecified => new AgentToolCallSafety(
+                    RequiresApproval: null,
+                    IsReadOnly: true,
+                    IsDestructive: false),
+                SafetyMode.ApprovalRequired => new AgentToolCallSafety(
+                    RequiresApproval: true,
+                    IsReadOnly: true,
+                    IsDestructive: false),
+                SafetyMode.Destructive => new AgentToolCallSafety(
+                    RequiresApproval: false,
+                    IsReadOnly: false,
+                    IsDestructive: true),
+                SafetyMode.ReadOnlyChanged => new AgentToolCallSafety(
+                    RequiresApproval: false,
+                    IsReadOnly: false,
+                    IsDestructive: false),
+                _ => new AgentToolCallSafety(
+                    RequiresApproval: false,
+                    IsReadOnly: true,
+                    IsDestructive: false),
+            };
         }
 
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
             ExecuteCount++;
             return Task.FromResult("{}");
+        }
+
+        private SafetyMode ResolveSafetyMode()
+        {
+            if (SafetyOverride is { } safetyOverride)
+                return safetyOverride;
+
+            if (AgentToolRequestContext.Current?.ExternalMetadata.TryGetValue("tool_safety_mode", out var mode) == true &&
+                Enum.TryParse<SafetyMode>(mode, ignoreCase: false, out var parsed))
+            {
+                return parsed;
+            }
+
+            return SafetyMode.Destructive;
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #3163 and addresses the production symptom tracked in #3162.
- Keeps the AgentRun actor-owned LLM/tool continuation model, but removes correctness dependence on the process-local `_authorizedToolStep` surviving reactivation.
- Persists only durable-safe pending call/safety/definition facts plus an actor-owned consumed waterline; bearer tokens, provider objects, tool instances, delegates, and executable authorization capabilities remain transient.
- Rebuilds durable fallback execution through the current step plan/catalog and `ChatRuntimeStepExecutor.ExecuteAuthorizedToolStepAsync`, with exact pending-call, safety, side-effect, and tool-definition fingerprint matching under `AgentToolContextScope`.

## Behavior
- Same-activation normal path still uses the transient `AgentRunAuthorizedToolStep`; it does not rebuild the catalog or make another LLM request.
- Durable fallback is opt-in from `AgentRunGAgent` only, after the actor has persisted the consumed waterline.
- If current catalog/safety/definition facts no longer match, or durable pending facts are missing/consumed, execution fails closed with the normal unauthorized tool result.
- The P1 review comment about same-name catalog replacement is addressed by persisting `tool_definition_fingerprint` and rejecting durable replay when description/schema/side-effect/safety drift.

## Validation
- `dotnet test /private/tmp/aevatar-nyxid-meai-tool-port/test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --no-restore --nologo --filter "AgentRunGAgentTests|AgentRunReplyGenerationExecutorTests"` — passed, 119/119.
- `dotnet test /private/tmp/aevatar-nyxid-meai-tool-port/test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter "MEAILLMProviderUsageTests|AgentToolAIFunctionSchemaSanitizationTests"` — passed, 14/14.
- `dotnet build /private/tmp/aevatar-nyxid-meai-tool-port/aevatar.slnx --nologo` — passed, 0 errors.
- `git -C /private/tmp/aevatar-nyxid-meai-tool-port diff --check` — passed.
- `bash /private/tmp/aevatar-nyxid-meai-tool-port/tools/ci/test_stability_guards.sh` — guard started and printed polling/coverage guard success, then failed in `project_reference_layer_guard.py` because local Python 3.12 cannot load `pyexpat` (`Symbol not found: _XML_SetAllocTrackerActivationThreshold`).
- `bash /private/tmp/aevatar-nyxid-meai-tool-port/tools/ci/architecture_guards.sh` — all preceding listed guards passed earlier, then failed at the same local Python `pyexpat` load error in `project_reference_layer_guard.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)