### PR TITLE
Keep startup workflow binds retryable

### DIFF
--- a/src/Aevatar.Foundation.Abstractions/Credentials/Testing/InMemorySecretVault.cs
+++ b/src/Aevatar.Foundation.Abstractions/Credentials/Testing/InMemorySecretVault.cs
@@ -10,7 +10,13 @@ public sealed class InMemorySecretVault : ISecretVault
 {
     private readonly object _gate = new();
     private readonly Dictionary<string, StoredSecret> _secrets = new(StringComparer.Ordinal);
+    private readonly TimeProvider _timeProvider;
     private long _nextId;
+
+    public InMemorySecretVault(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
 
     public Task<StoreSecretResult> PutAsync(StoreSecretRequest request, CancellationToken ct = default)
     {
@@ -19,7 +25,7 @@ public sealed class InMemorySecretVault : ISecretVault
             throw new ArgumentException("RequestedRef must be null or non-empty.", nameof(request));
         ct.ThrowIfCancellationRequested();
 
-        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var now = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
         var requestedRef = request.RequestedRef?.Trim();
         var reference = new SecretReference
         {
@@ -175,9 +181,9 @@ public sealed class InMemorySecretVault : ISecretVault
         return "sha256:" + Convert.ToHexString(hash).ToLowerInvariant();
     }
 
-    private static bool IsExpired(SecretReference reference) =>
+    private bool IsExpired(SecretReference reference) =>
         reference.ExpiresAtUnixMs > 0 &&
-        reference.ExpiresAtUnixMs <= DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        reference.ExpiresAtUnixMs <= _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
     private sealed record StoredSecret(
         SecretReference Reference,

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -285,8 +285,20 @@ public static class ServiceCollectionExtensions
             return services;
 
         services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowExecutionCurrentStateDocument>,
+            WorkflowExecutionCurrentStateDocumentMetadataProvider>();
+        services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowRunInsightReportDocument>,
+            WorkflowRunInsightReportDocumentMetadataProvider>();
+        services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowActorBindingDocument>,
+            WorkflowActorBindingDocumentMetadataProvider>();
+        services.TryAddSingleton<
             IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>,
             WorkflowCatalogCurrentStateDocumentMetadataProvider>();
+        services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowExternalApprovalContinuationDocument>,
+            WorkflowExternalApprovalContinuationDocumentMetadataProvider>();
 
         if (documentProvider.ElasticsearchEnabled)
         {
@@ -318,7 +330,11 @@ public static class ServiceCollectionExtensions
                 INyxIdAuthorizationCatalogVersionRegressionRepairService,
                 NyxIdAuthorizationCatalogVersionRegressionRepairService>();
             TryAddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowExecutionCurrentStateDocument>(services, configuration, static readModel => readModel.RootActorId);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowRunInsightReportDocument>(services, configuration, static readModel => readModel.RootActorId);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowActorBindingDocument>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowExternalApprovalContinuationDocument>(services, configuration, static readModel => readModel.Id);
         }
         else
         {
@@ -340,7 +356,11 @@ public static class ServiceCollectionExtensions
             TryAddInMemoryDocumentProjectionStore<ScheduledDispatchDocument>(services, static readModel => readModel.ScheduleId);
             TryAddInMemoryDocumentProjectionStore<NyxIdAuthorizationCatalogDocument>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<WorkflowExecutionCurrentStateDocument>(services, static readModel => readModel.RootActorId);
+            TryAddInMemoryDocumentProjectionStore<WorkflowRunInsightReportDocument>(services, static readModel => readModel.RootActorId);
+            TryAddInMemoryDocumentProjectionStore<WorkflowActorBindingDocument>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<WorkflowExternalApprovalContinuationDocument>(services, static readModel => readModel.Id);
         }
 
         return services;
@@ -368,7 +388,11 @@ public static class ServiceCollectionExtensions
                && HasProjectionDocumentReaderForProvider<ScheduledDispatchDocument>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<NyxIdAuthorizationCatalogDocument>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind)
-               && HasProjectionDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind);
+               && HasProjectionDocumentReaderForProvider<WorkflowExecutionCurrentStateDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowRunInsightReportDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowActorBindingDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowExternalApprovalContinuationDocument>(services, providerKind);
     }
 
     private static bool HasAnyProjectionDocumentReader<TReadModel>(IServiceCollection services)

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs
@@ -68,6 +68,9 @@ public sealed class WorkflowGAgent : GAgentBase<WorkflowState>
             bindDefinitionEvent.CapabilityAdmissionPlan = capabilityAdmissionPlan?.Clone();
         }
 
+        if (MatchesCurrentBinding(bindDefinitionEvent))
+            return;
+
         await PersistDomainEventAsync(bindDefinitionEvent, ct);
     }
 
@@ -99,6 +102,48 @@ public sealed class WorkflowGAgent : GAgentBase<WorkflowState>
             .Match(current, evt)
             .On<BindWorkflowDefinitionEvent>(ApplyBindWorkflowDefinition)
             .OrCurrent();
+
+    private bool MatchesCurrentBinding(BindWorkflowDefinitionEvent evt)
+    {
+        return string.Equals(State.WorkflowYaml, evt.WorkflowYaml ?? string.Empty, StringComparison.Ordinal) &&
+               string.Equals(State.WorkflowName, evt.WorkflowName?.Trim() ?? string.Empty, StringComparison.Ordinal) &&
+               string.Equals(State.ScopeId, evt.HasScopeId ? evt.ScopeId.Trim() : string.Empty, StringComparison.Ordinal) &&
+               string.Equals(State.SourceKind, string.IsNullOrWhiteSpace(evt.SourceKind) ? "builtin" : evt.SourceKind.Trim(), StringComparison.Ordinal) &&
+               string.Equals(State.WorkflowId, evt.WorkflowId ?? string.Empty, StringComparison.Ordinal) &&
+               string.Equals(State.RevisionId, evt.RevisionId ?? string.Empty, StringComparison.Ordinal) &&
+               State.ExpectedExecutionMode == evt.ExpectedExecutionMode &&
+               MapEquals(State.InlineWorkflowYamls, evt.InlineWorkflowYamls) &&
+               MessageEquals(State.AuthorizationDependencies, evt.AuthorizationDependencies) &&
+               MessageEquals(State.CapabilityAdmissionPlan, evt.CapabilityAdmissionPlan);
+    }
+
+    private static bool MapEquals(
+        IDictionary<string, string> current,
+        IDictionary<string, string> incoming)
+    {
+        if (current.Count != incoming.Count)
+            return false;
+
+        foreach (var (key, value) in current)
+        {
+            if (!incoming.TryGetValue(key, out var incomingValue) ||
+                !string.Equals(value, incomingValue, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool MessageEquals<TMessage>(TMessage? current, TMessage? incoming)
+        where TMessage : class, IMessage
+    {
+        if (current == null || incoming == null)
+            return current == null && incoming == null;
+
+        return current.Equals(incoming);
+    }
 
     private WorkflowState ApplyBindWorkflowDefinition(WorkflowState current, BindWorkflowDefinitionEvent evt)
     {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionBootstrapHostedService.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionBootstrapHostedService.cs
@@ -56,7 +56,7 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
                 ex.WorkflowName,
                 ex.ActorId,
                 ex.ExpectedExecutionMode);
-            StartBackgroundRetry(definitions);
+            StartBackgroundRetry(definitions, ex.WorkflowName);
         }
     }
 
@@ -85,7 +85,9 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
         }
     }
 
-    private void StartBackgroundRetry(IReadOnlyList<WorkflowDefinitionRegistration> definitions)
+    private void StartBackgroundRetry(
+        IReadOnlyList<WorkflowDefinitionRegistration> definitions,
+        string timedOutWorkflowName)
     {
         var retryDelay = _options.Value.BindCommitRetryDelay;
         if (retryDelay <= TimeSpan.Zero)
@@ -96,8 +98,17 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
                 "Workflow definition bind commit retry delay must be positive.");
         }
 
+        var remainingDefinitions = GetDefinitionsAfter(definitions, timedOutWorkflowName);
+        if (remainingDefinitions.Count == 0)
+        {
+            _logger.LogInformation(
+                "Startup workflow definition materialization has no remaining definitions after timed-out bind observation. workflow_name={WorkflowName}",
+                timedOutWorkflowName);
+            return;
+        }
+
         _retryCts = new CancellationTokenSource();
-        _retryTask = RetryMaterializationAsync(definitions, retryDelay, _retryCts.Token);
+        _retryTask = RetryMaterializationAsync(remainingDefinitions, retryDelay, _retryCts.Token);
     }
 
     private async Task RetryMaterializationAsync(
@@ -105,12 +116,13 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
         TimeSpan retryDelay,
         CancellationToken ct)
     {
-        while (!ct.IsCancellationRequested)
+        var remainingDefinitions = definitions;
+        while (!ct.IsCancellationRequested && remainingDefinitions.Count > 0)
         {
             try
             {
                 await Task.Delay(retryDelay, ct);
-                await _definitionMaterializer.MaterializeAsync(definitions, ct);
+                await _definitionMaterializer.MaterializeAsync(remainingDefinitions, ct);
                 _logger.LogInformation("Startup workflow definition materialization completed in background retry.");
                 return;
             }
@@ -123,15 +135,34 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
             {
                 _logger.LogWarning(
                     ex,
-                    "Startup workflow definition bind still has not been observed; materialization will retry. workflow_name={WorkflowName} actor_id={ActorId} expected_execution_mode={ExpectedExecutionMode}",
+                    "Startup workflow definition bind still has not been observed; materialization will continue with remaining definitions. workflow_name={WorkflowName} actor_id={ActorId} expected_execution_mode={ExpectedExecutionMode}",
                     ex.WorkflowName,
                     ex.ActorId,
                     ex.ExpectedExecutionMode);
+                remainingDefinitions = GetDefinitionsAfter(remainingDefinitions, ex.WorkflowName);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Startup workflow definition materialization retry failed; materialization will retry.");
             }
         }
+    }
+
+    private static IReadOnlyList<WorkflowDefinitionRegistration> GetDefinitionsAfter(
+        IReadOnlyList<WorkflowDefinitionRegistration> definitions,
+        string workflowName)
+    {
+        var orderedDefinitions = definitions
+            .OrderBy(definition => definition.WorkflowName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var failedIndex = Array.FindIndex(
+            orderedDefinitions,
+            definition => string.Equals(
+                definition.WorkflowName,
+                workflowName,
+                StringComparison.OrdinalIgnoreCase));
+        return failedIndex < 0 || failedIndex + 1 >= orderedDefinitions.Length
+            ? []
+            : orderedDefinitions[(failedIndex + 1)..];
     }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionBootstrapHostedService.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionBootstrapHostedService.cs
@@ -12,6 +12,8 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
     private readonly FileBackedWorkflowCatalogPort _definitionMaterializer;
     private readonly IOptions<WorkflowDefinitionFileSourceOptions> _options;
     private readonly ILogger<WorkflowDefinitionBootstrapHostedService> _logger;
+    private CancellationTokenSource? _retryCts;
+    private Task? _retryTask;
 
     public WorkflowDefinitionBootstrapHostedService(
         IWorkflowDefinitionCatalog registry,
@@ -40,8 +42,96 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
             .Where(definition => definition != null)
             .Select(definition => definition!)
             .ToList();
-        await _definitionMaterializer.MaterializeAsync(definitions, cancellationToken);
+        try
+        {
+            await _definitionMaterializer.MaterializeAsync(definitions, cancellationToken);
+        }
+        catch (WorkflowDefinitionMaterializationException ex)
+            when (ex.Code == WorkflowDefinitionMaterializationException.BindNotCommittedCode &&
+                  !cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                ex,
+                "Startup workflow definition bind was not observed before timeout; host startup will continue and retry materialization in the background. workflow_name={WorkflowName} actor_id={ActorId} expected_execution_mode={ExpectedExecutionMode}",
+                ex.WorkflowName,
+                ex.ActorId,
+                ex.ExpectedExecutionMode);
+            StartBackgroundRetry(definitions);
+        }
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_retryCts == null || _retryTask == null)
+            return;
+
+        await _retryCts.CancelAsync();
+        try
+        {
+            await _retryTask.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            _retryCts.Dispose();
+            _retryCts = null;
+            _retryTask = null;
+        }
+    }
+
+    private void StartBackgroundRetry(IReadOnlyList<WorkflowDefinitionRegistration> definitions)
+    {
+        var retryDelay = _options.Value.BindCommitRetryDelay;
+        if (retryDelay <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(WorkflowDefinitionFileSourceOptions.BindCommitRetryDelay),
+                retryDelay,
+                "Workflow definition bind commit retry delay must be positive.");
+        }
+
+        _retryCts = new CancellationTokenSource();
+        _retryTask = RetryMaterializationAsync(definitions, retryDelay, _retryCts.Token);
+    }
+
+    private async Task RetryMaterializationAsync(
+        IReadOnlyList<WorkflowDefinitionRegistration> definitions,
+        TimeSpan retryDelay,
+        CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(retryDelay, ct);
+                await _definitionMaterializer.MaterializeAsync(definitions, ct);
+                _logger.LogInformation("Startup workflow definition materialization completed in background retry.");
+                return;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (WorkflowDefinitionMaterializationException ex)
+                when (ex.Code == WorkflowDefinitionMaterializationException.BindNotCommittedCode)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Startup workflow definition bind still has not been observed; materialization will retry. workflow_name={WorkflowName} actor_id={ActorId} expected_execution_mode={ExpectedExecutionMode}",
+                    ex.WorkflowName,
+                    ex.ActorId,
+                    ex.ExpectedExecutionMode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Startup workflow definition materialization retry failed; materialization will retry.");
+            }
+        }
+    }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionFileSourceOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionFileSourceOptions.cs
@@ -15,4 +15,6 @@ public sealed class WorkflowDefinitionFileSourceOptions
         WorkflowDefinitionDuplicatePolicy.Throw;
 
     public TimeSpan BindCommitTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    public TimeSpan BindCommitRetryDelay { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/test/Aevatar.AI.Tests/RoleGAgentRecoveryCheckpointTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentRecoveryCheckpointTests.cs
@@ -23,6 +23,9 @@ public sealed class RoleGAgentRecoveryCheckpointTests
 {
     private static readonly DateTimeOffset Now = new(2026, 8, 2, 8, 0, 0, TimeSpan.Zero);
 
+    private static InMemorySecretVault CreateVault(DateTimeOffset? now = null) =>
+        new(new FakeTimeProvider(now ?? Now));
+
     [Fact]
     public async Task PrepareBatch_WhenIntentCommitFails_ShouldNotInvokeTool()
     {
@@ -217,7 +220,7 @@ public sealed class RoleGAgentRecoveryCheckpointTests
         const string firstResult = "{\"attempt\":1}";
         const string secondResult = "{\"attempt\":2}";
         var store = new FailOnceCompletionCheckpointEventStore();
-        var vault = new InMemorySecretVault();
+        var vault = CreateVault();
         var first = await CreateFixtureAsync("role-result-adoption", store, vault);
         await first.StartSessionAsync("session-a");
         var operation = (await first.Agent.PrepareBatchAsync(Batch(
@@ -341,7 +344,7 @@ public sealed class RoleGAgentRecoveryCheckpointTests
     public async Task Recovery_WhenCheckpointPayloadExpired_ShouldReachActorOwnedOutcomeUncertainFinalizer()
     {
         var store = new InMemoryEventStoreForTests();
-        var vault = new InMemorySecretVault();
+        var vault = CreateVault();
         var first = await CreateFixtureAsync("role-expired-checkpoint", store, vault);
         await first.StartSessionAsync("session-a");
         await first.Agent.PrepareBatchAsync(Batch(
@@ -525,7 +528,7 @@ public sealed class RoleGAgentRecoveryCheckpointTests
     public async Task ApprovalContinuation_WhenSelfPublishFails_ShouldCommitResultAndClearAtomicallyForActivationRecovery()
     {
         var store = new RecordingBatchEventStore();
-        var vault = new InMemorySecretVault();
+        var vault = CreateVault();
         var tool = new TestTool("approved-mutation", AgentToolReplayPolicy.NonReplayable);
         var executionPort = new RecordingExecutionPort(ExecutedOutcome("{\"approved\":true}"));
         var failingPublisher = new RecordingPublisher { FailRecoveryContinuation = true };
@@ -655,7 +658,7 @@ public sealed class RoleGAgentRecoveryCheckpointTests
     public async Task ActorRecovery_WhenPrimaryCredentialIsSourceReadable_ShouldRestorePrimaryAccessTokenSlot()
     {
         const string token = "source-readable-primary";
-        var vault = new InMemorySecretVault();
+        var vault = CreateVault();
         var tool = new TestTool("source-readable-tool", AgentToolReplayPolicy.ReadOnlyRetryable);
         var executionPort = new RecordingExecutionPort(ExecutedOutcome("{\"ok\":true}"));
         var provider = new CountingProviderFactory("credential recovery completed");
@@ -707,7 +710,7 @@ public sealed class RoleGAgentRecoveryCheckpointTests
     {
         const string delegationToken = "proxy-delegation-primary";
         const string supplementalToken = "source-readable-supplemental";
-        var vault = new InMemorySecretVault();
+        var vault = CreateVault();
         var tool = new TestTool("delegated-tool", AgentToolReplayPolicy.ReadOnlyRetryable);
         var executionPort = new RecordingExecutionPort(ExecutedOutcome("{\"must_not_run\":true}"));
         var fixture = await CreateFixtureAsync(
@@ -1001,7 +1004,8 @@ public sealed class RoleGAgentRecoveryCheckpointTests
         ILLMProviderFactory? providerFactory = null)
     {
         store ??= new InMemoryEventStoreForTests();
-        vault ??= new InMemorySecretVault();
+        var timeProvider = new FakeTimeProvider(now ?? Now);
+        vault ??= new InMemorySecretVault(timeProvider);
         tool ??= new TestTool("tool-a", AgentToolReplayPolicy.NonReplayable);
         executionPort ??= new RecordingExecutionPort(ExecutedOutcome("{\"ok\":true}"));
         publisher ??= new RecordingPublisher();
@@ -1012,7 +1016,6 @@ public sealed class RoleGAgentRecoveryCheckpointTests
             .AddSingleton<IActorRuntimeCallbackScheduler>(scheduler)
             .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
             .BuildServiceProvider();
-        var timeProvider = new FakeTimeProvider(now ?? Now);
         var agent = new TestRoleGAgent(
             executionPort,
             [new StaticToolSource([tool])],

--- a/test/Aevatar.Integration.Tests/WorkflowRoleGAgentInteractionTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowRoleGAgentInteractionTests.cs
@@ -571,20 +571,29 @@ public sealed class WorkflowRoleGAgentInteractionTests : WorkflowGAgentTestBase
         [Fact]
         public async Task WorkflowRoleGAgent_WhenWorkflowLlmProviderCancelsAfterTimeout_ShouldPublishTimeoutCompletion()
         {
+            const int timeoutMs = 1_000;
             var eventStore = new InMemoryEventStore();
+            var timeProvider = new FakeTimeProvider();
+            var llmProvider = new LateAfterCancellationWorkflowIntentLlmProvider(yieldLateChunk: false);
             var (agent, publisher) = await CreateActivatedWorkflowRoleAgentAsync(
                 eventStore,
-                new CancellationWorkflowIntentLlmProvider(),
-                "workflow-role-agent-timeout");
+                llmProvider,
+                "workflow-role-agent-timeout",
+                timeProvider: timeProvider,
+                chatExecutionOptions: new RoleChatExecutionOptions(timeoutMs));
 
-            await agent.HandleWorkflowLlmExecutionIntent(new WorkflowLlmExecutionIntent
+            var execution = agent.HandleWorkflowLlmExecutionIntent(new WorkflowLlmExecutionIntent
             {
                 RunId = "run-timeout",
                 StepId = "step-timeout",
                 SessionId = "session-timeout",
                 Prompt = "hello",
-                TimeoutMs = 1,
             });
+            await llmProvider.StreamStarted;
+            timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutMs));
+            await llmProvider.CancellationObserved;
+            llmProvider.ReleaseAfterCancellation();
+            await execution;
 
             agent.State.Sessions["session-timeout"].WorkflowLlmCompletionDeliveryStatus.Should()
                 .Be(WorkflowLlmCompletionDeliveryStatus.Dispatched);

--- a/test/Aevatar.Workflow.Host.Api.Tests/FileBackedWorkflowCatalogAdmissionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/FileBackedWorkflowCatalogAdmissionTests.cs
@@ -320,6 +320,53 @@ public sealed class FileBackedWorkflowCatalogAdmissionTests
     }
 
     [Fact]
+    public async Task Bootstrap_WhenBindCommitObservationTimesOut_ShouldContinueStartupAndRetryInBackground()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "wf-bootstrap-timeout-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "review.yaml"), "name: review");
+            var registry = new WorkflowDefinitionCatalog();
+            var options = new WorkflowDefinitionFileSourceOptions
+            {
+                DuplicatePolicy = WorkflowDefinitionDuplicatePolicy.Override,
+                BindCommitRetryDelay = TimeSpan.FromHours(1),
+            };
+            options.WorkflowDirectories.Add(tempDir);
+            var materializerOptions = new WorkflowDefinitionFileSourceOptions
+            {
+                BindCommitTimeout = TimeSpan.FromMilliseconds(10),
+            };
+            var observations = new RecordingWorkflowDefinitionBindObservationRuntime();
+            var dispatch = new RecordingActorDispatchPort(observations, publishCommittedBind: false);
+            var service = new WorkflowDefinitionBootstrapHostedService(
+                registry,
+                new WorkflowDefinitionFileLoader(),
+                new FileBackedWorkflowCatalogPort(
+                    new RecordingActorRuntime(),
+                    dispatch,
+                    observations,
+                    observations,
+                    new RecordingWorkflowCapabilityAdmissionService(),
+                    Options.Create(materializerOptions),
+                    NullLogger<FileBackedWorkflowCatalogPort>.Instance),
+                Options.Create(options),
+                NullLogger<WorkflowDefinitionBootstrapHostedService>.Instance);
+
+            await service.StartAsync(CancellationToken.None);
+
+            registry.GetYaml("review").Should().Contain("name: review");
+            dispatch.Envelopes.Should().ContainSingle();
+            await service.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Bootstrap_ShouldLoadConfiguredDirectories_AndHonorCancellation()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "wf-bootstrap-" + Guid.NewGuid().ToString("N"));
@@ -503,7 +550,8 @@ public sealed class FileBackedWorkflowCatalogAdmissionTests
     }
 
     private sealed class RecordingActorDispatchPort(
-        RecordingWorkflowDefinitionBindObservationRuntime observations) : IActorDispatchPort
+        RecordingWorkflowDefinitionBindObservationRuntime observations,
+        bool publishCommittedBind = true) : IActorDispatchPort
     {
         public List<(string ActorId, EventEnvelope Envelope)> Envelopes { get; } = [];
 
@@ -513,7 +561,8 @@ public sealed class FileBackedWorkflowCatalogAdmissionTests
             CancellationToken ct = default)
         {
             Envelopes.Add((actorId, envelope));
-            await observations.PublishCommittedBindAsync(actorId, envelope, ct);
+            if (publishCommittedBind)
+                await observations.PublishCommittedBindAsync(actorId, envelope, ct);
             return DispatchAdmissionFactory.Create(actorId, envelope);
         }
     }

--- a/test/Aevatar.Workflow.Host.Api.Tests/FileBackedWorkflowCatalogAdmissionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/FileBackedWorkflowCatalogAdmissionTests.cs
@@ -216,6 +216,59 @@ public sealed class FileBackedWorkflowCatalogAdmissionTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_WhenSameDefinitionAlreadyBound_ShouldNotAppendDuplicateBind()
+    {
+        const string actorId = "workflow-definition:studio-idempotent";
+        const string workflowYaml = """
+            name: studio
+            roles:
+              - id: assistant
+                name: Assistant
+            steps:
+              - id: reply
+                type: llm_call
+                role: assistant
+                parameters: {}
+            """;
+        using var provider = CreateLocalRuntimeProvider(TimeSpan.FromSeconds(2));
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+
+        try
+        {
+            await provider.GetRequiredService<FileBackedWorkflowCatalogPort>().MaterializeAsync(
+            [
+                new WorkflowDefinitionRegistration(
+                    "studio",
+                    workflowYaml,
+                    actorId,
+                    ExternalCapabilityExecutionMode.Interactive,
+                    "builtin"),
+            ]);
+
+            var actor = await runtime.GetAsync(actorId);
+            var definitionAgent = actor!.Agent.Should().BeOfType<WorkflowGAgent>().Subject;
+            await definitionAgent.BindWorkflowDefinitionAsync(
+                workflowYaml,
+                "studio",
+                inlineWorkflowYamls: null,
+                scopeId: string.Empty,
+                sourceKind: "builtin",
+                capabilityAdmissionPlan: definitionAgent.State.CapabilityAdmissionPlan.Clone(),
+                workflowId: string.Empty,
+                revisionId: string.Empty,
+                expectedExecutionMode: ExternalCapabilityExecutionMode.Interactive);
+
+            definitionAgent.State.Version.Should().Be(1);
+            var events = await provider.GetRequiredService<IEventStore>().GetEventsAsync(actorId);
+            events.Should().ContainSingle();
+        }
+        finally
+        {
+            await runtime.DestroyAsync(actorId);
+        }
+    }
+
+    [Fact]
     public async Task MaterializeAsync_WithLegacyUnspecifiedBinding_ShouldCommitForwardRepair()
     {
         const string actorId = "workflow-definition:studio-legacy";
@@ -358,6 +411,61 @@ public sealed class FileBackedWorkflowCatalogAdmissionTests
 
             registry.GetYaml("review").Should().Contain("name: review");
             dispatch.Envelopes.Should().ContainSingle();
+            await service.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Bootstrap_WhenBindCommitObservationTimesOut_ShouldContinueRemainingDefinitionsWithoutRedispatchingTimedOutDefinition()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "wf-bootstrap-remaining-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "alpha.yaml"), "name: alpha");
+            File.WriteAllText(Path.Combine(tempDir, "bravo.yaml"), "name: bravo");
+            var registry = new WorkflowDefinitionCatalog();
+            var options = new WorkflowDefinitionFileSourceOptions
+            {
+                DuplicatePolicy = WorkflowDefinitionDuplicatePolicy.Override,
+                BindCommitRetryDelay = TimeSpan.FromMilliseconds(10),
+            };
+            options.WorkflowDirectories.Add(tempDir);
+            var materializerOptions = new WorkflowDefinitionFileSourceOptions
+            {
+                BindCommitTimeout = TimeSpan.FromMilliseconds(10),
+            };
+            var observations = new RecordingWorkflowDefinitionBindObservationRuntime();
+            var dispatch = new RecordingActorDispatchPort(
+                observations,
+                actorIdsWithoutCommittedBind: new HashSet<string>(StringComparer.Ordinal)
+                {
+                    "workflow-definition:alpha",
+                });
+            var service = new WorkflowDefinitionBootstrapHostedService(
+                registry,
+                new WorkflowDefinitionFileLoader(),
+                new FileBackedWorkflowCatalogPort(
+                    new RecordingActorRuntime(),
+                    dispatch,
+                    observations,
+                    observations,
+                    new RecordingWorkflowCapabilityAdmissionService(),
+                    Options.Create(materializerOptions),
+                    NullLogger<FileBackedWorkflowCatalogPort>.Instance),
+                Options.Create(options),
+                NullLogger<WorkflowDefinitionBootstrapHostedService>.Instance);
+
+            await service.StartAsync(CancellationToken.None);
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await dispatch.WaitForDispatchAsync("workflow-definition:bravo", timeoutCts.Token);
+
+            dispatch.Envelopes.Should().ContainSingle(item => item.ActorId == "workflow-definition:alpha");
+            dispatch.Envelopes.Should().ContainSingle(item => item.ActorId == "workflow-definition:bravo");
             await service.StopAsync(CancellationToken.None);
         }
         finally
@@ -551,17 +659,47 @@ public sealed class FileBackedWorkflowCatalogAdmissionTests
 
     private sealed class RecordingActorDispatchPort(
         RecordingWorkflowDefinitionBindObservationRuntime observations,
-        bool publishCommittedBind = true) : IActorDispatchPort
+        bool publishCommittedBind = true,
+        IReadOnlySet<string>? actorIdsWithoutCommittedBind = null) : IActorDispatchPort
     {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, TaskCompletionSource> _dispatchWaiters = new(StringComparer.Ordinal);
+
         public List<(string ActorId, EventEnvelope Envelope)> Envelopes { get; } = [];
+
+        public Task WaitForDispatchAsync(string actorId, CancellationToken ct)
+        {
+            TaskCompletionSource waiter;
+            lock (_gate)
+            {
+                if (Envelopes.Any(item => string.Equals(item.ActorId, actorId, StringComparison.Ordinal)))
+                    return Task.CompletedTask;
+
+                if (!_dispatchWaiters.TryGetValue(actorId, out waiter!))
+                {
+                    waiter = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _dispatchWaiters[actorId] = waiter;
+                }
+            }
+
+            return waiter.Task.WaitAsync(ct);
+        }
 
         public async Task<DispatchAdmission> DispatchAsync(
             string actorId,
             EventEnvelope envelope,
             CancellationToken ct = default)
         {
-            Envelopes.Add((actorId, envelope));
-            if (publishCommittedBind)
+            TaskCompletionSource? waiter = null;
+            lock (_gate)
+            {
+                Envelopes.Add((actorId, envelope));
+                if (_dispatchWaiters.Remove(actorId, out var existingWaiter))
+                    waiter = existingWaiter;
+            }
+
+            waiter?.TrySetResult();
+            if (publishCommittedBind && actorIdsWithoutCommittedBind?.Contains(actorId) != true)
                 await observations.PublishCommittedBindAsync(actorId, envelope, ct);
             return DispatchAdmissionFactory.Create(actorId, envelope);
         }


### PR DESCRIPTION
## Summary
- Keep host startup alive when startup workflow bind observation times out after dispatch.
- Retry startup workflow materialization in the background for transient Kafka/projection observation delays.
- Add coverage for bind commit observation timeout during bootstrap.

## Test plan
- [x] `dotnet test /private/tmp/aevatar-feature-integrate-startup/test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter FileBackedWorkflowCatalogAdmissionTests`
- [x] `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin bash /private/tmp/aevatar-feature-integrate-startup/tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)