### PR TITLE
Fix NyxID chat activation recovery

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -2509,6 +2509,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
                 NormalizeOptional(registration.Id),
                 replyChannelContext.IdentityHints),
             ExternalMetadata = AgentToolExecutionContextMapper.StripOwnedControlKeys(replyMetadata),
+            ExecutionOwner = AgentToolExecutionOwners.ChannelRegistration(registration.Id),
         }).ToPayload();
 
         if (TryBuildSkillRecoveryContext(inboundEvent.Text, inboundEvent.Platform, defaultSkillName, out var skillRecovery))

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationGAgent.cs
@@ -22,6 +22,7 @@ public sealed class NyxIdChatConversationGAgent
     : GAgentBase<NyxIdChatConversationGAgentState>
 {
     private const string SharedInputHistoryText = "Shared input content.";
+    private static readonly TimeSpan ActivationRecoveryDelay = TimeSpan.FromMilliseconds(1);
     private static readonly TimeSpan HistoryInitializationRetryDelay = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan HistoryReservationRetryDelay = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan HistoryTerminalRetryDelay = TimeSpan.FromSeconds(5);
@@ -95,73 +96,25 @@ public sealed class NyxIdChatConversationGAgent
 
         if (State.PendingHistoryInitialization is { } pendingInitialization)
         {
-            await DispatchHistoryInitializationContinuationAsync(
-                    pendingInitialization,
-                    ct);
+            await ScheduleActivationHistoryInitializationAsync(pendingInitialization, ct);
         }
 
-        if (State.HistoryDeliveryReservation is
-            { Dispatched: false } pendingReservation)
+        if (State.HistoryDeliveryReservation is { Dispatched: false } pendingReservation)
         {
-            try
-            {
-                await ReserveHistoryDeliveryAsync(pendingReservation, ct);
-                await PersistDomainEventAsync(new NyxIdChatHistoryDeliveryReservationDispatchedEvent
-                {
-                    DeliveryId = pendingReservation.DeliveryId,
-                    SourceCommandId = pendingReservation.SourceCommandId,
-                    DispatchedAt = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-                }, CancellationToken.None);
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception exception)
-            {
-                Logger.LogWarning(
-                    "NyxIdChat pending history reservation recovery failed: actor={ActorId} delivery={DeliveryId} exceptionType={ExceptionType}",
-                    Id,
-                    pendingReservation.DeliveryId,
-                    exception.GetType().Name);
-                await ScheduleHistoryReservationRetryAsync(pendingReservation);
-            }
+            await ScheduleActivationHistoryReservationAsync(pendingReservation, ct);
         }
 
-        if (State.PendingHistoryTerminal is { } pendingTerminal)
+        if (State.PendingHistoryTerminal is { } pendingTerminal &&
+            State.HistoryDeliveryReservation?.Dispatched == true)
         {
-            await DispatchPendingHistoryTerminalAsync();
+            await ScheduleActivationHistoryTerminalAsync(pendingTerminal, ct);
         }
 
         var operation = ResolveOutstandingRecoveryOperation(State);
         if (operation?.Key is null)
             return;
 
-        var version = CurrentCommittedVersion();
-        var kind = operation.Kind == NyxIdChatStepKind.Postcondition &&
-                   operation.Phase == NyxIdChatOperationPhase.Requested
-            ? NyxIdChatRecoveryKind.PostconditionRedispatch
-            : NyxIdChatRecoveryKind.InterruptedOperationReconciliation;
-        var signal = new NyxIdChatRecoveryRequestedSignal
-        {
-            Key = operation.Key.Clone(),
-            ExpectedStateVersion = version,
-            Kind = kind,
-        };
-        var envelope = new EventEnvelope
-        {
-            Id = $"{operation.Key.OperationId}:recovery:{version}",
-            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-            Payload = Any.Pack(signal),
-            Route = EnvelopeRouteSemantics.CreateTopologyPublication(
-                Id,
-                TopologyAudience.Self),
-            Propagation = new EnvelopePropagation
-            {
-                CorrelationId = operation.Key.OperationId,
-            },
-        };
-        await _actorDispatchPort.DispatchAsync(Id, envelope, ct);
+        await ScheduleActivationRecoveryAsync(operation, ct);
     }
 
     [EventHandler(AllowSelfHandling = true)]
@@ -2176,6 +2129,148 @@ public sealed class NyxIdChatConversationGAgent
 
         state.PendingHistoryTerminal = outbox;
         return true;
+    }
+
+    private async Task ScheduleActivationHistoryInitializationAsync(
+        NyxIdChatHistoryInitializationOutbox pending,
+        CancellationToken ct)
+    {
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildStableIdentity(
+                    "history-initialization-activation",
+                    pending.OperationId,
+                    pending.Attempt.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                ActivationRecoveryDelay,
+                new NyxIdChatHistoryInitializationDispatchRequested
+                {
+                    OperationId = pending.OperationId,
+                    Attempt = pending.Attempt,
+                },
+                ct: ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Logger.LogWarning(
+                "NyxIdChat history initialization activation recovery scheduling failed: actor={ActorId} operation={OperationId} attempt={Attempt} exceptionType={ExceptionType}",
+                Id,
+                pending.OperationId,
+                pending.Attempt,
+                exception.GetType().Name);
+        }
+    }
+
+    private async Task ScheduleActivationHistoryReservationAsync(
+        NyxIdChatHistoryDeliveryReservationState pending,
+        CancellationToken ct)
+    {
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildStableIdentity(
+                    "history-reservation-activation",
+                    pending.DeliveryId,
+                    pending.Attempt.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                ActivationRecoveryDelay,
+                new NyxIdChatHistoryDeliveryReservationDispatchRequested
+                {
+                    DeliveryId = pending.DeliveryId,
+                    Attempt = pending.Attempt,
+                },
+                ct: ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Logger.LogWarning(
+                "NyxIdChat history reservation activation recovery scheduling failed: actor={ActorId} delivery={DeliveryId} attempt={Attempt} exceptionType={ExceptionType}",
+                Id,
+                pending.DeliveryId,
+                pending.Attempt,
+                exception.GetType().Name);
+        }
+    }
+
+    private async Task ScheduleActivationHistoryTerminalAsync(
+        NyxIdChatHistoryTerminalOutbox pending,
+        CancellationToken ct)
+    {
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildStableIdentity(
+                    "history-terminal-activation",
+                    pending.DeliveryId,
+                    pending.Attempt.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                ActivationRecoveryDelay,
+                new NyxIdChatHistoryTerminalDispatchRequested
+                {
+                    DeliveryId = pending.DeliveryId,
+                    Attempt = pending.Attempt,
+                },
+                ct: ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Logger.LogWarning(
+                "NyxIdChat history terminal activation recovery scheduling failed: actor={ActorId} delivery={DeliveryId} attempt={Attempt} exceptionType={ExceptionType}",
+                Id,
+                pending.DeliveryId,
+                pending.Attempt,
+                exception.GetType().Name);
+        }
+    }
+
+    private async Task ScheduleActivationRecoveryAsync(
+        NyxIdChatOperationState operation,
+        CancellationToken ct)
+    {
+        var version = CurrentCommittedVersion();
+        var kind = operation.Kind == NyxIdChatStepKind.Postcondition &&
+                   operation.Phase == NyxIdChatOperationPhase.Requested
+            ? NyxIdChatRecoveryKind.PostconditionRedispatch
+            : NyxIdChatRecoveryKind.InterruptedOperationReconciliation;
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildStableIdentity(
+                    "operation-recovery-activation",
+                    operation.Key.OperationId,
+                    version.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+                ActivationRecoveryDelay,
+                new NyxIdChatRecoveryRequestedSignal
+                {
+                    Key = operation.Key.Clone(),
+                    ExpectedStateVersion = version,
+                    Kind = kind,
+                },
+                ct: ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            Logger.LogWarning(
+                "NyxIdChat operation activation recovery scheduling failed: actor={ActorId} operation={OperationId} version={StateVersion} exceptionType={ExceptionType}",
+                Id,
+                operation.Key.OperationId,
+                version,
+                exception.GetType().Name);
+        }
     }
 
     private Task DispatchPendingHistoryTerminalAsync()

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationGAgent.cs
@@ -99,8 +99,10 @@ public sealed class NyxIdChatConversationGAgent
             await ScheduleActivationHistoryInitializationAsync(pendingInitialization, ct);
         }
 
+        var hasPendingHistoryReservation = false;
         if (State.HistoryDeliveryReservation is { Dispatched: false } pendingReservation)
         {
+            hasPendingHistoryReservation = true;
             await ScheduleActivationHistoryReservationAsync(pendingReservation, ct);
         }
 
@@ -110,11 +112,10 @@ public sealed class NyxIdChatConversationGAgent
             await ScheduleActivationHistoryTerminalAsync(pendingTerminal, ct);
         }
 
-        var operation = ResolveOutstandingRecoveryOperation(State);
-        if (operation?.Key is null)
+        if (hasPendingHistoryReservation)
             return;
 
-        await ScheduleActivationRecoveryAsync(operation, ct);
+        await ScheduleOutstandingOperationRecoveryAsync(ct);
     }
 
     [EventHandler(AllowSelfHandling = true)]
@@ -331,6 +332,7 @@ public sealed class NyxIdChatConversationGAgent
                 DispatchedAt = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
             }, CancellationToken.None);
             await DispatchPendingHistoryTerminalAsync();
+            await ScheduleOutstandingOperationRecoveryAsync(CancellationToken.None);
         }
         catch (OperationCanceledException)
         {
@@ -2162,6 +2164,7 @@ public sealed class NyxIdChatConversationGAgent
                 pending.OperationId,
                 pending.Attempt,
                 exception.GetType().Name);
+            throw;
         }
     }
 
@@ -2196,6 +2199,7 @@ public sealed class NyxIdChatConversationGAgent
                 pending.DeliveryId,
                 pending.Attempt,
                 exception.GetType().Name);
+            throw;
         }
     }
 
@@ -2230,7 +2234,16 @@ public sealed class NyxIdChatConversationGAgent
                 pending.DeliveryId,
                 pending.Attempt,
                 exception.GetType().Name);
+            throw;
         }
+    }
+
+    private Task ScheduleOutstandingOperationRecoveryAsync(CancellationToken ct)
+    {
+        var operation = ResolveOutstandingRecoveryOperation(State);
+        return operation?.Key is null
+            ? Task.CompletedTask
+            : ScheduleActivationRecoveryAsync(operation, ct);
     }
 
     private async Task ScheduleActivationRecoveryAsync(
@@ -2270,6 +2283,7 @@ public sealed class NyxIdChatConversationGAgent
                 operation.Key.OperationId,
                 version,
                 exception.GetType().Name);
+            throw;
         }
     }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
@@ -979,7 +979,7 @@ public sealed class NyxIdChatConversationGAgentTests
     }
 
     [Fact]
-    public async Task ActivateAsync_WithPendingReservation_ShouldReserveBeforePublishingOperationRecovery()
+    public async Task ActivateAsync_WithPendingReservation_ShouldScheduleCallbacksWithoutSelfDispatch()
     {
         const string conversationActorId = "conversation-alpha";
         var operations = new List<string>();
@@ -988,7 +988,8 @@ public sealed class NyxIdChatConversationGAgentTests
             ReserveException = new OperationCanceledException("crash after turn commit"),
         };
         var eventStore = new InMemoryEventStoreForTests();
-        using var services = BuildEventSourcingServices(eventStore, history);
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        using var services = BuildEventSourcingServices(eventStore, history, callbacks);
         var initial = new NyxIdChatConversationGAgent(
             new RecordingActorRuntime(operations),
             new RecordingActorDispatchPort(operations, static (_, _) => Task.CompletedTask),
@@ -1000,6 +1001,7 @@ public sealed class NyxIdChatConversationGAgentTests
         };
         AssignActorId(initial, conversationActorId);
         await initial.ActivateAsync();
+        callbacks.TimeoutRequests.Clear();
         await FluentActions.Invoking(() => initial.HandleEventAsync(
                 CreateEnvelope(conversationActorId, CreateStartTurnCommand())))
             .Should().ThrowAsync<OperationCanceledException>();
@@ -1009,6 +1011,7 @@ public sealed class NyxIdChatConversationGAgentTests
         history.ReserveException = null;
         history.Reservations.Clear();
         operations.Clear();
+        callbacks.TimeoutRequests.Clear();
         var recoveryDispatch = new RecordingActorDispatchPort(
             operations,
             static (_, _) => Task.CompletedTask);
@@ -1025,7 +1028,19 @@ public sealed class NyxIdChatConversationGAgentTests
 
         await recovered.ActivateAsync();
 
-        operations.Should().Equal("history.reserve", "dispatch");
+        operations.Should().BeEmpty();
+        recoveryDispatch.Calls.Should().BeEmpty();
+        callbacks.TimeoutRequests.Should().HaveCount(2);
+        var reservationCallback = callbacks.TimeoutRequests.Single(request =>
+            request.TriggerEnvelope.Payload.Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor));
+        var recoveryCallback = callbacks.TimeoutRequests.Single(request =>
+            request.TriggerEnvelope.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor));
+        reservationCallback.DueTime.Should().BePositive();
+        recoveryCallback.DueTime.Should().BePositive();
+
+        await recovered.HandleEventAsync(reservationCallback.TriggerEnvelope.Clone());
+
+        operations.Should().Equal("history.reserve");
         var replayedReservation = history.Reservations.Should().ContainSingle().Which;
         replayedReservation.Should().BeEquivalentTo(new ChatHistoryTurnDeliveryReservation(
             pending.DeliveryId,
@@ -1044,11 +1059,11 @@ public sealed class NyxIdChatConversationGAgentTests
         events.Select(static item => item.EventData.TypeUrl).Should().Equal(
             Any.Pack(new NyxIdChatTurnStartedEvent()).TypeUrl,
             Any.Pack(new NyxIdChatHistoryDeliveryReservationDispatchedEvent()).TypeUrl);
-        var recovery = recoveryDispatch.Calls.Should().ContainSingle().Which.Envelope.Payload
+        var recovery = recoveryCallback.TriggerEnvelope.Payload
             .Unpack<NyxIdChatRecoveryRequestedSignal>();
         recovery.Key.OperationId.Should().Be(
             recovered.State.ActiveTask.Steps.Single().Operation.Key.OperationId);
-        recovery.ExpectedStateVersion.Should().Be(events[^1].Version);
+        recovery.ExpectedStateVersion.Should().Be(events[0].Version);
     }
 
     [Fact]
@@ -1079,13 +1094,24 @@ public sealed class NyxIdChatConversationGAgentTests
         await recovered.ActivateAsync();
 
         recovered.State.HistoryDeliveryReservation.Dispatched.Should().BeFalse();
-        callbacks.TimeoutRequests.Should().ContainSingle();
-        recoveryDispatch.Calls.Should().ContainSingle(call =>
-            call.Envelope.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor),
-            "history recovery failure must not suppress operation recovery");
+        recoveryDispatch.Calls.Should().BeEmpty();
+        callbacks.TimeoutRequests.Should().HaveCount(2);
+        var reservationCallback = callbacks.TimeoutRequests.Single(request =>
+            request.TriggerEnvelope.Payload.Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor));
+        callbacks.TimeoutRequests.Should().Contain(request =>
+            request.TriggerEnvelope.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor),
+            "history recovery scheduling failure must not suppress operation recovery scheduling");
+
+        await recovered.HandleEventAsync(reservationCallback.TriggerEnvelope.Clone());
+
+        recovered.State.HistoryDeliveryReservation.Dispatched.Should().BeFalse();
+        callbacks.TimeoutRequests.Should().HaveCount(3);
+        var retryCallback = callbacks.TimeoutRequests.Last();
+        retryCallback.TriggerEnvelope.Payload
+            .Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor).Should().BeTrue();
 
         history.ReserveException = null;
-        await recovered.HandleEventAsync(callbacks.TimeoutRequests.Single().TriggerEnvelope.Clone());
+        await recovered.HandleEventAsync(retryCallback.TriggerEnvelope.Clone());
 
         recovered.State.HistoryDeliveryReservation.Dispatched.Should().BeTrue();
     }
@@ -1343,7 +1369,8 @@ public sealed class NyxIdChatConversationGAgentTests
             version: 1,
             CreatePendingHistoryTerminalState(controllerStatus, text, errorCode));
         var history = new RecordingChatHistoryCommandPort([]);
-        using var services = BuildEventSourcingServices(eventStore, history);
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        using var services = BuildEventSourcingServices(eventStore, history, callbacks);
         var dispatch = new RecordingActorDispatchPort(
             [],
             static (_, _) => Task.CompletedTask);
@@ -1351,7 +1378,9 @@ public sealed class NyxIdChatConversationGAgentTests
 
         await agent.ActivateAsync();
 
-        var selfEnvelope = dispatch.Calls.Should().ContainSingle().Which.Envelope.Clone();
+        dispatch.Calls.Should().BeEmpty();
+        var selfEnvelope = callbacks.TimeoutRequests.Should().ContainSingle().Which
+            .TriggerEnvelope.Clone();
         var signal = selfEnvelope.Payload
             .Unpack<NyxIdChatHistoryTerminalDispatchRequested>();
         signal.DeliveryId.Should().Be("delivery-terminal-alpha");
@@ -1406,7 +1435,10 @@ public sealed class NyxIdChatConversationGAgentTests
             static (_, _) => Task.CompletedTask);
         var initial = CreateController(services, conversationActorId, firstDispatch);
         await initial.ActivateAsync();
-        var firstSignal = firstDispatch.Calls.Should().ContainSingle().Which.Envelope.Clone();
+        firstDispatch.Calls.Should().BeEmpty();
+        var firstSignal = callbacks.TimeoutRequests.Should().ContainSingle().Which
+            .TriggerEnvelope.Clone();
+        callbacks.TimeoutRequests.Clear();
 
         await initial.HandleEventAsync(firstSignal);
 
@@ -1435,9 +1467,12 @@ public sealed class NyxIdChatConversationGAgentTests
         var recoveryDispatch = new RecordingActorDispatchPort(
             [],
             static (_, _) => Task.CompletedTask);
+        callbacks.TimeoutRequests.Clear();
         var recovered = CreateController(services, conversationActorId, recoveryDispatch);
         await recovered.ActivateAsync();
-        var recoveredSignal = recoveryDispatch.Calls.Should().ContainSingle().Which.Envelope.Clone();
+        recoveryDispatch.Calls.Should().BeEmpty();
+        var recoveredSignal = callbacks.TimeoutRequests.Should().ContainSingle().Which
+            .TriggerEnvelope.Clone();
         recoveredSignal.Payload.ToByteString().Should().Equal(
             timeout.TriggerEnvelope.Payload.ToByteString(),
             "activation and durable retry must address the same pending attempt");
@@ -1870,7 +1905,8 @@ public sealed class NyxIdChatConversationGAgentTests
         var initialDispatch = new RecordingActorDispatchPort(
             operations,
             static (_, _) => Task.CompletedTask);
-        using var services = BuildEventSourcingServices(eventStore, history);
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        using var services = BuildEventSourcingServices(eventStore, history, callbacks);
         var initial = new NyxIdChatConversationGAgent(
             new RecordingActorRuntime(operations),
             initialDispatch,
@@ -1896,6 +1932,7 @@ public sealed class NyxIdChatConversationGAgentTests
         history.ReserveException = null;
         history.Reservations.Clear();
         operations.Clear();
+        callbacks.TimeoutRequests.Clear();
         var recoveryDispatch = new RecordingActorDispatchPort(
             operations,
             static (_, _) => Task.CompletedTask);
@@ -1911,6 +1948,14 @@ public sealed class NyxIdChatConversationGAgentTests
         AssignActorId(recovered, conversationActorId);
 
         await recovered.ActivateAsync();
+
+        operations.Should().BeEmpty();
+        recoveryDispatch.Calls.Should().BeEmpty();
+        var reservationCallback = callbacks.TimeoutRequests.Should().ContainSingle().Which;
+        reservationCallback.TriggerEnvelope.Payload
+            .Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor).Should().BeTrue();
+
+        await recovered.HandleEventAsync(reservationCallback.TriggerEnvelope.Clone());
 
         operations.Should().Equal("history.reserve");
         history.Reservations.Should().ContainSingle();
@@ -2913,7 +2958,8 @@ public sealed class NyxIdChatConversationGAgentTests
     {
         const string conversationActorId = "conversation-alpha";
         var eventStore = new InMemoryEventStoreForTests();
-        using var services = BuildEventSourcingServices(eventStore);
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        using var services = BuildEventSourcingServices(eventStore, callbackScheduler: callbacks);
         var initial = CreateController(services, conversationActorId);
         await initial.ActivateAsync();
         await initial.HandleEventAsync(CreateEnvelope(
@@ -2944,19 +2990,21 @@ public sealed class NyxIdChatConversationGAgentTests
                 IEventSourcingBehaviorFactory<NyxIdChatConversationGAgentState>>(),
         };
         AssignActorId(reactivated, conversationActorId);
+        callbacks.TimeoutRequests.Clear();
         await reactivated.ActivateAsync();
         var steering = CreateSteeringCommand(expectedStateVersion: checkpointVersion);
+        var activationRecovery = callbacks.TimeoutRequests.Should().ContainSingle().Which
+            .TriggerEnvelope.Clone();
+        activationRecovery.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor).Should().BeTrue(
+            "activation queues typed recovery for the requested LLM waterline");
+        dispatch.RecoveryCalls.Should().BeEmpty();
 
         await reactivated.HandleEventAsync(CreateEnvelope(conversationActorId, steering));
 
         reactivated.State.ContinuationAdmission.Status.Should().Be(
             NyxIdChatContinuationAdmissionStatus.Accepted);
-        dispatch.RecoveryCalls.Should().ContainSingle(
-            "activation queues typed recovery for the requested LLM waterline");
         dispatch.StartTurnCalls.Should().ContainSingle(
             "steering queues one continuation");
-        var activationRecovery = dispatch.Calls.Single(call =>
-            call.Envelope.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor)).Envelope.Clone();
         var firstSelfMessage = dispatch.Calls.Single(call =>
             call.Envelope.Payload.Is(NyxIdChatStartTurnCommand.Descriptor)).Envelope.Clone();
         var beforeReplay = await eventStore.GetEventsAsync(conversationActorId);
@@ -2966,7 +3014,7 @@ public sealed class NyxIdChatConversationGAgentTests
         (await eventStore.GetEventsAsync(conversationActorId)).Should().HaveCount(
             beforeReplay.Count,
             "the steering commits advance the version and make the earlier activation recovery stale");
-        dispatch.RecoveryCalls.Should().ContainSingle(
+        dispatch.RecoveryCalls.Should().BeEmpty(
             "stale recovery cannot replay the old LLM or create a turn actor");
         dispatch.StartTurnCalls.Should().ContainSingle();
 

--- a/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
@@ -1030,16 +1030,18 @@ public sealed class NyxIdChatConversationGAgentTests
 
         operations.Should().BeEmpty();
         recoveryDispatch.Calls.Should().BeEmpty();
-        callbacks.TimeoutRequests.Should().HaveCount(2);
-        var reservationCallback = callbacks.TimeoutRequests.Single(request =>
-            request.TriggerEnvelope.Payload.Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor));
-        var recoveryCallback = callbacks.TimeoutRequests.Single(request =>
-            request.TriggerEnvelope.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor));
+        var reservationCallback = callbacks.TimeoutRequests.Should().ContainSingle().Which;
+        reservationCallback.TriggerEnvelope.Payload
+            .Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor).Should().BeTrue();
         reservationCallback.DueTime.Should().BePositive();
-        recoveryCallback.DueTime.Should().BePositive();
 
         await recovered.HandleEventAsync(reservationCallback.TriggerEnvelope.Clone());
 
+        callbacks.TimeoutRequests.Should().HaveCount(2);
+        var recoveryCallback = callbacks.TimeoutRequests.Last();
+        recoveryCallback.TriggerEnvelope.Payload
+            .Is(NyxIdChatRecoveryRequestedSignal.Descriptor).Should().BeTrue();
+        recoveryCallback.DueTime.Should().BePositive();
         operations.Should().Equal("history.reserve");
         var replayedReservation = history.Reservations.Should().ContainSingle().Which;
         replayedReservation.Should().BeEquivalentTo(new ChatHistoryTurnDeliveryReservation(
@@ -1063,11 +1065,11 @@ public sealed class NyxIdChatConversationGAgentTests
             .Unpack<NyxIdChatRecoveryRequestedSignal>();
         recovery.Key.OperationId.Should().Be(
             recovered.State.ActiveTask.Steps.Single().Operation.Key.OperationId);
-        recovery.ExpectedStateVersion.Should().Be(events[0].Version);
+        recovery.ExpectedStateVersion.Should().Be(events[^1].Version);
     }
 
     [Fact]
-    public async Task ActivateAsync_WhenPendingReservationRecoveryFails_ShouldScheduleRetryAndContinueOperationRecovery()
+    public async Task ActivateAsync_WhenPendingReservationRecoveryFails_ShouldScheduleRetryThenOperationRecovery()
     {
         const string conversationActorId = "conversation-alpha";
         var operations = new List<string>();
@@ -1095,17 +1097,14 @@ public sealed class NyxIdChatConversationGAgentTests
 
         recovered.State.HistoryDeliveryReservation.Dispatched.Should().BeFalse();
         recoveryDispatch.Calls.Should().BeEmpty();
-        callbacks.TimeoutRequests.Should().HaveCount(2);
-        var reservationCallback = callbacks.TimeoutRequests.Single(request =>
-            request.TriggerEnvelope.Payload.Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor));
-        callbacks.TimeoutRequests.Should().Contain(request =>
-            request.TriggerEnvelope.Payload.Is(NyxIdChatRecoveryRequestedSignal.Descriptor),
-            "history recovery scheduling failure must not suppress operation recovery scheduling");
+        var reservationCallback = callbacks.TimeoutRequests.Should().ContainSingle().Which;
+        reservationCallback.TriggerEnvelope.Payload
+            .Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor).Should().BeTrue();
 
         await recovered.HandleEventAsync(reservationCallback.TriggerEnvelope.Clone());
 
         recovered.State.HistoryDeliveryReservation.Dispatched.Should().BeFalse();
-        callbacks.TimeoutRequests.Should().HaveCount(3);
+        callbacks.TimeoutRequests.Should().HaveCount(2);
         var retryCallback = callbacks.TimeoutRequests.Last();
         retryCallback.TriggerEnvelope.Payload
             .Is(NyxIdChatHistoryDeliveryReservationDispatchRequested.Descriptor).Should().BeTrue();
@@ -1114,6 +1113,36 @@ public sealed class NyxIdChatConversationGAgentTests
         await recovered.HandleEventAsync(retryCallback.TriggerEnvelope.Clone());
 
         recovered.State.HistoryDeliveryReservation.Dispatched.Should().BeTrue();
+        callbacks.TimeoutRequests.Should().HaveCount(3);
+        callbacks.TimeoutRequests.Last().TriggerEnvelope.Payload
+            .Is(NyxIdChatRecoveryRequestedSignal.Descriptor).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ActivateAsync_WhenRecoverySchedulingFails_ShouldFailActivation()
+    {
+        const string conversationActorId = "conversation-alpha";
+        var history = new RecordingChatHistoryCommandPort([])
+        {
+            ReserveException = new OperationCanceledException("crash after turn commit"),
+        };
+        var eventStore = new InMemoryEventStoreForTests();
+        var callbacks = new RecordingRuntimeCallbackScheduler();
+        using var services = BuildEventSourcingServices(eventStore, history, callbacks);
+        var initial = CreateController(services, conversationActorId);
+        await initial.ActivateAsync();
+        await FluentActions.Invoking(() => initial.HandleEventAsync(
+                CreateEnvelope(conversationActorId, CreateStartTurnCommand())))
+            .Should().ThrowAsync<OperationCanceledException>();
+
+        callbacks.TimeoutRequests.Clear();
+        callbacks.ScheduleException = new InvalidOperationException("scheduler unavailable");
+        var recovered = CreateController(services, conversationActorId);
+
+        await FluentActions.Invoking(() => recovered.ActivateAsync())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("scheduler unavailable");
+        callbacks.TimeoutRequests.Should().BeEmpty();
     }
 
     [Fact]
@@ -4314,12 +4343,16 @@ public sealed class NyxIdChatConversationGAgentTests
     private sealed class RecordingRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
     {
         public List<RuntimeCallbackTimeoutRequest> TimeoutRequests { get; } = [];
+        public Exception? ScheduleException { get; set; }
 
         public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
             RuntimeCallbackTimeoutRequest request,
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            if (ScheduleException is not null)
+                return Task.FromException<RuntimeCallbackLease>(ScheduleException);
+
             TimeoutRequests.Add(new RuntimeCallbackTimeoutRequest
             {
                 ActorId = request.ActorId,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -367,6 +367,8 @@ public sealed class ChannelConversationTurnRunnerTests
         toolContext.Caller.OwnerSubject.Should().Be("scope-1");
         toolContext.Caller.ResponseId.Should().Be("msg-sched-1");
         toolContext.Channel.RegistrationScopeId.Should().Be("scope-1");
+        toolContext.ExecutionOwner.Kind.Should().Be(AgentToolExecutionOwnerKind.ChannelRegistration);
+        toolContext.ExecutionOwner.OwnerId.Should().Be("reg-1");
         // The inbound bot's provider slug is also exposed as the default OUTBOUND delivery provider,
         // so scheduled_agent_creator resolves one without manual config.
         toolContext.ExternalMetadata.Should().ContainKey(ChannelMetadataKeys.OutboundProviderSlug)


### PR DESCRIPTION
## Summary
- Move NyxID chat activation recovery to durable self callbacks instead of activation-time same-actor dispatch or side effects.
- Preserve existing typed recovery handlers while letting actor activation complete before recovery work runs.
- Update NyxID chat tests to assert callback-driven activation recovery and no activation-time dispatch.

## Test plan
- [x] `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter "FullyQualifiedName~NyxIdChatConversationGAgentTests"` (`75 passed, 0 failed`)
- [ ] `bash tools/ci/test_stability_guards.sh` blocked locally after initial checks by Python `pyexpat`/`libexpat` loader error (`ImportError: No module named expat; use SimpleXMLTreeBuilder instead`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)