### PR TITLE
Honor legacy workflow binding execution mode

### DIFF
--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/ProjectionWorkflowActorBindingReader.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/ProjectionWorkflowActorBindingReader.cs
@@ -206,6 +206,7 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
         var definitionActorId = string.IsNullOrWhiteSpace(document.DefinitionActorId) && actorKind == WorkflowActorKind.Definition
             ? actorId
             : document.DefinitionActorId ?? string.Empty;
+        var expectedExecutionMode = ResolveExpectedExecutionMode(document);
 
         return new WorkflowActorBinding(
             actorKind,
@@ -215,7 +216,7 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
             document.WorkflowName ?? string.Empty,
             document.WorkflowYaml ?? string.Empty,
             new Dictionary<string, string>(document.InlineWorkflowYamls, StringComparer.OrdinalIgnoreCase),
-            document.ExpectedExecutionMode,
+            expectedExecutionMode,
             document.ScopeId ?? string.Empty,
             document.StateVersion,
             document.LastEventId ?? string.Empty,
@@ -225,5 +226,14 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
             document.CapabilityAdmissionPlan?.Clone(),
             document.WorkflowId ?? string.Empty,
             document.RevisionId ?? string.Empty);
+    }
+
+    private static ExternalCapabilityExecutionMode ResolveExpectedExecutionMode(
+        WorkflowActorBindingDocument document)
+    {
+        if (document.ExpectedExecutionMode != ExternalCapabilityExecutionMode.Unspecified)
+            return document.ExpectedExecutionMode;
+
+        return document.CapabilityAdmissionPlan?.ExecutionMode ?? ExternalCapabilityExecutionMode.Unspecified;
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/RuntimeWorkflowActorBindingReaderTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/RuntimeWorkflowActorBindingReaderTests.cs
@@ -84,6 +84,33 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
     }
 
     [Fact]
+    public async Task GetAsync_ShouldUseCapabilityAdmissionExecutionMode_WhenProjectedExpectedModeMissing()
+    {
+        var capabilityAdmissionPlan = WorkflowCapabilityAdmissionPlanIntegrity.Create(
+            "yaml",
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            ExternalCapabilityExecutionMode.Interactive,
+            [],
+            []);
+        var reader = CreateReader(
+            getDocumentAsync: (_, _) => Task.FromResult<WorkflowActorBindingDocument?>(new WorkflowActorBindingDocument
+            {
+                Id = "actor-legacy",
+                ActorId = "actor-legacy",
+                ActorKind = WorkflowActorKind.Definition,
+                DefinitionActorId = "actor-legacy",
+                WorkflowName = "legacy",
+                WorkflowYaml = "yaml",
+                CapabilityAdmissionPlan = capabilityAdmissionPlan,
+            }));
+
+        var result = await reader.GetAsync("actor-legacy", CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.ExpectedExecutionMode.Should().Be(ExternalCapabilityExecutionMode.Interactive);
+    }
+
+    [Fact]
     public async Task GetAsync_ShouldUseProjectedDocumentKind_WhenRuntimeWouldInferDifferentKind()
     {
         var reader = CreateReader(


### PR DESCRIPTION
## Summary
- Map legacy workflow actor binding readmodels to the capability admission execution mode when `expected_execution_mode` was not projected yet.
- Keep explicit projected `expected_execution_mode` authoritative for newly materialized binding documents.
- Add a focused reader regression test for legacy binding documents.

## Test plan
- [x] `dotnet test /private/tmp/aevatar-workflow-binding-mode/test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo`
- [x] `PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" bash /private/tmp/aevatar-workflow-binding-mode/tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)