### PR TITLE
Propagate workflow file refs to role tools

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
@@ -161,6 +161,8 @@ internal static class ProtoToolArguments
             case JsonObject obj:
                 NormalizeEnumProperty(obj, "wait", NormalizeWaitEnum);
                 NormalizeEnumProperty(obj, "kind", NormalizeContentPartKind);
+                NormalizeEnumProperty(obj, "sourceKind", NormalizeChatFileSourceKind);
+                NormalizeEnumProperty(obj, "source_kind", NormalizeChatFileSourceKind);
                 foreach (var (_, child) in obj)
                     NormalizeToolEnums(child);
                 break;
@@ -179,7 +181,10 @@ internal static class ProtoToolArguments
         if (obj[propertyName] is not JsonValue value)
             return;
 
-        var raw = value.GetValue<string?>()?.Trim();
+        if (!value.TryGetValue<string>(out var raw))
+            return;
+
+        raw = raw.Trim();
         if (string.IsNullOrWhiteSpace(raw))
             return;
 
@@ -211,6 +216,22 @@ internal static class ProtoToolArguments
             "invocation_content_part_kind_audio" => "INVOCATION_CONTENT_PART_KIND_AUDIO",
             "invocation_content_part_kind_video" => "INVOCATION_CONTENT_PART_KIND_VIDEO",
             "invocation_content_part_kind_file" => "INVOCATION_CONTENT_PART_KIND_FILE",
+            _ => raw,
+        };
+
+    private static string NormalizeChatFileSourceKind(string raw) =>
+        raw.ToLowerInvariant() switch
+        {
+            "chat_input" => "CHAT_FILE_SOURCE_KIND_CHAT_INPUT",
+            "form_upload" => "CHAT_FILE_SOURCE_KIND_FORM_UPLOAD",
+            "connected_service_resource" => "CHAT_FILE_SOURCE_KIND_CONNECTED_SERVICE_RESOURCE",
+            "external_resource" => "CHAT_FILE_SOURCE_KIND_EXTERNAL_RESOURCE",
+            "generated" => "CHAT_FILE_SOURCE_KIND_GENERATED",
+            "chat_file_source_kind_chat_input" => "CHAT_FILE_SOURCE_KIND_CHAT_INPUT",
+            "chat_file_source_kind_form_upload" => "CHAT_FILE_SOURCE_KIND_FORM_UPLOAD",
+            "chat_file_source_kind_connected_service_resource" => "CHAT_FILE_SOURCE_KIND_CONNECTED_SERVICE_RESOURCE",
+            "chat_file_source_kind_external_resource" => "CHAT_FILE_SOURCE_KIND_EXTERNAL_RESOURCE",
+            "chat_file_source_kind_generated" => "CHAT_FILE_SOURCE_KIND_GENERATED",
             _ => raw,
         };
 }

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -287,6 +287,9 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<
             IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>,
             WorkflowCatalogCurrentStateDocumentMetadataProvider>();
+        services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowActorBindingDocument>,
+            WorkflowActorBindingDocumentMetadataProvider>();
 
         if (documentProvider.ElasticsearchEnabled)
         {
@@ -319,6 +322,7 @@ public static class ServiceCollectionExtensions
                 NyxIdAuthorizationCatalogVersionRegressionRepairService>();
             TryAddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowActorBindingDocument>(services, configuration, static readModel => readModel.Id);
         }
         else
         {
@@ -341,6 +345,7 @@ public static class ServiceCollectionExtensions
             TryAddInMemoryDocumentProjectionStore<NyxIdAuthorizationCatalogDocument>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<WorkflowActorBindingDocument>(services, static readModel => readModel.Id);
         }
 
         return services;
@@ -368,7 +373,8 @@ public static class ServiceCollectionExtensions
                && HasProjectionDocumentReaderForProvider<ScheduledDispatchDocument>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<NyxIdAuthorizationCatalogDocument>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind)
-               && HasProjectionDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind);
+               && HasProjectionDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowActorBindingDocument>(services, providerKind);
     }
 
     private static bool HasAnyProjectionDocumentReader<TReadModel>(IServiceCollection services)

--- a/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Integration.AI/WorkflowRoleGAgent.cs
@@ -1064,6 +1064,7 @@ public class WorkflowRoleGAgent(
         {
             InvocationSurface = AgentToolInvocationSurface.WorkflowLlmToolLoop,
             Chat = WorkflowChatContext(intent.RunId, intent.SessionId, intent.StepId),
+            InputFileRefs = intent.InputFileRefs.Select(ToChatFileRef).ToArray(),
         };
 
         var request = new ChatRequestEvent

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1475,7 +1475,7 @@ public sealed class AevatarInvocationToolSourceTests
                     "file_ref": {
                       "file_id": "file-lark-1",
                       "artifact_id": "workflow-file://file-lark-1",
-                      "source_kind": 3,
+                      "source_kind": "chat_file_source_kind_connected_service_resource",
                       "source_message_id": "om_lark_1",
                       "source_resource_key": "file_key_1",
                       "file_name": "invoice.pdf",

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -461,6 +461,9 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         app.Services.GetRequiredService<IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument>>()
             .Should()
             .NotBeNull();
+        app.Services.GetRequiredService<IProjectionDocumentReader<WorkflowActorBindingDocument, string>>()
+            .Should()
+            .NotBeNull();
         AssertNoWorkflowCapabilitiesStartupArtifactServices(builder.Services);
     }
 
@@ -596,6 +599,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<UserConfigCurrentStateDocument, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowActorBindingDocument, string>>().Should().NotBeNull();
         AssertNoWorkflowCapabilitiesStartupArtifactServices(services);
         services.Count(x => x.ServiceType == typeof(IProjectionDocumentReader<ServiceCatalogReadModel, string>)).Should().Be(1);
     }
@@ -649,6 +653,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         provider.GetRequiredService<IProjectionDocumentReader<GAgentRunTerminalReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowActorBindingDocument, string>>().Should().NotBeNull();
         AssertNoWorkflowCapabilitiesStartupArtifactServices(services);
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -221,6 +221,20 @@ public sealed class WorkflowRoleGAgentMappingTests
         fileRef.Sha256.Should().Be("sha-file-role");
         fileRef.CreatedAtUnixMs.Should().Be(1710000000000);
         fileRef.ExpiresAtUnixMs.Should().Be(1710003600000);
+
+        provider.LastRequest.ToolContext.Should().NotBeNull();
+        var toolContextFileRef = provider.LastRequest.ToolContext!.InputFileRefs.Should().ContainSingle().Subject;
+        toolContextFileRef.FileId.Should().Be("file-role");
+        toolContextFileRef.ArtifactId.Should().Be("workflow-file://file-role");
+        toolContextFileRef.SourceKind.Should().Be(Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource);
+        toolContextFileRef.SourceMessageId.Should().Be("om_1");
+        toolContextFileRef.SourceResourceKey.Should().Be("image_key_1");
+        toolContextFileRef.FileName.Should().Be("file-role.png");
+        toolContextFileRef.MediaType.Should().Be("image/png");
+        toolContextFileRef.SizeBytes.Should().Be(3);
+        toolContextFileRef.Sha256.Should().Be("sha-file-role");
+        toolContextFileRef.CreatedAtUnixMs.Should().Be(1710000000000);
+        toolContextFileRef.ExpiresAtUnixMs.Should().Be(1710003600000);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Preserve workflow input file refs in the role LLM tool context so downstream workflow tools can resolve the current input file.
- Reuse the existing `document_extract` / `spreadsheet_extract` file artifact read path instead of adding a new download path.
- Accept lowercase `source_kind` enum strings in `aevatar_start_workflow` tool arguments to match real Lark payloads.
- Register workflow actor binding projection stores in GAgentService projection provider composition so standalone capability hosts can resolve workflow binding readers.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowRoleGAgentMappingTests"`
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo --filter "FullyQualifiedName~StartWorkflow"`
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests.AddGAgentServiceCapabilityBundle_ShouldStartStandaloneWithoutMainnetWorkflowProviders"`
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests.AddGAgentServiceProjectionReadModelProviders"`
- [x] `PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)