### PR TITLE
Expose workflow file refs to role tools

### DIFF
--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -44,8 +45,13 @@ public static class ServiceCollectionExtensions
         // Replace the Noop fallback from Application layer with the real file export adapter.
         services.Replace(ServiceDescriptor.Singleton<IWorkflowRunReportExportPort, FileSystemWorkflowRunReportExporter>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, WorkflowFileArtifactCleanupHostedService>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowDocumentExtractToolSource>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowSpreadsheetExtractToolSource>());
+        services.TryAddSingleton<WorkflowDocumentExtractToolSource>();
+        services.TryAddSingleton<WorkflowSpreadsheetExtractToolSource>();
+        services.AddSingleton<IWorkflowToolSource>(sp =>
+            sp.GetRequiredService<WorkflowDocumentExtractToolSource>());
+        services.AddSingleton<IWorkflowToolSource>(sp =>
+            sp.GetRequiredService<WorkflowSpreadsheetExtractToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, WorkflowFileExtractionAgentToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowConnectedServiceResourceFetchToolSource>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowToolSource, WorkflowFileSubmitToolSource>());
         services.TryAddSingleton<

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowFileExtractionAgentToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowFileExtractionAgentToolSource.cs
@@ -41,16 +41,37 @@ public sealed class WorkflowFileExtractionAgentToolSource(
             "document_extract" =>
                 "{\"type\":\"object\",\"properties\":{\"fileRef\":{\"type\":\"object\"},\"extraction_kind\":{\"type\":\"string\",\"enum\":[\"text\",\"schema_bound_json\"]},\"maxChars\":{\"type\":\"integer\"},\"schema_contract\":{\"type\":\"object\"}},\"additionalProperties\":true}",
             "spreadsheet_extract" =>
-                "{\"type\":\"object\",\"properties\":{\"fileRef\":{\"type\":\"object\"},\"worksheet\":{\"type\":\"string\"},\"maxRows\":{\"type\":\"integer\"}},\"additionalProperties\":true}",
+                "{\"type\":\"object\",\"properties\":{\"fileRef\":{\"type\":\"object\"}},\"additionalProperties\":true}",
             _ => "{\"type\":\"object\"}",
         };
 
         public bool IsReadOnly => true;
 
+        public async Task<AgentToolTerminalOutcome> ExecuteWithOutcomeAsync(
+            string callId,
+            string toolName,
+            string argumentsJson,
+            CancellationToken ct = default)
+        {
+            var result = await ExecuteWorkflowToolAsync(argumentsJson, ct).ConfigureAwait(false);
+            var resultJson = ToResultJson(result);
+            return new AgentToolTerminalOutcome(
+                resultJson,
+                ToReceipt(callId, toolName, resultJson, result.Failure));
+        }
+
         public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
         {
+            var result = await ExecuteWorkflowToolAsync(argumentsJson, ct).ConfigureAwait(false);
+            return ToResultJson(result);
+        }
+
+        private async Task<WorkflowToolExecutionResult> ExecuteWorkflowToolAsync(
+            string argumentsJson,
+            CancellationToken ct)
+        {
             var context = AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty;
-            var result = await _tool.ExecuteAsync(
+            return await _tool.ExecuteAsync(
                 new WorkflowToolExecutionRequest(
                     string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson,
                     Normalize(context.WorkflowRuntime.ParentRunId) ?? Normalize(context.Request.RequestId) ?? string.Empty,
@@ -64,7 +85,26 @@ public sealed class WorkflowFileExtractionAgentToolSource(
                     IdempotencyKey: Normalize(context.Request.IdempotencyKey) ?? string.Empty,
                     ScheduleId: Normalize(context.Schedule.ScheduleId) ?? string.Empty),
                 ct).ConfigureAwait(false);
+        }
 
+        private AgentToolReceipt ToReceipt(
+            string callId,
+            string toolName,
+            string resultJson,
+            WorkflowToolExecutionFailure? failure) =>
+            new()
+            {
+                CallId = callId ?? string.Empty,
+                ToolName = string.IsNullOrWhiteSpace(toolName) ? Name : toolName,
+                Status = failure == null ? AgentToolReceiptStatus.Success : AgentToolReceiptStatus.Error,
+                ApprovalMode = AgentToolReceiptApprovalMode.NeverRequire,
+                ResultJson = resultJson ?? string.Empty,
+                ErrorCode = failure?.ErrorCode ?? string.Empty,
+                ErrorMessage = failure?.ErrorMessage ?? string.Empty,
+            };
+
+        private static string ToResultJson(WorkflowToolExecutionResult result)
+        {
             if (result.Failure == null || !string.IsNullOrWhiteSpace(result.ResultJson))
                 return result.ResultJson;
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowFileExtractionAgentToolSource.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowFileExtractionAgentToolSource.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Core.Modules;
+
+namespace Aevatar.Workflow.Infrastructure.Runs;
+
+public sealed class WorkflowFileExtractionAgentToolSource(
+    WorkflowDocumentExtractToolSource documentExtractToolSource,
+    WorkflowSpreadsheetExtractToolSource spreadsheetExtractToolSource) : IAgentToolSource
+{
+    private readonly WorkflowDocumentExtractToolSource _documentExtractToolSource = documentExtractToolSource;
+    private readonly WorkflowSpreadsheetExtractToolSource _spreadsheetExtractToolSource = spreadsheetExtractToolSource;
+
+    public async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+    {
+        var tools = new List<IAgentTool>();
+        tools.AddRange((await _documentExtractToolSource.GetToolsAsync(ct).ConfigureAwait(false))
+            .Select(static tool => new WorkflowFileExtractionAgentTool(tool)));
+        tools.AddRange((await _spreadsheetExtractToolSource.GetToolsAsync(ct).ConfigureAwait(false))
+            .Select(static tool => new WorkflowFileExtractionAgentTool(tool)));
+        return tools;
+    }
+
+    private sealed class WorkflowFileExtractionAgentTool(IWorkflowTool tool) : IAgentTool
+    {
+        private readonly IWorkflowTool _tool = tool;
+
+        public string Name => _tool.Name;
+
+        public string Description => _tool.Name switch
+        {
+            "document_extract" => "Extract text or schema-bound JSON from a workflow input document file reference.",
+            "spreadsheet_extract" => "Extract workbook data from a workflow input spreadsheet file reference.",
+            _ => "Read a workflow input file reference.",
+        };
+
+        public string ParametersSchema => _tool.Name switch
+        {
+            "document_extract" =>
+                "{\"type\":\"object\",\"properties\":{\"fileRef\":{\"type\":\"object\"},\"extraction_kind\":{\"type\":\"string\",\"enum\":[\"text\",\"schema_bound_json\"]},\"maxChars\":{\"type\":\"integer\"},\"schema_contract\":{\"type\":\"object\"}},\"additionalProperties\":true}",
+            "spreadsheet_extract" =>
+                "{\"type\":\"object\",\"properties\":{\"fileRef\":{\"type\":\"object\"},\"worksheet\":{\"type\":\"string\"},\"maxRows\":{\"type\":\"integer\"}},\"additionalProperties\":true}",
+            _ => "{\"type\":\"object\"}",
+        };
+
+        public bool IsReadOnly => true;
+
+        public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+        {
+            var context = AgentToolRequestContext.Current ?? AgentToolExecutionContext.Empty;
+            var result = await _tool.ExecuteAsync(
+                new WorkflowToolExecutionRequest(
+                    string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson,
+                    Normalize(context.WorkflowRuntime.ParentRunId) ?? Normalize(context.Request.RequestId) ?? string.Empty,
+                    Normalize(context.WorkflowRuntime.ParentStepId) ?? string.Empty,
+                    Normalize(context.Request.IdempotencyKey) ?? Normalize(context.Request.CallId) ?? string.Empty,
+                    Normalize(context.Request.CallId) ?? string.Empty,
+                    Normalize(context.Caller.ScopeId) ?? Normalize(context.Caller.OwnerScopeId) ?? string.Empty,
+                    ToWorkflowCallerCredential(context),
+                    ToWorkflowRuntimeContext(context.WorkflowRuntime),
+                    InputFileRefs: context.InputFileRefs.Select(ToWorkflowFileRef).ToArray(),
+                    IdempotencyKey: Normalize(context.Request.IdempotencyKey) ?? string.Empty,
+                    ScheduleId: Normalize(context.Schedule.ScheduleId) ?? string.Empty),
+                ct).ConfigureAwait(false);
+
+            if (result.Failure == null || !string.IsNullOrWhiteSpace(result.ResultJson))
+                return result.ResultJson;
+
+            return JsonSerializer.Serialize(new
+            {
+                error = new
+                {
+                    code = result.Failure.ErrorCode,
+                    message = result.Failure.ErrorMessage,
+                },
+            });
+        }
+
+        private static WorkflowCallerCredential ToWorkflowCallerCredential(AgentToolExecutionContext context) =>
+            new()
+            {
+                BearerToken = Normalize(context.Credentials.NyxIdAccessToken) ??
+                              Normalize(context.Credentials.SenderNyxIdAccessToken) ??
+                              string.Empty,
+                NyxIdAuthority = new WorkflowCallerNyxIdAuthority
+                {
+                    Platform = Normalize(context.NyxIdAuthority.Platform) ?? string.Empty,
+                    Tenant = Normalize(context.NyxIdAuthority.Tenant) ?? string.Empty,
+                    ExternalUserId = Normalize(context.NyxIdAuthority.ExternalUserId) ?? string.Empty,
+                    Scope = Normalize(context.NyxIdAuthority.Scope) ?? string.Empty,
+                    BindingId = Normalize(context.SenderBinding.BindingId) ?? string.Empty,
+                },
+            };
+
+        private static WorkflowToolRuntimeContext ToWorkflowRuntimeContext(AgentWorkflowRuntimeContext context) =>
+            new(
+                Normalize(context.ParentActorId) ?? string.Empty,
+                Normalize(context.ParentRunId) ?? string.Empty,
+                Normalize(context.ParentStepId) ?? string.Empty,
+                Normalize(context.RootRunId) ?? string.Empty,
+                Math.Max(0, context.Depth));
+
+        private static WorkflowFileRef ToWorkflowFileRef(ChatFileRef source) =>
+            new()
+            {
+                FileId = Normalize(source.FileId) ?? string.Empty,
+                ArtifactId = Normalize(source.ArtifactId) ?? string.Empty,
+                SourceKind = source.SourceKind switch
+                {
+                    ChatFileSourceKind.ChatInput => WorkflowFileSourceKind.ChatInput,
+                    ChatFileSourceKind.FormUpload => WorkflowFileSourceKind.FormUpload,
+                    ChatFileSourceKind.ConnectedServiceResource => WorkflowFileSourceKind.ConnectedServiceResource,
+                    ChatFileSourceKind.ExternalResource => WorkflowFileSourceKind.ExternalResource,
+                    ChatFileSourceKind.Generated => WorkflowFileSourceKind.Generated,
+                    _ => WorkflowFileSourceKind.Unspecified,
+                },
+                SourceMessageId = Normalize(source.SourceMessageId) ?? string.Empty,
+                SourceResourceKey = Normalize(source.SourceResourceKey) ?? string.Empty,
+                FileName = Normalize(source.FileName) ?? string.Empty,
+                MediaType = Normalize(source.MediaType) ?? string.Empty,
+                SizeBytes = source.SizeBytes,
+                Sha256 = Normalize(source.Sha256) ?? string.Empty,
+                CreatedAtUnixMs = source.CreatedAtUnixMs,
+                ExpiresAtUnixMs = source.ExpiresAtUnixMs,
+                OwnerRunId = Normalize(source.OwnerRunId) ?? string.Empty,
+                OwnerScopeId = Normalize(source.OwnerScopeId) ?? string.Empty,
+            };
+
+        private static string? Normalize(string? value) =>
+            string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
@@ -851,7 +851,13 @@ public sealed class WorkflowDocumentExtractToolTests
                 InputFileRefs = [ToChatInputFileRef(result.FileRef)],
             };
 
-            var output = await tool.ExecuteAsync("{}");
+            var outcome = await tool.ExecuteWithOutcomeAsync("agent-call-1", tool.Name, "{}");
+            var output = outcome.ResultJson;
+
+            outcome.Receipt.Should().NotBeNull();
+            outcome.Receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+            outcome.Receipt.ResultJson.Should().Be(output);
+            outcome.Receipt.ResultJson.Should().NotContain("tool_outcome_unknown");
 
             using var document = JsonDocument.Parse(output);
             var rootElement = document.RootElement;
@@ -866,6 +872,24 @@ public sealed class WorkflowDocumentExtractToolTests
             if (Directory.Exists(root))
                 Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task WorkflowFileExtractionAgentTool_ShouldAdvertiseOnlySupportedSpreadsheetArguments()
+    {
+        var source = new WorkflowFileExtractionAgentToolSource(
+            new WorkflowDocumentExtractToolSource(CreateFileArtifactPort(Path.GetTempPath())),
+            new WorkflowSpreadsheetExtractToolSource(
+                CreateFileArtifactPort(Path.GetTempPath()),
+                Microsoft.Extensions.Options.Options.Create(new WorkflowSpreadsheetExtractOptions())));
+        var agentTools = await source.DiscoverToolsAsync();
+        var tool = agentTools.Should().ContainSingle(x => x.Name == "spreadsheet_extract").Subject;
+
+        using var schema = JsonDocument.Parse(tool.ParametersSchema);
+        var properties = schema.RootElement.GetProperty("properties");
+        properties.TryGetProperty("fileRef", out _).Should().BeTrue();
+        properties.TryGetProperty("worksheet", out _).Should().BeFalse();
+        properties.TryGetProperty("maxRows", out _).Should().BeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDocumentExtractToolTests.cs
@@ -1,4 +1,6 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
@@ -822,6 +824,51 @@ public sealed class WorkflowDocumentExtractToolTests
     }
 
     [Fact]
+    public async Task WorkflowFileExtractionAgentTool_ShouldUseAmbientInputFileRef()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-file-extraction-agent-tool-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var port = CreateFileArtifactPort(root);
+            var result = await port.IngestAsync(new FileArtifactIngressRequest(
+                System.Text.Encoding.UTF8.GetBytes("invoice total 42"),
+                ApplicationFileArtifactSourceKind.ChatInput,
+                FileName: "invoice.txt",
+                MediaType: "text/plain"));
+            var source = new WorkflowFileExtractionAgentToolSource(
+                new WorkflowDocumentExtractToolSource(port),
+                new WorkflowSpreadsheetExtractToolSource(
+                    port,
+                    Microsoft.Extensions.Options.Options.Create(new WorkflowSpreadsheetExtractOptions())));
+            var agentTools = await source.DiscoverToolsAsync();
+            var tool = agentTools.Should().ContainSingle(x => x.Name == "document_extract").Subject;
+            tool.IsReadOnly.Should().BeTrue();
+
+            AgentToolRequestContext.Current = AgentToolExecutionContext.Empty with
+            {
+                Caller = new AgentToolCallerContext("scope-1", null, null),
+                WorkflowRuntime = new AgentWorkflowRuntimeContext("actor-1", "run-1", "extract", "run-1", 1),
+                InputFileRefs = [ToChatInputFileRef(result.FileRef)],
+            };
+
+            var output = await tool.ExecuteAsync("{}");
+
+            using var document = JsonDocument.Parse(output);
+            var rootElement = document.RootElement;
+            rootElement.GetProperty("extraction_kind").GetString().Should().Be("utf8_text");
+            rootElement.GetProperty("media_type").GetString().Should().Be("text/plain");
+            rootElement.GetProperty("file").GetProperty("file_id").GetString().Should().Be(result.FileRef.FileId);
+            rootElement.GetProperty("text").GetString().Should().Be("invoice total 42");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task WorkflowDocumentExtractTool_ShouldNotTreatAttachmentRefAsFileIdentity()
     {
         var root = Path.Combine(Path.GetTempPath(), "aevatar-workflow-document-extract-attachment-ref-tests", Guid.NewGuid().ToString("N"));
@@ -1281,6 +1328,32 @@ public sealed class WorkflowDocumentExtractToolTests
         var tools = await source.GetToolsAsync();
         return tools.Should().ContainSingle(x => x.Name == "document_extract").Subject;
     }
+
+    private static Aevatar.AI.Abstractions.ChatFileRef ToChatInputFileRef(ApplicationFileArtifactRef fileRef) =>
+        new()
+        {
+            FileId = fileRef.FileId ?? string.Empty,
+            ArtifactId = fileRef.ArtifactId ?? string.Empty,
+            SourceKind = fileRef.SourceKind switch
+            {
+                ApplicationFileArtifactSourceKind.ChatInput => Aevatar.AI.Abstractions.ChatFileSourceKind.ChatInput,
+                ApplicationFileArtifactSourceKind.FormUpload => Aevatar.AI.Abstractions.ChatFileSourceKind.FormUpload,
+                ApplicationFileArtifactSourceKind.ConnectedServiceResource => Aevatar.AI.Abstractions.ChatFileSourceKind.ConnectedServiceResource,
+                ApplicationFileArtifactSourceKind.ExternalResource => Aevatar.AI.Abstractions.ChatFileSourceKind.ExternalResource,
+                ApplicationFileArtifactSourceKind.Generated => Aevatar.AI.Abstractions.ChatFileSourceKind.Generated,
+                _ => Aevatar.AI.Abstractions.ChatFileSourceKind.Unspecified,
+            },
+            SourceMessageId = fileRef.SourceMessageId ?? string.Empty,
+            SourceResourceKey = fileRef.SourceResourceKey ?? string.Empty,
+            FileName = fileRef.FileName ?? string.Empty,
+            MediaType = fileRef.MediaType ?? string.Empty,
+            SizeBytes = fileRef.SizeBytes,
+            Sha256 = fileRef.Sha256 ?? string.Empty,
+            CreatedAtUnixMs = fileRef.CreatedAtUnixMs,
+            ExpiresAtUnixMs = fileRef.ExpiresAtUnixMs,
+            OwnerRunId = fileRef.OwnerRunId ?? string.Empty,
+            OwnerScopeId = fileRef.OwnerScopeId ?? string.Empty,
+        };
 
     private static ProtoWorkflowFileRef ToProtoInputFileRef(ApplicationFileArtifactRef fileRef) =>
         new()

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
@@ -97,6 +98,15 @@ public sealed class WorkflowInfrastructureCoverageTests
 
         toolNames.Should().Contain("document_extract");
         toolNames.Should().Contain("spreadsheet_extract");
+        var agentToolNames = new List<string>();
+        foreach (var agentToolSource in provider.GetServices<IAgentToolSource>())
+        {
+            var agentTools = await agentToolSource.DiscoverToolsAsync();
+            agentToolNames.AddRange(agentTools.Select(x => x.Name));
+        }
+
+        agentToolNames.Should().Contain("document_extract");
+        agentToolNames.Should().Contain("spreadsheet_extract");
         provider.GetRequiredService<IOptions<WorkflowSpreadsheetExtractOptions>>()
             .Value.MaxRowsPerSheet.Should().Be(50);
         services.Should().Contain(x =>


### PR DESCRIPTION
## Summary
- Expose the existing workflow document/spreadsheet extraction tools through the agent tool surface for workflow role tool loops.
- Carry workflow input file refs into the role tool execution context so extraction tools can reuse the existing artifact-backed `OpenReadAsync` path.
- Add focused coverage for ambient input file refs through the agent adapter and DI registration.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter \"FullyQualifiedName~WorkflowRoleGAgent_ShouldMapWorkflowFileRefsToChatUriPartsWithoutBase64\" -v:q`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter \"FullyQualifiedName~WorkflowFileExtractionAgentTool_ShouldUseAmbientInputFileRef|FullyQualifiedName~AddWorkflowInfrastructure_ShouldReplaceReportSink_AndRegisterPorts\" -v:q`
- [x] `PATH=\"/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin\" bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)