### PR TITLE
Preserve workflow input file refs

### DIFF
--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -452,7 +452,7 @@ public sealed class AevatarInvocationDispatcher
                 .Where(static item => !string.IsNullOrWhiteSpace(item))
                 .Select(static item => item.Trim())
                 .ToArray();
-        var workflowName = request.WorkflowId.Trim();
+        var workflowName = request.WorkflowId!.Trim();
         var actorId = string.IsNullOrWhiteSpace(request.ActorId) ? null : request.ActorId.Trim();
         if (isManagedWorkflowRuntime)
         {
@@ -468,6 +468,7 @@ public sealed class AevatarInvocationDispatcher
                 workflowRuntimeContext,
                 workflowName,
                 workflowYamls,
+                toolContext,
                 ct);
         }
 
@@ -735,6 +736,7 @@ public sealed class AevatarInvocationDispatcher
         AgentWorkflowRuntimeContext workflowRuntimeContext,
         string workflowName,
         IReadOnlyList<string>? workflowYamls,
+        AgentToolExecutionContext? toolContext,
         CancellationToken ct)
     {
         if (!string.IsNullOrWhiteSpace(request.ActorId))
@@ -765,18 +767,21 @@ public sealed class AevatarInvocationDispatcher
                 : workflowRuntimeContext.RootRunId.Trim(),
             RequestedDepth = Math.Max(0, workflowRuntimeContext.Depth) + 1,
         };
-        managedStart.InputFileRefs.Add(request.Inputs.InputParts
+        var effectiveInputParts = ToEffectiveInputParts(request.Inputs, toolContext);
+        managedStart.InputFileRefs.Add(effectiveInputParts
             .Select(static part => ToWorkflowEventFileRef(part.FileRef))
             .Where(static fileRef => fileRef != null)
             .Select(static fileRef => fileRef!.Clone()));
         var firstManagedFileRef = managedStart.InputFileRefs.FirstOrDefault();
         _logger.LogWarning(
-            "Managed sub-workflow input file refs resolved: workflowId={WorkflowId} parentRunId={ParentRunId} parentStepId={ParentStepId} commandId={CommandId} explicitInputPartCount={ExplicitInputPartCount} managedInputFileRefCount={ManagedInputFileRefCount} firstFileId={FirstFileId} firstArtifactId={FirstArtifactId} firstMediaType={FirstMediaType}",
+            "Managed sub-workflow input file refs resolved: workflowId={WorkflowId} parentRunId={ParentRunId} parentStepId={ParentStepId} commandId={CommandId} explicitInputPartCount={ExplicitInputPartCount} explicitInputFileRefCount={ExplicitInputFileRefCount} ambientToolContextFileRefCount={AmbientToolContextFileRefCount} managedInputFileRefCount={ManagedInputFileRefCount} firstFileId={FirstFileId} firstArtifactId={FirstArtifactId} firstMediaType={FirstMediaType}",
             workflowName,
             parentRunId,
             parentStepId,
             commandId,
             request.Inputs.InputParts.Count,
+            CountExplicitInputFileRefs(request.Inputs),
+            toolContext?.InputFileRefs.Count ?? 0,
             managedStart.InputFileRefs.Count,
             firstManagedFileRef?.FileId ?? string.Empty,
             firstManagedFileRef?.ArtifactId ?? string.Empty,

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -1103,11 +1103,12 @@ public sealed partial class WorkflowRunGAgent
             .Select(fileRef =>
             {
                 var clone = fileRef.Clone();
-                if (!string.IsNullOrWhiteSpace(clone.OwnerRunId))
-                    return clone;
+                if (string.IsNullOrWhiteSpace(clone.OwnerRunId))
+                {
+                    clone.OwnerRunId = runId;
+                    clone.OwnerScopeId = scopeId ?? string.Empty;
+                }
 
-                clone.OwnerRunId = runId;
-                clone.OwnerScopeId = scopeId ?? string.Empty;
                 return clone;
             })
             .ToArray();
@@ -1122,15 +1123,12 @@ public sealed partial class WorkflowRunGAgent
 
         foreach (var fileRef in fileRefs)
         {
-            if (!ShouldBindInputFileArtifact(fileRef, runId))
-                continue;
-
             try
             {
                 await _fileArtifactOwnership.BindOwnerAsync(
                     ToApplicationFileArtifactRef(fileRef),
-                    runId,
-                    scopeId,
+                    ResolveInputFileArtifactOwnerRunId(fileRef, runId),
+                    ResolveInputFileArtifactOwnerScopeId(fileRef, scopeId),
                     CancellationToken.None);
             }
             catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or FileNotFoundException or IOException or UnauthorizedAccessException)
@@ -1143,8 +1141,11 @@ public sealed partial class WorkflowRunGAgent
         return true;
     }
 
-    private static bool ShouldBindInputFileArtifact(WorkflowFileRef fileRef, string runId) =>
-        string.Equals(fileRef.OwnerRunId?.Trim(), runId, StringComparison.Ordinal);
+    private static string ResolveInputFileArtifactOwnerRunId(WorkflowFileRef fileRef, string runId) =>
+        string.IsNullOrWhiteSpace(fileRef.OwnerRunId) ? runId : fileRef.OwnerRunId.Trim();
+
+    private static string ResolveInputFileArtifactOwnerScopeId(WorkflowFileRef fileRef, string scopeId) =>
+        string.IsNullOrWhiteSpace(fileRef.OwnerScopeId) ? scopeId : fileRef.OwnerScopeId.Trim();
 
     private static ApplicationFileArtifactRef ToApplicationFileArtifactRef(WorkflowFileRef source) =>
         new()

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -1103,6 +1103,9 @@ public sealed partial class WorkflowRunGAgent
             .Select(fileRef =>
             {
                 var clone = fileRef.Clone();
+                if (!string.IsNullOrWhiteSpace(clone.OwnerRunId))
+                    return clone;
+
                 clone.OwnerRunId = runId;
                 clone.OwnerScopeId = scopeId ?? string.Empty;
                 return clone;
@@ -1119,6 +1122,9 @@ public sealed partial class WorkflowRunGAgent
 
         foreach (var fileRef in fileRefs)
         {
+            if (!ShouldBindInputFileArtifact(fileRef, runId))
+                continue;
+
             try
             {
                 await _fileArtifactOwnership.BindOwnerAsync(
@@ -1136,6 +1142,9 @@ public sealed partial class WorkflowRunGAgent
 
         return true;
     }
+
+    private static bool ShouldBindInputFileArtifact(WorkflowFileRef fileRef, string runId) =>
+        string.Equals(fileRef.OwnerRunId?.Trim(), runId, StringComparison.Ordinal);
 
     private static ApplicationFileArtifactRef ToApplicationFileArtifactRef(WorkflowFileRef source) =>
         new()

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -573,7 +573,7 @@ public sealed partial class WorkflowRunGAgent
             firstInputFileRef?.FileId ?? string.Empty,
             firstInputFileRef?.ArtifactId ?? string.Empty,
             firstInputFileRef?.MediaType ?? string.Empty);
-        if (!await BindInputFileArtifactsAsync(inputFileRefs, runId, scopeId ?? string.Empty))
+        if (!await BindInputFileArtifactsAsync(inputFileRefs, runId))
         {
             await HandleWorkflowCompleted(new WorkflowCompletedEvent
             {
@@ -1106,7 +1106,7 @@ public sealed partial class WorkflowRunGAgent
                 if (string.IsNullOrWhiteSpace(clone.OwnerRunId))
                 {
                     clone.OwnerRunId = runId;
-                    clone.OwnerScopeId = scopeId ?? string.Empty;
+                    clone.OwnerScopeId = scopeId;
                 }
 
                 return clone;
@@ -1115,8 +1115,7 @@ public sealed partial class WorkflowRunGAgent
 
     private async Task<bool> BindInputFileArtifactsAsync(
         IReadOnlyList<WorkflowFileRef> fileRefs,
-        string runId,
-        string scopeId)
+        string runId)
     {
         if (fileRefs.Count == 0 || _fileArtifactOwnership == null)
             return true;
@@ -1127,8 +1126,8 @@ public sealed partial class WorkflowRunGAgent
             {
                 await _fileArtifactOwnership.BindOwnerAsync(
                     ToApplicationFileArtifactRef(fileRef),
-                    ResolveInputFileArtifactOwnerRunId(fileRef, runId),
-                    ResolveInputFileArtifactOwnerScopeId(fileRef, scopeId),
+                    fileRef.OwnerRunId!,
+                    fileRef.OwnerScopeId,
                     CancellationToken.None);
             }
             catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or FileNotFoundException or IOException or UnauthorizedAccessException)
@@ -1140,12 +1139,6 @@ public sealed partial class WorkflowRunGAgent
 
         return true;
     }
-
-    private static string ResolveInputFileArtifactOwnerRunId(WorkflowFileRef fileRef, string runId) =>
-        string.IsNullOrWhiteSpace(fileRef.OwnerRunId) ? runId : fileRef.OwnerRunId.Trim();
-
-    private static string ResolveInputFileArtifactOwnerScopeId(WorkflowFileRef fileRef, string scopeId) =>
-        string.IsNullOrWhiteSpace(fileRef.OwnerScopeId) ? scopeId : fileRef.OwnerScopeId.Trim();
 
     private static ApplicationFileArtifactRef ToApplicationFileArtifactRef(WorkflowFileRef source) =>
         new()

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -3068,7 +3068,7 @@ public sealed class AevatarInvocationToolSourceTests
     }
 
     [Fact]
-    public async Task StartWorkflow_WhenManagedRuntimeExists_ShouldNotPopulateInputFileRefsFromAmbientRefs()
+    public async Task StartWorkflow_WhenManagedRuntimeExists_ShouldPopulateInputFileRefsFromAmbientRefs()
     {
         var harness = new Harness();
         var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
@@ -3107,7 +3107,15 @@ public sealed class AevatarInvocationToolSourceTests
         receipt!.ManagedWorkflowHandoff.Should().NotBeNull();
         var requested = harness.ActorDispatch.Calls.Should().ContainSingle().Subject.Envelope.Payload
             .Unpack<SubWorkflowInvokeRequestedEvent>();
-        requested.InputFileRefs.Should().BeEmpty();
+        var fileRef = requested.InputFileRefs.Should().ContainSingle().Subject;
+        fileRef.FileId.Should().Be("file-ambient-child-1");
+        fileRef.ArtifactId.Should().Be("workflow-file://file-ambient-child-1");
+        fileRef.SourceKind.Should().Be(Aevatar.Workflow.Abstractions.WorkflowFileSourceKind.ConnectedServiceResource);
+        fileRef.SourceMessageId.Should().Be("om_ambient_child_1");
+        fileRef.SourceResourceKey.Should().Be("file_key_ambient_child_1");
+        fileRef.FileName.Should().Be("ambient-child.pdf");
+        fileRef.MediaType.Should().Be("application/pdf");
+        fileRef.SizeBytes.Should().Be(654);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentRelayedTerminalAdoptionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentRelayedTerminalAdoptionTests.cs
@@ -479,6 +479,45 @@ public sealed class WorkflowRunGAgentRelayedTerminalAdoptionTests
     }
 
     [Fact]
+    public async Task ChatRequest_WhenInputFileRefHasNoOwner_ShouldBindWithCurrentRunOwner()
+    {
+        var runId = "run-file-ownerless-" + Guid.NewGuid().ToString("N");
+        var ownershipPort = new RecordingWorkflowFileArtifactOwnershipPort();
+        var harness = await CreateRunAsync(runId, fileOwnershipPort: ownershipPort);
+        var request = CreateNotificationTargetRequest();
+        request.InputParts.Add(new WorkflowChatInputPartPayload
+        {
+            Kind = WorkflowChatInputPartKind.File,
+            FileRef = new WorkflowFileRef
+            {
+                FileId = "file-ownerless-1",
+                ArtifactId = "workflow-file://file-ownerless-1",
+                SourceKind = WorkflowFileSourceKind.ChatInput,
+            },
+        });
+
+        await harness.Agent.HandleEventAsync(EnvelopeFrom(
+            "api",
+            request,
+            envelopeId: "command-1",
+            correlationId: "correlation-1"));
+
+        var bindRequest = ownershipPort.BindRequests.Should().ContainSingle().Subject;
+        bindRequest.OwnerRunId.Should().Be(runId);
+        bindRequest.OwnerScopeId.Should().Be("scope-1");
+        var fileRef = CommittedEvents<WorkflowRunExecutionStartedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle()
+            .Subject
+            .InputFileRefs
+            .Should()
+            .ContainSingle()
+            .Subject;
+        fileRef.OwnerRunId.Should().Be(runId);
+        fileRef.OwnerScopeId.Should().Be("scope-1");
+    }
+
+    [Fact]
     public async Task RelayedOwnRunCompletion_WithNotificationTarget_ShouldDispatchAdoptedTerminal()
     {
         var harness = await CreateStartedRunAsync(includeCompletionNotificationTarget: true);

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentRelayedTerminalAdoptionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentRelayedTerminalAdoptionTests.cs
@@ -438,6 +438,45 @@ public sealed class WorkflowRunGAgentRelayedTerminalAdoptionTests
     }
 
     [Fact]
+    public async Task ChatRequest_WhenInputFileRefAlreadyHasOwner_ShouldNotRebindOwner()
+    {
+        var runId = "run-file-prebound-" + Guid.NewGuid().ToString("N");
+        var ownershipPort = new RecordingWorkflowFileArtifactOwnershipPort();
+        var harness = await CreateRunAsync(runId, fileOwnershipPort: ownershipPort);
+        var request = CreateNotificationTargetRequest();
+        request.InputParts.Add(new WorkflowChatInputPartPayload
+        {
+            Kind = WorkflowChatInputPartKind.File,
+            FileRef = new WorkflowFileRef
+            {
+                FileId = "file-1",
+                ArtifactId = "workflow-file://file-1",
+                SourceKind = WorkflowFileSourceKind.ChatInput,
+                OwnerRunId = "source-run",
+                OwnerScopeId = "source-scope",
+            },
+        });
+
+        await harness.Agent.HandleEventAsync(EnvelopeFrom(
+            "api",
+            request,
+            envelopeId: "command-1",
+            correlationId: "correlation-1"));
+
+        ownershipPort.BindRequests.Should().BeEmpty();
+        var fileRef = CommittedEvents<WorkflowRunExecutionStartedEvent>(harness.CommittedPublisher)
+            .Should()
+            .ContainSingle()
+            .Subject
+            .InputFileRefs
+            .Should()
+            .ContainSingle()
+            .Subject;
+        fileRef.OwnerRunId.Should().Be("source-run");
+        fileRef.OwnerScopeId.Should().Be("source-scope");
+    }
+
+    [Fact]
     public async Task RelayedOwnRunCompletion_WithNotificationTarget_ShouldDispatchAdoptedTerminal()
     {
         var harness = await CreateStartedRunAsync(includeCompletionNotificationTarget: true);
@@ -1155,6 +1194,22 @@ public sealed class WorkflowRunGAgentRelayedTerminalAdoptionTests
             string? ownerScopeId,
             CancellationToken cancellationToken = default) =>
             ValueTask.FromException(new InvalidOperationException("file owner binding failed"));
+    }
+
+    private sealed class RecordingWorkflowFileArtifactOwnershipPort
+        : Aevatar.Workflow.Application.Abstractions.Runs.IFileArtifactOwnershipPort
+    {
+        public List<(Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactRef FileRef, string OwnerRunId, string? OwnerScopeId)> BindRequests { get; } = [];
+
+        public ValueTask BindOwnerAsync(
+            Aevatar.Workflow.Application.Abstractions.Runs.FileArtifactRef fileRef,
+            string ownerRunId,
+            string? ownerScopeId,
+            CancellationToken cancellationToken = default)
+        {
+            BindRequests.Add((fileRef, ownerRunId, ownerScopeId));
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class EmptyEventModuleFactory : IEventModuleFactory<IWorkflowExecutionContext>

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentRelayedTerminalAdoptionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentRelayedTerminalAdoptionTests.cs
@@ -438,7 +438,7 @@ public sealed class WorkflowRunGAgentRelayedTerminalAdoptionTests
     }
 
     [Fact]
-    public async Task ChatRequest_WhenInputFileRefAlreadyHasOwner_ShouldNotRebindOwner()
+    public async Task ChatRequest_WhenInputFileRefAlreadyHasOwner_ShouldBindWithExistingOwner()
     {
         var runId = "run-file-prebound-" + Guid.NewGuid().ToString("N");
         var ownershipPort = new RecordingWorkflowFileArtifactOwnershipPort();
@@ -463,7 +463,9 @@ public sealed class WorkflowRunGAgentRelayedTerminalAdoptionTests
             envelopeId: "command-1",
             correlationId: "correlation-1"));
 
-        ownershipPort.BindRequests.Should().BeEmpty();
+        var bindRequest = ownershipPort.BindRequests.Should().ContainSingle().Subject;
+        bindRequest.OwnerRunId.Should().Be("source-run");
+        bindRequest.OwnerScopeId.Should().Be("source-scope");
         var fileRef = CommittedEvents<WorkflowRunExecutionStartedEvent>(harness.CommittedPublisher)
             .Should()
             .ContainSingle()


### PR DESCRIPTION
## Summary
- Normalize ambient tool-context file refs into the existing `aevatar_start_workflow` input file-ref path when explicit file refs are absent.
- Apply the same ambient file-ref normalization to managed sub-workflow starts.
- Preserve pre-owned workflow input file refs and only bind ownerless/current-run refs.

## Test plan
- [x] `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo --filter "StartWorkflow"`
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowRunGAgentRelayedTerminalAdoptionTests"`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)