### PR TITLE
Verify scope workflow read tool results

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/BindingToolResultReceipts.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/BindingToolResultReceipts.cs
@@ -35,7 +35,8 @@ internal static class BindingToolResultReceipts
             "external_capability_readiness_failed",
             static root =>
                 TryGetString(root, "status", out var status) &&
-                string.Equals(status, ReadyStatus, StringComparison.Ordinal));
+                string.Equals(status, ReadyStatus, StringComparison.Ordinal),
+            readReadinessStatus: true);
 
     public static AgentToolReceipt? CreateExplicitRequestPreview(
         string defaultToolName,
@@ -55,13 +56,56 @@ internal static class BindingToolResultReceipts
                 HasProperty(root, "confirmations", JsonValueKind.Array) &&
                 HasProperty(root, "requests", JsonValueKind.Array));
 
+    public static AgentToolReceipt? CreateScopeWorkflowList(
+        string defaultToolName,
+        string callId,
+        string toolName,
+        string resultJson) =>
+        CreateReadOnly(
+            defaultToolName,
+            callId,
+            toolName,
+            resultJson,
+            "scope_workflow_list_failed",
+            static root =>
+                HasNonEmptyString(root, "scope_id") &&
+                HasProperty(root, "workflows", JsonValueKind.Array));
+
+    public static AgentToolReceipt? CreateScopeWorkflowGet(
+        string defaultToolName,
+        string callId,
+        string toolName,
+        string resultJson) =>
+        CreateReadOnly(
+            defaultToolName,
+            callId,
+            toolName,
+            resultJson,
+            "scope_workflow_get_failed",
+            static root =>
+            {
+                if (!HasProperty(root, "available", JsonValueKind.True) &&
+                    !HasProperty(root, "available", JsonValueKind.False))
+                {
+                    return false;
+                }
+
+                if (!HasNonEmptyString(root, "scope_id"))
+                    return false;
+
+                return root.GetProperty("available").GetBoolean()
+                    ? HasProperty(root, "workflow", JsonValueKind.Object)
+                    : HasNonEmptyString(root, "workflow_id") && HasNonEmptyString(root, "status");
+            });
+
     private static AgentToolReceipt? CreateReadOnly(
         string defaultToolName,
         string callId,
         string toolName,
         string resultJson,
         string defaultErrorCode,
-        Func<JsonElement, bool> isVerifiedSuccess)
+        Func<JsonElement, bool> isVerifiedSuccess,
+        bool readReadinessStatus = false)
     {
         if (!TryParseObject(resultJson, out var document))
             return null;
@@ -70,7 +114,7 @@ internal static class BindingToolResultReceipts
         {
             var root = document.RootElement;
             if (TryReadError(root, defaultErrorCode, out var errorCode, out var errorMessage) ||
-                TryReadReadinessError(root, out errorCode, out errorMessage))
+                (readReadinessStatus && TryReadReadinessError(root, out errorCode, out errorMessage)))
             {
                 return Receipt(
                     defaultToolName,

--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsGetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsGetTool.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
@@ -38,6 +39,13 @@ public sealed class ScopeWorkflowsGetTool : IAgentTool
         """;
 
     public bool IsReadOnly => true;
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        BindingToolResultReceipts.CreateScopeWorkflowGet(Name, callId, toolName, resultJson);
 
     private static string BuildUnavailableMessage(
         string scopeId,

--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsListTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsListTool.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgentService.Abstractions.Ports;
 
@@ -38,6 +39,13 @@ public sealed class ScopeWorkflowsListTool : IAgentTool
         """;
 
     public bool IsReadOnly => true;
+
+    public AgentToolReceipt? CreateResultReceipt(
+        string callId,
+        string toolName,
+        string argumentsJson,
+        string resultJson) =>
+        BindingToolResultReceipts.CreateScopeWorkflowList(Name, callId, toolName, resultJson);
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -958,6 +958,39 @@ public class BindingToolsTests
     }
 
     [Fact]
+    public async Task ScopeWorkflowsListTool_ShouldEmitTypedResultReceipt()
+    {
+        IAgentTool tool = new ScopeWorkflowsListTool(
+            new StubScopeWorkflowQueryPort(listResult:
+            [
+                BuildWorkflowSummary("scope-workflows", "wf-1"),
+            ]),
+            new BindingToolOptions());
+
+        AgentToolRequestContext.Current = OwnerContext("scope-workflows");
+
+        try
+        {
+            var result = await tool.ExecuteAsync("{}");
+            var receipt = tool.CreateResultReceipt(
+                "call-scope-workflows-list",
+                tool.Name,
+                "{}",
+                result);
+
+            receipt.Should().NotBeNull();
+            receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+            receipt.CallId.Should().Be("call-scope-workflows-list");
+            receipt.ToolName.Should().Be("scope_workflows_list");
+            receipt.ResultJson.Should().Be(result);
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
     public async Task ScopeWorkflowsListTool_ValidatesScopeContext()
     {
         var tool = new ScopeWorkflowsListTool(
@@ -1017,6 +1050,89 @@ public class BindingToolsTests
     }
 
     [Fact]
+    public async Task ScopeWorkflowsGetTool_ShouldEmitTypedResultReceipt()
+    {
+        IAgentTool tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
+            getResult: BuildWorkflowSummary("scope-workflows", "wf-1")));
+
+        AgentToolRequestContext.Current = OwnerContext("scope-workflows");
+
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"workflow_id":"wf-1"}""");
+            var receipt = tool.CreateResultReceipt(
+                "call-scope-workflows-get",
+                tool.Name,
+                """{"workflow_id":"wf-1"}""",
+                result);
+
+            receipt.Should().NotBeNull();
+            receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+            receipt.CallId.Should().Be("call-scope-workflows-get");
+            receipt.ToolName.Should().Be("scope_workflows_get");
+            receipt.ResultJson.Should().Be(result);
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsGetTool_ShouldKeepVerifiedReadOnlySuccessThroughStreamingExecutor()
+    {
+        var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
+            getResult: BuildWorkflowSummary("scope-workflows", "wf-1")));
+        var tools = new ToolManager();
+        tools.Register(tool);
+        var executionContext = OwnerContext("scope-workflows") with
+        {
+            Request = new AgentToolRequestIdentity("scope-workflows-get-request", "tc-scope-workflows-get"),
+            ExecutionOwner = AgentToolExecutionOwners.HostService(nameof(BindingToolsTests)),
+        };
+        var executor = new StreamingToolExecutor(
+            tools,
+            toolContext: executionContext,
+            toolExecutionPort: CreateToolExecutionPort());
+        using var executionState = executor.CreateExecutionState();
+
+        AgentToolRequestContext.Current = executionContext;
+
+        try
+        {
+            var prepared = await executor.PrepareBatchAsync(
+                "binding-tools-test:tc-scope-workflows-get",
+                round: 0,
+                [new ToolCall
+                {
+                    Id = "tc-scope-workflows-get",
+                    Name = tool.Name,
+                    ArgumentsJson = """{"workflow_id":"wf-1"}""",
+                }]);
+            executor.AddTool(executionState, prepared.Single());
+
+            var results = new List<ToolExecutionResult>();
+            await foreach (var result in executor.GetRemainingResultsAsync(executionState, CancellationToken.None))
+                results.Add(result);
+
+            var toolResult = results.Should().ContainSingle().Which;
+            toolResult.IsError.Should().BeFalse();
+            toolResult.Result.Should().Contain("\"workflow\"");
+            toolResult.Result.Should().NotBe("""{"status":"unknown","message":"The tool outcome could not be verified."}""");
+            var receipt = toolResult.Receipt;
+            receipt.Should().NotBeNull();
+            receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+            receipt.ApprovalMode.Should().Be(AgentToolReceiptApprovalMode.NeverRequire);
+            receipt.SideEffectKind.Should().BeEmpty();
+            receipt.ResultJson.Should().Be(toolResult.Result);
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
     public async Task ScopeWorkflowsGetTool_ValidatesWorkflowId()
     {
         var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort());
@@ -1049,6 +1165,46 @@ public class BindingToolsTests
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("available").GetBoolean().Should().BeFalse();
             doc.RootElement.GetProperty("workflow_id").GetString().Should().Be("missing");
+        }
+        finally
+        {
+            AgentToolRequestContext.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsGetTool_ShouldVerifyUnavailableAndErrorResults()
+    {
+        IAgentTool missingTool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(getResult: null));
+
+        AgentToolRequestContext.Current = OwnerContext("scope-workflows");
+
+        try
+        {
+            var missingResult = await missingTool.ExecuteAsync("""{"workflow_id":"missing"}""");
+            var missingReceipt = missingTool.CreateResultReceipt(
+                "call-scope-workflows-missing",
+                missingTool.Name,
+                """{"workflow_id":"missing"}""",
+                missingResult);
+
+            missingReceipt.Should().NotBeNull();
+            missingReceipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+            missingReceipt.ErrorCode.Should().Be("scope_workflow_get_failed");
+            missingReceipt.ResultJson.Should().Be(missingResult);
+
+            IAgentTool invalidTool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort());
+            var invalidResult = await invalidTool.ExecuteAsync("{}");
+            var invalidReceipt = invalidTool.CreateResultReceipt(
+                "call-scope-workflows-invalid",
+                invalidTool.Name,
+                "{}",
+                invalidResult);
+
+            invalidReceipt.Should().NotBeNull();
+            invalidReceipt!.Status.Should().Be(AgentToolReceiptStatus.Error);
+            invalidReceipt.ErrorCode.Should().Be("scope_workflow_get_failed");
+            invalidReceipt.ResultJson.Should().Be(invalidResult);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Add typed read-only receipts for `scope_workflows_list` and `scope_workflows_get` so successful workflow reads are not finalized as `tool_outcome_unknown`.
- Keep capability readiness status handling scoped to readiness results, so workflow statuses like `Runnable` are not misclassified as readiness failures.
- Cover direct receipt creation and the `StreamingToolExecutor` path for `scope_workflows_get`.

## Test plan
- [x] `dotnet test /private/tmp/aevatar-workflow-start-runid-feature/test/Aevatar.AI.ToolProviders.Binding.Tests/Aevatar.AI.ToolProviders.Binding.Tests.csproj --nologo`
- [x] `dotnet build /private/tmp/aevatar-workflow-start-runid-feature/src/workflow/Aevatar.Workflow.Core/Aevatar.Workflow.Core.csproj --nologo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)