### PR TITLE
Map backend failures to actionable Workflow Activity toasts

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -229,6 +229,50 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.nodeInspector.targetRole': 'Target role',
   'workflowActivityVNext.nodeInspector.title': 'Configure {name}',
   'workflowActivityVNext.nodeInspector.type': 'Type',
+  'workflowActivityVNext.failure.accessDenied':
+    'You do not have access to use this service or model.',
+  'workflowActivityVNext.failure.accessDeniedGuidance':
+    'Request access or choose a service and model available to your account.',
+  'workflowActivityVNext.failure.cancelled': 'Run cancelled.',
+  'workflowActivityVNext.failure.cancelledGuidance':
+    'The run stopped without being reported as a system failure.',
+  'workflowActivityVNext.failure.chooseAllowedService':
+    'Choose allowed service',
+  'workflowActivityVNext.failure.copyTrackingId': 'Copy tracking ID',
+  'workflowActivityVNext.failure.internal':
+    'The request could not be completed.',
+  'workflowActivityVNext.failure.internalGuidance':
+    'Try again or contact support with the tracking ID when one is available.',
+  'workflowActivityVNext.failure.invalidInput':
+    'The input or workflow definition needs attention.',
+  'workflowActivityVNext.failure.invalidInputGuidance':
+    'Review the affected input or workflow step before trying again.',
+  'workflowActivityVNext.failure.rateLimited': 'This request was rate limited.',
+  'workflowActivityVNext.failure.rateLimitedGuidance':
+    'Wait for the quota window to reset before trying again.',
+  'workflowActivityVNext.failure.reloadLatest': 'Reload latest',
+  'workflowActivityVNext.failure.resourceMissing':
+    'This run is no longer available.',
+  'workflowActivityVNext.failure.resourceMissingGuidance':
+    'Refresh Activity or return to the run list.',
+  'workflowActivityVNext.failure.retryAfter': 'Try again in {seconds} seconds.',
+  'workflowActivityVNext.failure.reviewInput': 'Review input',
+  'workflowActivityVNext.failure.sessionExpired': 'Your session has expired.',
+  'workflowActivityVNext.failure.sessionExpiredGuidance':
+    'Sign in again to continue.',
+  'workflowActivityVNext.failure.signInAgain': 'Sign in again',
+  'workflowActivityVNext.failure.stateConflict':
+    'This run changed since it was loaded.',
+  'workflowActivityVNext.failure.stateConflictGuidance':
+    'Reload the latest state before continuing.',
+  'workflowActivityVNext.failure.timeoutOrOffline':
+    'The request timed out or the connection was interrupted.',
+  'workflowActivityVNext.failure.timeoutOrOfflineGuidance':
+    'Check the connection, then try again.',
+  'workflowActivityVNext.failure.upstreamUnavailable':
+    'The selected service is temporarily unavailable.',
+  'workflowActivityVNext.failure.upstreamUnavailableGuidance':
+    'Check service status or try again later.',
   'workflowActivityVNext.nav.activity': 'Activity',
   'workflowActivityVNext.nav.aria': 'Workflow workbench',
   'workflowActivityVNext.nav.openMenu': 'Open navigation',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -217,6 +217,42 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.nodeInspector.targetRole': '目标角色',
     'workflowActivityVNext.nodeInspector.title': '配置 {name}',
     'workflowActivityVNext.nodeInspector.type': '类型',
+    'workflowActivityVNext.failure.accessDenied': '你无权使用此服务或模型。',
+    'workflowActivityVNext.failure.accessDeniedGuidance':
+      '请申请权限，或选择你的账户可用的服务和模型。',
+    'workflowActivityVNext.failure.cancelled': '运行已取消。',
+    'workflowActivityVNext.failure.cancelledGuidance':
+      '此次运行已停止，但未被报告为系统故障。',
+    'workflowActivityVNext.failure.chooseAllowedService': '选择可用服务',
+    'workflowActivityVNext.failure.copyTrackingId': '复制跟踪 ID',
+    'workflowActivityVNext.failure.internal': '请求无法完成。',
+    'workflowActivityVNext.failure.internalGuidance':
+      '请重试；如果仍然失败，请在有跟踪 ID 时联系支持。',
+    'workflowActivityVNext.failure.invalidInput': '输入或工作流定义需要处理。',
+    'workflowActivityVNext.failure.invalidInputGuidance':
+      '请检查受影响的输入或工作流步骤后再试。',
+    'workflowActivityVNext.failure.rateLimited': '请求受到速率限制。',
+    'workflowActivityVNext.failure.rateLimitedGuidance':
+      '请等待配额窗口重置后再试。',
+    'workflowActivityVNext.failure.reloadLatest': '加载最新状态',
+    'workflowActivityVNext.failure.resourceMissing': '此次运行已不可用。',
+    'workflowActivityVNext.failure.resourceMissingGuidance':
+      '请刷新活动记录或返回运行列表。',
+    'workflowActivityVNext.failure.retryAfter': '{seconds} 秒后重试。',
+    'workflowActivityVNext.failure.reviewInput': '检查输入',
+    'workflowActivityVNext.failure.sessionExpired': '登录会话已过期。',
+    'workflowActivityVNext.failure.sessionExpiredGuidance':
+      '请重新登录后继续。',
+    'workflowActivityVNext.failure.signInAgain': '重新登录',
+    'workflowActivityVNext.failure.stateConflict': '加载后此次运行已发生变化。',
+    'workflowActivityVNext.failure.stateConflictGuidance':
+      '请加载最新状态后再继续。',
+    'workflowActivityVNext.failure.timeoutOrOffline': '请求超时或连接中断。',
+    'workflowActivityVNext.failure.timeoutOrOfflineGuidance':
+      '请检查网络连接后再试。',
+    'workflowActivityVNext.failure.upstreamUnavailable': '所选服务暂时不可用。',
+    'workflowActivityVNext.failure.upstreamUnavailableGuidance':
+      '请检查服务状态或稍后重试。',
     'workflowActivityVNext.nav.activity': '活动',
     'workflowActivityVNext.nav.aria': '工作流工作台',
     'workflowActivityVNext.nav.openMenu': '打开导航',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
@@ -1,10 +1,24 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import * as React from 'react';
+import { history } from '@/shared/navigation/history';
 import {
   cleanupTestQueryClients,
   renderWithQueryClient,
 } from '../../../../tests/reactQueryTestUtils';
 import RunDetailPage from './RunDetailPage';
+
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
 
 jest.mock('@umijs/max', () => ({
   getIntl: () => ({
@@ -59,6 +73,10 @@ jest.mock('@/shared/navigation/history', () => ({
 jest.mock('@/shared/ui/ConsoleHeaderActions', () => ({
   ConsoleAuthActions: () => <button type="button">Account</button>,
   ConsoleLanguageSwitch: () => <button type="button">Language</button>,
+}));
+
+jest.mock('@/shared/ui/ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
 }));
 
 const mockWorkflowActivityApi = jest.requireMock(
@@ -282,6 +300,64 @@ describe('Workflow Activity vNext run detail recovery', () => {
     for (const rawError of screen.getAllByText('Approval timed out')) {
       expect(rawError).not.toBeVisible();
     }
+  });
+
+  it('shows one actionable toast for repeated GROUP_NOT_ALLOWED evidence', async () => {
+    const run = buildRunDetail();
+    run.finalError = 'This group cannot use the selected model.';
+    run.diagnostics = [
+      {
+        timestampUtc: '2026-08-04T10:01:00Z',
+        severity: 'error',
+        code: 'GROUP_NOT_ALLOWED',
+        source: 'workflow',
+        message: 'This group cannot use the selected model.',
+        hint: 'Choose an allowed model',
+        stepId: 'step-failed',
+        stepType: 'llm_call',
+        targetRole: '',
+      },
+      {
+        timestampUtc: '2026-08-04T10:01:01Z',
+        severity: 'error',
+        code: 'GROUP_NOT_ALLOWED',
+        source: 'final_error',
+        message: 'This group cannot use the selected model.',
+        hint: '',
+        stepId: 'step-failed',
+        stepType: 'llm_call',
+        targetRole: '',
+      },
+    ];
+    run.steps[0].error = 'This group cannot use the selected model.';
+    mockWorkflowActivityApi.getRun.mockResolvedValue(run);
+
+    renderWithQueryClient(
+      <RunDetailPage runId="run-source-alpha" scopeId="scope-alpha" />,
+    );
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledTimes(1),
+    );
+    const [content, options] = mockConsoleToast.error.mock.calls[0];
+    expect(options).toEqual({
+      duration: 0,
+      key: 'run-failure:run-source-alpha:access_denied',
+    });
+    const toastContent = render(content).container;
+    expect(
+      within(toastContent).getByText(
+        'This group cannot use the selected model.',
+      ),
+    ).toBeVisible();
+    fireEvent.click(
+      within(toastContent).getByRole('button', {
+        name: 'Choose allowed service',
+      }),
+    );
+    expect(history.push).toHaveBeenCalledWith(
+      '/scopes/scope-alpha/workflow-activity-vnext/settings',
+    );
   });
 
   it('uses a product title instead of a raw run ID when the workflow name is missing', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx
@@ -71,7 +71,10 @@ function readCommittedRunFailure(
   if (!run) return null;
   const status = run.summary.status.trim().toLowerCase();
   if (status === 'cancelled' || status === 'canceled') {
-    return { code: 'RUN_CANCELLED', message: 'Run cancelled.' };
+    return {
+      code: 'RUN_CANCELLED',
+      message: t('workflowActivityVNext.failure.cancelled', 'Run cancelled.'),
+    };
   }
   if (run.summary.success !== false && status !== 'failed') return null;
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx
@@ -7,12 +7,25 @@ import {
   workflowActivityApi,
 } from '@/shared/api/workflowActivityApi';
 import { t } from '@/shared/i18n/messages';
-import type { WorkflowRunForkAcceptedReceipt } from '@/shared/models/workflowActivity';
+import type {
+  WorkflowActivityRunDetail,
+  WorkflowRunForkAcceptedReceipt,
+} from '@/shared/models/workflowActivity';
 import { history } from '@/shared/navigation/history';
-import { buildWorkflowActivitySectionHref } from '../navigation';
+import { useConsoleToast } from '@/shared/ui/ConsoleToast';
+import {
+  buildWorkflowActivityRunHref,
+  buildWorkflowActivitySectionHref,
+} from '../navigation';
 import TableScrollRegion from '../TableScrollRegion';
 import TechnicalDetails from '../TechnicalDetails';
 import WorkflowActivityVNextShell from '../WorkflowActivityVNextShell';
+import {
+  classifyRunFailure,
+  type RunFailureAction,
+  type RunFailureEvidence,
+  RunFailureToastContent,
+} from './runFailurePresentation';
 import { getRunOriginLabel, getRunStatusPresentation } from './runPresentation';
 import { resolveRunRecovery } from './runRecovery';
 
@@ -36,6 +49,42 @@ function failureTitle(error: unknown): string {
     }
   }
   return t('workflowActivityVNext.run.unavailable', 'Run unavailable');
+}
+
+function readApiFailure(error: unknown): RunFailureEvidence | null {
+  if (error instanceof WorkflowActivityApiError) {
+    return {
+      code: error.code,
+      correlationId: error.correlationId,
+      message: error.message,
+      retryAfterSeconds: error.retryAfterSeconds,
+      status: error.status,
+    };
+  }
+  if (error instanceof Error) return { message: error.message };
+  return null;
+}
+
+function readCommittedRunFailure(
+  run: WorkflowActivityRunDetail | undefined,
+): RunFailureEvidence | null {
+  if (!run) return null;
+  const status = run.summary.status.trim().toLowerCase();
+  if (status === 'cancelled' || status === 'canceled') {
+    return { code: 'RUN_CANCELLED', message: 'Run cancelled.' };
+  }
+  if (run.summary.success !== false && status !== 'failed') return null;
+
+  const primaryDiagnostic = run.diagnostics.find(
+    (diagnostic) => diagnostic.severity.trim().toLowerCase() === 'error',
+  );
+  return {
+    code: primaryDiagnostic?.code,
+    message:
+      primaryDiagnostic?.message ||
+      run.finalError ||
+      run.steps.find((step) => step.error)?.error,
+  };
 }
 
 function RunFailureSummary({
@@ -67,6 +116,7 @@ const RunDetailPage: React.FC<{
   readonly runId: string;
   readonly scopeId: string;
 }> = ({ runId, scopeId }) => {
+  const toast = useConsoleToast();
   const detail = useQuery({
     queryKey: ['workflow-activity-vnext', 'run-detail', scopeId, runId],
     queryFn: () => workflowActivityApi.getRun(scopeId, runId),
@@ -85,6 +135,63 @@ const RunDetailPage: React.FC<{
     readonly kind: 'retry' | 'run_again';
     readonly stepId: string;
   } | null>(null);
+  const shownFailureKeys = React.useRef(new Set<string>());
+
+  const failurePresentation = React.useMemo(() => {
+    const evidence = detail.error
+      ? readApiFailure(detail.error)
+      : readCommittedRunFailure(detail.data);
+    return evidence ? classifyRunFailure(evidence) : null;
+  }, [detail.data, detail.error]);
+
+  const performFailureAction = React.useCallback(
+    (action: RunFailureAction) => {
+      const activityHref = buildWorkflowActivitySectionHref(
+        scopeId,
+        'activity',
+      );
+      switch (action) {
+        case 'sign_in': {
+          const returnTo = buildWorkflowActivityRunHref(scopeId, runId);
+          history.push(`/login?redirect=${encodeURIComponent(returnTo)}`);
+          return;
+        }
+        case 'open_settings':
+          history.push(buildWorkflowActivitySectionHref(scopeId, 'settings'));
+          return;
+        case 'back_to_activity':
+        case 'open_activity':
+          history.push(activityHref);
+          return;
+        case 'reload':
+        case 'retry':
+          void detail.refetch();
+          void graph.refetch();
+          return;
+        case 'review_input':
+          return;
+      }
+    },
+    [detail, graph, runId, scopeId],
+  );
+
+  React.useEffect(() => {
+    if (!failurePresentation) return;
+    const key = `run-failure:${runId}:${failurePresentation.category}`;
+    if (shownFailureKeys.current.has(key)) return;
+    shownFailureKeys.current.add(key);
+    toast[failurePresentation.intent](
+      <RunFailureToastContent
+        onAction={
+          failurePresentation.action === 'review_input'
+            ? undefined
+            : performFailureAction
+        }
+        presentation={failurePresentation}
+      />,
+      { duration: failurePresentation.duration, key },
+    );
+  }, [failurePresentation, performFailureAction, runId, toast]);
 
   const recovery = resolveRunRecovery(detail.data?.steps ?? [], graph.data);
   const fork = async (startAtStepId: string): Promise<boolean> => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  classifyRunFailure,
+  RunFailureToastContent,
+} from './runFailurePresentation';
+
+describe('Workflow Activity run failure presentation', () => {
+  it.each([
+    [
+      { status: 401, message: 'Your session expired.' },
+      'session_expired',
+      'error',
+      0,
+    ],
+    [
+      {
+        status: 403,
+        code: 'GROUP_NOT_ALLOWED',
+        message: 'This group cannot use the selected model.',
+      },
+      'access_denied',
+      'error',
+      0,
+    ],
+    [
+      { status: 429, message: 'Too many requests.', retryAfterSeconds: 12 },
+      'rate_limited',
+      'warning',
+      0,
+    ],
+    [
+      {
+        status: 422,
+        code: 'INVALID_WORKFLOW',
+        message: 'The workflow input is invalid.',
+      },
+      'invalid_input',
+      'warning',
+      0,
+    ],
+    [
+      { status: 404, message: 'The run was not found.' },
+      'resource_missing',
+      'error',
+      5,
+    ],
+    [
+      {
+        status: 409,
+        code: 'STATE_VERSION_CONFLICT',
+        message: 'A newer version is available.',
+      },
+      'state_conflict',
+      'warning',
+      0,
+    ],
+    [
+      { status: 504, message: 'The provider timed out.' },
+      'timeout_or_offline',
+      'warning',
+      5,
+    ],
+    [
+      {
+        status: 503,
+        code: 'PROVIDER_UNAVAILABLE',
+        message: 'The provider is unavailable.',
+      },
+      'upstream_unavailable',
+      'error',
+      5,
+    ],
+    [
+      { code: 'RUN_CANCELLED', message: 'Cancelled by the user.' },
+      'cancelled',
+      'info',
+      3,
+    ],
+    [
+      {
+        status: 500,
+        message: 'The service could not complete the request.',
+        correlationId: 'corr-alpha',
+      },
+      'internal_failure',
+      'error',
+      0,
+    ],
+    [
+      { status: 418, code: 'UNRECOGNIZED_CODE', message: '' },
+      'internal_failure',
+      'error',
+      0,
+    ],
+  ] as const)('classifies %p as %s', (evidence, category, intent, duration) => {
+    expect(classifyRunFailure(evidence)).toMatchObject({
+      category,
+      duration,
+      intent,
+    });
+  });
+
+  it('uses the safe backend message, retry countdown, and accessible action', () => {
+    const onAction = jest.fn();
+    const presentation = classifyRunFailure({
+      status: 429,
+      message: 'Try again after the quota window resets.',
+      retryAfterSeconds: 12,
+    });
+
+    render(
+      <RunFailureToastContent
+        onAction={onAction}
+        presentation={presentation}
+      />,
+    );
+
+    expect(
+      screen.getByText('Try again after the quota window resets.'),
+    ).toBeVisible();
+    expect(screen.getByText('Try again in 12 seconds.')).toBeVisible();
+    const action = screen.getByRole('button', { name: 'Retry' });
+    action.focus();
+    fireEvent.keyDown(action, { key: 'Enter' });
+    fireEvent.click(action);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('copies a typed correlation ID without exposing raw payloads', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const presentation = classifyRunFailure({
+      status: 500,
+      message: 'The service could not complete the request.',
+      correlationId: 'corr-alpha',
+    });
+
+    render(<RunFailureToastContent presentation={presentation} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy tracking ID' }));
+    expect(writeText).toHaveBeenCalledWith('corr-alpha');
+    expect(screen.queryByText(/stack|provider payload|raw json/i)).toBeNull();
+  });
+});

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx
@@ -1,0 +1,359 @@
+import { Button, Space } from 'antd';
+import React from 'react';
+import { t } from '@/shared/i18n/messages';
+
+export type RunFailureCategory =
+  | 'access_denied'
+  | 'cancelled'
+  | 'internal_failure'
+  | 'invalid_input'
+  | 'rate_limited'
+  | 'resource_missing'
+  | 'session_expired'
+  | 'state_conflict'
+  | 'timeout_or_offline'
+  | 'upstream_unavailable';
+
+export type RunFailureAction =
+  | 'back_to_activity'
+  | 'open_activity'
+  | 'open_settings'
+  | 'reload'
+  | 'retry'
+  | 'review_input'
+  | 'sign_in';
+
+export type RunFailureEvidence = {
+  readonly code?: string;
+  readonly correlationId?: string;
+  readonly message?: string;
+  readonly retryAfterSeconds?: number;
+  readonly status?: number;
+};
+
+export type RunFailurePresentation = {
+  readonly action: RunFailureAction;
+  readonly actionLabel: string;
+  readonly category: RunFailureCategory;
+  readonly correlationId?: string;
+  readonly duration: number;
+  readonly guidance: string;
+  readonly intent: 'error' | 'info' | 'warning';
+  readonly message: string;
+  readonly retryAfterSeconds?: number;
+};
+
+type CategoryDefinition = Omit<
+  RunFailurePresentation,
+  'correlationId' | 'message' | 'retryAfterSeconds'
+> & {
+  readonly fallbackMessage: string;
+};
+
+function normalizeCode(value: string | undefined): string {
+  return value?.trim().toUpperCase() ?? '';
+}
+
+function isSafeUserMessage(value: string | undefined): value is string {
+  const normalized = value?.replace(/\s+/g, ' ').trim() ?? '';
+  if (!normalized || normalized.length > 240) return false;
+  return !(
+    /(?:GET|POST|PUT|PATCH|DELETE)\s+\//i.test(normalized) ||
+    /(?:stack\s*trace|\bat\s+[A-Za-z_$][\w$]*\s*\()/i.test(normalized) ||
+    /https?:\/\//i.test(normalized) ||
+    (/^[[{]/.test(normalized) && /[}\]]$/.test(normalized))
+  );
+}
+
+function categoryFor(evidence: RunFailureEvidence): RunFailureCategory {
+  const code = normalizeCode(evidence.code);
+  const status = evidence.status;
+
+  if (status === 401 || /(?:SESSION|TOKEN).*(?:EXPIRED|INVALID)/.test(code))
+    return 'session_expired';
+  if (
+    status === 403 ||
+    /(?:ACCESS_DENIED|FORBIDDEN|GROUP_NOT_ALLOWED|MODEL_NOT_ALLOWED)/.test(code)
+  )
+    return 'access_denied';
+  if (status === 429 || /RATE_LIMIT/.test(code)) return 'rate_limited';
+  if (status === 400 || status === 422 || /(?:INVALID|VALIDATION)/.test(code))
+    return 'invalid_input';
+  if (status === 404 || /NOT_FOUND/.test(code)) return 'resource_missing';
+  if (
+    status === 409 ||
+    status === 412 ||
+    /(?:CONFLICT|STATE_VERSION)/.test(code)
+  )
+    return 'state_conflict';
+  if (
+    status === 0 ||
+    status === 408 ||
+    status === 504 ||
+    /(?:NETWORK|OFFLINE|TIMEOUT|TIMED_OUT)/.test(code)
+  )
+    return 'timeout_or_offline';
+  if (
+    status === 502 ||
+    status === 503 ||
+    /(?:PROVIDER|UPSTREAM).*UNAVAILABLE/.test(code)
+  )
+    return 'upstream_unavailable';
+  if (status === 499 || /(?:CANCELLED|CANCELED|ABORTED)/.test(code))
+    return 'cancelled';
+  return 'internal_failure';
+}
+
+function definitionFor(category: RunFailureCategory): CategoryDefinition {
+  switch (category) {
+    case 'session_expired':
+      return {
+        action: 'sign_in',
+        actionLabel: t(
+          'workflowActivityVNext.failure.signInAgain',
+          'Sign in again',
+        ),
+        category,
+        duration: 0,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.sessionExpired',
+          'Your session has expired.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.sessionExpiredGuidance',
+          'Sign in again to continue.',
+        ),
+        intent: 'error',
+      };
+    case 'access_denied':
+      return {
+        action: 'open_settings',
+        actionLabel: t(
+          'workflowActivityVNext.failure.chooseAllowedService',
+          'Choose allowed service',
+        ),
+        category,
+        duration: 0,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.accessDenied',
+          'You do not have access to use this service or model.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.accessDeniedGuidance',
+          'Request access or choose a service and model available to your account.',
+        ),
+        intent: 'error',
+      };
+    case 'rate_limited':
+      return {
+        action: 'retry',
+        actionLabel: t('workflowActivityVNext.common.retry', 'Retry'),
+        category,
+        duration: 0,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.rateLimited',
+          'This request was rate limited.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.rateLimitedGuidance',
+          'Wait for the quota window to reset before trying again.',
+        ),
+        intent: 'warning',
+      };
+    case 'invalid_input':
+      return {
+        action: 'review_input',
+        actionLabel: t(
+          'workflowActivityVNext.failure.reviewInput',
+          'Review input',
+        ),
+        category,
+        duration: 0,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.invalidInput',
+          'The input or workflow definition needs attention.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.invalidInputGuidance',
+          'Review the affected input or workflow step before trying again.',
+        ),
+        intent: 'warning',
+      };
+    case 'resource_missing':
+      return {
+        action: 'back_to_activity',
+        actionLabel: t(
+          'workflowActivityVNext.run.backAria',
+          'Back to Activity',
+        ),
+        category,
+        duration: 5,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.resourceMissing',
+          'This run is no longer available.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.resourceMissingGuidance',
+          'Refresh Activity or return to the run list.',
+        ),
+        intent: 'error',
+      };
+    case 'state_conflict':
+      return {
+        action: 'reload',
+        actionLabel: t(
+          'workflowActivityVNext.failure.reloadLatest',
+          'Reload latest',
+        ),
+        category,
+        duration: 0,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.stateConflict',
+          'This run changed since it was loaded.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.stateConflictGuidance',
+          'Reload the latest state before continuing.',
+        ),
+        intent: 'warning',
+      };
+    case 'timeout_or_offline':
+      return {
+        action: 'retry',
+        actionLabel: t('workflowActivityVNext.common.retry', 'Retry'),
+        category,
+        duration: 5,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.timeoutOrOffline',
+          'The request timed out or the connection was interrupted.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.timeoutOrOfflineGuidance',
+          'Check the connection, then try again.',
+        ),
+        intent: 'warning',
+      };
+    case 'upstream_unavailable':
+      return {
+        action: 'retry',
+        actionLabel: t('workflowActivityVNext.common.retry', 'Retry'),
+        category,
+        duration: 5,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.upstreamUnavailable',
+          'The selected service is temporarily unavailable.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.upstreamUnavailableGuidance',
+          'Check service status or try again later.',
+        ),
+        intent: 'error',
+      };
+    case 'cancelled':
+      return {
+        action: 'open_activity',
+        actionLabel: t(
+          'workflowActivityVNext.editor.openActivity',
+          'Open Activity',
+        ),
+        category,
+        duration: 3,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.cancelled',
+          'Run cancelled.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.cancelledGuidance',
+          'The run stopped without being reported as a system failure.',
+        ),
+        intent: 'info',
+      };
+    case 'internal_failure':
+      return {
+        action: 'reload',
+        actionLabel: t(
+          'workflowActivityVNext.failure.reloadLatest',
+          'Reload latest',
+        ),
+        category,
+        duration: 0,
+        fallbackMessage: t(
+          'workflowActivityVNext.failure.internal',
+          'The request could not be completed.',
+        ),
+        guidance: t(
+          'workflowActivityVNext.failure.internalGuidance',
+          'Try again or contact support with the tracking ID when one is available.',
+        ),
+        intent: 'error',
+      };
+  }
+}
+
+export function classifyRunFailure(
+  evidence: RunFailureEvidence,
+): RunFailurePresentation {
+  const category = categoryFor(evidence);
+  const definition = definitionFor(category);
+  const retryAfterSeconds =
+    typeof evidence.retryAfterSeconds === 'number' &&
+    Number.isFinite(evidence.retryAfterSeconds) &&
+    evidence.retryAfterSeconds >= 0
+      ? Math.ceil(evidence.retryAfterSeconds)
+      : undefined;
+  return {
+    ...definition,
+    correlationId: evidence.correlationId?.trim() || undefined,
+    message: isSafeUserMessage(evidence.message)
+      ? evidence.message.replace(/\s+/g, ' ').trim()
+      : definition.fallbackMessage,
+    retryAfterSeconds,
+  };
+}
+
+export const RunFailureToastContent: React.FC<{
+  readonly onAction?: (action: RunFailureAction) => void;
+  readonly presentation: RunFailurePresentation;
+}> = ({ onAction, presentation }) => {
+  const correlationId = presentation.correlationId;
+  return (
+    <div>
+      <div>{presentation.message}</div>
+      <div>{presentation.guidance}</div>
+      {presentation.retryAfterSeconds !== undefined ? (
+        <div>
+          {t(
+            'workflowActivityVNext.failure.retryAfter',
+            'Try again in {seconds} seconds.',
+            { seconds: presentation.retryAfterSeconds },
+          )}
+        </div>
+      ) : null}
+      <Space size="small" wrap>
+        {onAction ? (
+          <Button
+            onClick={() => onAction(presentation.action)}
+            size="small"
+            type="link"
+          >
+            {presentation.actionLabel}
+          </Button>
+        ) : null}
+        {correlationId ? (
+          <Button
+            onClick={() => {
+              void navigator.clipboard?.writeText(correlationId);
+            }}
+            size="small"
+            type="link"
+          >
+            {t(
+              'workflowActivityVNext.failure.copyTrackingId',
+              'Copy tracking ID',
+            )}
+          </Button>
+        ) : null}
+      </Space>
+    </div>
+  );
+};

--- a/apps/aevatar-console-web/src/shared/api/http/error.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/http/error.test.ts
@@ -1,42 +1,82 @@
-import { readResponseError, readResponseErrorDetails } from "./error";
+import { readResponseError, readResponseErrorDetails } from './error';
 
-describe("readResponseError", () => {
-  it("includes ASP.NET validation problem details", async () => {
+describe('readResponseError', () => {
+  it('includes ASP.NET validation problem details', async () => {
     await expect(
       readResponseError({
         status: 400,
-        statusText: "Bad Request",
+        statusText: 'Bad Request',
         text: async () =>
           JSON.stringify({
-            title: "One or more validation errors occurred.",
+            title: 'One or more validation errors occurred.',
             status: 400,
             errors: {
-              "$.serviceInvocation.payload.value": [
-                "The JSON value could not be converted to Google.Protobuf.ByteString.",
+              '$.serviceInvocation.payload.value': [
+                'The JSON value could not be converted to Google.Protobuf.ByteString.',
               ],
             },
           }),
       }),
     ).resolves.toBe(
-      "One or more validation errors occurred.: $.serviceInvocation.payload.value: The JSON value could not be converted to Google.Protobuf.ByteString.",
+      'One or more validation errors occurred.: $.serviceInvocation.payload.value: The JSON value could not be converted to Google.Protobuf.ByteString.',
     );
   });
 
-  it("reads machine error codes from the backend error field", async () => {
+  it('reads machine error codes from the backend error field', async () => {
     await expect(
       readResponseErrorDetails({
         status: 502,
-        statusText: "Bad Gateway",
+        statusText: 'Bad Gateway',
         text: async () =>
           JSON.stringify({
-            error: "issued_binding_invalid",
-            detail: "The issued binding could not be adopted.",
+            error: 'issued_binding_invalid',
+            detail: 'The issued binding could not be adopted.',
+          }),
+      }),
+    ).resolves.toMatchObject({
+      code: 'issued_binding_invalid',
+      message: 'issued_binding_invalid',
+      status: 502,
+    });
+  });
+
+  it('preserves typed correlation and retry guidance from an API problem', async () => {
+    await expect(
+      readResponseErrorDetails({
+        status: 429,
+        statusText: 'Too Many Requests',
+        text: async () =>
+          JSON.stringify({
+            code: 'RATE_LIMITED',
+            correlationId: 'corr-alpha',
+            message: 'The request quota has been reached.',
+            retryAfterSeconds: 17,
           }),
       }),
     ).resolves.toEqual({
-      code: "issued_binding_invalid",
-      message: "issued_binding_invalid",
-      status: 502,
+      code: 'RATE_LIMITED',
+      correlationId: 'corr-alpha',
+      message: 'The request quota has been reached.',
+      retryAfterSeconds: 17,
+      status: 429,
     });
+  });
+
+  it('reads the standard Retry-After header when the body omits a countdown', async () => {
+    await expect(
+      readResponseErrorDetails({
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === 'retry-after' ? '23' : null,
+        },
+        status: 429,
+        statusText: 'Too Many Requests',
+        text: async () =>
+          JSON.stringify({
+            code: 'RATE_LIMITED',
+            message: 'The request quota has been reached.',
+          }),
+      }),
+    ).resolves.toMatchObject({ retryAfterSeconds: 23 });
   });
 });

--- a/apps/aevatar-console-web/src/shared/api/http/error.ts
+++ b/apps/aevatar-console-web/src/shared/api/http/error.ts
@@ -1,21 +1,23 @@
-import { t } from "@/shared/i18n/messages";
+import { t } from '@/shared/i18n/messages';
 
 function normalizeWhitespace(value: string | null | undefined): string {
-  return String(value ?? "")
-    .replace(/\s+/g, " ")
+  return String(value ?? '')
+    .replace(/\s+/g, ' ')
     .trim();
 }
 
 function formatHttpError(status: number, statusText: string): string {
   const normalizedStatusText = normalizeWhitespace(statusText);
-  return normalizedStatusText ? `HTTP ${status} ${normalizedStatusText}` : `HTTP ${status}`;
+  return normalizedStatusText
+    ? `HTTP ${status} ${normalizedStatusText}`
+    : `HTTP ${status}`;
 }
 
 function stripHtmlTags(value: string): string {
   return value
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, " ")
-    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, " ")
-    .replace(/<[^>]+>/g, " ");
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ' ')
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
 }
 
 function extractHtmlErrorSummary(value: string): string | null {
@@ -33,14 +35,14 @@ function extractHtmlErrorSummary(value: string): string | null {
   const titleMatch = value.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
   const headingMatch = value.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
   const summary = normalizeWhitespace(
-    stripHtmlTags(titleMatch?.[1] ?? headingMatch?.[1] ?? value)
+    stripHtmlTags(titleMatch?.[1] ?? headingMatch?.[1] ?? value),
   );
 
   return summary || null;
 }
 
 function readJsonErrorText(value: unknown): string | null {
-  if (typeof value !== "string") {
+  if (typeof value !== 'string') {
     return null;
   }
 
@@ -50,27 +52,53 @@ function readJsonErrorText(value: unknown): string | null {
 
 export type ResponseErrorPayload = {
   readonly code?: string;
+  readonly correlationId?: string;
   readonly detail?: string;
   readonly error?: string;
   readonly errors?: unknown;
   readonly message?: string;
   readonly status?: number;
   readonly title?: string;
+  readonly retryAfterSeconds?: number;
 };
 
 export type ResponseErrorDetails = {
   readonly code?: string;
+  readonly correlationId?: string;
   readonly fieldErrors?: Readonly<Record<string, readonly string[]>>;
   readonly message: string;
   readonly preflightLocator?: string;
   readonly requiredStateVersion?: number;
   readonly retryable?: boolean;
+  readonly retryAfterSeconds?: number;
   readonly status: number;
 };
 
+type ErrorResponse = Pick<Response, 'status' | 'statusText' | 'text'> & {
+  readonly headers?: Pick<Headers, 'get'>;
+};
+
+function readRetryAfterSeconds(
+  payload: ResponseErrorPayload,
+  response: ErrorResponse,
+): number | undefined {
+  if (
+    typeof payload.retryAfterSeconds === 'number' &&
+    Number.isFinite(payload.retryAfterSeconds) &&
+    payload.retryAfterSeconds >= 0
+  ) {
+    return payload.retryAfterSeconds;
+  }
+
+  const headerValue = response.headers?.get('Retry-After')?.trim() ?? '';
+  if (!/^\d+(?:\.\d+)?$/.test(headerValue)) return undefined;
+  const seconds = Number(headerValue);
+  return Number.isFinite(seconds) ? Math.ceil(seconds) : undefined;
+}
+
 function readResponseErrorFromPayload(
   payload: ResponseErrorPayload,
-  response: Pick<Response, "status" | "statusText">
+  response: Pick<Response, 'status' | 'statusText'>,
 ): string {
   const message = readJsonErrorText(payload.message);
   if (message) {
@@ -106,17 +134,17 @@ function readResponseErrorFromPayload(
     return code;
   }
 
-  if (typeof payload.status === "number" && Number.isFinite(payload.status)) {
+  if (typeof payload.status === 'number' && Number.isFinite(payload.status)) {
     return formatHttpError(payload.status, response.statusText);
   }
 
-  return "";
+  return '';
 }
 
 function readValidationErrorMap(
   value: unknown,
 ): Readonly<Record<string, readonly string[]>> | undefined {
-  if (!value || typeof value !== "object") {
+  if (!value || typeof value !== 'object') {
     return undefined;
   }
 
@@ -144,12 +172,14 @@ function readValidationErrors(value: unknown): string | null {
   const fields = readValidationErrorMap(value);
   if (!fields) return null;
   return Object.entries(fields)
-    .flatMap(([field, messages]) => messages.map((message) => `${field}: ${message}`))
-    .join("; ");
+    .flatMap(([field, messages]) =>
+      messages.map((message) => `${field}: ${message}`),
+    )
+    .join('; ');
 }
 
 export async function readResponseErrorDetails(
-  response: Pick<Response, "status" | "statusText" | "text">
+  response: ErrorResponse,
 ): Promise<ResponseErrorDetails> {
   const text = await response.text();
   if (!text) {
@@ -162,25 +192,34 @@ export async function readResponseErrorDetails(
   try {
     const payload = JSON.parse(text) as ResponseErrorPayload;
     const message =
-      readResponseErrorFromPayload(payload, response) || normalizeWhitespace(text);
+      readResponseErrorFromPayload(payload, response) ||
+      normalizeWhitespace(text);
     return {
       code:
         readJsonErrorText(payload.code) ??
         readJsonErrorText(payload.error) ??
         undefined,
+      correlationId: readJsonErrorText(payload.correlationId) ?? undefined,
       fieldErrors: readValidationErrorMap(payload.errors),
       message,
       preflightLocator:
-        readJsonErrorText((payload as ResponseErrorPayload & { preflightLocator?: unknown }).preflightLocator) ??
-        undefined,
+        readJsonErrorText(
+          (payload as ResponseErrorPayload & { preflightLocator?: unknown })
+            .preflightLocator,
+        ) ?? undefined,
       requiredStateVersion:
-        typeof (payload as ResponseErrorPayload & { requiredStateVersion?: unknown }).requiredStateVersion === "number"
-          ? (payload as ResponseErrorPayload & { requiredStateVersion: number }).requiredStateVersion
+        typeof (
+          payload as ResponseErrorPayload & { requiredStateVersion?: unknown }
+        ).requiredStateVersion === 'number'
+          ? (payload as ResponseErrorPayload & { requiredStateVersion: number })
+              .requiredStateVersion
           : undefined,
       retryable:
-        typeof (payload as ResponseErrorPayload & { retryable?: unknown }).retryable === "boolean"
+        typeof (payload as ResponseErrorPayload & { retryable?: unknown })
+          .retryable === 'boolean'
           ? (payload as ResponseErrorPayload & { retryable: boolean }).retryable
           : undefined,
+      retryAfterSeconds: readRetryAfterSeconds(payload, response),
       status: response.status,
     };
   } catch {
@@ -195,7 +234,9 @@ export async function readResponseErrorDetails(
     const httpError = formatHttpError(response.status, response.statusText);
     const normalizedHttpError = httpError.toLowerCase();
     const normalizedHtmlSummary = htmlSummary.toLowerCase();
-    const normalizedStatusText = normalizeWhitespace(response.statusText).toLowerCase();
+    const normalizedStatusText = normalizeWhitespace(
+      response.statusText,
+    ).toLowerCase();
 
     if (
       normalizedHttpError.includes(normalizedHtmlSummary) ||
@@ -208,14 +249,17 @@ export async function readResponseErrorDetails(
     }
 
     return {
-      message: t("shared.api.http.error.copy", "{value1}: {value2}", { value1: httpError, value2: htmlSummary }),
+      message: t('shared.api.http.error.copy', '{value1}: {value2}', {
+        value1: httpError,
+        value2: htmlSummary,
+      }),
       status: response.status,
     };
   }
 }
 
 export async function readResponseError(
-  response: Pick<Response, "status" | "statusText" | "text">
+  response: ErrorResponse,
 ): Promise<string> {
   return (await readResponseErrorDetails(response)).message;
 }

--- a/apps/aevatar-console-web/src/shared/api/workflowActivityApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/workflowActivityApi.test.ts
@@ -233,4 +233,28 @@ describe('workflowActivityApi', () => {
       'runId must not be blank',
     );
   });
+
+  it('preserves typed failure guidance for actionable run toasts', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          code: 'RATE_LIMITED',
+          correlationId: 'corr-alpha',
+          message: 'The request quota has been reached.',
+          retryAfterSeconds: 17,
+        },
+        429,
+      ),
+    ) as typeof global.fetch;
+
+    await expect(
+      workflowActivityApi.getRun('scope-alpha', 'run-alpha'),
+    ).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      correlationId: 'corr-alpha',
+      message: 'The request quota has been reached.',
+      retryAfterSeconds: 17,
+      status: 429,
+    });
+  });
 });

--- a/apps/aevatar-console-web/src/shared/api/workflowActivityApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/workflowActivityApi.ts
@@ -35,12 +35,24 @@ const JSON_HEADERS = {
 
 export class WorkflowActivityApiError extends Error {
   readonly code?: string;
+  readonly correlationId?: string;
+  readonly retryAfterSeconds?: number;
   readonly status: number;
 
-  constructor(message: string, status: number, code?: string) {
+  constructor(
+    message: string,
+    status: number,
+    code?: string,
+    guidance?: {
+      readonly correlationId?: string;
+      readonly retryAfterSeconds?: number;
+    },
+  ) {
     super(message);
     this.name = 'WorkflowActivityApiError';
     this.code = code;
+    this.correlationId = guidance?.correlationId;
+    this.retryAfterSeconds = guidance?.retryAfterSeconds;
     this.status = status;
   }
 }
@@ -443,6 +455,10 @@ async function requestActivityJson<T>(
       details.message,
       details.status,
       details.code,
+      {
+        correlationId: details.correlationId,
+        retryAfterSeconds: details.retryAfterSeconds,
+      },
     );
   }
   return decode(await response.json());


### PR DESCRIPTION
## Problem

Workflow Activity vNext collapsed known backend and committed run failures into generic text while repeating the same evidence in final error, diagnostics, steps, and timeline. Users could not see the primary cause or a useful recovery action.

## Solution

- Classify run/API failures into the 10 user-facing categories defined by #3224, with explicit severity, persistence, fallback copy, and recovery intent.
- Preserve typed `correlationId` and `retryAfterSeconds` from API problem responses, including numeric `Retry-After` headers.
- Emit one keyed toast per run/category and select one primary committed diagnostic, so repeated `GROUP_NOT_ALLOWED` evidence does not create duplicate notifications.
- Show safe backend messages directly, keep raw run/step evidence under Technical details, and provide native accessible action buttons.
- Navigate access-denied users to Settings, expired sessions to sign-in, and retryable failures through a fresh read-model refresh.

## Impact paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx`
- `apps/aevatar-console-web/src/shared/api/http/error.ts`
- `apps/aevatar-console-web/src/shared/api/workflowActivityApi.ts`

## Local verification

- Related/changed tests: `pnpm exec jest src/shared/api/http/error.test.ts src/shared/api/workflowActivityApi.test.ts src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx --runInBand` — 4 suites, 30 tests passed.
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx src/shared/api/http/error.test.ts src/shared/api/http/error.ts src/shared/api/workflowActivityApi.test.ts src/shared/api/workflowActivityApi.ts` — passed.
- Test stability: `bash tools/ci/test_stability_guards.sh` — passed.
- Diff validation: `git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD` — passed.
- A repository-native affected TypeScript target is unavailable, so local typecheck was skipped.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.

## Contract note

Committed run diagnostics currently do not expose a typed correlation ID. The UI copies it when the API problem contract provides one and does not relabel `runId` as a correlation ID.

Closes #3224


## Post-rebase CI follow-up verification

- Related, changed, and locale contract tests: `pnpm exec jest src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx src/shared/api/http/error.test.ts src/shared/api/workflowActivityApi.test.ts src/locales/catalog.test.ts src/locales/hardcodedCopyAudit.test.ts --runInBand` - passed 6 suites and 44 tests.
- Changed-file static checks: `pnpm exec biome check` on all 10 analyzer-selected frontend files - passed.
- Patch integrity: `git diff --check` - passed.
- Full frontend suite/typecheck/build: delegated to GitHub CI by the personal incremental frontend policy.