### PR TITLE
Distinguish duplicate workflows in the catalogue

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -402,8 +402,8 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.allView': 'All workflows',
   'workflowActivityVNext.workflows.clearFilters': 'Clear filters',
   'workflowActivityVNext.workflows.columnActions': 'Actions',
-  'workflowActivityVNext.workflows.columnUpdated': 'Updated',
   'workflowActivityVNext.workflows.columnWorkflow': 'Workflow',
+  'workflowActivityVNext.workflows.copyReference': 'Copy workflow reference',
   'workflowActivityVNext.workflows.description':
     'Create, edit, and run your workflows.',
   'workflowActivityVNext.workflows.draftsUnavailable':
@@ -411,6 +411,9 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.draftsUnavailableDescription':
     'Try again to load draft workflows.',
   'workflowActivityVNext.workflows.draftsView': 'Drafts',
+  'workflowActivityVNext.workflows.draftStatus': 'Draft',
+  'workflowActivityVNext.workflows.duplicateNameWarning':
+    'Another workflow already uses this name. Duplicate names are allowed.',
   'workflowActivityVNext.workflows.deleteDescription':
     'This deletes only the editable draft. Published versions and run history remain available.',
   'workflowActivityVNext.workflows.deleteAria': 'Delete {name}',
@@ -448,7 +451,20 @@ const workflowActivityVNextMessages = {
     "Activity couldn't be opened for this workflow",
   'workflowActivityVNext.workflows.partialUnavailable':
     "Some workflows couldn't be loaded",
+  'workflowActivityVNext.workflows.publishedRevision': 'Published {revision}',
+  'workflowActivityVNext.workflows.referenceCopied':
+    'Workflow reference copied',
+  'workflowActivityVNext.workflows.referenceCopyFailed':
+    "Workflow reference couldn't be copied",
+  'workflowActivityVNext.workflows.rename': 'Rename',
+  'workflowActivityVNext.workflows.renameFailed':
+    "Workflow couldn't be renamed",
+  'workflowActivityVNext.workflows.renameSave': 'Save name',
+  'workflowActivityVNext.workflows.renameSuccess': 'Workflow renamed',
+  'workflowActivityVNext.workflows.renameTitle': 'Rename workflow',
+  'workflowActivityVNext.workflows.updatedContext': 'Updated {updatedAt}',
   'workflowActivityVNext.workflows.viewActivity': 'Activity',
+  'workflowActivityVNext.workflows.workspaceOwner': 'Workspace',
 } as const;
 
 export default workflowActivityVNextMessages;

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -375,14 +375,17 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.allView': '全部工作流',
     'workflowActivityVNext.workflows.clearFilters': '清除筛选',
     'workflowActivityVNext.workflows.columnActions': '操作',
-    'workflowActivityVNext.workflows.columnUpdated': '更新时间',
     'workflowActivityVNext.workflows.columnWorkflow': '工作流',
+    'workflowActivityVNext.workflows.copyReference': '复制工作流引用',
     'workflowActivityVNext.workflows.description':
       '创建、编辑并运行你的工作流。',
     'workflowActivityVNext.workflows.draftsUnavailable': '草稿工作流不可用',
     'workflowActivityVNext.workflows.draftsUnavailableDescription':
       '请重试加载草稿工作流。',
     'workflowActivityVNext.workflows.draftsView': '草稿',
+    'workflowActivityVNext.workflows.draftStatus': '草稿',
+    'workflowActivityVNext.workflows.duplicateNameWarning':
+      '另一个工作流已使用此名称。允许使用重复名称。',
     'workflowActivityVNext.workflows.deleteDescription':
       '此操作只删除可编辑草稿，已发布版本和运行历史会继续保留。',
     'workflowActivityVNext.workflows.deleteAria': '删除 {name}',
@@ -419,7 +422,17 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.activityResolutionFailed':
       '无法打开此工作流的活动记录',
     'workflowActivityVNext.workflows.partialUnavailable': '部分工作流无法加载',
+    'workflowActivityVNext.workflows.publishedRevision': '已发布 {revision}',
+    'workflowActivityVNext.workflows.referenceCopied': '已复制工作流引用',
+    'workflowActivityVNext.workflows.referenceCopyFailed': '无法复制工作流引用',
+    'workflowActivityVNext.workflows.rename': '重命名',
+    'workflowActivityVNext.workflows.renameFailed': '无法重命名工作流',
+    'workflowActivityVNext.workflows.renameSave': '保存名称',
+    'workflowActivityVNext.workflows.renameSuccess': '工作流已重命名',
+    'workflowActivityVNext.workflows.renameTitle': '重命名工作流',
+    'workflowActivityVNext.workflows.updatedContext': '更新于 {updatedAt}',
     'workflowActivityVNext.workflows.viewActivity': '活动',
+    'workflowActivityVNext.workflows.workspaceOwner': '工作区',
   };
 
 export default workflowActivityVNextMessages;

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -97,6 +97,7 @@ jest.mock('@/shared/studio/api', () => ({
     getUserConfigRuntime: jest.fn(),
     getUserLlmSettings: jest.fn(),
     getWorkflow: jest.fn(),
+    getWorkflowDraft: jest.fn(),
     getWorkflowDraftFile: jest.fn(),
     listWorkflowDrafts: jest.fn(),
     parseYaml: jest.fn(),
@@ -105,6 +106,7 @@ jest.mock('@/shared/studio/api', () => ({
     saveAndBindWorkflow: jest.fn(),
     saveUserLlmSettings: jest.fn(),
     serializeYaml: jest.fn(),
+    updateWorkflowDraft: jest.fn(),
   },
 }));
 
@@ -196,6 +198,7 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   getUserConfigRuntime: jest.Mock;
   getUserLlmSettings: jest.Mock;
   getWorkflow: jest.Mock;
+  getWorkflowDraft: jest.Mock;
   getWorkflowDraftFile: jest.Mock;
   listWorkflowDrafts: jest.Mock;
   parseYaml: jest.Mock;
@@ -204,6 +207,7 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   saveAndBindWorkflow: jest.Mock;
   saveUserLlmSettings: jest.Mock;
   serializeYaml: jest.Mock;
+  updateWorkflowDraft: jest.Mock;
 };
 const mockCreateWorkflowRevisionIdentityCandidate = jest.requireMock(
   '@/shared/studio/explicitRequestConfirmation',
@@ -355,6 +359,196 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
+  it('distinguishes same-name workflows with purpose, publication state, ownership, and localized update context', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
+      {
+        workflowId: 'wf-support-emea',
+        name: 'Support triage',
+        description: 'Route urgent EMEA requests to the on-call queue',
+        fileName: 'support-emea.yaml',
+        filePath: '/emea/support-emea.yaml',
+        directoryId: 'directory-emea',
+        directoryLabel: 'EMEA operations',
+        stepCount: 3,
+        hasLayout: true,
+        updatedAtUtc: '2026-08-04T10:00:00Z',
+      },
+      {
+        activeRevisionId: 'rev-support-apac-7',
+        serviceKey: 'svc-support-apac',
+        workflowId: 'wf-support-apac',
+        name: 'Support triage',
+        description: 'Escalate APAC billing requests to finance',
+        fileName: 'support-apac.yaml',
+        filePath: '/apac/support-apac.yaml',
+        directoryId: 'directory-apac',
+        directoryLabel: 'APAC operations',
+        stepCount: 5,
+        hasLayout: true,
+        updatedAtUtc: '2026-08-05T11:30:00Z',
+      },
+    ]);
+    mockScopesApi.listWorkflows.mockResolvedValue([
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-support-apac',
+        displayName: 'Support triage',
+        serviceKey: 'svc-support-apac',
+        workflowName: 'support_triage_apac',
+        actorId: 'definition-support-apac',
+        activeRevisionId: 'rev-support-apac-7',
+        deploymentId: 'deployment-support-apac',
+        deploymentStatus: 'active',
+        updatedAt: '2026-08-05T11:30:00Z',
+      },
+    ]);
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const duplicateNames = await screen.findAllByText('Support triage');
+    expect(duplicateNames).toHaveLength(2);
+    const emeaRow = screen
+      .getByText('Route urgent EMEA requests to the on-call queue')
+      .closest('tr');
+    const apacRow = screen
+      .getByText('Escalate APAC billing requests to finance')
+      .closest('tr');
+    expect(emeaRow).not.toBeNull();
+    expect(apacRow).not.toBeNull();
+    expect(within(emeaRow as HTMLElement).getByText('Draft')).toBeVisible();
+    expect(
+      within(emeaRow as HTMLElement).getByText(/EMEA operations/),
+    ).toBeVisible();
+    expect(
+      within(apacRow as HTMLElement).getByText('Published rev-support-apac-7'),
+    ).toBeVisible();
+    expect(
+      within(apacRow as HTMLElement).getByText(/APAC operations/),
+    ).toBeVisible();
+    expect(
+      within(apacRow as HTMLElement).queryByText('wf-support-apac'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(apacRow as HTMLElement).queryByText('svc-support-apac'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(apacRow as HTMLElement).getByRole('button', {
+        name: 'More actions for Support triage',
+      }),
+    );
+    expect(
+      await screen.findByRole('menuitem', { name: 'Rename' }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('menuitem', { name: 'Copy workflow reference' }),
+    );
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith('wf-support-apac'),
+    );
+    expect(writeText).not.toHaveBeenCalledWith('svc-support-apac');
+  });
+
+  it('renames a duplicate workflow without changing its definition identity', async () => {
+    let drafts = [
+      {
+        workflowId: 'wf-support-emea',
+        name: 'Support triage',
+        description: 'Route urgent EMEA requests',
+        fileName: 'support-emea.yaml',
+        filePath: '/emea/support-emea.yaml',
+        directoryId: 'directory-emea',
+        directoryLabel: 'EMEA operations',
+        stepCount: 3,
+        hasLayout: true,
+        updatedAtUtc: '2026-08-04T10:00:00Z',
+      },
+      {
+        workflowId: 'wf-support-apac',
+        name: 'Support triage',
+        description: 'Escalate APAC billing requests',
+        fileName: 'support-apac.yaml',
+        filePath: '/apac/support-apac.yaml',
+        directoryId: 'directory-apac',
+        directoryLabel: 'APAC operations',
+        stepCount: 5,
+        hasLayout: true,
+        updatedAtUtc: '2026-08-05T11:30:00Z',
+      },
+    ];
+    mockStudioApi.listWorkflowDrafts.mockImplementation(async () => drafts);
+    mockScopesApi.listWorkflows.mockResolvedValue([]);
+    mockStudioApi.getWorkflowDraft.mockResolvedValue({
+      workflowId: 'wf-support-apac',
+      name: 'Support triage',
+      fileName: 'support-apac.yaml',
+      filePath: '/apac/support-apac.yaml',
+      directoryId: 'directory-apac',
+      directoryLabel: 'APAC operations',
+      yaml: 'name: support_triage\nroles: []\nsteps: []\n',
+      layout: { nodes: [] },
+      updatedAtUtc: '2026-08-05T11:30:00Z',
+    });
+    mockStudioApi.updateWorkflowDraft.mockImplementation(async () => {
+      drafts = drafts.map((draft) =>
+        draft.workflowId === 'wf-support-apac'
+          ? { ...draft, name: 'APAC support triage' }
+          : draft,
+      );
+      return {
+        workflowId: 'wf-support-apac',
+        name: 'APAC support triage',
+        fileName: 'support-apac.yaml',
+        filePath: '/apac/support-apac.yaml',
+        directoryId: 'directory-apac',
+        directoryLabel: 'APAC operations',
+        yaml: 'name: support_triage\nroles: []\nsteps: []\n',
+        layout: { nodes: [] },
+        updatedAtUtc: '2026-08-05T11:31:00Z',
+      };
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const apacRow = (
+      await screen.findByText('Escalate APAC billing requests')
+    ).closest('tr');
+    fireEvent.click(
+      within(apacRow as HTMLElement).getByRole('button', {
+        name: 'More actions for Support triage',
+      }),
+    );
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
+    expect(
+      await screen.findByText(
+        'Another workflow already uses this name. Duplicate names are allowed.',
+      ),
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'APAC support triage' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+
+    await waitFor(() =>
+      expect(mockStudioApi.updateWorkflowDraft).toHaveBeenCalledWith({
+        directoryId: 'directory-apac',
+        fileName: 'support-apac.yaml',
+        layout: { nodes: [] },
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-support-apac',
+        workflowName: 'APAC support triage',
+        yaml: 'name: support_triage\nroles: []\nsteps: []\n',
+      }),
+    );
+    expect(await screen.findByText('APAC support triage')).toBeVisible();
+    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
+  });
+
   it('reports an Activity resolution request failure with a toast instead of a page alert', async () => {
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
     mockScopesApi.listWorkflows.mockResolvedValue([
@@ -418,7 +612,7 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
-  it('uses one editor entry point and exposes direct deletion only for editable drafts', async () => {
+  it('uses one editor entry point and exposes draft-only deletion with row actions', async () => {
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([
       {
         workflowId: 'wf-draft-alpha',
@@ -469,10 +663,10 @@ describe('Workflow Activity vNext catalogue', () => {
       }),
     ).toBeEnabled();
     expect(
-      within(draftRow as HTMLElement).queryByRole('button', {
+      within(draftRow as HTMLElement).getByRole('button', {
         name: 'More actions for Support triage',
       }),
-    ).not.toBeInTheDocument();
+    ).toBeEnabled();
     expect(
       within(committedRow as HTMLElement).queryByRole('button', {
         name: 'Delete Invoice review',
@@ -545,10 +739,10 @@ describe('Workflow Activity vNext catalogue', () => {
       await screen.findByText('Committed support source'),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', {
+      screen.getByRole('button', {
         name: 'More actions for Committed support source',
       }),
-    ).not.toBeInTheDocument();
+    ).toBeEnabled();
   });
 
   it('keeps the draft and offers retry when deletion fails', async () => {
@@ -3792,9 +3986,48 @@ describe('Workflow Activity vNext creation', () => {
         },
       ],
     });
+    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
+    mockScopesApi.listWorkflows.mockResolvedValue([]);
   });
 
   afterEach(() => cleanupTestQueryClients());
+
+  it('warns about a duplicate workflow name without blocking creation', async () => {
+    mockScopesApi.listWorkflows.mockResolvedValue([
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-existing-incident-review',
+        displayName: 'Incident review',
+        serviceKey: 'svc-incident-review',
+        workflowName: 'incident_review',
+        actorId: 'definition-incident-review',
+        activeRevisionId: 'rev-incident-review-3',
+        deploymentId: 'deployment-incident-review',
+        deploymentStatus: 'active',
+        updatedAt: '2026-08-04T09:00:00Z',
+      },
+    ]);
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const blankButton = await screen.findByRole('button', {
+      name: 'Start blank',
+    });
+    await waitFor(() => expect(blankButton).toBeEnabled());
+    fireEvent.click(blankButton);
+    fireEvent.change(screen.getByLabelText('Workflow name'), {
+      target: { value: ' incident REVIEW ' },
+    });
+
+    expect(
+      await screen.findByText(
+        'Another workflow already uses this name. Duplicate names are allowed.',
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Create workflow' }),
+    ).toBeEnabled();
+  });
 
   it('creates a blank draft with a server directory and navigates only after materialization', async () => {
     mockStudioApi.createWorkflowDraft.mockResolvedValue({

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -138,13 +138,15 @@ export const workflowActivityVNextCss = `
 }
 .wa-vnext__table th:first-child { border-top-left-radius: 7px; }
 .wa-vnext__table th:last-child { border-top-right-radius: 7px; }
-.wa-vnext__table td { border-bottom: 1px solid var(--wa-line); height: 56px; overflow-wrap: anywhere; padding: 10px 12px; vertical-align: middle; }
+.wa-vnext__table td { border-bottom: 1px solid var(--wa-line); height: 76px; overflow-wrap: anywhere; padding: 10px 12px; vertical-align: middle; }
 .wa-vnext__table tr:last-child td { border-bottom: 0; }
 .wa-vnext__table tbody tr:hover { background: #f9fafb; }
 .wa-vnext__table pre { margin: 0; max-width: 100%; white-space: pre-wrap; word-break: break-word; }
 .wa-vnext__run-link { max-width: 100%; min-width: 0; overflow: hidden; }
 .wa-vnext__title { display: block; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wa-vnext__sub { color: var(--wa-muted); display: block; font-size: 12px; line-height: 17px; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.wa-vnext__workflow-context { align-items: center; color: var(--wa-muted); display: flex; flex-wrap: wrap; font-size: 11px; gap: 4px 7px; line-height: 16px; margin-top: 7px; }
+.wa-vnext__workflow-context .wa-vnext__status { min-height: 20px; }
 .wa-vnext__status { align-items: center; border: 1px solid currentColor; border-radius: 5px; display: inline-flex; font-size: 11px; font-weight: 600; gap: 6px; min-height: 24px; padding: 0 8px; white-space: nowrap; }
 .wa-vnext__status::before { background: currentColor; border-radius: 50%; content: ""; height: 6px; width: 6px; }
 .wa-vnext__status--draft { background: #f4f3ff; color: #6941c6; }
@@ -165,6 +167,8 @@ export const workflowActivityVNextCss = `
 .wa-vnext__form > div > span:first-child { font-size: 12px; font-weight: 600; }
 .wa-vnext__form-actions { display: flex; flex-wrap: wrap; gap: 8px; }
 .wa-vnext__field-control { display: block; margin-top: 6px; width: 100%; }
+.wa-vnext__duplicate-warning { color: var(--wa-amber); font-size: 12px; line-height: 17px; margin: 6px 0 0; }
+.wa-vnext__modal-field { display: grid; font-size: 12px; font-weight: 600; gap: 6px; }
 .wa-vnext__mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
 .wa-vnext__split { display: grid; gap: 20px; grid-template-columns: minmax(0, 1fr) minmax(280px, 34%); }
 .wa-vnext__creation-options { border: 0; display: grid; gap: 12px; grid-template-columns: repeat(4, minmax(0, 1fr)); margin: 0; min-width: 0; padding: 0; }

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
@@ -8,6 +8,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { Alert, Button, Input, Select, Space, Typography } from 'antd';
 import React from 'react';
+import { scopesApi } from '@/shared/api/scopesApi';
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
 import { studioApi } from '@/shared/studio/api';
@@ -99,6 +100,16 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
   const workspace = useQuery({
     queryKey: ['workflow-activity-vnext', 'workspace', scopeId],
     queryFn: () => studioApi.getWorkspaceSettings(scopeId),
+    retry: false,
+  });
+  const existingWorkflows = useQuery({
+    queryKey: ['workflow-activity-vnext', 'drafts', scopeId],
+    queryFn: () => studioApi.listWorkflowDrafts(scopeId),
+    retry: false,
+  });
+  const existingCommittedWorkflows = useQuery({
+    queryKey: ['workflow-activity-vnext', 'committed', scopeId],
+    queryFn: () => scopesApi.listWorkflows(scopeId),
     retry: false,
   });
 
@@ -199,6 +210,20 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
 
   const selectedTemplate = BUNDLED_WORKFLOW_TEMPLATES.find(
     (item) => item.id === templateId,
+  );
+  const normalizedName = name.trim().toLocaleLowerCase();
+  const duplicateName = Boolean(
+    normalizedName &&
+      (existingWorkflows.data?.some(
+        (workflow) =>
+          workflow.name.trim().toLocaleLowerCase() === normalizedName,
+      ) ||
+        existingCommittedWorkflows.data?.some(
+          (workflow) =>
+            (workflow.displayName || workflow.workflowName)
+              .trim()
+              .toLocaleLowerCase() === normalizedName,
+        )),
   );
   const templateName = t(
     'workflowActivityVNext.new.templateName.incidentTriage',
@@ -355,6 +380,14 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                 className="wa-vnext__field-control"
                 value={name}
               />
+              {duplicateName ? (
+                <p className="wa-vnext__duplicate-warning" role="status">
+                  {t(
+                    'workflowActivityVNext.workflows.duplicateNameWarning',
+                    'Another workflow already uses this name. Duplicate names are allowed.',
+                  )}
+                </p>
+              ) : null}
             </div>
 
             {mode === 'describe' ? (

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -1,11 +1,14 @@
 import {
+  CopyOutlined,
   DeleteOutlined,
+  EditOutlined,
+  MoreOutlined,
   PlusOutlined,
   ReloadOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Input, Modal, Select, Space, Tooltip } from 'antd';
+import { Button, Dropdown, Input, Modal, Select, Space, Tooltip } from 'antd';
 import React from 'react';
 import { scopesApi } from '@/shared/api/scopesApi';
 import { t } from '@/shared/i18n/messages';
@@ -24,10 +27,12 @@ import TableScrollRegion from '../TableScrollRegion';
 import WorkflowActivityVNextShell from '../WorkflowActivityVNextShell';
 
 type WorkflowRow = {
+  readonly activeRevisionId: string;
   readonly description: string;
   readonly hasCommittedSource: boolean;
   readonly hasDraftSource: boolean;
   readonly name: string;
+  readonly ownershipLabel: string;
   readonly stepCount?: number;
   readonly updatedAtUtc: string | null;
   readonly workflowId: string;
@@ -38,10 +43,15 @@ function toDraftRow(
   committed?: WorkflowRow,
 ): WorkflowRow {
   return {
+    activeRevisionId:
+      item.activeRevisionId?.trim() || committed?.activeRevisionId || '',
     description: item.description,
     hasCommittedSource: Boolean(committed),
     hasDraftSource: true,
     name: item.name,
+    ownershipLabel:
+      item.directoryLabel.trim() ||
+      t('workflowActivityVNext.workflows.workspaceOwner', 'Workspace'),
     stepCount: item.stepCount,
     updatedAtUtc: item.updatedAtUtc,
     workflowId: item.workflowId,
@@ -50,10 +60,15 @@ function toDraftRow(
 
 function toCommittedRow(item: ScopeWorkflowSummary): WorkflowRow {
   return {
+    activeRevisionId: item.activeRevisionId.trim(),
     description: '',
     hasCommittedSource: true,
     hasDraftSource: false,
     name: item.displayName || item.workflowName,
+    ownershipLabel: t(
+      'workflowActivityVNext.workflows.workspaceOwner',
+      'Workspace',
+    ),
     updatedAtUtc: item.updatedAt,
     workflowId: item.workflowId,
   };
@@ -77,6 +92,10 @@ function formatDate(value: string | null): string {
       }).format(date);
 }
 
+function normalizeWorkflowName(value: string): string {
+  return value.trim().toLocaleLowerCase();
+}
+
 const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const location = useConsoleLocation();
   const toast = useConsoleToast();
@@ -91,6 +110,11 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     readWorkflowView(initialParams),
   );
   const [activityWorkflowId, setActivityWorkflowId] = React.useState('');
+  const [renameTarget, setRenameTarget] = React.useState<WorkflowRow | null>(
+    null,
+  );
+  const [renameName, setRenameName] = React.useState('');
+  const [renaming, setRenaming] = React.useState(false);
   const [deleteTarget, setDeleteTarget] = React.useState<WorkflowRow | null>(
     null,
   );
@@ -156,6 +180,18 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   }, [committed.data, draftWorkflowIds, drafts.data, query, view]);
   const totalFailure = drafts.isError && committed.isError;
   const filtersActive = Boolean(query.trim()) || view === 'drafts';
+  const renameDuplicates = React.useMemo(() => {
+    if (!renameTarget) return false;
+    const normalizedName = normalizeWorkflowName(renameName);
+    return Boolean(
+      normalizedName &&
+        rows.some(
+          (row) =>
+            row.workflowId !== renameTarget.workflowId &&
+            normalizeWorkflowName(row.name) === normalizedName,
+        ),
+    );
+  }, [renameName, renameTarget, rows]);
 
   React.useEffect(() => {
     if (loading || (!drafts.isError && !committed.isError)) return;
@@ -219,6 +255,75 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       );
     } finally {
       setActivityWorkflowId('');
+    }
+  };
+
+  const copyWorkflowReference = async (row: WorkflowRow) => {
+    try {
+      if (!navigator.clipboard?.writeText)
+        throw new Error('Clipboard unavailable');
+      await navigator.clipboard.writeText(row.workflowId);
+      toast.success(
+        t(
+          'workflowActivityVNext.workflows.referenceCopied',
+          'Workflow reference copied',
+        ),
+      );
+    } catch {
+      toast.error(
+        t(
+          'workflowActivityVNext.workflows.referenceCopyFailed',
+          "Workflow reference couldn't be copied",
+        ),
+      );
+    }
+  };
+
+  const openRename = (row: WorkflowRow) => {
+    setRenameTarget(row);
+    setRenameName(row.name);
+  };
+
+  const closeRename = () => {
+    if (renaming) return;
+    setRenameTarget(null);
+    setRenameName('');
+  };
+
+  const confirmRename = async () => {
+    const workflowName = renameName.trim();
+    if (!renameTarget || !workflowName || renaming) return;
+    setRenaming(true);
+    try {
+      const draft = await studioApi.getWorkflowDraft(
+        renameTarget.workflowId,
+        scopeId,
+      );
+      await studioApi.updateWorkflowDraft({
+        directoryId: draft.directoryId,
+        fileName: draft.fileName,
+        layout: draft.layout,
+        scopeId,
+        workflowId: renameTarget.workflowId,
+        workflowName,
+        yaml: draft.yaml,
+      });
+      const refreshed = await drafts.refetch();
+      if (refreshed.isError) throw refreshed.error;
+      setRenameTarget(null);
+      setRenameName('');
+      toast.success(
+        t('workflowActivityVNext.workflows.renameSuccess', 'Workflow renamed'),
+      );
+    } catch {
+      toast.error(
+        t(
+          'workflowActivityVNext.workflows.renameFailed',
+          "Workflow couldn't be renamed",
+        ),
+      );
+    } finally {
+      setRenaming(false);
     }
   };
 
@@ -474,12 +579,6 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 </th>
                 <th>
                   {t(
-                    'workflowActivityVNext.workflows.columnUpdated',
-                    'Updated',
-                  )}
-                </th>
-                <th>
-                  {t(
                     'workflowActivityVNext.workflows.columnActions',
                     'Actions',
                   )}
@@ -499,14 +598,36 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                     {row.description ? (
                       <span className="wa-vnext__sub">{row.description}</span>
                     ) : null}
-                  </td>
-                  <td
-                    data-label={t(
-                      'workflowActivityVNext.workflows.columnUpdated',
-                      'Updated',
-                    )}
-                  >
-                    {formatDate(row.updatedAtUtc)}
+                    <span className="wa-vnext__workflow-context">
+                      <span
+                        className={`wa-vnext__status ${
+                          row.activeRevisionId
+                            ? 'wa-vnext__status--committed'
+                            : 'wa-vnext__status--draft'
+                        }`}
+                      >
+                        {row.activeRevisionId
+                          ? t(
+                              'workflowActivityVNext.workflows.publishedRevision',
+                              'Published {revision}',
+                              { revision: row.activeRevisionId },
+                            )
+                          : t(
+                              'workflowActivityVNext.workflows.draftStatus',
+                              'Draft',
+                            )}
+                      </span>
+                      <span aria-hidden="true">·</span>
+                      <span>{row.ownershipLabel}</span>
+                      <span aria-hidden="true">·</span>
+                      <span>
+                        {t(
+                          'workflowActivityVNext.workflows.updatedContext',
+                          'Updated {updatedAt}',
+                          { updatedAt: formatDate(row.updatedAtUtc) },
+                        )}
+                      </span>
+                    </span>
                   </td>
                   <td
                     data-label={t(
@@ -573,6 +694,49 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                           />
                         </Tooltip>
                       ) : null}
+                      <Dropdown
+                        menu={{
+                          items: [
+                            ...(row.hasDraftSource
+                              ? [
+                                  {
+                                    icon: <EditOutlined />,
+                                    key: 'rename',
+                                    label: t(
+                                      'workflowActivityVNext.workflows.rename',
+                                      'Rename',
+                                    ),
+                                  },
+                                ]
+                              : []),
+                            {
+                              icon: <CopyOutlined />,
+                              key: 'copy-reference',
+                              label: t(
+                                'workflowActivityVNext.workflows.copyReference',
+                                'Copy workflow reference',
+                              ),
+                            },
+                          ],
+                          onClick: ({ key }) => {
+                            if (key === 'rename') openRename(row);
+                            if (key === 'copy-reference')
+                              void copyWorkflowReference(row);
+                          },
+                        }}
+                        placement="bottomRight"
+                        trigger={['click']}
+                      >
+                        <Button
+                          aria-label={t(
+                            'workflowActivityVNext.workflows.moreActionsAria',
+                            'More actions for {name}',
+                            { name: row.name },
+                          )}
+                          icon={<MoreOutlined />}
+                          type="text"
+                        />
+                      </Dropdown>
                     </Space>
                   </td>
                 </tr>
@@ -581,6 +745,42 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           </table>
         </TableScrollRegion>
       )}
+      <Modal
+        cancelText={t('workflowActivityVNext.common.cancel', 'Cancel')}
+        closable={!renaming}
+        confirmLoading={renaming}
+        mask={{ closable: false }}
+        okButtonProps={{ disabled: !renameName.trim() }}
+        okText={t('workflowActivityVNext.workflows.renameSave', 'Save name')}
+        onCancel={closeRename}
+        onOk={() => void confirmRename()}
+        open={Boolean(renameTarget)}
+        title={t(
+          'workflowActivityVNext.workflows.renameTitle',
+          'Rename workflow',
+        )}
+      >
+        <div className="wa-vnext__modal-field">
+          <label htmlFor="wa-vnext-rename-name">
+            {t('workflowActivityVNext.new.name', 'Workflow name')}
+          </label>
+          <Input
+            aria-label={t('workflowActivityVNext.new.name', 'Workflow name')}
+            autoFocus
+            id="wa-vnext-rename-name"
+            onChange={(event) => setRenameName(event.target.value)}
+            value={renameName}
+          />
+        </div>
+        {renameDuplicates ? (
+          <p className="wa-vnext__duplicate-warning" role="status">
+            {t(
+              'workflowActivityVNext.workflows.duplicateNameWarning',
+              'Another workflow already uses this name. Duplicate names are allowed.',
+            )}
+          </p>
+        ) : null}
+      </Modal>
       <Modal
         cancelText={t('workflowActivityVNext.common.cancel', 'Cancel')}
         closable={!deleting}


### PR DESCRIPTION
## Problem and solution

Same-name workflow rows exposed too little authoritative context to choose the right definition. This change makes purpose, Draft/Published revision, save-location ownership, and localized update time part of the row hierarchy. It adds an accessible row menu for Rename and Copy workflow reference, and warns on duplicate names during create/rename without enforcing uniqueness.

Copy reference uses the actual `workflowId`. It never substitutes a member identity or published service identity. The current catalogue contracts do not expose last-editor identity; the frontend omits that fact rather than inferring it from auth, route, or another identifier.

## Impact paths

- `/scopes/:scopeId/workflow-activity-vnext/workflows`
- `/scopes/:scopeId/workflow-activity-vnext/workflows/new`
- Workflow Activity vNext EN/ZH locale catalogues and responsive table styling
- Route-level catalogue and creation integration coverage

## Local verification

- Related/changed tests: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx` - PASS, 73/73 tests
- Changed-file static checks: `pnpm exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx` from `apps/aevatar-console-web` - PASS, 6 files
- Test stability: `bash tools/ci/test_stability_guards.sh` - PASS
- Design baseline: `python3 docs/design-baselines/workflow-activity-vnext/verify-baseline.py` from `apps/aevatar-console-web` - PASS, hash verified and 17/17 frames
- Diff integrity: `git diff --check` - PASS
- A reliable repository-native affected typecheck target is unavailable, so local typecheck was skipped.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.

## Design baseline

Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py

Closes #3218