### PR TITLE
Keep new workflow setup recoverable

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -264,6 +264,8 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.new.name': 'Workflow name',
   'workflowActivityVNext.new.noDirectories':
     'No save location is available. Try again later or contact your administrator.',
+  'workflowActivityVNext.new.noDirectoriesDescription':
+    'A save location is required to own the workflow. You can prepare your input here while access is restored.',
   'workflowActivityVNext.new.observationFailed': "Workflow couldn't be opened",
   'workflowActivityVNext.new.observing': 'Creating workflow…',
   'workflowActivityVNext.new.projectionDelayed':
@@ -271,6 +273,9 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.new.retryDescription':
     'Your work is safe. Try again to finish opening the workflow.',
   'workflowActivityVNext.new.retryObservation': 'Try again',
+  'workflowActivityVNext.new.reviewAccess': 'Review access',
+  'workflowActivityVNext.new.saveTargetRequired':
+    'Choose an available save location before creating the workflow.',
   'workflowActivityVNext.new.template': 'Template',
   'workflowActivityVNext.new.templateDescription.incidentTriage':
     'Classify an incident, prepare a response, and request human approval.',
@@ -278,8 +283,12 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.new.title': 'New workflow',
   'workflowActivityVNext.new.validateCreate': 'Validate and create',
   'workflowActivityVNext.new.workspaceLoading': 'Loading save locations…',
+  'workflowActivityVNext.new.workspaceLoadingDescription':
+    'Choose a creation method now. Your input stays on this page while the current workspace save location loads.',
   'workflowActivityVNext.new.workspaceUnavailable':
     'Save locations unavailable',
+  'workflowActivityVNext.new.workspaceUnavailableDescription':
+    'Choose a creation method now. Your input stays on this page while you restore access.',
   'workflowActivityVNext.new.yaml': 'Workflow YAML',
   'workflowActivityVNext.run.backAria': 'Back to Activity',
   'workflowActivityVNext.run.commandId': 'Request ID',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -251,12 +251,17 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.new.name': '工作流名称',
     'workflowActivityVNext.new.noDirectories':
       '没有可用的保存位置，请稍后重试或联系管理员。',
+    'workflowActivityVNext.new.noDirectoriesDescription':
+      '工作流需要明确的保存位置来确定归属；恢复访问权限期间，你可以先在此准备输入。',
     'workflowActivityVNext.new.observationFailed': '无法打开工作流',
     'workflowActivityVNext.new.observing': '正在创建工作流…',
     'workflowActivityVNext.new.projectionDelayed': '所需时间比预期更长',
     'workflowActivityVNext.new.retryDescription':
       '你的内容已保留，请重试以完成打开工作流。',
     'workflowActivityVNext.new.retryObservation': '重试',
+    'workflowActivityVNext.new.reviewAccess': '检查访问权限',
+    'workflowActivityVNext.new.saveTargetRequired':
+      '请先选择可用的保存位置，再创建工作流。',
     'workflowActivityVNext.new.template': '模板',
     'workflowActivityVNext.new.templateDescription.incidentTriage':
       '对事件分类、准备响应并请求人工审批。',
@@ -264,7 +269,11 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.new.title': '新建工作流',
     'workflowActivityVNext.new.validateCreate': '验证并创建',
     'workflowActivityVNext.new.workspaceLoading': '正在加载保存位置…',
+    'workflowActivityVNext.new.workspaceLoadingDescription':
+      '现在可以先选择创建方式；当前工作区的保存位置加载期间，你的输入会保留在此页面。',
     'workflowActivityVNext.new.workspaceUnavailable': '保存位置不可用',
+    'workflowActivityVNext.new.workspaceUnavailableDescription':
+      '现在可以先选择创建方式；恢复访问权限期间，你的输入会保留在此页面。',
     'workflowActivityVNext.new.yaml': '工作流 YAML',
     'workflowActivityVNext.run.backAria': '返回活动列表',
     'workflowActivityVNext.run.commandId': '请求 ID',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { history } from '@/shared/navigation/history';
+import {
+  cleanupTestQueryClients,
+  renderWithQueryClient,
+} from '../../../../tests/reactQueryTestUtils';
+import NewWorkflowPage from './NewWorkflowPage';
+
+jest.mock('@umijs/max', () => ({
+  getIntl: () => ({
+    formatMessage: (
+      { defaultMessage, id }: { defaultMessage?: string; id: string },
+      values?: Record<string, unknown>,
+    ) =>
+      (defaultMessage ?? id).replace(
+        /\{(\w+)\}/g,
+        (_match: string, key: string) => String(values?.[key] ?? ''),
+      ),
+  }),
+  getLocale: () => 'en-US',
+  history: {},
+  setLocale: jest.fn(),
+  useIntl: () => ({
+    formatMessage: ({
+      defaultMessage,
+      id,
+    }: {
+      defaultMessage?: string;
+      id: string;
+    }) => defaultMessage ?? id,
+  }),
+  useModel: () => ({ initialState: { auth: { authenticated: true } } }),
+}));
+
+jest.mock('@/shared/studio/api', () => ({
+  isStudioApiStatus: (error: unknown, status: number) =>
+    Boolean(
+      error &&
+        typeof error === 'object' &&
+        'status' in error &&
+        error.status === status,
+    ),
+  studioApi: {
+    authorWorkflow: jest.fn(),
+    createWorkflowDraft: jest.fn(),
+    getWorkspaceSettings: jest.fn(),
+    parseYaml: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/navigation/history', () => ({
+  history: { push: jest.fn(), replace: jest.fn() },
+}));
+
+jest.mock('../hooks/useDraftMaterialization', () => ({
+  useDraftMaterialization: () => ({
+    error: null,
+    observe: jest.fn(),
+    phase: 'idle',
+    retry: jest.fn(),
+  }),
+}));
+
+jest.mock('@/shared/ui/ConsoleHeaderActions', () => ({
+  ConsoleAuthActions: () => <button type="button">Account</button>,
+  ConsoleLanguageSwitch: () => <button type="button">Language</button>,
+}));
+
+const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
+  authorWorkflow: jest.Mock;
+  createWorkflowDraft: jest.Mock;
+  getWorkspaceSettings: jest.Mock;
+  parseYaml: jest.Mock;
+};
+
+const readyWorkspace = {
+  runtimeBaseUrl: '',
+  directories: [
+    {
+      directoryId: 'directory-alpha',
+      isBuiltIn: true,
+      label: 'Workflows',
+      path: '/workflows',
+    },
+  ],
+};
+
+describe('New workflow save-target recovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => cleanupTestQueryClients());
+
+  it('allows method selection and input while save locations are loading', () => {
+    mockStudioApi.getWorkspaceSettings.mockReturnValue(new Promise(() => {}));
+
+    renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
+
+    expect(screen.getByText('Loading save locations…')).toBeVisible();
+    const importYaml = screen.getByRole('button', { name: 'Import YAML' });
+    expect(importYaml).toBeEnabled();
+    fireEvent.click(importYaml);
+    fireEvent.change(screen.getByLabelText('Workflow YAML'), {
+      target: { value: 'name: prepared_workflow' },
+    });
+    expect(screen.getByLabelText('Workflow YAML')).toHaveValue(
+      'name: prepared_workflow',
+    );
+  });
+
+  it('keeps every creation method available after a network failure', async () => {
+    mockStudioApi.getWorkspaceSettings.mockRejectedValue(
+      new TypeError('Failed to fetch'),
+    );
+
+    renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText(
+        "The current workspace's save location couldn't be loaded.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        'Choose a creation method now. Your input stays on this page while you restore access.',
+      ),
+    ).toBeVisible();
+    for (const name of [
+      'Describe',
+      'Start blank',
+      'Import YAML',
+      'Use template',
+    ]) {
+      expect(screen.getByRole('button', { name })).toBeEnabled();
+    }
+  });
+
+  it('names an unauthorized save target and provides access recovery', async () => {
+    mockStudioApi.getWorkspaceSettings.mockRejectedValue({ status: 403 });
+
+    renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText(
+        "You don't have access to a save location in the current workspace.",
+      ),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Review access' }));
+    expect(history.push).toHaveBeenCalledWith(
+      '/scopes/scope-alpha/workflow-activity-vnext/settings',
+    );
+  });
+
+  it('keeps preparation available but prevents implicit ownership when no directory exists', async () => {
+    mockStudioApi.getWorkspaceSettings.mockResolvedValue({
+      runtimeBaseUrl: '',
+      directories: [],
+    });
+
+    renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText(
+        'No save location is available in the current workspace.',
+      ),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Start blank' }));
+    fireEvent.change(screen.getByLabelText('Workflow name'), {
+      target: { value: 'Prepared workflow' },
+    });
+    expect(
+      screen.getByRole('button', { name: 'Create workflow' }),
+    ).toBeDisabled();
+    expect(mockStudioApi.createWorkflowDraft).not.toHaveBeenCalled();
+  });
+
+  it('preserves the selected method and input when retry discovers a save location', async () => {
+    mockStudioApi.getWorkspaceSettings
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(readyWorkspace);
+
+    renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText(
+        "The current workspace's save location couldn't be loaded.",
+      ),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Import YAML' }));
+    fireEvent.change(screen.getByLabelText('Workflow YAML'), {
+      target: { value: 'name: prepared_workflow' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() =>
+      expect(mockStudioApi.getWorkspaceSettings).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "The current workspace's save location couldn't be loaded.",
+        ),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole('heading', { name: 'Import YAML' })).toBeVisible();
+    expect(screen.getByLabelText('Workflow YAML')).toHaveValue(
+      'name: prepared_workflow',
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { scopesApi } from '@/shared/api/scopesApi';
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
-import { studioApi } from '@/shared/studio/api';
+import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
 import type {
   StudioValidationFinding,
   StudioWorkflowSaveResult,
@@ -114,9 +114,16 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
   });
 
   React.useEffect(() => {
-    if (!directoryId && workspace.data?.directories[0]?.directoryId) {
-      setDirectoryId(workspace.data.directories[0].directoryId);
+    if (!workspace.data) return;
+    if (
+      directoryId &&
+      workspace.data.directories.some(
+        (item) => item.directoryId === directoryId,
+      )
+    ) {
+      return;
     }
+    setDirectoryId(workspace.data.directories[0]?.directoryId ?? '');
   }, [directoryId, workspace.data]);
 
   const navigateToWorkflow = React.useCallback(
@@ -139,7 +146,16 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
 
   const persist = async (nextYaml: string, suggestedName?: string) => {
     const workflowName = (name || suggestedName || '').trim();
-    if (!workflowName || !directoryId || submitting) return;
+    if (!workflowName || submitting) return;
+    if (!directoryId) {
+      setFailure(
+        t(
+          'workflowActivityVNext.new.saveTargetRequired',
+          'Choose an available save location before creating the workflow.',
+        ),
+      );
+      return;
+    }
     setSubmitting(true);
     setFailure('');
     try {
@@ -233,10 +249,12 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
     'workflowActivityVNext.new.templateDescription.incidentTriage',
     'Classify an incident, prepare a response, and request human approval.',
   );
-  const disabledByWorkspace =
-    workspace.isPending ||
-    workspace.isError ||
-    workspace.data?.directories.length === 0;
+  const saveTargetUnavailable = !directoryId;
+  const workspaceAccessDenied =
+    isStudioApiStatus(workspace.error, 401) ||
+    isStudioApiStatus(workspace.error, 403);
+  const reviewAccess = () =>
+    history.push(buildWorkflowActivitySectionHref(scopeId, 'settings'));
   const selectMode = (nextMode: WorkflowCreationMode) => {
     setFailure('');
     setFindings([]);
@@ -265,6 +283,10 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
     >
       {workspace.isPending ? (
         <Alert
+          description={t(
+            'workflowActivityVNext.new.workspaceLoadingDescription',
+            'Choose a creation method now. Your input stays on this page while the current workspace save location loads.',
+          )}
           message={t(
             'workflowActivityVNext.new.workspaceLoading',
             'Loading save locations…',
@@ -276,13 +298,26 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
       {workspace.isError ? (
         <Alert
           action={
-            <Button onClick={() => void workspace.refetch()}>
-              {t('workflowActivityVNext.common.retry', 'Retry')}
-            </Button>
+            <Space wrap>
+              <Button onClick={() => void workspace.refetch()}>
+                {t('workflowActivityVNext.common.retry', 'Retry')}
+              </Button>
+              <Button onClick={reviewAccess}>
+                {t('workflowActivityVNext.new.reviewAccess', 'Review access')}
+              </Button>
+            </Space>
           }
+          description={t(
+            'workflowActivityVNext.new.workspaceUnavailableDescription',
+            'Choose a creation method now. Your input stays on this page while you restore access.',
+          )}
           message={t(
-            'workflowActivityVNext.new.workspaceUnavailable',
-            'Save locations unavailable',
+            workspaceAccessDenied
+              ? 'workflowActivityVNext.new.workspaceUnauthorized'
+              : 'workflowActivityVNext.new.workspaceUnavailable',
+            workspaceAccessDenied
+              ? "You don't have access to a save location in the current workspace."
+              : "The current workspace's save location couldn't be loaded.",
           )}
           showIcon
           type="error"
@@ -290,9 +325,23 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
       ) : null}
       {workspace.data?.directories.length === 0 ? (
         <Alert
+          action={
+            <Space wrap>
+              <Button onClick={() => void workspace.refetch()}>
+                {t('workflowActivityVNext.common.retry', 'Retry')}
+              </Button>
+              <Button onClick={reviewAccess}>
+                {t('workflowActivityVNext.new.reviewAccess', 'Review access')}
+              </Button>
+            </Space>
+          }
+          description={t(
+            'workflowActivityVNext.new.noDirectoriesDescription',
+            'A save location is required to own the workflow. You can prepare your input here while access is restored.',
+          )}
           message={t(
             'workflowActivityVNext.new.noDirectories',
-            'No save location is available. Try again later or contact your administrator.',
+            'No save location is available in the current workspace.',
           )}
           showIcon
           type="warning"
@@ -310,7 +359,6 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
           {modeItems.map((item) => (
             <button
               aria-label={item.label}
-              disabled={disabledByWorkspace}
               className="wa-vnext__creation-option"
               key={item.key}
               onClick={() => selectMode(item.key)}
@@ -364,6 +412,8 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                   value: item.directoryId,
                 }))}
                 className="wa-vnext__field-control"
+                disabled={saveTargetUnavailable}
+                loading={workspace.isPending}
                 value={directoryId || undefined}
               />
             </div>
@@ -443,7 +493,7 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                   </Button>
                   {generatedYaml && generatedReady ? (
                     <Button
-                      disabled={!name.trim()}
+                      disabled={!name.trim() || saveTargetUnavailable}
                       loading={submitting}
                       onClick={() => void persist(generatedYaml)}
                       type="primary"
@@ -460,7 +510,7 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
 
             {mode === 'blank' ? (
               <Button
-                disabled={!name.trim()}
+                disabled={!name.trim() || saveTargetUnavailable}
                 loading={submitting}
                 onClick={() => void persist(createBlankWorkflowYaml(name))}
                 type="primary"
@@ -487,7 +537,7 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                   />
                 </div>
                 <Button
-                  disabled={!yaml.trim()}
+                  disabled={!yaml.trim() || saveTargetUnavailable}
                   loading={submitting}
                   onClick={() => void validateAndPersist(yaml)}
                   type="primary"
@@ -529,7 +579,9 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                   </div>
                 ) : null}
                 <Button
-                  disabled={!selectedTemplate || !name.trim()}
+                  disabled={
+                    !selectedTemplate || !name.trim() || saveTargetUnavailable
+                  }
                   loading={submitting}
                   onClick={() =>
                     selectedTemplate &&


### PR DESCRIPTION
## Problem and solution

Save-location discovery currently disables every workflow creation method. This change separates method selection and input preparation from the authoritative save-target preflight. Loading, network failure, unauthorized, and empty-directory states now explain the current workspace prerequisite, preserve input, and expose Retry plus Review access. Final create actions remain disabled until the API supplies a real directoryId, so no workflow ownership is guessed.

Closes #3220

## Impacted paths

- apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
- apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx

## Focused verification

- pnpm exec jest src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx --runInBand
  - PASS: 1 suite, 5 tests
- pnpm exec biome check src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
  - PASS: 2 changed files
- bash tools/ci/test_stability_guards.sh
  - PASS
- git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD --check
  - PASS

A repository-native affected typecheck is unavailable, so local typecheck was skipped. The full frontend suite, typecheck, and production build are delegated to GitHub CI under the incremental frontend policy.


## CI follow-up verification

- Related and locale contract tests: `pnpm exec jest src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx src/locales/catalog.test.ts src/locales/hardcodedCopyAudit.test.ts --runInBand` - passed 3 suites and 19 tests.
- Changed-file static checks: `pnpm exec biome check` on all 4 analyzer-selected frontend files - passed.
- Patch integrity: `git diff --check` - passed.
- Full frontend suite/typecheck/build: delegated to GitHub CI by the personal incremental frontend policy.