### PR TITLE
Fix Settings save action dock

### DIFF
--- a/apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/README.md
+++ b/apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/README.md
@@ -143,7 +143,7 @@ failures rather than undocumented implementation choices.
 - `prototype-create-mobile.png`：移动端 Workflow 画布，保留 Run、Add node、Edit YAML、Save 和 Publish。
 - `prototype-editor-mobile-node.png`：移动端点击节点后的底部配置面板。
 - `prototype-settings-llm.png`：重构后的 AI defaults 桌面视图。
-- `prototype-settings-save.png`：产生修改后才出现的 sticky save bar 与保存确认状态。
+- `prototype-settings-save.png`：展示来源原型中产生修改后才出现的 sticky save bar 与保存确认状态；生产实现按专项设计改为 shell-fixed dock。
 - `prototype-settings-account.png`：Account 身份、会话与 service access 桌面视图。
 - `prototype-settings-advanced.png`：独立的只读 Runtime 与 request values 视图。
 - `prototype-settings-tablet.png`：Settings 的 768px 布局。
@@ -251,7 +251,7 @@ Settings 的功能来源仍然是当前 Aevatar Console，但信息架构已经�
 - `Account`：当前浏览器身份、User ID、roles、groups、会话到期时间、NyxID provider、scope、Sign in / Sign out 和 Manage service access；字段本身足够明确，不再重复配小节说明。
 - `Advanced`：只保留一份 effective request values。Runtime mode 与 base URL 不再同时出现在只读输入和 raw values 两处。
 
-独立原型会把 AI 默认值保存在浏览器 `localStorage`，仅用于演示重开页面后的交互连续性。生产实现必须通过真实 Settings API 读取、保存并观察 AI 默认值，不能读取这份原型存储。选择 exact connected service 时，模型列表会跟着服务切换。默认状态保持安静；只有产生修改后，sticky save bar 才出现。保存动作先进入 accepted / confirming saved values，再根据权威查询更新已保存 service。fallback、catalog unavailable 与 provider unavailable 只在异常状态出现。Account 的 Sign in、Sign out 与 service access 继续复用现有真实逻辑。
+独立原型会把 AI 默认值保存在浏览器 `localStorage`，仅用于演示重开页面后的交互连续性。生产实现必须通过真实 Settings API 读取、保存并观察 AI 默认值，不能读取这份原型存储。选择 exact connected service 时，模型列表会跟着服务切换。默认状态保持安静；只有产生修改后，来源原型中的 sticky save bar 才出现；生产实现必须按 `2026-08-06-settings-save-action-dock-design.md` 使用 shell-fixed dock。保存动作先进入 accepted / confirming saved values，再根据权威查询更新已保存 service。fallback、catalog unavailable 与 provider unavailable 只在异常状态出现。Account 的 Sign in、Sign out 与 service access 继续复用现有真实逻辑。
 
 ## 基线完整性校验
 

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-settings-save-action-dock.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-settings-save-action-dock.md
@@ -15,7 +15,7 @@
 **Files:**
 - Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
 
-- [ ] **Step 1: Add a focused route integration test**
+- [x] **Step 1: Add a focused route integration test**
 
 Add a test in the existing `Workflow Activity vNext settings` describe block. Use distinct authoritative service data, edit Preferred service through the rendered select, and assert the accessible ownership contract:
 
@@ -91,7 +91,7 @@ it('keeps dirty save actions outside the scrolling AI defaults panel', async () 
 
 Reuse the file's existing `within` import from Testing Library.
 
-- [ ] **Step 2: Run the exact test and verify RED**
+- [x] **Step 2: Run the exact test and verify RED**
 
 Run from the repository root:
 
@@ -113,7 +113,7 @@ Expected: FAIL because no region named `Unsaved settings actions` exists and the
 - Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`
 - Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`
 
-- [ ] **Step 1: Add a route-neutral shell footer slot**
+- [x] **Step 1: Add a route-neutral shell footer slot**
 
 Extend `ShellProps` with:
 
@@ -139,63 +139,37 @@ render the current main DOM and scrolling unchanged. When present, render:
 
 Do not add the wrapper on routes without a footer.
 
-- [ ] **Step 2: Move the action surface out of `aiPanel`**
+- [x] **Step 2: Move the action surface out of `aiPanel`**
 
 Delete the dirty action JSX from the `wa-vnext__form`. Create one route-owned
 action region using the same handlers and state:
 
 ```tsx
-const settingsFooter = dirty ? (
-  <div className="wa-vnext__settings-footer">
-    <section
-      aria-label={t(
-        'workflowActivityVNext.settings.unsavedActionsAria',
-        'Unsaved settings actions',
-      )}
-      className="wa-vnext__settings-savebar"
-    >
-      <div aria-live="polite" role="status">
-        <strong>
-          {t('workflowActivityVNext.settings.unsaved', 'Unsaved changes')}
-        </strong>
-        <span>
-          {t(
-            'workflowActivityVNext.settings.unsavedDescription',
-            'Your AI defaults have not been saved.',
+const settingsFooter = (
+  <>
+    {dirty ? (
+      <div className="wa-vnext__settings-footer">
+        <section
+          aria-label={t(
+            'workflowActivityVNext.settings.unsavedActionsAria',
+            'Unsaved settings actions',
           )}
-        </span>
+          className="wa-vnext__settings-savebar"
+        >
+          {/* Existing status copy and Restore / Save controls. */}
+        </section>
       </div>
-      <Space className="wa-vnext__settings-actions" wrap>
-        <Button
-          disabled={savePhase === 'saving' || savePhase === 'accepted'}
-          onClick={discard}
-        >
-          {t(
-            'workflowActivityVNext.settings.discard',
-            'Restore saved settings',
-          )}
-        </Button>
-        <Button
-          disabled={
-            !llm.data?.capabilities.canSave || savePhase === 'accepted'
-          }
-          icon={<SaveOutlined />}
-          loading={savePhase === 'saving'}
-          onClick={() => void save()}
-          type="primary"
-        >
-          {t('workflowActivityVNext.settings.save', 'Save changes')}
-        </Button>
-      </Space>
-    </section>
-  </div>
-) : undefined;
+    ) : null}
+  </>
+);
 ```
 
-Pass `footer={settingsFooter}` to `WorkflowActivityVNextShell`. Keep save,
-discard, accepted-to-observed, error, delayed, and navigation logic unchanged.
+Pass `footer={settingsFooter}` to `WorkflowActivityVNextShell`. The fragment is
+always present so toggling dirty state does not replace the shell's scroll
+subtree. Keep save, discard, accepted-to-observed, error, delayed, and
+navigation logic unchanged.
 
-- [ ] **Step 3: Add synchronized locale messages**
+- [x] **Step 3: Add synchronized locale messages**
 
 Add to the English catalogue:
 
@@ -210,7 +184,7 @@ Add to the Chinese catalogue:
 'workflowActivityVNext.settings.unsavedActionsAria': '未保存设置操作',
 ```
 
-- [ ] **Step 4: Implement stable scroll ownership and responsive sizing**
+- [x] **Step 4: Implement stable scroll ownership and responsive sizing**
 
 Add the shell contract:
 
@@ -241,13 +215,13 @@ Change the save bar to normal layout inside the shell footer: remove
 360 px change the action grid to one column. The dock must never overlay the
 scroll region.
 
-- [ ] **Step 5: Run the exact test and verify GREEN**
+- [x] **Step 5: Run the exact test and verify GREEN**
 
 Run the Task 1 Jest command again.
 
 Expected: PASS with one test and no warning or console error.
 
-- [ ] **Step 6: Run dependency-related route coverage**
+- [x] **Step 6: Run dependency-related route coverage**
 
 Run the complete colocated route file because shell composition is shared by
 all vNext child routes:
@@ -269,7 +243,7 @@ Expected: PASS for every test in that file.
 - Modify: `apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/README.md`
 - Modify: `apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-settings-save-action-dock.md`
 
-- [ ] **Step 1: Record the approved and implemented contract**
+- [x] **Step 1: Record the approved and implemented contract**
 
 Mark the new design approved for implementation, then implemented after the
 focused checks pass. Replace the two sticky references at lines 520 and 666 of
@@ -280,7 +254,7 @@ Keep the imported Excalidraw, generator, PNGs, and prototype byte-identical;
 document the required production deviation instead of editing those source
 assets.
 
-- [ ] **Step 2: Run the frontend scope analyzer**
+- [x] **Step 2: Run the frontend scope analyzer**
 
 ```bash
 python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py \
@@ -292,7 +266,7 @@ Read the JSON. Run every changed test explicitly and dependency-related Jest
 tests for changed source files. Pass only reported `staticCheckFiles` to Biome.
 Do not run a full local frontend test, lint, typecheck, or production build.
 
-- [ ] **Step 3: Run documentation and repository hygiene checks**
+- [x] **Step 3: Run documentation and repository hygiene checks**
 
 ```bash
 python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py
@@ -304,7 +278,7 @@ git diff --check
 Expected: baseline SHA matches, 17/17 frames pass, docs lint passes, test
 stability guard passes, and no whitespace error is reported.
 
-- [ ] **Step 4: Verify real layout behavior in the existing browser**
+- [x] **Step 4: Verify real layout behavior in the existing browser**
 
 Start the worktree frontend on a free non-5000/non-5050 port with matching
 local OAuth origin configuration and no mock data. At 1440 x 900, 834 x 1112,
@@ -320,12 +294,17 @@ Capture screenshots as task evidence. If real authenticated backend state is
 unavailable, report that exact residual gap and do not inject production mock
 data.
 
+Result: the real application ran on port 5187 with `MOCK=none`, but that origin
+had no authenticated session and the registered NyxID callback port 5173 was
+owned by another process. No session or Settings data was mocked. Authenticated
+responsive screenshots remain a preview-environment verification item.
+
 ### Task 4: Review, Commit, Deliver, And Reach Mergeable State
 
 **Files:**
 - Review every file changed from `origin/feat/2026-08-04_workflow-activity-vnext`
 
-- [ ] **Step 1: Review the complete diff**
+- [x] **Step 1: Review the complete diff**
 
 Confirm that the diff is frontend-only, contains no imported baseline artifact
 changes, preserves all save contracts, and includes no unrelated worktree

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-settings-save-action-dock.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-settings-save-action-dock.md
@@ -1,0 +1,361 @@
+# Settings Save Action Dock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep dirty Workflow Activity vNext Settings save actions stationary at the bottom of the main work area without covering form content or changing save semantics.
+
+**Architecture:** Add an optional footer slot to `WorkflowActivityVNextShell`. Only routes providing that slot split the main column into an independently scrolling body and a natural-height footer; `SettingsPage` provides the existing dirty actions through the slot and keeps all form/save state local.
+
+**Tech Stack:** React 19, TypeScript, Umi Max, Ant Design, Jest, Testing Library, CSS template strings, Biome.
+
+---
+
+### Task 1: Protect The Shell-Owned Dirty Action Contract
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] **Step 1: Add a focused route integration test**
+
+Add a test in the existing `Workflow Activity vNext settings` describe block. Use distinct authoritative service data, edit Preferred service through the rendered select, and assert the accessible ownership contract:
+
+```tsx
+it('keeps dirty save actions outside the scrolling AI defaults panel', async () => {
+  mockStudioApi.getUserLlmSettings.mockResolvedValue({
+    savedSelection: null,
+    savedRouteLabel: 'System default',
+    selectionStatus: 'system_default',
+    catalogDiagnostic: 'unspecified',
+    remediation: 'none',
+    catalogStatus: 'ready',
+    capabilities: {
+      canEditRoute: true,
+      canEditModel: true,
+      canSave: true,
+      canRetryCatalog: true,
+    },
+    routeOptions: [
+      {
+        routeValue: '/api/v1/proxy/s/service-alpha',
+        label: 'Service alpha',
+        source: 'user_service',
+        status: 'ready',
+        allowed: true,
+        ready: true,
+        userServiceId: 'us-alpha',
+        serviceSlug: 'service-alpha',
+        modelCatalog: {
+          certainty: 'enumerated',
+          modelIds: ['model-alpha'],
+          defaultModelId: 'model-alpha',
+          diagnostic: 'unspecified',
+        },
+        description: null,
+      },
+    ],
+    modelGroupsByRoute: [],
+  });
+
+  renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+  expect(
+    screen.queryByRole('region', { name: 'Unsaved settings actions' }),
+  ).not.toBeInTheDocument();
+  fireEvent.mouseDown(
+    await screen.findByRole('combobox', { name: 'Preferred service' }),
+  );
+  fireEvent.click(await screen.findByText('Service alpha'));
+
+  const aiDefaultsPanel = screen.getByRole('region', {
+    name: 'AI defaults',
+  });
+  const saveActions = screen.getByRole('region', {
+    name: 'Unsaved settings actions',
+  });
+  expect(aiDefaultsPanel).not.toContainElement(saveActions);
+  expect(
+    within(saveActions).getByRole('button', { name: 'Save changes' }),
+  ).toBeEnabled();
+
+  fireEvent.click(
+    within(saveActions).getByRole('button', {
+      name: 'Restore saved settings',
+    }),
+  );
+  expect(
+    screen.queryByRole('region', { name: 'Unsaved settings actions' }),
+  ).not.toBeInTheDocument();
+  expect(mockStudioApi.saveUserLlmSettings).not.toHaveBeenCalled();
+});
+```
+
+Reuse the file's existing `within` import from Testing Library.
+
+- [ ] **Step 2: Run the exact test and verify RED**
+
+Run from the repository root:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest \
+  --runInBand \
+  --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx \
+  --testNamePattern 'keeps dirty save actions outside the scrolling AI defaults panel'
+```
+
+Expected: FAIL because no region named `Unsaved settings actions` exists and the current action bar remains inside the AI defaults form.
+
+### Task 2: Add The Optional Shell Footer And Move The Actions
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts`
+- Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`
+- Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`
+
+- [ ] **Step 1: Add a route-neutral shell footer slot**
+
+Extend `ShellProps` with:
+
+```tsx
+readonly footer?: React.ReactNode;
+```
+
+Build the existing header and content as `mainBody`. When `footer` is absent,
+render the current main DOM and scrolling unchanged. When present, render:
+
+```tsx
+<main
+  className={`wa-vnext__main${footer ? ' wa-vnext__main--with-footer' : ''}`}
+>
+  {footer ? (
+    <div className="wa-vnext__main-scroll">{mainBody}</div>
+  ) : (
+    mainBody
+  )}
+  {footer ? <div className="wa-vnext__main-footer">{footer}</div> : null}
+</main>
+```
+
+Do not add the wrapper on routes without a footer.
+
+- [ ] **Step 2: Move the action surface out of `aiPanel`**
+
+Delete the dirty action JSX from the `wa-vnext__form`. Create one route-owned
+action region using the same handlers and state:
+
+```tsx
+const settingsFooter = dirty ? (
+  <div className="wa-vnext__settings-footer">
+    <section
+      aria-label={t(
+        'workflowActivityVNext.settings.unsavedActionsAria',
+        'Unsaved settings actions',
+      )}
+      className="wa-vnext__settings-savebar"
+    >
+      <div aria-live="polite" role="status">
+        <strong>
+          {t('workflowActivityVNext.settings.unsaved', 'Unsaved changes')}
+        </strong>
+        <span>
+          {t(
+            'workflowActivityVNext.settings.unsavedDescription',
+            'Your AI defaults have not been saved.',
+          )}
+        </span>
+      </div>
+      <Space className="wa-vnext__settings-actions" wrap>
+        <Button
+          disabled={savePhase === 'saving' || savePhase === 'accepted'}
+          onClick={discard}
+        >
+          {t(
+            'workflowActivityVNext.settings.discard',
+            'Restore saved settings',
+          )}
+        </Button>
+        <Button
+          disabled={
+            !llm.data?.capabilities.canSave || savePhase === 'accepted'
+          }
+          icon={<SaveOutlined />}
+          loading={savePhase === 'saving'}
+          onClick={() => void save()}
+          type="primary"
+        >
+          {t('workflowActivityVNext.settings.save', 'Save changes')}
+        </Button>
+      </Space>
+    </section>
+  </div>
+) : undefined;
+```
+
+Pass `footer={settingsFooter}` to `WorkflowActivityVNextShell`. Keep save,
+discard, accepted-to-observed, error, delayed, and navigation logic unchanged.
+
+- [ ] **Step 3: Add synchronized locale messages**
+
+Add to the English catalogue:
+
+```ts
+'workflowActivityVNext.settings.unsavedActionsAria':
+  'Unsaved settings actions',
+```
+
+Add to the Chinese catalogue:
+
+```ts
+'workflowActivityVNext.settings.unsavedActionsAria': '未保存设置操作',
+```
+
+- [ ] **Step 4: Implement stable scroll ownership and responsive sizing**
+
+Add the shell contract:
+
+```css
+.wa-vnext__main--with-footer {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  overflow: hidden;
+}
+.wa-vnext__main-scroll {
+  min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.wa-vnext__main-footer { min-width: 0; }
+.wa-vnext__settings-footer {
+  background: var(--wa-surface);
+  padding: 0 40px max(12px, env(safe-area-inset-bottom));
+}
+```
+
+Change the save bar to normal layout inside the shell footer: remove
+`position`, `bottom`, and `margin-top`; add `margin: 0 auto` and
+`max-width: 1120px`. Use 32 px footer gutters below 1100 px and 16 px below
+768 px. Preserve the current stacked mobile copy/actions at 600 px, and at
+360 px change the action grid to one column. The dock must never overlay the
+scroll region.
+
+- [ ] **Step 5: Run the exact test and verify GREEN**
+
+Run the Task 1 Jest command again.
+
+Expected: PASS with one test and no warning or console error.
+
+- [ ] **Step 6: Run dependency-related route coverage**
+
+Run the complete colocated route file because shell composition is shared by
+all vNext child routes:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest \
+  --runInBand \
+  --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx
+```
+
+Expected: PASS for every test in that file.
+
+### Task 3: Align Normative Documentation And Verify The Change
+
+**Files:**
+- Modify: `apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-settings-save-action-dock-design.md`
+- Modify: `apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-design.md`
+- Modify: `apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-user-paths.md`
+- Modify: `apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/README.md`
+- Modify: `apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-settings-save-action-dock.md`
+
+- [ ] **Step 1: Record the approved and implemented contract**
+
+Mark the new design approved for implementation, then implemented after the
+focused checks pass. Replace the two sticky references at lines 520 and 666 of
+the original design, the dirty-step reference at line 674 of the user paths,
+and the two prototype-description references at lines 146 and 254 of the
+baseline README with `shell-fixed Restore and Save changes dock` language.
+Keep the imported Excalidraw, generator, PNGs, and prototype byte-identical;
+document the required production deviation instead of editing those source
+assets.
+
+- [ ] **Step 2: Run the frontend scope analyzer**
+
+```bash
+python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py \
+  --repo . \
+  --base origin/feat/2026-08-04_workflow-activity-vnext
+```
+
+Read the JSON. Run every changed test explicitly and dependency-related Jest
+tests for changed source files. Pass only reported `staticCheckFiles` to Biome.
+Do not run a full local frontend test, lint, typecheck, or production build.
+
+- [ ] **Step 3: Run documentation and repository hygiene checks**
+
+```bash
+python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py
+bash tools/docs/lint.sh
+bash tools/ci/test_stability_guards.sh
+git diff --check
+```
+
+Expected: baseline SHA matches, 17/17 frames pass, docs lint passes, test
+stability guard passes, and no whitespace error is reported.
+
+- [ ] **Step 4: Verify real layout behavior in the existing browser**
+
+Start the worktree frontend on a free non-5000/non-5050 port with matching
+local OAuth origin configuration and no mock data. At 1440 x 900, 834 x 1112,
+and 390 x 844, verify:
+
+- the dirty dock stays stationary while Settings content scrolls;
+- the last field and durable alerts can scroll fully above the dock;
+- the dock never enters the navigation rail;
+- actions remain reachable and do not overlap;
+- mobile has no page-level horizontal overflow and includes safe-area spacing.
+
+Capture screenshots as task evidence. If real authenticated backend state is
+unavailable, report that exact residual gap and do not inject production mock
+data.
+
+### Task 4: Review, Commit, Deliver, And Reach Mergeable State
+
+**Files:**
+- Review every file changed from `origin/feat/2026-08-04_workflow-activity-vnext`
+
+- [ ] **Step 1: Review the complete diff**
+
+Confirm that the diff is frontend-only, contains no imported baseline artifact
+changes, preserves all save contracts, and includes no unrelated worktree
+files. Review long-label behavior and all conditional shell paths.
+
+- [ ] **Step 2: Commit only task files as AbigailDeng**
+
+Stage explicit paths only. Commit with:
+
+```bash
+git -c user.name=AbigailDeng \
+  -c user.email=108705114+AbigailDeng@users.noreply.github.com \
+  commit -m "Fix Settings save action dock"
+```
+
+- [ ] **Step 3: Push and open the pull request**
+
+Push `fix/2026-08-06_settings-save-action-dock` and create a PR with base
+`feat/2026-08-04_workflow-activity-vnext`. Verify the PR author is
+`AbigailDeng`. Include the required design-baseline declaration, affected
+paths, exact focused command results, screenshots or the exact browser-QA gap,
+and:
+
+```text
+Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
+```
+
+- [ ] **Step 4: Make the PR mergeable**
+
+Poll required checks, review comments, merge conflicts, and GitHub mergeability.
+Fix branch-owned failures, push updates, and recheck until the PR reports no
+conflict and all required checks pass. Never create or update the PR as
+`Abigail940404`.

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-design.md
@@ -517,9 +517,11 @@ menu that preserves the same section labels and focus behavior.
 
 Normal state contains two decisions: Preferred service and Default model.
 Changing service refreshes the valid model choices. Dirty state alone reveals
-the sticky Discard and Save changes bar. Save uses the existing LLM settings
-contract and follows accepted-to-observed semantics; success appears only when
-the authoritative query observes the selected values.
+the shell-fixed Restore and Save changes dock. Settings keeps the shell footer
+slot mounted in clean and dirty states so showing the dock does not remount the
+form or move focus. Save uses the existing LLM settings contract and follows
+accepted-to-observed semantics; success appears only when the authoritative
+query observes the selected values.
 
 Fallback, provider unavailable, and catalogue unavailable are exceptional
 states with direct recovery actions. The UI must not silently select and save
@@ -663,7 +665,7 @@ hierarchy and density while using production tokens and real data states.
 | Fork | Failed | Source remains unchanged; inputs preserved | Retry request |
 | Settings | Loading | Stable controls without default invention | Wait |
 | Settings | Clean | Quiet current values | Edit |
-| Settings | Dirty | Sticky Discard and Save changes | Save or discard |
+| Settings | Dirty | Shell-fixed Restore and Save changes dock | Save or restore |
 | Settings | Save accepted | Confirming saved values | Continue observing |
 | Settings | Save failed | Preserve dirty choices | Retry or discard |
 | Settings | Catalogue unavailable | Existing choice remains visible | Retry catalogue |

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-user-paths.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-user-paths.md
@@ -671,8 +671,8 @@ PUT /api/user-config/llm
 1. Settings opens AI defaults and loads the current real selection and
    available connected-service/model catalogue through existing adapters.
 2. Changing Preferred service updates valid model choices without saving.
-3. Changing either value makes the page dirty and reveals the sticky Discard
-   and Save changes bar.
+3. Changing either value makes the page dirty and reveals the shell-fixed
+   Restore and Save changes dock without remounting the edited form control.
 4. Discard restores the last authoritative values.
 5. Save sends the selected intent and receives an accepted receipt.
 6. The UI says `Confirming saved values`, not Saved.
@@ -758,7 +758,7 @@ the mobile editor references in the baseline directory.
   remain available without desktop-only hover.
 - Run detail: failure, output, step trace, Retry, and Run again eligibility
   remain accessible.
-- Settings: section navigation, dirty save bar, save observation, Account
+- Settings: section navigation, shell-fixed dirty save dock, save observation, Account
   actions, and Advanced values remain operable.
 - Login and callback: the existing NyxID flow remains usable at mobile width,
   and the existing language switch remains reachable without desktop chrome.

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-settings-save-action-dock-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-settings-save-action-dock-design.md
@@ -2,12 +2,12 @@
 
 ## Status
 
-Proposed for written review on 2026-08-06.
+Approved and implemented on 2026-08-06.
 
 This specification covers only the Workflow Activity vNext Settings save
 action layout. It is based on branch
 `feat/2026-08-04_workflow-activity-vnext` at
-`fad9adf6283a620c60b4b4afd377615653f999e9`.
+`3416817a147df0d362bcf770b9cf59f65b624ab8`.
 
 The approved direction is a shell-owned bottom action area. It supersedes the
 earlier use of the word `sticky` for this save bar in the Workflow Activity
@@ -103,11 +103,13 @@ or editor layout.
 
 ### Settings Ownership
 
-`SettingsPage` provides the footer only while the AI defaults draft is dirty.
-The save action component is removed from the AI defaults form body. It remains
-owned by `SettingsPage`, so it uses the existing `draft`, `baseline`,
-`savePhase`, `discard`, and `save` state and handlers without introducing a
-second state container.
+`SettingsPage` always provides the shell footer slot so changing dirty state
+does not remount the scrolling form or move focus away from the edited control.
+The slot renders no visible content while the draft is clean and renders the
+action dock only while it is dirty. The save action component is removed from
+the AI defaults form body. It remains owned by `SettingsPage`, so it uses the
+existing `draft`, `baseline`, `savePhase`, `discard`, and `save` state and
+handlers without introducing a second state container.
 
 The footer wrapper follows the same responsive horizontal gutters as the
 Settings content. The dark action surface is centered at the existing Settings
@@ -216,6 +218,15 @@ CSS is verified through browser QA at 1440 x 900, 834 x 1112, and 390 x 844.
 The checks confirm a stationary dock during content scrolling, no covered last
 field or alert, no page-level horizontal overflow, reachable buttons, and
 correct mobile safe-area spacing.
+
+Local authenticated browser QA was attempted on port 5187 with the real API
+proxy and `MOCK=none`. The temporary origin had no authenticated session, and
+the configured NyxID client returned to the registered port 5173, which was
+already owned by another process. The implementation did not inject a session,
+copy browser storage, or substitute mock Settings data. Final authenticated
+screenshots therefore remain preview-environment verification; focused route
+tests, locale parity, changed-file static checks, and CI protect the local
+implementation contract.
 
 Local automated verification remains focused on changed and dependency-related
 files. Full frontend tests, typecheck, and production build are delegated to

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-settings-save-action-dock-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-settings-save-action-dock-design.md
@@ -1,0 +1,278 @@
+# Settings Save Action Dock Design
+
+## Status
+
+Proposed for written review on 2026-08-06.
+
+This specification covers only the Workflow Activity vNext Settings save
+action layout. It is based on branch
+`feat/2026-08-04_workflow-activity-vnext` at
+`fad9adf6283a620c60b4b4afd377615653f999e9`.
+
+The approved direction is a shell-owned bottom action area. It supersedes the
+earlier use of the word `sticky` for this save bar in the Workflow Activity
+vNext design specification and user paths. The save contract, authoritative
+data source, colors, navigation, and Settings information architecture remain
+unchanged.
+
+## Sources And Precedence
+
+This specification must be read with:
+
+1. `docs/canon/frontend-design.md`, including the Workflow Activity vNext
+   NyxID visual-alignment rules;
+2. `docs/design-baselines/workflow-activity-vnext/README.md` and its primary
+   Excalidraw artifact;
+3. `2026-08-04-workflow-activity-vnext-design.md`;
+4. `2026-08-04-workflow-activity-vnext-user-paths.md`.
+
+This document has precedence only for the location, scroll ownership,
+responsive layout, and accessibility semantics of the dirty Settings save
+actions. All other contracts retain their existing precedence.
+
+## Problem
+
+The current dirty action bar is rendered inside the AI defaults form and uses
+`position: sticky`. Its containing page owns the vertical scroll. As a result:
+
+- the action bar moves with the form before reaching its sticky threshold;
+- its location is coupled to the form card rather than the Settings work area;
+- below 600 px, CSS changes it to `position: static`, so it is no longer
+  persistent at all;
+- adding content above or below the form can change when and where it appears;
+- a viewport-fixed replacement would need fragile sidebar and gutter offsets
+  and could cover the last form field.
+
+The user needs the pending save decision to remain continuously reachable
+after editing without covering editable content or moving with that content.
+
+## Goals
+
+- Keep dirty Settings actions stationary at the bottom of the Settings main
+  work area on desktop, tablet, and mobile.
+- Let the header, local Settings navigation, form, alerts, and technical
+  details scroll in a separate region above the actions.
+- Keep the action area outside the 200 px desktop navigation rail.
+- Preserve the current Aevatar colors and Workflow Activity vNext visual
+  language while following the NyxID-derived spacing, density, and responsive
+  rules.
+- Preserve the existing accepted-to-observed save lifecycle, dirty navigation
+  guard, and authoritative API behavior.
+- Keep every form field, validation message, and recovery message reachable
+  without being covered by the action area.
+
+## Non-Goals
+
+- No backend, API, query, cache, authentication, routing, or persistence
+  change.
+- No redesign of Preferred service, Default model, Account, or Advanced.
+- No new global footer, global navigation behavior, or legacy Settings change.
+- No color, typography-family, or brand change.
+- No viewport-fixed positioning and no sidebar-width calculation.
+- No change to success, failure, delayed-observation, or leave-confirmation
+  semantics.
+
+## Chosen Layout
+
+### Shell Footer Slot
+
+`WorkflowActivityVNextShell` receives an optional footer slot. The shell uses
+its current layout when the slot is absent. When the slot is present, the main
+column becomes two rows:
+
+```text
+Workflow Activity vNext shell
+  top bar
+  navigation rail | main column
+                    scroll region
+                      page header
+                      route content
+                    footer region
+                      route-provided action dock
+```
+
+The main column, not the viewport, establishes the boundary. The scroll region
+uses `minmax(0, 1fr)` and owns vertical overflow. The footer occupies its
+natural height and never scrolls with the content. This keeps it aligned with
+the shell when the desktop rail is visible and when the rail becomes a mobile
+drawer.
+
+Routes that do not provide a footer retain the existing main-column scrolling
+behavior. The change must not alter Workflows, Activity, Run detail, creation,
+or editor layout.
+
+### Settings Ownership
+
+`SettingsPage` provides the footer only while the AI defaults draft is dirty.
+The save action component is removed from the AI defaults form body. It remains
+owned by `SettingsPage`, so it uses the existing `draft`, `baseline`,
+`savePhase`, `discard`, and `save` state and handlers without introducing a
+second state container.
+
+The footer wrapper follows the same responsive horizontal gutters as the
+Settings content. The dark action surface is centered at the existing Settings
+maximum width of 1120 px. It retains the current Aevatar background, border,
+text, button colors, radius, and restrained shadow.
+
+## Interaction And State Contract
+
+| State | Dock | Controls | Existing feedback |
+| --- | --- | --- | --- |
+| Clean | Hidden | None | Quiet current values |
+| Dirty | Fixed in shell footer | Restore and Save enabled according to capabilities | Unsaved title and description |
+| Saving | Fixed in shell footer | Restore disabled; Save loading and duplicate submission blocked | Existing saving state remains visible |
+| Accepted, awaiting observation | Fixed in shell footer | Restore and Save disabled | Existing confirming state remains visible |
+| Observed | Removed after baseline matches submitted values | None | Existing success toast |
+| Delayed | Fixed because the draft remains dirty | Retry Save or Restore according to current behavior | Existing durable delayed alert |
+| Failed | Fixed because the draft remains dirty | Save can be retried; Restore remains available | Existing durable error details |
+
+The dock appears and disappears from actual dirty state only. It does not use
+a timer, animation completion, request acceptance, or browser storage as its
+authority.
+
+Leaving through local navigation or the browser continues to use the existing
+dirty-navigation confirmation and `beforeunload` protection. Moving the
+actions must not bypass or duplicate those paths.
+
+## Responsive Contract
+
+### Desktop, At Least 1200 px
+
+- The 200 px navigation rail and 52 px top bar remain unchanged.
+- The footer is confined to the flexible main column.
+- Its content uses 40 px horizontal gutters and the Settings 1120 px maximum
+  width.
+- The status copy is on the left and the two actions are on the right.
+- The footer consumes layout space; it never overlays the scroll region.
+
+### Tablet, 768-1199 px
+
+- The footer uses the shell's medium horizontal gutter.
+- Copy and controls may wrap within the action surface without changing scroll
+  ownership.
+- Both commands remain visible without horizontal page overflow.
+
+### Mobile, Below 768 px
+
+- The hidden rail and drawer behavior remain unchanged.
+- The footer uses 16 px horizontal gutters and
+  `env(safe-area-inset-bottom)`.
+- Status copy and actions stack when required by available width.
+- Actions use stable responsive tracks; at the narrowest supported widths they
+  become one column rather than truncating or overlapping.
+- The scroll region shrinks to the remaining height, so focused fields,
+  validation messages, alerts, and technical details can scroll fully above
+  the dock.
+- The page must have no horizontal overflow at the 390 x 844 acceptance
+  viewport.
+
+## Accessibility
+
+- The footer is an explicitly named region, using localized copy equivalent
+  to `Unsaved settings actions`.
+- Live save status is scoped to status text rather than placing interactive
+  buttons inside a `role="status"` container.
+- Restore and Save retain native button semantics, visible focus, disabled and
+  loading behavior, and their current accessible names.
+- DOM order places the footer after the scroll region, matching its visual
+  order and keyboard sequence.
+- The fixed layout does not trap focus. When the dock appears, focus remains
+  on the field the user edited; no automatic focus jump occurs.
+- Reduced-motion preferences remain respected. The footer requires no
+  entrance or exit animation.
+
+## Error Handling
+
+This redesign does not create a new error surface. Existing save lifecycle
+feedback remains authoritative:
+
+- request failure preserves the dirty draft and technical error details;
+- accepted-but-unobserved state remains distinct from saved success;
+- delayed observation retains recovery actions;
+- only authoritative readback produces the saved success toast and clears the
+  dock.
+
+The layout must keep durable alerts inside the scroll region reachable while
+the dock remains present. The footer cannot cover or replace those alerts.
+
+## Test Strategy
+
+The highest-value evidence is the existing Workflow Activity vNext route
+integration test because the regression involves rendered Settings state,
+shell composition, and user actions together.
+
+Add focused coverage that proves:
+
+1. editing AI defaults renders a named save-action region with Restore and
+   Save while the clean state does not render that region;
+2. the shell exposes the footer as a sibling of its main scroll region, so the
+   actions are not children of the form panel;
+3. Restore clears dirty state and removes the footer without calling the save
+   API;
+4. existing Save loading, accepted-to-observed, failure, and dirty-navigation
+   tests continue to pass.
+
+CSS is verified through browser QA at 1440 x 900, 834 x 1112, and 390 x 844.
+The checks confirm a stationary dock during content scrolling, no covered last
+field or alert, no page-level horizontal overflow, reachable buttons, and
+correct mobile safe-area spacing.
+
+Local automated verification remains focused on changed and dependency-related
+files. Full frontend tests, typecheck, and production build are delegated to
+GitHub CI by the personal frontend workflow policy.
+
+## Affected Files
+
+The expected implementation surface is:
+
+- `src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx` for the
+  optional footer slot and scroll-region composition;
+- `src/pages/workflow-activity-vnext/settings/SettingsPage.tsx` for providing
+  the dirty action dock outside the form;
+- `src/pages/workflow-activity-vnext/styles.ts` for main-column, footer,
+  responsive, and safe-area layout;
+- `src/pages/workflow-activity-vnext/index.test.tsx` for route-level behavior;
+- both Workflow Activity vNext locale catalogues for the region label;
+- the existing vNext design and user-path documents to replace the superseded
+  sticky wording with the shell-fixed action contract.
+
+## Acceptance Criteria
+
+- Dirty save actions remain stationary at the bottom of the Settings main
+  column while Settings content scrolls.
+- The actions never enter or cover the desktop navigation rail.
+- The footer occupies layout space and never covers a field, alert, technical
+  detail, or focused control.
+- Clean, dirty, saving, accepted, observed, delayed, failed, restore, and
+  leave-confirmation behavior preserves the existing authoritative contract.
+- Other vNext routes retain their current layout and scroll behavior.
+- Desktop, tablet, and mobile have no action overlap or page-level horizontal
+  overflow, and mobile accounts for the bottom safe area.
+- The action region and controls are keyboard reachable and correctly named.
+- Existing Aevatar colors and the NyxID-derived non-color visual rules remain
+  intact.
+
+## Required Pull Request Declaration
+
+```text
+Design baseline:
+  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
+Primary design:
+  aevatar-workflow-activity-vnext.excalidraw
+Design SHA-256:
+  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
+Contract specification:
+  apps/aevatar-console-web/docs/superpowers/specs/
+  2026-08-04-workflow-activity-vnext-design.md
+User paths:
+  apps/aevatar-console-web/docs/superpowers/specs/
+  2026-08-04-workflow-activity-vnext-user-paths.md
+Authentication and localization:
+  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
+  presentation may change, behavior may not.
+Production data source:
+  Real APIs and API-acknowledged user actions only; no mock fallback.
+Baseline integrity:
+  python3 apps/aevatar-console-web/docs/design-baselines/
+  workflow-activity-vnext/verify-baseline.py
+```

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -385,6 +385,8 @@ const workflowActivityVNextMessages = {
     'Uses the system-selected service and model.',
   'workflowActivityVNext.settings.title': 'Settings',
   'workflowActivityVNext.settings.unsaved': 'Unsaved changes',
+  'workflowActivityVNext.settings.unsavedActionsAria':
+    'Unsaved settings actions',
   'workflowActivityVNext.settings.unsavedDescription':
     'Your AI defaults have not been saved.',
   'workflowActivityVNext.settings.unsavedLeaveDescription':

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -361,6 +361,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
       '使用系统选择的服务和模型。',
     'workflowActivityVNext.settings.title': '设置',
     'workflowActivityVNext.settings.unsaved': '未保存的更改',
+    'workflowActivityVNext.settings.unsavedActionsAria': '未保存设置操作',
     'workflowActivityVNext.settings.unsavedDescription':
       'AI 默认设置尚未保存。',
     'workflowActivityVNext.settings.unsavedLeaveDescription':

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
@@ -22,6 +22,7 @@ type ShellProps = {
   readonly activeSection: WorkflowActivitySection;
   readonly children: React.ReactNode;
   readonly description: string;
+  readonly footer?: React.ReactNode;
   readonly headerActions?: React.ReactNode;
   readonly onNavigate?: (target: string) => void;
   readonly scopeId: string;
@@ -103,6 +104,7 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
   activeSection,
   children,
   description,
+  footer,
   headerActions,
   onNavigate,
   scopeId,
@@ -113,6 +115,20 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
   const activeLabel = activeItem
     ? t(`workflowActivityVNext.nav.${activeItem.labelKey}`, activeItem.fallback)
     : title;
+  const mainBody = (
+    <>
+      <header className="wa-vnext__header">
+        <div className="wa-vnext__heading-copy">
+          <h1>{title}</h1>
+          <p>{description}</p>
+        </div>
+        {headerActions ? (
+          <div className="wa-vnext__header-actions">{headerActions}</div>
+        ) : null}
+      </header>
+      <div className="wa-vnext__content">{children}</div>
+    </>
+  );
 
   return (
     <div className="wa-vnext">
@@ -160,17 +176,15 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
           scopeId={scopeId}
         />
       </aside>
-      <main className="wa-vnext__main">
-        <header className="wa-vnext__header">
-          <div className="wa-vnext__heading-copy">
-            <h1>{title}</h1>
-            <p>{description}</p>
-          </div>
-          {headerActions ? (
-            <div className="wa-vnext__header-actions">{headerActions}</div>
-          ) : null}
-        </header>
-        <div className="wa-vnext__content">{children}</div>
+      <main
+        className={`wa-vnext__main${footer ? ' wa-vnext__main--with-footer' : ''}`}
+      >
+        {footer ? (
+          <div className="wa-vnext__main-scroll">{mainBody}</div>
+        ) : (
+          mainBody
+        )}
+        {footer ? <div className="wa-vnext__main-footer">{footer}</div> : null}
       </main>
       <Drawer
         className="wa-vnext__drawer"

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1018,6 +1018,76 @@ describe('Workflow Activity vNext settings', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('keeps dirty save actions outside the scrolling AI defaults panel', async () => {
+    mockStudioApi.getUserLlmSettings.mockResolvedValue({
+      savedSelection: null,
+      savedRouteLabel: 'System default',
+      selectionStatus: 'system_default',
+      catalogDiagnostic: 'unspecified',
+      remediation: 'none',
+      catalogStatus: 'ready',
+      capabilities: {
+        canEditRoute: true,
+        canEditModel: true,
+        canSave: true,
+        canRetryCatalog: true,
+      },
+      routeOptions: [
+        {
+          routeValue: '/api/v1/proxy/s/service-alpha',
+          label: 'Service alpha',
+          source: 'user_service',
+          status: 'ready',
+          allowed: true,
+          ready: true,
+          userServiceId: 'us-alpha',
+          serviceSlug: 'service-alpha',
+          modelCatalog: {
+            certainty: 'enumerated',
+            modelIds: ['model-alpha'],
+            defaultModelId: 'model-alpha',
+            diagnostic: 'unspecified',
+          },
+          description: null,
+        },
+      ],
+      modelGroupsByRoute: [],
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(
+      screen.queryByRole('region', { name: 'Unsaved settings actions' }),
+    ).not.toBeInTheDocument();
+    const routeSelect = await screen.findByRole('combobox', {
+      name: 'Preferred service',
+    });
+    fireEvent.mouseDown(routeSelect);
+    fireEvent.click(await screen.findByText('Service alpha'));
+
+    expect(routeSelect).toBeInTheDocument();
+    const aiDefaultsPanel = screen.getByRole('region', {
+      name: 'AI defaults',
+    });
+    const saveActions = screen.getByRole('region', {
+      name: 'Unsaved settings actions',
+    });
+    expect(aiDefaultsPanel).not.toContainElement(saveActions);
+    expect(
+      within(saveActions).getByRole('button', { name: 'Save changes' }),
+    ).toBeEnabled();
+
+    fireEvent.click(
+      within(saveActions).getByRole('button', {
+        name: 'Restore saved settings',
+      }),
+    );
+    expect(
+      screen.queryByRole('region', { name: 'Unsaved settings actions' }),
+    ).not.toBeInTheDocument();
+    expect(mockStudioApi.saveUserLlmSettings).not.toHaveBeenCalled();
+  });
+
   it('keeps connected services selectable without an enumerated model catalogue', async () => {
     mockStudioApi.getUserLlmSettings.mockResolvedValue({
       savedSelection: {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
@@ -473,43 +473,6 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           </div>
         )}
       </div>
-      {dirty ? (
-        <div className="wa-vnext__settings-savebar" role="status">
-          <div>
-            <strong>
-              {t('workflowActivityVNext.settings.unsaved', 'Unsaved changes')}
-            </strong>
-            <span>
-              {t(
-                'workflowActivityVNext.settings.unsavedDescription',
-                'Your AI defaults have not been saved.',
-              )}
-            </span>
-          </div>
-          <Space wrap>
-            <Button
-              disabled={savePhase === 'saving' || savePhase === 'accepted'}
-              onClick={discard}
-            >
-              {t(
-                'workflowActivityVNext.settings.discard',
-                'Restore saved settings',
-              )}
-            </Button>
-            <Button
-              disabled={
-                !llm.data?.capabilities.canSave || savePhase === 'accepted'
-              }
-              icon={<SaveOutlined />}
-              loading={savePhase === 'saving'}
-              onClick={() => void save()}
-              type="primary"
-            >
-              {t('workflowActivityVNext.settings.save', 'Save changes')}
-            </Button>
-          </Space>
-        </div>
-      ) : null}
       {savePhase !== 'idle' ? (
         <Alert
           message={
@@ -726,6 +689,55 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     },
   ];
   const active = sections.find((item) => item.key === section) ?? sections[0];
+  const settingsFooter = (
+    <>
+      {dirty ? (
+        <div className="wa-vnext__settings-footer">
+          <section
+            aria-label={t(
+              'workflowActivityVNext.settings.unsavedActionsAria',
+              'Unsaved settings actions',
+            )}
+            className="wa-vnext__settings-savebar"
+          >
+            <div aria-live="polite" role="status">
+              <strong>
+                {t('workflowActivityVNext.settings.unsaved', 'Unsaved changes')}
+              </strong>
+              <span>
+                {t(
+                  'workflowActivityVNext.settings.unsavedDescription',
+                  'Your AI defaults have not been saved.',
+                )}
+              </span>
+            </div>
+            <Space className="wa-vnext__settings-actions" wrap>
+              <Button
+                disabled={savePhase === 'saving' || savePhase === 'accepted'}
+                onClick={discard}
+              >
+                {t(
+                  'workflowActivityVNext.settings.discard',
+                  'Restore saved settings',
+                )}
+              </Button>
+              <Button
+                disabled={
+                  !llm.data?.capabilities.canSave || savePhase === 'accepted'
+                }
+                icon={<SaveOutlined />}
+                loading={savePhase === 'saving'}
+                onClick={() => void save()}
+                type="primary"
+              >
+                {t('workflowActivityVNext.settings.save', 'Save changes')}
+              </Button>
+            </Space>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
 
   return (
     <WorkflowActivityVNextShell
@@ -734,6 +746,7 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         'workflowActivityVNext.settings.description',
         'Personal defaults and access.',
       )}
+      footer={settingsFooter}
       scopeId={scopeId}
       title={t('workflowActivityVNext.settings.title', 'Settings')}
       onNavigate={requestNavigation}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -93,6 +93,9 @@ export const workflowActivityVNextCss = `
   overflow-y: auto;
   overscroll-behavior: contain;
 }
+.wa-vnext__main--with-footer { display: grid; grid-template-rows: minmax(0, 1fr) auto; overflow: hidden; }
+.wa-vnext__main-scroll { min-height: 0; min-width: 0; overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; }
+.wa-vnext__main-footer { min-width: 0; }
 .wa-vnext__header {
   align-items: flex-end;
   display: flex;
@@ -223,7 +226,8 @@ export const workflowActivityVNextCss = `
 .wa-vnext__settings-field-copy strong { display: block; font-size: 12px; line-height: 17px; }
 .wa-vnext__settings-field-copy span { color: var(--wa-muted); display: block; font-size: 12px; line-height: 17px; margin-top: 3px; text-wrap: pretty; }
 .wa-vnext__settings-field .ant-select { max-width: 520px; width: 100%; }
-.wa-vnext__settings-savebar { align-items: center; background: #1d2939; border: 1px solid #344054; border-radius: var(--wa-radius); bottom: 12px; box-shadow: 0 12px 30px rgba(16, 24, 40, .2); color: #fff; display: flex; gap: 20px; justify-content: space-between; margin-top: 20px; padding: 10px 12px; position: sticky; z-index: 8; }
+.wa-vnext__settings-footer { background: var(--wa-surface); padding: 0 40px max(12px, env(safe-area-inset-bottom)); }
+.wa-vnext__settings-savebar { align-items: center; background: #1d2939; border: 1px solid #344054; border-radius: var(--wa-radius); box-shadow: 0 12px 30px rgba(16, 24, 40, .2); color: #fff; display: flex; gap: 20px; justify-content: space-between; margin: 0 auto; max-width: 1120px; padding: 10px 12px; }
 .wa-vnext__settings-savebar strong { display: block; font-size: 12px; }
 .wa-vnext__settings-savebar span { color: #d0d5dd; display: block; font-size: 11px; margin-top: 2px; }
 .wa-vnext__settings-savebar .ant-btn-default { background: transparent; border-color: #667085; color: #fff; }
@@ -274,6 +278,7 @@ export const workflowActivityVNextCss = `
 @media (max-width: 1100px) {
   .wa-vnext__header { padding-inline: 32px; }
   .wa-vnext__content { padding-inline: 32px; }
+  .wa-vnext__settings-footer { padding-inline: 32px; }
   .wa-vnext__creation-options { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .wa-vnext__split { grid-template-columns: 1fr; }
 }
@@ -290,6 +295,7 @@ export const workflowActivityVNextCss = `
   .wa-vnext__header h1 { font-size: 22px; line-height: 22px; }
   .wa-vnext__header-actions { max-width: 50%; }
   .wa-vnext__content { padding: 16px 16px 40px; }
+  .wa-vnext__settings-footer { padding-inline: 16px; }
   .wa-vnext__table-wrap { max-height: min(560px, calc(100dvh - 240px)); }
   .wa-vnext__settings-layout { max-width: none; }
   .wa-vnext__node-inspector { bottom: 12px; left: 12px; max-height: calc(100% - 24px); max-width: none; right: 12px; top: auto; width: auto; }
@@ -315,11 +321,14 @@ export const workflowActivityVNextCss = `
   .wa-vnext__settings-nav { gap: 18px; }
   .wa-vnext__settings-field { align-items: stretch; gap: 8px; grid-template-columns: 1fr; min-height: 0; padding: 16px 0; }
   .wa-vnext__settings-field .ant-select { max-width: none; }
-  .wa-vnext__settings-savebar { align-items: stretch; bottom: max(8px, env(safe-area-inset-bottom)); flex-direction: column; gap: 10px; position: static; }
-  .wa-vnext__settings-savebar .ant-space { display: grid; grid-template-columns: 1fr 1fr; width: 100%; }
+  .wa-vnext__settings-savebar { align-items: stretch; flex-direction: column; gap: 10px; }
+  .wa-vnext__settings-actions.ant-space { display: grid; gap: 8px !important; grid-template-columns: 1fr 1fr; width: 100%; }
   .wa-vnext__settings-savebar .ant-btn { width: 100%; }
   .wa-vnext__state--compact { padding: 18px; }
   .wa-vnext__publish-review-item { gap: 6px; padding-block: 10px; }
+}
+@media (max-width: 360px) {
+  .wa-vnext__settings-actions.ant-space { grid-template-columns: 1fr; }
 }
 @media (prefers-reduced-motion: reduce) { .wa-vnext *, .wa-vnext *::before, .wa-vnext *::after { scroll-behavior: auto !important; transition: none !important; } }
 `;


### PR DESCRIPTION
## Problem and solution

The Workflow Activity vNext Settings save bar lived inside the AI defaults form and used `position: sticky`, so it moved with form content and stopped being persistent on mobile.

This change adds an optional shell footer slot and moves the dirty Restore / Save actions into that shell-owned bottom row. Settings keeps the slot mounted in clean and dirty states, preserving the form subtree and focus while the header, tabs, fields, alerts, and technical details scroll independently above it. Existing colors, API calls, dirty navigation protection, and accepted-to-observed save semantics are unchanged.

## Affected paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/**`
- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.*.ts`
- Workflow Activity vNext design, user-path, baseline, and focused implementation-plan docs

## Design baseline declaration

The imported Workflow Activity vNext Excalidraw source, generated prototype, and 17 reference PNG frames remain byte-identical. The production-only deviation from the source prototype's sticky save bar is documented as the shell-fixed Settings action dock.

Baseline verifier result: SHA-256 `30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de`, 17/17 frames, generator byte-identical.

## Local verification

- Related and changed tests: `pnpm exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx src/locales/catalog.test.ts` from `apps/aevatar-console-web` - 2 suites passed, 78 tests passed
- Changed-file static checks: `pnpm exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/settings/SettingsPage.tsx src/pages/workflow-activity-vnext/styles.ts` - 6 files checked, 0 errors
- Baseline: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py` - PASS
- Documentation: `bash tools/docs/lint.sh` - 87 files checked, 0 errors
- Stability guard: `bash tools/ci/test_stability_guards.sh` - PASS
- Whitespace: `git diff --check` - PASS
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

## Browser QA

The real frontend was started on port 5187 with `MOCK=none`. That origin had no authenticated session, while the registered NyxID callback port 5173 was already owned by another process, so authenticated responsive Settings screenshots could not be captured without substituting session or production data. No auth state or Settings data was mocked; final authenticated layout verification remains assigned to the preview/CI environment.
