### PR TITLE
Redesign Account as the authoritative identity surface

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -9,6 +9,7 @@ const enUSMessages = {
   'common.language.label': 'Language',
   'common.language.switch': 'Switch language',
   'common.language.zhCN': '中文',
+  'common.user.account': 'Account',
   'common.user.logout': 'Logout',
   'common.user.settings': 'Settings',
   'common.user.signIn': 'Sign in',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -347,6 +347,7 @@ const workflowActivityVNextMessages = {
     'Your profile and access.',
   'workflowActivityVNext.settings.accountLoading': 'Loading account…',
   'workflowActivityVNext.settings.accountUnavailable': 'Account unavailable',
+  'workflowActivityVNext.settings.accessNotLoaded': 'Not loaded',
   'workflowActivityVNext.settings.activeRuntime': 'Active connection URL',
   'workflowActivityVNext.settings.advanced': 'Advanced',
   'workflowActivityVNext.settings.advancedDescription':
@@ -359,6 +360,8 @@ const workflowActivityVNextMessages = {
     'Your saved choice is unchanged. Try again to load available services.',
   'workflowActivityVNext.settings.catalogUnavailableTitle':
     'Services unavailable',
+  'workflowActivityVNext.settings.capabilityContractMissing':
+    'Capability details are not provided by the current account service.',
   'workflowActivityVNext.settings.defaultModel': 'Default model',
   'workflowActivityVNext.settings.defaultModelHelp':
     'Leave unset to use the service default.',
@@ -370,10 +373,14 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.settings.email': 'Email',
   'workflowActivityVNext.settings.expires': 'Expires',
   'workflowActivityVNext.settings.failed': "Changes couldn't be saved",
+  'workflowActivityVNext.settings.groups': 'Group claims',
   'workflowActivityVNext.settings.llmLoading': 'Loading AI defaults…',
   'workflowActivityVNext.settings.llmUnavailable': 'AI defaults unavailable',
   'workflowActivityVNext.settings.localRuntime': 'Local connection URL',
   'workflowActivityVNext.settings.name': 'Name',
+  'workflowActivityVNext.settings.manageServiceAccess': 'Manage service access',
+  'workflowActivityVNext.settings.notLoaded': 'Not loaded',
+  'workflowActivityVNext.settings.notProvided': 'Not provided',
   'workflowActivityVNext.settings.notAccepted':
     'The settings update was not accepted.',
   'workflowActivityVNext.settings.observed': 'Changes saved',
@@ -382,6 +389,8 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.settings.preferredServiceHelp':
     'Choose which service new sessions use.',
   'workflowActivityVNext.settings.provider': 'Sign-in method',
+  'workflowActivityVNext.settings.productAccess': 'Product access',
+  'workflowActivityVNext.settings.refreshStatus': 'Refresh status',
   'workflowActivityVNext.settings.remoteRuntime': 'Remote connection URL',
   'workflowActivityVNext.settings.roles': 'Access',
   'workflowActivityVNext.settings.runtimeLoading':
@@ -389,6 +398,16 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.settings.runtimeMode': 'Connection mode',
   'workflowActivityVNext.settings.runtimeUnavailable':
     'Connection details unavailable',
+  'workflowActivityVNext.settings.serviceAccessFailed':
+    'Could not start service access review. Try again.',
+  'workflowActivityVNext.settings.sessionActive': 'Active',
+  'workflowActivityVNext.settings.sessionExpired': 'Expired',
+  'workflowActivityVNext.settings.sessionExpiringSoon': 'Expiring soon',
+  'workflowActivityVNext.settings.sessionInvalid': 'Invalid',
+  'workflowActivityVNext.settings.sessionState': 'Session state',
+  'workflowActivityVNext.settings.signInAgain': 'Sign in again',
+  'workflowActivityVNext.settings.signOut': 'Sign out',
+  'workflowActivityVNext.settings.supportDetails': 'Support details',
   'workflowActivityVNext.settings.retryGuidance':
     'Try loading this section again.',
   'workflowActivityVNext.settings.save': 'Save changes',
@@ -405,6 +424,9 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.settings.systemDefaultModel':
     'Uses the system-selected service and model.',
   'workflowActivityVNext.settings.title': 'Settings',
+  'workflowActivityVNext.settings.unauthorized': 'Unauthorized',
+  'workflowActivityVNext.settings.unauthorizedDescription':
+    'Your current session cannot view account or capability details.',
   'workflowActivityVNext.settings.unsaved': 'Unsaved changes',
   'workflowActivityVNext.settings.unsavedActionsAria':
     'Unsaved settings actions',
@@ -414,6 +436,8 @@ const workflowActivityVNextMessages = {
     'Save your changes, discard them, or stay in Settings.',
   'workflowActivityVNext.settings.unsavedLeaveTitle':
     'Unsaved AI default changes',
+  'workflowActivityVNext.settings.userId': 'User ID',
+  'workflowActivityVNext.settings.workspaceContext': 'Workspace context',
   'workflowActivityVNext.state.forbidden':
     "You don't have access to this workspace",
   'workflowActivityVNext.state.unauthorized': 'Sign in to continue',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -329,6 +329,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
       '你的个人资料与访问权限。',
     'workflowActivityVNext.settings.accountLoading': '正在加载账户…',
     'workflowActivityVNext.settings.accountUnavailable': '账户信息不可用',
+    'workflowActivityVNext.settings.accessNotLoaded': '未加载',
     'workflowActivityVNext.settings.activeRuntime': '当前连接 URL',
     'workflowActivityVNext.settings.advanced': '高级',
     'workflowActivityVNext.settings.advancedDescription':
@@ -340,6 +341,8 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.settings.catalogUnavailable':
       '已保存的选择没有改变，请重试加载可用服务。',
     'workflowActivityVNext.settings.catalogUnavailableTitle': '服务不可用',
+    'workflowActivityVNext.settings.capabilityContractMissing':
+      '当前账户服务未提供产品能力详情。',
     'workflowActivityVNext.settings.defaultModel': '默认模型',
     'workflowActivityVNext.settings.defaultModelHelp':
       '留空时使用服务默认模型。',
@@ -350,10 +353,14 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.settings.email': '邮箱',
     'workflowActivityVNext.settings.expires': '过期时间',
     'workflowActivityVNext.settings.failed': '无法保存更改',
+    'workflowActivityVNext.settings.groups': '群组声明',
     'workflowActivityVNext.settings.llmLoading': '正在加载 AI 默认设置…',
     'workflowActivityVNext.settings.llmUnavailable': 'AI 默认设置不可用',
     'workflowActivityVNext.settings.localRuntime': '本地连接 URL',
     'workflowActivityVNext.settings.name': '名称',
+    'workflowActivityVNext.settings.manageServiceAccess': '管理服务访问权限',
+    'workflowActivityVNext.settings.notLoaded': '未加载',
+    'workflowActivityVNext.settings.notProvided': '未提供',
     'workflowActivityVNext.settings.notAccepted': '设置更新未被接受。',
     'workflowActivityVNext.settings.observed': '更改已保存',
     'workflowActivityVNext.settings.providerDefault': 'Provider 默认值',
@@ -361,11 +368,23 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.settings.preferredServiceHelp':
       '选择新会话默认使用的服务。',
     'workflowActivityVNext.settings.provider': '登录方式',
+    'workflowActivityVNext.settings.productAccess': '产品访问权限',
+    'workflowActivityVNext.settings.refreshStatus': '刷新状态',
     'workflowActivityVNext.settings.remoteRuntime': '远端连接 URL',
     'workflowActivityVNext.settings.roles': '访问权限',
     'workflowActivityVNext.settings.runtimeLoading': '正在加载连接信息…',
     'workflowActivityVNext.settings.runtimeMode': '连接模式',
     'workflowActivityVNext.settings.runtimeUnavailable': '连接信息不可用',
+    'workflowActivityVNext.settings.serviceAccessFailed':
+      '无法启动服务访问权限检查，请重试。',
+    'workflowActivityVNext.settings.sessionActive': '有效',
+    'workflowActivityVNext.settings.sessionExpired': '已过期',
+    'workflowActivityVNext.settings.sessionExpiringSoon': '即将过期',
+    'workflowActivityVNext.settings.sessionInvalid': '无效',
+    'workflowActivityVNext.settings.sessionState': '会话状态',
+    'workflowActivityVNext.settings.signInAgain': '重新登录',
+    'workflowActivityVNext.settings.signOut': '退出登录',
+    'workflowActivityVNext.settings.supportDetails': '支持详情',
     'workflowActivityVNext.settings.retryGuidance': '请重试加载此部分。',
     'workflowActivityVNext.settings.save': '保存更改',
     'workflowActivityVNext.settings.saveLeave': '保存并离开',
@@ -380,6 +399,9 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.settings.systemDefaultModel':
       '使用系统选择的服务和模型。',
     'workflowActivityVNext.settings.title': '设置',
+    'workflowActivityVNext.settings.unauthorized': '无访问权限',
+    'workflowActivityVNext.settings.unauthorizedDescription':
+      '当前会话无权查看账户或能力详情。',
     'workflowActivityVNext.settings.unsaved': '未保存的更改',
     'workflowActivityVNext.settings.unsavedActionsAria': '未保存设置操作',
     'workflowActivityVNext.settings.unsavedDescription':
@@ -388,6 +410,8 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
       '保存更改、放弃更改，或留在设置页面。',
     'workflowActivityVNext.settings.unsavedLeaveTitle':
       'AI 默认设置有未保存的更改',
+    'workflowActivityVNext.settings.userId': '用户 ID',
+    'workflowActivityVNext.settings.workspaceContext': '工作区上下文',
     'workflowActivityVNext.state.forbidden': '你无权访问此工作区',
     'workflowActivityVNext.state.unauthorized': '请登录后继续',
     'workflowActivityVNext.unavailable.body': '请检查地址或返回其他页面。',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -9,6 +9,7 @@ const zhCNMessages = {
   'common.language.label': '语言',
   'common.language.switch': '切换语言',
   'common.language.zhCN': '中文',
+  'common.user.account': '账户',
   'common.user.logout': '退出登录',
   'common.user.settings': '设置',
   'common.user.signIn': '登录',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/TechnicalDetails.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/TechnicalDetails.tsx
@@ -3,10 +3,12 @@ import { t } from '@/shared/i18n/messages';
 
 const TechnicalDetails: React.FC<{
   readonly children: React.ReactNode;
-}> = ({ children }) => (
+  readonly summary?: string;
+}> = ({ children, summary }) => (
   <details className="wa-vnext__technical-details">
     <summary>
-      {t('workflowActivityVNext.common.technicalDetails', 'Technical details')}
+      {summary ||
+        t('workflowActivityVNext.common.technicalDetails', 'Technical details')}
     </summary>
     <div className="wa-vnext__technical-details-body" translate="no">
       {children}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
@@ -19,6 +19,11 @@ import {
 import { workflowActivityVNextCss } from './styles';
 
 type ShellProps = {
+  readonly accountPrincipal?: {
+    readonly authenticated: boolean;
+    readonly displayName: string;
+    readonly picture: string | null;
+  } | null;
   readonly activeSection: WorkflowActivitySection;
   readonly children: React.ReactNode;
   readonly description: string;
@@ -101,6 +106,7 @@ function Navigation({
 }
 
 const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
+  accountPrincipal,
   activeSection,
   children,
   description,
@@ -166,7 +172,7 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
         </div>
         <div className="wa-vnext__topbar-actions">
           <ConsoleLanguageSwitch />
-          <ConsoleAuthActions />
+          <ConsoleAuthActions principal={accountPrincipal} />
         </div>
       </header>
       <aside className="wa-vnext__rail">
@@ -204,7 +210,7 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
         />
         <div className="wa-vnext__drawer-actions">
           <ConsoleLanguageSwitch />
-          <ConsoleAuthActions />
+          <ConsoleAuthActions principal={accountPrincipal} />
         </div>
       </Drawer>
     </div>

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -229,7 +229,21 @@ jest.mock('@/shared/navigation/history', () => ({
 }));
 
 jest.mock('@/shared/ui/ConsoleHeaderActions', () => ({
-  ConsoleAuthActions: () => <button type="button">Account</button>,
+  ConsoleAuthActions: ({
+    principal,
+  }: {
+    principal?: {
+      authenticated: boolean;
+      displayName: string;
+    } | null;
+  }) => (
+    <button
+      data-auth-source={principal === undefined ? 'stored' : 'account'}
+      type="button"
+    >
+      {principal?.authenticated ? principal.displayName : 'Account'}
+    </button>
+  ),
   ConsoleLanguageSwitch: () => <button type="button">Language</button>,
 }));
 
@@ -1191,7 +1205,7 @@ describe('Workflow Activity vNext settings', () => {
         authenticated: true,
         scopeId: 'scope-alpha',
         scopeSource: 'nyxid-session',
-        expiresAtUtc: '2026-08-05T10:00:00Z',
+        expiresAtUtc: '2099-08-05T10:00:00Z',
       },
     });
     mockStudioApi.getUserConfigRuntime.mockResolvedValue({
@@ -1211,7 +1225,7 @@ describe('Workflow Activity vNext settings', () => {
 
   afterEach(() => cleanupTestQueryClients());
 
-  it('renders account facts while keeping runtime connection values behind technical details', async () => {
+  it('renders the same authoritative identity in the shell and Account while keeping support values secondary', async () => {
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     expect(
@@ -1224,21 +1238,21 @@ describe('Workflow Activity vNext settings', () => {
     );
     fireEvent.click(accountLink);
     expect(accountLink).toHaveAttribute('aria-current', 'page');
-    expect(await screen.findByText('Ada Operator')).toBeInTheDocument();
+    expect(await screen.findAllByText('Ada Operator')).toHaveLength(2);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('ada@example.test')).toBeInTheDocument();
     expect(screen.getByText('NyxID')).toBeInTheDocument();
-    expect(screen.getByText('operator')).toBeInTheDocument();
-    expect(screen.queryByText('user-subject-alpha')).not.toBeInTheDocument();
-    expect(screen.queryByText('platform')).not.toBeInTheDocument();
+    expect(screen.getByText('scope-alpha')).toBeInTheDocument();
+    expect(screen.getByText(/GMT|UTC/)).toHaveTextContent(/in .+ days/);
+    expect(screen.getByText('Support details')).toBeInTheDocument();
+    expect(screen.getByText('user-subject-alpha')).not.toBeVisible();
+    expect(screen.getByText('operator')).not.toBeVisible();
+    expect(screen.getByText('platform')).not.toBeVisible();
     expect(screen.queryByText('nyxid-session')).not.toBeInTheDocument();
-    expect(screen.queryByText('scope-alpha')).not.toBeInTheDocument();
-    expect(
-      screen.getByText(
-        new Intl.DateTimeFormat('en-US', {
-          dateStyle: 'medium',
-          timeStyle: 'short',
-        }).format(new Date('2026-08-05T10:00:00Z')),
-      ),
-    ).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Support details'));
+    expect(screen.getByText('user-subject-alpha')).toBeVisible();
+    expect(screen.getByText('operator')).toBeVisible();
+    expect(screen.getByText('platform')).toBeVisible();
 
     const advancedLink = screen.getByRole('link', { name: 'Advanced' });
     fireEvent.click(advancedLink);
@@ -1251,6 +1265,114 @@ describe('Workflow Activity vNext settings', () => {
       await screen.findAllByText('https://runtime.example.test'),
     ).toHaveLength(2);
     expect(screen.getByText('remote')).toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      label: 'expired',
+      session: {
+        authenticated: false,
+        scopeId: 'scope-alpha',
+        expiresAtUtc: '2000-01-01T00:00:00Z',
+      },
+      authenticated: false,
+      expected: 'Expired',
+    },
+    {
+      label: 'invalid',
+      session: {
+        authenticated: false,
+        scopeId: 'scope-alpha',
+        expiresAtUtc: '2099-08-05T10:00:00Z',
+      },
+      authenticated: true,
+      expected: 'Invalid',
+    },
+  ])('offers direct sign-in recovery for an $label session', async ({
+    authenticated,
+    expected,
+    session,
+  }) => {
+    mockStudioApi.getAuthSession.mockResolvedValue({
+      enabled: true,
+      authenticated,
+      providerDisplayName: 'NyxID',
+      name: 'Ada Operator',
+      profile: null,
+      session,
+    });
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/settings?section=account';
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in again' })).toBeEnabled();
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+
+  it('renders optional missing fields without guessing that policy hid them', async () => {
+    mockStudioApi.getAuthSession.mockResolvedValueOnce({
+      enabled: true,
+      authenticated: true,
+      providerDisplayName: 'NyxID',
+      profile: {
+        subject: 'user-subject-alpha',
+        name: 'Ada Operator',
+        email: null,
+        emailVerified: null,
+        picture: null,
+        roles: [],
+        groups: [],
+      },
+      session: {
+        authenticated: true,
+        scopeId: null,
+        expiresAtUtc: null,
+      },
+    });
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/settings?section=account';
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect((await screen.findAllByText('Not provided')).length).toBeGreaterThan(
+      1,
+    );
+    expect(screen.queryByText('Hidden by policy')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      label: 'capability denial',
+      error: Object.assign(new Error('forbidden'), { status: 403 }),
+      expected: 'Unauthorized',
+    },
+    {
+      label: 'transient load failure',
+      error: Object.assign(new Error('temporarily unavailable'), {
+        status: 503,
+      }),
+      expected: 'Not loaded',
+    },
+  ])('keeps $label distinct from absent profile data', async ({
+    error,
+    expected,
+  }) => {
+    mockStudioApi.getAuthSession.mockRejectedValue(error);
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/settings?section=account';
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText(expected)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Account' })).toHaveAttribute(
+      'data-auth-source',
+      'account',
+    );
+    if (expected === 'Not loaded') {
+      expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled();
+    }
+    expect(screen.queryByText('Not provided')).not.toBeInTheDocument();
   });
 
   it('keeps an AI defaults decoding failure compact and actionable', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.tsx
@@ -194,9 +194,7 @@ const AccountPanel: React.FC<AccountPanelProps> = ({
               ),
               children:
                 identity.provider.kind === 'value' ? (
-                  <Typography.Text
-                    copyable={{ text: identity.provider.value }}
-                  >
+                  <Typography.Text copyable={{ text: identity.provider.value }}>
                     {identity.provider.value}
                   </Typography.Text>
                 ) : (

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.tsx
@@ -1,0 +1,279 @@
+import {
+  LoginOutlined,
+  LogoutOutlined,
+  ReloadOutlined,
+  SafetyCertificateOutlined,
+  UserOutlined,
+} from '@ant-design/icons';
+import { Alert, Avatar, Button, Descriptions, Space, Typography } from 'antd';
+import React from 'react';
+import { NyxIDAuthClient } from '@/shared/auth/client';
+import { getNyxIDRuntimeConfig } from '@/shared/auth/config';
+import {
+  clearStoredAuthSession,
+  sanitizeReturnTo,
+} from '@/shared/auth/session';
+import { t } from '@/shared/i18n/messages';
+import { history } from '@/shared/navigation/history';
+import { AevatarCompactText } from '@/shared/ui/compactText';
+import TechnicalDetails from '../TechnicalDetails';
+import type { AccountField, AccountIdentity } from './accountIdentity';
+
+type AccountPanelProps = {
+  readonly identity: AccountIdentity;
+  readonly onRefresh: () => void;
+  readonly returnTo: string;
+};
+
+function accountFieldValue(field: AccountField): React.ReactNode {
+  if (field.kind === 'value') return field.value;
+  return t('workflowActivityVNext.settings.notProvided', 'Not provided');
+}
+
+function sessionStateLabel(identity: AccountIdentity): string {
+  switch (identity.sessionState) {
+    case 'active':
+      return t('workflowActivityVNext.settings.sessionActive', 'Active');
+    case 'expiring_soon':
+      return t(
+        'workflowActivityVNext.settings.sessionExpiringSoon',
+        'Expiring soon',
+      );
+    case 'expired':
+      return t('workflowActivityVNext.settings.sessionExpired', 'Expired');
+    case 'invalid':
+      return t('workflowActivityVNext.settings.sessionInvalid', 'Invalid');
+  }
+}
+
+function buildLoginHref(returnTo: string): string {
+  return `/login?${new URLSearchParams({
+    redirect: sanitizeReturnTo(returnTo),
+  }).toString()}`;
+}
+
+const AccountPanel: React.FC<AccountPanelProps> = ({
+  identity,
+  onRefresh,
+  returnTo,
+}) => {
+  const [reviewPending, setReviewPending] = React.useState(false);
+  const [reviewError, setReviewError] = React.useState('');
+  const recoverable =
+    identity.sessionState === 'expired' || identity.sessionState === 'invalid';
+  const displayName = accountFieldValue(identity.displayName);
+
+  const signInAgain = () => {
+    clearStoredAuthSession();
+    history.push(buildLoginHref(returnTo));
+  };
+
+  const signOut = () => {
+    clearStoredAuthSession();
+    window.location.replace('/login');
+  };
+
+  const reviewServiceAccess = async () => {
+    try {
+      setReviewPending(true);
+      setReviewError('');
+      await new NyxIDAuthClient(getNyxIDRuntimeConfig()).loginWithRedirect({
+        flow: 'serviceAccessReview',
+        returnTo,
+      });
+    } catch {
+      setReviewPending(false);
+      setReviewError(
+        t(
+          'workflowActivityVNext.settings.serviceAccessFailed',
+          'Could not start service access review. Try again.',
+        ),
+      );
+    }
+  };
+
+  return (
+    <div className="wa-vnext__account">
+      <div className="wa-vnext__account-profile">
+        <Avatar icon={<UserOutlined />} size={56} src={identity.picture} />
+        <div>
+          <Typography.Title level={3}>{displayName}</Typography.Title>
+          <Typography.Text type="secondary">
+            {accountFieldValue(identity.email)}
+          </Typography.Text>
+        </div>
+      </div>
+
+      <Descriptions
+        bordered
+        column={{ xs: 1, sm: 2, md: 2, lg: 2, xl: 2, xxl: 2 }}
+        items={[
+          {
+            key: 'session',
+            label: t(
+              'workflowActivityVNext.settings.sessionState',
+              'Session state',
+            ),
+            children: sessionStateLabel(identity),
+          },
+          {
+            key: 'scope',
+            label: t(
+              'workflowActivityVNext.settings.workspaceContext',
+              'Workspace context',
+            ),
+            children: accountFieldValue(identity.scope),
+          },
+          {
+            key: 'expiry',
+            label: t('workflowActivityVNext.settings.expires', 'Expires'),
+            children: accountFieldValue(identity.expiry),
+          },
+          {
+            key: 'access',
+            label: t(
+              'workflowActivityVNext.settings.productAccess',
+              'Product access',
+            ),
+            children: t(
+              'workflowActivityVNext.settings.accessNotLoaded',
+              'Not loaded',
+            ),
+          },
+        ]}
+      />
+
+      <Space wrap>
+        {recoverable ? (
+          <Button icon={<LoginOutlined />} onClick={signInAgain} type="primary">
+            {t('workflowActivityVNext.settings.signInAgain', 'Sign in again')}
+          </Button>
+        ) : (
+          <>
+            <Button icon={<ReloadOutlined />} onClick={onRefresh}>
+              {t(
+                'workflowActivityVNext.settings.refreshStatus',
+                'Refresh status',
+              )}
+            </Button>
+            <Button
+              icon={<SafetyCertificateOutlined />}
+              loading={reviewPending}
+              onClick={() => void reviewServiceAccess()}
+            >
+              {t(
+                'workflowActivityVNext.settings.manageServiceAccess',
+                'Manage service access',
+              )}
+            </Button>
+            <Button danger icon={<LogoutOutlined />} onClick={signOut}>
+              {t('workflowActivityVNext.settings.signOut', 'Sign out')}
+            </Button>
+          </>
+        )}
+      </Space>
+
+      {reviewError ? (
+        <Alert message={reviewError} role="alert" showIcon type="error" />
+      ) : null}
+
+      <TechnicalDetails
+        summary={t(
+          'workflowActivityVNext.settings.supportDetails',
+          'Support details',
+        )}
+      >
+        <Descriptions
+          column={1}
+          items={[
+            {
+              key: 'provider',
+              label: t(
+                'workflowActivityVNext.settings.provider',
+                'Sign-in method',
+              ),
+              children:
+                identity.provider.kind === 'value' ? (
+                  <Typography.Text
+                    copyable={{ text: identity.provider.value }}
+                  >
+                    {identity.provider.value}
+                  </Typography.Text>
+                ) : (
+                  accountFieldValue(identity.provider)
+                ),
+            },
+            ...(identity.support.subject
+              ? [
+                  {
+                    key: 'subject',
+                    label: t(
+                      'workflowActivityVNext.settings.userId',
+                      'User ID',
+                    ),
+                    children: (
+                      <AevatarCompactText
+                        copyable
+                        head={12}
+                        monospace
+                        tail={8}
+                        value={identity.support.subject}
+                      />
+                    ),
+                  },
+                ]
+              : []),
+            ...(identity.support.roles.length
+              ? [
+                  {
+                    key: 'roles',
+                    label: t(
+                      'workflowActivityVNext.settings.roles',
+                      'Access claims',
+                    ),
+                    children: (
+                      <Typography.Text
+                        copyable={{ text: identity.support.roles.join(', ') }}
+                      >
+                        {identity.support.roles.join(', ')}
+                      </Typography.Text>
+                    ),
+                  },
+                ]
+              : []),
+            ...(identity.support.groups.length
+              ? [
+                  {
+                    key: 'groups',
+                    label: t(
+                      'workflowActivityVNext.settings.groups',
+                      'Group claims',
+                    ),
+                    children: (
+                      <Typography.Text
+                        copyable={{ text: identity.support.groups.join(', ') }}
+                      >
+                        {identity.support.groups.join(', ')}
+                      </Typography.Text>
+                    ),
+                  },
+                ]
+              : []),
+          ]}
+        />
+      </TechnicalDetails>
+
+      <Typography.Paragraph
+        className="wa-vnext__account-contract-note"
+        type="secondary"
+      >
+        {t(
+          'workflowActivityVNext.settings.capabilityContractMissing',
+          'Capability details are not provided by the current account service.',
+        )}
+      </Typography.Paragraph>
+    </div>
+  );
+};
+
+export default AccountPanel;

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
@@ -15,11 +15,13 @@ import {
 } from '@/pages/settings/userLlmSelection';
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
-import { studioApi } from '@/shared/studio/api';
+import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { useConsoleLocation } from '../hooks/useConsoleLocation';
 import TechnicalDetails from '../TechnicalDetails';
 import WorkflowActivityVNextShell from '../WorkflowActivityVNextShell';
+import AccountPanel from './AccountPanel';
+import { buildAccountIdentity } from './accountIdentity';
 
 type SettingsSection = 'ai' | 'account' | 'advanced';
 type SavePhase =
@@ -32,18 +34,6 @@ type SavePhase =
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function formatDateTime(value: string | null | undefined): string {
-  if (!value)
-    return t('workflowActivityVNext.common.unavailable', 'Unavailable');
-  const date = new Date(value);
-  return Number.isNaN(date.getTime())
-    ? value
-    : new Intl.DateTimeFormat(getLocale(), {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      }).format(date);
 }
 
 function readSection(search: string): SettingsSection {
@@ -119,6 +109,13 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     queryFn: () => studioApi.getUserConfigRuntime(),
     retry: false,
   });
+  const accountIdentity = React.useMemo(
+    () =>
+      auth.data
+        ? buildAccountIdentity(auth.data, Date.now(), getLocale())
+        : null,
+    [auth.data],
+  );
   const [draft, setDraft] = React.useState<UserLlmSelectionDraft | undefined>(
     undefined,
   );
@@ -517,74 +514,33 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         'Loading account session',
       )}
     />
+  ) : auth.isError && isStudioApiStatus(auth.error, 403) ? (
+    <div className="wa-vnext__state wa-vnext__state--compact" role="alert">
+      <div>
+        <h3>
+          {t('workflowActivityVNext.settings.unauthorized', 'Unauthorized')}
+        </h3>
+        <p>
+          {t(
+            'workflowActivityVNext.settings.unauthorizedDescription',
+            'Your current session cannot view account or capability details.',
+          )}
+        </p>
+      </div>
+    </div>
   ) : auth.isError ? (
     <SettingsErrorState
       error={auth.error}
       onRetry={() => void auth.refetch()}
-      title={t(
-        'workflowActivityVNext.settings.accountUnavailable',
-        'Account session unavailable',
-      )}
+      title={t('workflowActivityVNext.settings.notLoaded', 'Not loaded')}
     />
-  ) : (
-    <div className="wa-vnext__settings-facts">
-      <Descriptions
-        bordered
-        column={{ xs: 1, sm: 2, md: 2, lg: 2, xl: 2, xxl: 2 }}
-        items={[
-          {
-            key: 'status',
-            label: t(
-              'workflowActivityVNext.settings.authenticated',
-              'Signed in',
-            ),
-            children: auth.data?.authenticated
-              ? t('workflowActivityVNext.common.yes', 'Yes')
-              : t('workflowActivityVNext.common.no', 'No'),
-          },
-          {
-            key: 'name',
-            label: t('workflowActivityVNext.settings.name', 'Name'),
-            children:
-              auth.data?.profile?.name ||
-              auth.data?.name ||
-              t('workflowActivityVNext.common.unavailable', 'Unavailable'),
-          },
-          {
-            key: 'email',
-            label: t('workflowActivityVNext.settings.email', 'Email'),
-            children:
-              auth.data?.profile?.email ||
-              auth.data?.email ||
-              t('workflowActivityVNext.common.unavailable', 'Unavailable'),
-          },
-          {
-            key: 'provider',
-            label: t(
-              'workflowActivityVNext.settings.provider',
-              'Sign-in method',
-            ),
-            children:
-              auth.data?.providerDisplayName ||
-              auth.data?.session?.providerDisplayName ||
-              t('workflowActivityVNext.common.unavailable', 'Unavailable'),
-          },
-          {
-            key: 'roles',
-            label: t('workflowActivityVNext.settings.roles', 'Access'),
-            children: auth.data?.profile?.roles.length
-              ? auth.data.profile.roles.join(', ')
-              : t('workflowActivityVNext.common.unavailable', 'Unavailable'),
-          },
-          {
-            key: 'expiry',
-            label: t('workflowActivityVNext.settings.expires', 'Expires'),
-            children: formatDateTime(auth.data?.session?.expiresAtUtc),
-          },
-        ]}
-      />
-    </div>
-  );
+  ) : auth.data && accountIdentity ? (
+    <AccountPanel
+      identity={accountIdentity}
+      onRefresh={() => void auth.refetch()}
+      returnTo={`${location.pathname}?section=account`}
+    />
+  ) : null;
 
   const runtimePanel = runtime.isPending ? (
     <SettingsLoadingState
@@ -741,6 +697,20 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
 
   return (
     <WorkflowActivityVNextShell
+      accountPrincipal={
+        accountIdentity
+          ? {
+              authenticated:
+                accountIdentity.sessionState === 'active' ||
+                accountIdentity.sessionState === 'expiring_soon',
+              displayName:
+                accountIdentity.displayName.kind === 'value'
+                  ? accountIdentity.displayName.value
+                  : t('workflowActivityVNext.settings.account', 'Account'),
+              picture: accountIdentity.picture,
+            }
+          : null
+      }
       activeSection="settings"
       description={t(
         'workflowActivityVNext.settings.description',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.test.ts
@@ -1,0 +1,128 @@
+import type { StudioAuthSession } from '@/shared/studio/models';
+import { buildAccountIdentity } from './accountIdentity';
+
+const NOW = Date.parse('2026-08-06T08:00:00Z');
+
+function createAuthSession(
+  overrides: Partial<StudioAuthSession> = {},
+): StudioAuthSession {
+  return {
+    enabled: true,
+    authenticated: true,
+    providerDisplayName: 'NyxID',
+    profile: {
+      subject: 'user-alpha',
+      name: 'Ada Operator',
+      email: 'ada@example.test',
+      emailVerified: true,
+      picture: null,
+      roles: ['operator'],
+      groups: ['platform'],
+    },
+    session: {
+      authenticated: true,
+      providerDisplayName: 'NyxID',
+      scopeId: 'scope-alpha',
+      scopeSource: 'nyxid-session',
+      expiresAtUtc: '2026-08-08T08:00:00Z',
+    },
+    ...overrides,
+  };
+}
+
+describe('account identity presentation', () => {
+  it.each([
+    {
+      label: 'active',
+      auth: createAuthSession(),
+      expected: 'active',
+    },
+    {
+      label: 'expiring soon',
+      auth: createAuthSession({
+        session: {
+          authenticated: true,
+          expiresAtUtc: '2026-08-06T12:00:00Z',
+        },
+      }),
+      expected: 'expiring_soon',
+    },
+    {
+      label: 'expired',
+      auth: createAuthSession({
+        authenticated: false,
+        session: {
+          authenticated: false,
+          expiresAtUtc: '2026-08-06T07:59:00Z',
+        },
+      }),
+      expected: 'expired',
+    },
+    {
+      label: 'invalid',
+      auth: createAuthSession({
+        authenticated: true,
+        session: {
+          authenticated: false,
+          expiresAtUtc: '2026-08-08T08:00:00Z',
+        },
+      }),
+      expected: 'invalid',
+    },
+  ])('classifies $label without contradicting authentication facts', ({
+    auth,
+    expected,
+  }) => {
+    expect(buildAccountIdentity(auth, NOW, 'en-US').sessionState).toBe(
+      expected,
+    );
+  });
+
+  it('formats expiry in local time with a timezone and relative time', () => {
+    const presentation = buildAccountIdentity(
+      createAuthSession({
+        session: {
+          authenticated: true,
+          expiresAtUtc: '2026-08-06T12:00:00Z',
+        },
+      }),
+      NOW,
+      'en-US',
+    );
+
+    if (presentation.expiry.kind !== 'value') {
+      throw new Error('Expected a formatted expiry value.');
+    }
+    expect(presentation.expiry.value).toContain('in 4 hours');
+    expect(presentation.expiry.value).toMatch(/UTC|GMT/);
+  });
+
+  it('does not guess that missing profile data was hidden by policy', () => {
+    const missing = buildAccountIdentity(
+      createAuthSession({
+        profile: {
+          subject: 'user-alpha',
+          name: 'Ada Operator',
+          email: null,
+          emailVerified: null,
+          picture: null,
+          roles: [],
+          groups: [],
+        },
+      }),
+      NOW,
+      'en-US',
+    );
+    const missingProfile = buildAccountIdentity(
+      createAuthSession({
+        name: 'Ada Operator',
+        profile: null,
+      }),
+      NOW,
+      'en-US',
+    );
+
+    expect(missing.email.kind).toBe('not_provided');
+    expect(missingProfile.email.kind).toBe('not_provided');
+  });
+});

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.ts
@@ -1,0 +1,117 @@
+import type { StudioAuthSession } from '@/shared/studio/models';
+
+export type AccountSessionState =
+  | 'active'
+  | 'expiring_soon'
+  | 'expired'
+  | 'invalid';
+
+export type AccountField =
+  | { readonly kind: 'value'; readonly value: string }
+  | { readonly kind: 'not_provided' };
+
+export type AccountIdentity = {
+  readonly displayName: AccountField;
+  readonly email: AccountField;
+  readonly expiry: AccountField;
+  readonly picture: string | null;
+  readonly provider: AccountField;
+  readonly scope: AccountField;
+  readonly sessionState: AccountSessionState;
+  readonly support: {
+    readonly groups: readonly string[];
+    readonly roles: readonly string[];
+    readonly subject: string | null;
+  };
+};
+
+const EXPIRING_SOON_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function valueOrMissing(value: string | null | undefined): AccountField {
+  const normalized = value?.trim();
+  return normalized
+    ? { kind: 'value', value: normalized }
+    : { kind: 'not_provided' };
+}
+
+function formatRelativeExpiry(
+  expiryMs: number,
+  nowMs: number,
+  locale: string,
+): string {
+  const differenceMs = expiryMs - nowMs;
+  const absoluteDifference = Math.abs(differenceMs);
+  const [divisor, unit] =
+    absoluteDifference >= 24 * 60 * 60 * 1000
+      ? [24 * 60 * 60 * 1000, 'day' as const]
+      : absoluteDifference >= 60 * 60 * 1000
+        ? [60 * 60 * 1000, 'hour' as const]
+        : [60 * 1000, 'minute' as const];
+  const amount = Math.round(differenceMs / divisor);
+  return new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }).format(
+    amount,
+    unit,
+  );
+}
+
+function formatExpiry(
+  value: string | null | undefined,
+  nowMs: number,
+  locale: string,
+): AccountField {
+  if (!value?.trim()) return { kind: 'not_provided' };
+  const expiryMs = Date.parse(value);
+  if (Number.isNaN(expiryMs)) return { kind: 'not_provided' };
+  const localTime = new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(expiryMs);
+  return {
+    kind: 'value',
+    value: `${localTime} · ${formatRelativeExpiry(expiryMs, nowMs, locale)}`,
+  };
+}
+
+function resolveSessionState(
+  auth: StudioAuthSession,
+  nowMs: number,
+): AccountSessionState {
+  const expiryValue = auth.session?.expiresAtUtc;
+  const expiryMs = expiryValue ? Date.parse(expiryValue) : Number.NaN;
+  if (!Number.isNaN(expiryMs) && expiryMs <= nowMs) return 'expired';
+  if (!auth.authenticated || auth.session?.authenticated === false)
+    return 'invalid';
+  if (!Number.isNaN(expiryMs) && expiryMs - nowMs <= EXPIRING_SOON_WINDOW_MS)
+    return 'expiring_soon';
+  return 'active';
+}
+
+export function buildAccountIdentity(
+  auth: StudioAuthSession,
+  nowMs: number,
+  locale: string,
+): AccountIdentity {
+  const profileName = auth.profile?.name || auth.name;
+  const profileEmail = auth.profile?.email || auth.email;
+
+  return {
+    displayName: valueOrMissing(profileName),
+    email: valueOrMissing(profileEmail),
+    expiry: formatExpiry(auth.session?.expiresAtUtc, nowMs, locale),
+    picture: auth.profile?.picture || auth.picture || null,
+    provider: valueOrMissing(
+      auth.session?.providerDisplayName || auth.providerDisplayName,
+    ),
+    scope: valueOrMissing(auth.session?.scopeId || auth.scopeId),
+    sessionState: resolveSessionState(auth, nowMs),
+    support: {
+      groups: auth.profile?.groups ?? [],
+      roles: auth.profile?.roles ?? [],
+      subject: auth.profile?.subject?.trim() || null,
+    },
+  };
+}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -251,6 +251,14 @@ export const workflowActivityVNextCss = `
 .wa-vnext__settings-facts .ant-descriptions { border-radius: var(--wa-radius); overflow: hidden; }
 .wa-vnext__settings-facts .ant-descriptions-item-label { color: var(--wa-muted); font-size: 12px; }
 .wa-vnext__settings-facts .ant-descriptions-item-content { color: var(--wa-ink); font-size: 12px; min-width: 0; overflow-wrap: anywhere; }
+.wa-vnext__account { display: flex; flex-direction: column; gap: 18px; padding-top: 16px; }
+.wa-vnext__account-profile { align-items: center; display: flex; gap: 14px; min-width: 0; }
+.wa-vnext__account-profile > div { min-width: 0; }
+.wa-vnext__account-profile .ant-typography { margin: 0; overflow-wrap: anywhere; }
+.wa-vnext__account .ant-descriptions { border-radius: var(--wa-radius); overflow: hidden; }
+.wa-vnext__account .ant-descriptions-item-label { color: var(--wa-muted); font-size: 12px; }
+.wa-vnext__account .ant-descriptions-item-content { color: var(--wa-ink); font-size: 12px; min-width: 0; overflow-wrap: anywhere; }
+.wa-vnext__account-contract-note { font-size: 12px; margin: 0 !important; }
 .wa-vnext__technical-details { color: var(--wa-muted); font-size: 12px; margin-top: 16px; max-width: 100%; }
 .wa-vnext__technical-details summary { cursor: pointer; font-weight: 600; }
 .wa-vnext__technical-details-body { background: #fff; border: 1px solid var(--wa-line); border-radius: 6px; display: block; margin-top: 8px; max-width: 100%; overflow-wrap: anywhere; padding: 10px; }

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
@@ -1,84 +1,88 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { getLocale, setLocale } from "@umijs/max";
-import React from "react";
+import { fireEvent, render, screen } from '@testing-library/react';
+import { getLocale, setLocale } from '@umijs/max';
+import React from 'react';
 import {
   clearStoredAuthSession,
   persistAuthSession,
-} from "@/shared/auth/session";
+} from '@/shared/auth/session';
 import {
   ConsoleAuthActions,
   ConsoleHeaderActions,
-} from "./ConsoleHeaderActions";
+} from './ConsoleHeaderActions';
 
 const mockedHistoryPush = jest.fn();
 
-jest.mock("@/shared/navigation/history", () => ({
+jest.mock('@/shared/navigation/history', () => ({
   history: {
     push: (...args: unknown[]) => mockedHistoryPush(...args),
   },
 }));
 
-describe("ConsoleHeaderActions", () => {
+describe('ConsoleHeaderActions', () => {
   beforeEach(() => {
     clearStoredAuthSession();
     mockedHistoryPush.mockReset();
-    setLocale("en-US", false);
-    window.history.replaceState({}, "", "/runtime/mission-wall?focusRunId=run-1");
+    setLocale('en-US', false);
+    window.history.replaceState(
+      {},
+      '',
+      '/runtime/mission-wall?focusRunId=run-1',
+    );
   });
 
   afterEach(() => {
     clearStoredAuthSession();
   });
 
-  it("renders a login entry when there is no restorable auth session", () => {
+  it('renders a login entry when there is no restorable auth session', () => {
     render(React.createElement(ConsoleHeaderActions));
 
     expect(
-      screen.getByRole("button", { name: "Switch language" }),
+      screen.getByRole('button', { name: 'Switch language' }),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
 
     expect(mockedHistoryPush).toHaveBeenCalledWith(
-      "/login?redirect=%2Fruntime%2Fmission-wall%3FfocusRunId%3Drun-1",
+      '/login?redirect=%2Fruntime%2Fmission-wall%3FfocusRunId%3Drun-1',
     );
   });
 
-  it("keeps the language switch and authenticated user menu together", () => {
+  it('keeps the language switch and authenticated user menu together', () => {
     persistAuthSession({
       tokens: {
-        accessToken: "token",
+        accessToken: 'token',
         expiresAt: Date.now() + 60_000,
         expiresIn: 60,
-        tokenType: "Bearer",
+        tokenType: 'Bearer',
       },
       user: {
-        email: "abigail@example.com",
-        name: "Abigail Deng",
-        picture: "https://example.com/avatar.png",
-        sub: "user-abigail",
+        email: 'abigail@example.com',
+        name: 'Abigail Deng',
+        picture: 'https://example.com/avatar.png',
+        sub: 'user-abigail',
       },
     });
 
     render(React.createElement(ConsoleHeaderActions));
 
-    fireEvent.click(screen.getByRole("button", { name: "Switch language" }));
-    fireEvent.click(screen.getByText("中文"));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch language' }));
+    fireEvent.click(screen.getByText('中文'));
 
-    expect(getLocale()).toBe("zh-CN");
-    expect(screen.getByText("Abigail Deng")).toBeInTheDocument();
+    expect(getLocale()).toBe('zh-CN');
+    expect(screen.getByText('Abigail Deng')).toBeInTheDocument();
   });
 
-  it("renders a supplied authoritative principal instead of the stored session identity", () => {
+  it('renders a supplied authoritative principal instead of the stored session identity', () => {
     persistAuthSession({
       tokens: {
-        accessToken: "token",
+        accessToken: 'token',
         expiresAt: Date.now() + 60_000,
         expiresIn: 60,
-        tokenType: "Bearer",
+        tokenType: 'Bearer',
       },
       user: {
-        name: "Stale Browser Name",
-        sub: "stored-user",
+        name: 'Stale Browser Name',
+        sub: 'stored-user',
       },
     });
 
@@ -86,68 +90,68 @@ describe("ConsoleHeaderActions", () => {
       React.createElement(ConsoleAuthActions, {
         principal: {
           authenticated: true,
-          displayName: "Authoritative Account Name",
+          displayName: 'Authoritative Account Name',
           picture: null,
         },
       }),
     );
 
-    expect(screen.getByText("Authoritative Account Name")).toBeInTheDocument();
-    expect(screen.queryByText("Stale Browser Name")).not.toBeInTheDocument();
+    expect(screen.getByText('Authoritative Account Name')).toBeInTheDocument();
+    expect(screen.queryByText('Stale Browser Name')).not.toBeInTheDocument();
   });
 
-  it("does not fall back to a stored identity when the authoritative principal is unavailable", () => {
+  it('does not fall back to a stored identity when the authoritative principal is unavailable', () => {
     persistAuthSession({
       tokens: {
-        accessToken: "token",
+        accessToken: 'token',
         expiresAt: Date.now() + 60_000,
         expiresIn: 60,
-        tokenType: "Bearer",
+        tokenType: 'Bearer',
       },
       user: {
-        name: "Stale Browser Name",
-        sub: "stored-user",
+        name: 'Stale Browser Name',
+        sub: 'stored-user',
       },
     });
 
     render(React.createElement(ConsoleAuthActions, { principal: null }));
 
-    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
-    expect(screen.queryByText("Stale Browser Name")).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.queryByText('Stale Browser Name')).not.toBeInTheDocument();
   });
 
-  it("applies an optional dropdown root class to action menus", async () => {
+  it('applies an optional dropdown root class to action menus', async () => {
     persistAuthSession({
       tokens: {
-        accessToken: "token",
+        accessToken: 'token',
         expiresAt: Date.now() + 60_000,
         expiresIn: 60,
-        tokenType: "Bearer",
+        tokenType: 'Bearer',
       },
       user: {
-        email: "abigail@example.com",
-        name: "Abigail Deng",
-        picture: "https://example.com/avatar.png",
-        sub: "user-abigail",
+        email: 'abigail@example.com',
+        name: 'Abigail Deng',
+        picture: 'https://example.com/avatar.png',
+        sub: 'user-abigail',
       },
     });
 
     render(
       React.createElement(ConsoleHeaderActions, {
-        dropdownRootClassName: "mission-wall-header-menu",
+        dropdownRootClassName: 'mission-wall-header-menu',
       }),
     );
 
-    expect(document.querySelector(".console-header-actions")).toHaveAttribute(
-      "data-dropdown-root-class-name",
-      "mission-wall-header-menu",
+    expect(document.querySelector('.console-header-actions')).toHaveAttribute(
+      'data-dropdown-root-class-name',
+      'mission-wall-header-menu',
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Switch language" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch language' }));
 
-    expect(await screen.findByText("中文")).toBeInTheDocument();
+    expect(await screen.findByText('中文')).toBeInTheDocument();
     expect(
-      document.querySelector(".mission-wall-header-menu"),
+      document.querySelector('.mission-wall-header-menu'),
     ).toBeInTheDocument();
   });
 });

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
@@ -5,7 +5,10 @@ import {
   clearStoredAuthSession,
   persistAuthSession,
 } from "@/shared/auth/session";
-import { ConsoleHeaderActions } from "./ConsoleHeaderActions";
+import {
+  ConsoleAuthActions,
+  ConsoleHeaderActions,
+} from "./ConsoleHeaderActions";
 
 const mockedHistoryPush = jest.fn();
 
@@ -63,6 +66,54 @@ describe("ConsoleHeaderActions", () => {
 
     expect(getLocale()).toBe("zh-CN");
     expect(screen.getByText("Abigail Deng")).toBeInTheDocument();
+  });
+
+  it("renders a supplied authoritative principal instead of the stored session identity", () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: "token",
+        expiresAt: Date.now() + 60_000,
+        expiresIn: 60,
+        tokenType: "Bearer",
+      },
+      user: {
+        name: "Stale Browser Name",
+        sub: "stored-user",
+      },
+    });
+
+    render(
+      React.createElement(ConsoleAuthActions, {
+        principal: {
+          authenticated: true,
+          displayName: "Authoritative Account Name",
+          picture: null,
+        },
+      }),
+    );
+
+    expect(screen.getByText("Authoritative Account Name")).toBeInTheDocument();
+    expect(screen.queryByText("Stale Browser Name")).not.toBeInTheDocument();
+  });
+
+  it("does not fall back to a stored identity when the authoritative principal is unavailable", () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: "token",
+        expiresAt: Date.now() + 60_000,
+        expiresIn: 60,
+        tokenType: "Bearer",
+      },
+      user: {
+        name: "Stale Browser Name",
+        sub: "stored-user",
+      },
+    });
+
+    render(React.createElement(ConsoleAuthActions, { principal: null }));
+
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.queryByText("Stale Browser Name")).not.toBeInTheDocument();
   });
 
   it("applies an optional dropdown root class to action menus", async () => {

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
@@ -5,31 +5,31 @@ import {
   LogoutOutlined,
   SettingOutlined,
   UserOutlined,
-} from "@ant-design/icons";
-import { getLocale, setLocale, useIntl } from "@umijs/max";
-import { Avatar, Button, Dropdown, Typography } from "antd";
-import React from "react";
+} from '@ant-design/icons';
+import { getLocale, setLocale, useIntl } from '@umijs/max';
+import { Avatar, Button, Dropdown, Typography } from 'antd';
+import React from 'react';
 import {
   clearStoredAuthSession,
   loadRestorableAuthSession,
   sanitizeReturnTo,
-} from "@/shared/auth/session";
-import { normalizeConsoleLocale } from "@/shared/i18n/localeProvider";
-import { history } from "@/shared/navigation/history";
+} from '@/shared/auth/session';
+import { normalizeConsoleLocale } from '@/shared/i18n/localeProvider';
+import { history } from '@/shared/navigation/history';
 
 type ConsoleLocaleOption = {
-  readonly key: "zh-CN" | "en-US";
-  readonly messageId: "common.language.zhCN" | "common.language.english";
+  readonly key: 'zh-CN' | 'en-US';
+  readonly messageId: 'common.language.zhCN' | 'common.language.english';
 };
 
 const CONSOLE_LOCALE_OPTIONS: readonly ConsoleLocaleOption[] = [
-  { key: "zh-CN", messageId: "common.language.zhCN" },
-  { key: "en-US", messageId: "common.language.english" },
+  { key: 'zh-CN', messageId: 'common.language.zhCN' },
+  { key: 'en-US', messageId: 'common.language.english' },
 ];
 
 function getCurrentReturnTo(): string {
-  if (typeof window === "undefined") {
-    return "/";
+  if (typeof window === 'undefined') {
+    return '/';
   }
 
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
@@ -78,7 +78,7 @@ export const ConsoleLanguageSwitch: React.FC<ConsoleHeaderActionThemeProps> = ({
           label: intl.formatMessage({ id: option.messageId }),
         })),
         onClick: ({ key }) => {
-          const nextLocale = key === "en-US" ? "en-US" : "zh-CN";
+          const nextLocale = key === 'en-US' ? 'en-US' : 'zh-CN';
           if (nextLocale === selectedLocale) {
             return;
           }
@@ -88,15 +88,15 @@ export const ConsoleLanguageSwitch: React.FC<ConsoleHeaderActionThemeProps> = ({
         selectedKeys: [selectedLocale],
       }}
       placement="bottomRight"
-      trigger={["click"]}
+      trigger={['click']}
     >
       <Button
-        aria-label={intl.formatMessage({ id: "common.language.switch" })}
+        aria-label={intl.formatMessage({ id: 'common.language.switch' })}
         className="console-header-actions__language"
         icon={<GlobalOutlined />}
         style={{
-          alignItems: "center",
-          display: "inline-flex",
+          alignItems: 'center',
+          display: 'inline-flex',
           height: 36,
         }}
         type="text"
@@ -128,8 +128,8 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
         type="link"
       >
         {intl.formatMessage({
-          defaultMessage: "Sign in",
-          id: "common.user.signIn",
+          defaultMessage: 'Sign in',
+          id: 'common.user.signIn',
         })}
       </Button>
     );
@@ -138,15 +138,15 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
   const displayName = hasAuthoritativePrincipal
     ? principal?.displayName ||
       intl.formatMessage({
-        defaultMessage: "Account",
-        id: "common.user.account",
+        defaultMessage: 'Account',
+        id: 'common.user.account',
       })
     : storedSession?.user.name ||
       storedSession?.user.email ||
       storedSession?.user.sub ||
       intl.formatMessage({
-        defaultMessage: "Account",
-        id: "common.user.account",
+        defaultMessage: 'Account',
+        id: 'common.user.account',
       });
   const picture = hasAuthoritativePrincipal
     ? principal?.picture
@@ -164,44 +164,44 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
       menu={{
         items: [
           {
-            key: "settings",
+            key: 'settings',
             icon: <SettingOutlined />,
-            label: intl.formatMessage({ id: "common.user.settings" }),
+            label: intl.formatMessage({ id: 'common.user.settings' }),
           },
           {
-            key: "logout",
+            key: 'logout',
             icon: <LogoutOutlined />,
-            label: intl.formatMessage({ id: "common.user.logout" }),
+            label: intl.formatMessage({ id: 'common.user.logout' }),
           },
         ],
         onClick: ({ key }) => {
-          if (key === "settings") {
-            history.push("/settings");
+          if (key === 'settings') {
+            history.push('/settings');
             return;
           }
 
-          if (key === "logout") {
+          if (key === 'logout') {
             clearStoredAuthSession();
-            window.location.replace("/login");
+            window.location.replace('/login');
           }
         },
       }}
       placement="bottomRight"
-      trigger={["click"]}
+      trigger={['click']}
     >
       <span
         className="console-header-actions__user"
         style={{
-          alignItems: "center",
-          background: "var(--ant-color-fill-tertiary)",
-          border: "1px solid var(--ant-color-border-secondary)",
+          alignItems: 'center',
+          background: 'var(--ant-color-fill-tertiary)',
+          border: '1px solid var(--ant-color-border-secondary)',
           borderRadius: 999,
-          cursor: "pointer",
-          display: "inline-flex",
+          cursor: 'pointer',
+          display: 'inline-flex',
           gap: 8,
           height: 36,
           maxWidth: 220,
-          padding: "0 10px 0 6px",
+          padding: '0 10px 0 6px',
         }}
         title={displayName}
       >
@@ -210,12 +210,12 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
           className="console-header-actions__user-name"
           style={{
             flex: 1,
-            color: "var(--ant-color-text)",
-            lineHeight: "20px",
+            color: 'var(--ant-color-text)',
+            lineHeight: '20px',
             marginBottom: 0,
             maxWidth: 160,
             minWidth: 0,
-            whiteSpace: "nowrap",
+            whiteSpace: 'nowrap',
           }}
           ellipsis={{ tooltip: displayName }}
         >
@@ -224,7 +224,7 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
         <DownOutlined
           className="console-header-actions__user-caret"
           style={{
-            color: "var(--ant-color-text-tertiary)",
+            color: 'var(--ant-color-text-tertiary)',
             fontSize: 11,
           }}
         />
@@ -237,9 +237,9 @@ export const ConsoleHeaderActions: React.FC<{
   readonly className?: string;
   readonly dropdownRootClassName?: string;
 }> = ({ className, dropdownRootClassName }) => {
-  const rootClassName = ["console-header-actions", className]
+  const rootClassName = ['console-header-actions', className]
     .filter(Boolean)
-    .join(" ");
+    .join(' ');
 
   return (
     <div

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
@@ -46,6 +46,14 @@ type ConsoleHeaderActionThemeProps = {
   readonly dropdownRootClassName?: string;
 };
 
+type ConsoleAuthActionsProps = ConsoleHeaderActionThemeProps & {
+  readonly principal?: {
+    readonly authenticated: boolean;
+    readonly displayName: string;
+    readonly picture: string | null;
+  } | null;
+};
+
 export const ConsoleLanguageSwitch: React.FC<ConsoleHeaderActionThemeProps> = ({
   dropdownRootClassName,
 }) => {
@@ -99,12 +107,17 @@ export const ConsoleLanguageSwitch: React.FC<ConsoleHeaderActionThemeProps> = ({
   );
 };
 
-export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
+export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
   dropdownRootClassName,
+  principal,
 }) => {
   const intl = useIntl();
-  const session = loadRestorableAuthSession();
-  if (!session) {
+  const storedSession = loadRestorableAuthSession();
+  const hasAuthoritativePrincipal = principal !== undefined;
+  const signedIn = hasAuthoritativePrincipal
+    ? Boolean(principal?.authenticated)
+    : Boolean(storedSession);
+  if (!signedIn) {
     return (
       <Button
         className="console-header-actions__login"
@@ -122,8 +135,22 @@ export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
     );
   }
 
-  const displayName =
-    session.user.name || session.user.email || session.user.sub;
+  const displayName = hasAuthoritativePrincipal
+    ? principal?.displayName ||
+      intl.formatMessage({
+        defaultMessage: "Account",
+        id: "common.user.account",
+      })
+    : storedSession?.user.name ||
+      storedSession?.user.email ||
+      storedSession?.user.sub ||
+      intl.formatMessage({
+        defaultMessage: "Account",
+        id: "common.user.account",
+      });
+  const picture = hasAuthoritativePrincipal
+    ? principal?.picture
+    : storedSession?.user.picture;
 
   return (
     <Dropdown
@@ -178,11 +205,7 @@ export const ConsoleAuthActions: React.FC<ConsoleHeaderActionThemeProps> = ({
         }}
         title={displayName}
       >
-        <Avatar
-          icon={<UserOutlined />}
-          size={24}
-          src={session.user.picture}
-        />
+        <Avatar icon={<UserOutlined />} size={24} src={picture} />
         <Typography.Text
           className="console-header-actions__user-name"
           style={{


### PR DESCRIPTION
## Problem and solution

Account settings previously presented a flat subset of authentication data while the vNext shell independently rendered browser-stored identity. That could expose stale or contradictory principal state and did not distinguish session health, optional profile absence, authorization denial, or transient load failure.

This change makes `GET /api/auth/me` the Account authority, derives a typed identity presentation once, and passes that same principal to the shell account control. Account now shows profile, workspace context, localized absolute and relative expiry, and explicit Active / Expiring soon / Expired / Invalid states. Expired and invalid sessions receive direct sign-in recovery. Support identifiers and claims remain collapsed, individually copyable, secondary, and secret-free.

## Impact paths

- Workflow Activity vNext Settings Account surface
- Workflow Activity vNext desktop and mobile shell account controls
- Shared `ConsoleAuthActions` optional authoritative-principal contract
- English and Simplified Chinese vNext message catalogues
- Account state classification and Settings/shared-header regression coverage

## Backend contract dependency

The current `GET /api/auth/me` contract does not provide a typed field-visibility reason. A successful response with a missing optional value is therefore rendered as `Not provided`; the frontend does not infer `Hidden by policy`.

The account service also does not provide a typed product-capability summary. Product access remains honestly labeled `Not loaded` with an explanatory note, while `403` is rendered as `Unauthorized` and transient request failures remain `Not loaded` with Retry. A backend contract extension is required before policy-hidden fields or detailed capability states can be rendered authoritatively.

## Local verification

- Scope analysis: `python3 /Users/abigaildeng/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext` selected 3 Jest files and 12 static-check files.
- Related and changed tests: `pnpm --dir apps/aevatar-console-web jest --selectProjects jsdom --runTestsByPath src/pages/workflow-activity-vnext/settings/accountIdentity.test.ts src/pages/workflow-activity-vnext/index.test.tsx src/shared/ui/ConsoleHeaderActions.test.tsx --runInBand` passed 3 suites and 86 tests.
- Changed-file static checks: `pnpm exec biome lint <12 analyzer-selected files>` passed, 12 files checked with no fixes.
- Test stability: `bash tools/ci/test_stability_guards.sh` passed.
- Baseline integrity: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py` passed; 17/17 frames, byte-identical generator output.
- Patch integrity: `git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD --check` passed.
- No reliable repository-native affected typecheck target is available. Full frontend suite, typecheck, and production build are delegated to GitHub CI by personal local workflow policy.

## Visual verification

The local vNext Account route was opened at `/scopes/scope-alpha/workflow-activity-vnext/settings?section=account`. The isolated worktree correctly preserved the sanitized return URL but stopped at the existing NyxID configuration gate because `NYXID_BASE_URL` was not configured. No credential or authentication bypass was used. Automated integration tests cover the Account UI state families.

## Design declaration

```text
Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py
```

Closes #3227


## Post-rebase CI follow-up verification

- Related, changed, and locale contract tests: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/settings/accountIdentity.test.ts src/shared/ui/ConsoleHeaderActions.test.tsx src/locales/catalog.test.ts src/locales/hardcodedCopyAudit.test.ts --runInBand` - passed 5 suites and 107 tests.
- Changed-file static checks: `pnpm exec biome check` on all 14 analyzer-selected frontend files - passed.
- Patch integrity: `git diff --check` - passed.
- Full frontend suite/typecheck/build: delegated to GitHub CI by the personal incremental frontend policy.