### PR TITLE
[P0][bug] Preserve workflow context in row Activity

### DIFF
--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-design.md
@@ -140,8 +140,10 @@ identity.
   other IDs must never be used to reconstruct it.
 - `workflowId` identifies a workspace draft or scope Workflow definition. It
   is not a member ID and is not automatically callable.
-- `definitionActorId` comes from `ScopeWorkflowDetail.source` and is the only
-  reviewed identity suitable for the Activity `definition` filter.
+- `workflowId` from a catalogue row is the URL-owned Workflow filter context.
+  Activity resolves that exact scoped identity through `ScopeWorkflowDetail`;
+  only the returned `definitionActorId` may become the observatory
+  `definition` request filter.
 - `memberId` remains Team-member authority. The vNext draft routes do not
   invent one or route through member APIs.
 - `publishedServiceId` is a callable runtime identity. It must be supplied by
@@ -309,7 +311,7 @@ The Excalidraw frame order is the review order and acceptance checklist:
 | 06 Template - populated Workflow draft | A chosen template creates an independent editable draft | Templates are versioned frontend product content unless an authoritative catalogue already exists; they are never pretend backend records |
 | 07 Run - unified execution dialog | Confirm target, input, connections, and external effects | Show only facts supported by the current document and capability preview; do not claim that Activity has already saved the Run |
 | 08 Running draft - Studio canvas and Run console | Keep the editor context while streaming accepted/running output | Show `Accepted` or `Running`, then separately show `Observed in Activity` only after the observatory returns the Run |
-| 09 Activity - filtered by Workflow | Enter Activity with a Workflow filter | Resolve `definitionActorId` from Workflow detail; never filter by display name or guessed actor ID |
+| 09 Activity - filtered by Workflow | Enter Activity with the row's `workflowId` visible in the URL and page | Resolve `definitionActorId` from Workflow detail before querying Runs; never filter by display name or guessed actor ID, and never fall back to global Runs when resolution fails |
 | 10 Activity - all retained Runs | Newest-first scope ledger with server filters | The endpoint is bounded by `take`; call it recent retained Runs, never claim a complete lifetime total |
 | 11 Run detail - immutable record | Input, output/error, diagnostics, steps, timeline, graph, statistics, and usage | Detail-level duration and usage are derived only from detail DTO fields; the source record is read-only |
 | 12 Failed Run - recovery creates a new record | Explain failure and preview Retry or Run again | Fork returns a new accepted receipt; it never edits the source Run and durable lineage is not claimed |
@@ -468,11 +470,16 @@ approval data live in detail and do not form a stable list filter contract.
 
 ### Workflow Filter
 
-Opening Activity from a Workflow resolves its
-`ScopeWorkflowDetail.source.definitionActorId`, then sends that exact value as
-the observatory `definition` filter. If the source is not available, the UI
-opens unfiltered Activity and explains that the Workflow-specific filter is
-unavailable. It must not substitute Workflow name or parse any actor string.
+Opening Activity from a catalogue row immediately encodes that row's exact
+`workflowId` in the Activity URL. Activity keeps that filter visible and
+removable, resolves the exact scoped Workflow detail, then sends only its
+`ScopeWorkflowDetail.source.definitionActorId` as the observatory `definition`
+filter. Refresh, copied URLs, back, and forward therefore restore the same
+Workflow context. If the URL identity is missing, the detail request fails, or
+the source has no definition identity, the UI shows an honest invalid, error,
+or unavailable state and does not issue an unfiltered Runs query. Removing the
+filter returns to global Activity. The UI must not substitute Workflow name,
+`memberId`, `publishedServiceId`, or a parsed actor string.
 
 ### Immutable Run Detail
 
@@ -688,8 +695,9 @@ hierarchy and density while using production tokens and real data states.
   do not optimistically synthesize authoritative IDs or projection versions.
 - Save and Run failures keep user-authored input. A retry repeats only the
   user's explicit action.
-- `Open Activity` from a Workflow uses an authoritative definition filter when
-  available. `Back to Workflow` appears only when the Run response provides a
+- `Open Activity` from a Workflow carries the catalogue row's authoritative
+  `workflowId` in the URL and resolves the definition filter at the Activity
+  boundary. `Back to Workflow` appears only when the Run response provides a
   trustworthy association; name matching is insufficient.
 - Browser back closes modal/detail layers before leaving the owning workbench
   when those layers are URL-addressable.
@@ -1044,8 +1052,10 @@ are true:
   never inferred from one another.
 - Run shows Accepted/Running separately from Activity observation and never
   fabricates an Activity record.
-- Activity filters use only supported server parameters and authoritative
-  definition identity.
+- Activity URLs preserve the catalogue row's authoritative `workflowId`, and
+  Activity sends only the resolved definition identity through supported
+  server parameters. Missing or invalid Workflow context never falls back to
+  an unfiltered Runs query.
 - Activity list rows contain only summary facts; duration, usage, diagnostics,
   and outputs appear only from Run detail.
 - Run detail is immutable, and Retry/Run again always create a new accepted

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-user-paths.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-04-workflow-activity-vnext-user-paths.md
@@ -170,7 +170,7 @@ flowchart TD
 | UP-06 | Open, edit, validate, and save | 03-06, 08 | Authoritative draft update succeeds; unsaved state clears |
 | UP-07 | Run a current draft | 07, 08 | Real draft-run stream/receipt reaches Accepted or Running |
 | UP-08 | Observe a Run in Activity | 08-10, 13 | Observatory returns an authoritative `runId` and `stateVersion` |
-| UP-09 | Filter Activity by Workflow | 09 | Exact `definitionActorId` is applied, or the filter is honestly unavailable |
+| UP-09 | Filter Activity by Workflow | 09 | The row's exact `workflowId` remains visible in the URL and resolves to an exact `definitionActorId`, or the filtered view is honestly unavailable |
 | UP-10 | Inspect immutable Run detail | 11 | Detail response renders committed facts; graph may load independently |
 | UP-11 | Retry a failed Run | 12 | Fork API accepts an explicit failed `stepId`; source Run remains unchanged |
 | UP-12 | Run a completed Workflow again | 11, 12 | Fork API accepts an explicit first execution step; source remains unchanged |
@@ -548,21 +548,27 @@ HTTP success status cannot insert an Activity row or invent a `stateVersion`.
 
 **Steps:**
 
-1. The frontend resolves the scope Workflow detail through
+1. The catalogue action encodes that row's exact draft `workflowId` in the
+   Activity route query string without substituting a member, service, display
+   name, or actor identity.
+2. Activity keeps the Workflow filter visible and removable, and resolves the
+   scope Workflow detail through
    `GET /api/scopes/:scopeId/workflows/:workflowId`.
-2. Only `ScopeWorkflowDetail.source.definitionActorId` supplies the
+3. Only `ScopeWorkflowDetail.source.definitionActorId` supplies the
    observatory `definition` filter.
-3. The Activity route encodes the supported filter in its query string so
-   refresh/back navigation preserves it.
-4. The ledger shows only the server-filtered response window.
+4. Refresh, copied URLs, back, and forward restore the same `workflowId` and
+   repeat the same authoritative resolution.
+5. The ledger shows only the server-filtered response window. Removing the
+   Workflow filter removes it from the URL and returns to global Activity.
 
-**Completion:** The active filter is visible, removable, and backed by the
-exact definition identity.
+**Completion:** The active `workflowId` filter is URL-backed, visible,
+removable, and backed by the exact resolved definition identity.
 
-**Recovery:** A draft-only Workflow may not have a definition actor. In that
-case the user enters unfiltered Activity with a concise filter-unavailable
-message. The UI does not substitute `workflowId`, Workflow name, `serviceKey`,
-or a parsed actor prefix.
+**Recovery:** A missing or invalid `workflowId`, failed Workflow-detail read,
+or draft-only Workflow without a definition actor produces an honest
+invalid, error, or unavailable state. The Runs query remains disabled so the
+page never silently shows global Activity. The UI does not substitute Workflow
+name, `memberId`, `publishedServiceId`, `serviceKey`, or a parsed actor prefix.
 
 ## UP-10: Inspect Immutable Run Detail
 
@@ -853,8 +859,9 @@ Every frame has a corresponding user path:
   creates and observes a new draft, then adopts its returned ID.
 - Draft Run reaches Accepted/Running before it can reach Activity observation.
 - Activity observation requires a real observatory `runId` and `stateVersion`.
-- Workflow-specific Activity filtering uses only an exact returned
-  `definitionActorId`.
+- Workflow-specific Activity preserves the catalogue row's exact `workflowId`
+  in the URL and uses only the exact returned `definitionActorId` for the Runs
+  request; invalid resolution never falls back to global Activity.
 - Run detail remains immutable in success, failure, partial graph, Retry, and
   Run again paths.
 - Retry and Run again require explicit step identity and create a new accepted

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -34,8 +34,24 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.activity.unnamed': 'Unnamed workflow',
   'workflowActivityVNext.activity.unavailableDescription':
     'Try again to load recent workflow runs.',
-  'workflowActivityVNext.activity.workflowFilterUnavailable':
-    "This workflow can't be filtered yet. Showing all activity.",
+  'workflowActivityVNext.activity.removeWorkflowFilterAria':
+    'Remove workflow filter {workflowId}',
+  'workflowActivityVNext.activity.workflowFilterInvalidDescription':
+    'This Activity link does not contain a workflow identity.',
+  'workflowActivityVNext.activity.workflowFilterInvalidTitle':
+    'Choose a workflow to filter Activity',
+  'workflowActivityVNext.activity.workflowFilterLabel':
+    'Workflow: {workflowId}',
+  'workflowActivityVNext.activity.workflowFilterLoading':
+    'Loading workflow activity…',
+  'workflowActivityVNext.activity.workflowFilterResolutionFailed':
+    'Workflow activity unavailable',
+  'workflowActivityVNext.activity.workflowFilterResolutionFailedDescription':
+    'Try again or remove the workflow filter.',
+  'workflowActivityVNext.activity.workflowFilterUnavailableDescription':
+    'No runs are shown because this workflow does not expose an Activity filter.',
+  'workflowActivityVNext.activity.workflowFilterUnavailableTitle':
+    'Activity filtering is unavailable',
   'workflowActivityVNext.brand.subtitle': 'AUTOMATION LEDGER',
   'workflowActivityVNext.common.cancel': 'Cancel',
   'workflowActivityVNext.common.close': 'Close',
@@ -468,10 +484,6 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.unavailableDescription':
     'Try again to load your workflows.',
   'workflowActivityVNext.workflows.viewFilter': 'Workflow view',
-  'workflowActivityVNext.workflows.activityFilterUnavailable':
-    "Activity filtering isn't available for this workflow yet.",
-  'workflowActivityVNext.workflows.activityResolutionFailed':
-    "Activity couldn't be opened for this workflow",
   'workflowActivityVNext.workflows.partialUnavailable':
     "Some workflows couldn't be loaded",
   'workflowActivityVNext.workflows.publishedRevision': 'Published {revision}',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -38,8 +38,24 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.activity.unnamed': '未命名工作流',
     'workflowActivityVNext.activity.unavailableDescription':
       '请重试加载最近的工作流运行记录。',
-    'workflowActivityVNext.activity.workflowFilterUnavailable':
-      '暂时无法按此工作流筛选，当前显示全部活动记录。',
+    'workflowActivityVNext.activity.removeWorkflowFilterAria':
+      '移除工作流筛选条件 {workflowId}',
+    'workflowActivityVNext.activity.workflowFilterInvalidDescription':
+      '此活动链接不包含工作流身份。',
+    'workflowActivityVNext.activity.workflowFilterInvalidTitle':
+      '请选择要筛选活动的工作流',
+    'workflowActivityVNext.activity.workflowFilterLabel':
+      '工作流：{workflowId}',
+    'workflowActivityVNext.activity.workflowFilterLoading':
+      '正在加载工作流活动…',
+    'workflowActivityVNext.activity.workflowFilterResolutionFailed':
+      '工作流活动不可用',
+    'workflowActivityVNext.activity.workflowFilterResolutionFailedDescription':
+      '请重试或移除工作流筛选条件。',
+    'workflowActivityVNext.activity.workflowFilterUnavailableDescription':
+      '此工作流未提供活动筛选条件，因此不显示任何运行记录。',
+    'workflowActivityVNext.activity.workflowFilterUnavailableTitle':
+      '活动筛选不可用',
     'workflowActivityVNext.brand.subtitle': '自动化账本',
     'workflowActivityVNext.common.cancel': '取消',
     'workflowActivityVNext.common.close': '关闭',
@@ -438,10 +454,6 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.unavailableDescription':
       '请重试加载工作流。',
     'workflowActivityVNext.workflows.viewFilter': '工作流视图',
-    'workflowActivityVNext.workflows.activityFilterUnavailable':
-      '暂时无法筛选此工作流的活动记录。',
-    'workflowActivityVNext.workflows.activityResolutionFailed':
-      '无法打开此工作流的活动记录',
     'workflowActivityVNext.workflows.partialUnavailable': '部分工作流无法加载',
     'workflowActivityVNext.workflows.publishedRevision': '已发布 {revision}',
     'workflowActivityVNext.workflows.referenceCopied': '已复制工作流引用',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
@@ -51,6 +51,10 @@ jest.mock('@/shared/api/workflowActivityApi', () => {
   };
 });
 
+jest.mock('@/shared/api/scopesApi', () => ({
+  scopesApi: { getWorkflowDetail: jest.fn() },
+}));
+
 jest.mock('@/shared/navigation/history', () => ({
   history: { push: jest.fn(), replace: jest.fn() },
 }));
@@ -70,6 +74,8 @@ jest.mock('../hooks/useConsoleLocation', () => ({
 
 const mockListRuns = jest.requireMock('@/shared/api/workflowActivityApi')
   .workflowActivityApi.listRuns as jest.Mock;
+const mockGetWorkflowDetail = jest.requireMock('@/shared/api/scopesApi')
+  .scopesApi.getWorkflowDetail as jest.Mock;
 
 describe('Workflow Activity vNext Activity ledger', () => {
   beforeEach(() => {
@@ -80,24 +86,89 @@ describe('Workflow Activity vNext Activity ledger', () => {
 
   afterEach(() => cleanupTestQueryClients());
 
-  it('preserves the honest unavailable notice for a workflow without definition identity', async () => {
-    mockSearch = '?workflowFilter=unavailable';
+  it('restores a visible workflow filter from the URL and removes it back to global Activity', async () => {
+    mockSearch = '?workflowId=wf-alpha';
+    mockGetWorkflowDetail.mockResolvedValue({
+      available: true,
+      scopeId: 'scope-alpha',
+      workflow: null,
+      source: {
+        definitionActorId: 'definition-alpha',
+        inlineWorkflowYamls: null,
+        workflowYaml: '',
+      },
+    });
 
     renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
 
-    expect(
-      await screen.findByText(
-        "This workflow can't be filtered yet. Showing all activity.",
-      ),
-    ).toBeInTheDocument();
     await waitFor(() =>
       expect(mockListRuns).toHaveBeenCalledWith('scope-alpha', {
         status: undefined,
         origins: undefined,
-        definitionActorIds: undefined,
+        definitionActorIds: ['definition-alpha'],
         take: 100,
       }),
     );
+    expect(mockGetWorkflowDetail).toHaveBeenCalledWith(
+      'scope-alpha',
+      'wf-alpha',
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Remove workflow filter wf-alpha',
+      }),
+    );
+
+    expect(history.replace).toHaveBeenLastCalledWith(
+      '/scopes/scope-alpha/workflow-activity-vnext/activity',
+    );
+  });
+
+  it('does not query global runs when the workflow filter is empty', async () => {
+    mockSearch = '?workflowId=';
+
+    renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText('Choose a workflow to filter Activity'),
+    ).toBeInTheDocument();
+    expect(mockGetWorkflowDetail).not.toHaveBeenCalled();
+    expect(mockListRuns).not.toHaveBeenCalled();
+  });
+
+  it('keeps an unresolved workflow filter visible without showing global runs', async () => {
+    mockSearch = '?workflowId=wf-missing';
+    mockGetWorkflowDetail.mockRejectedValue(new Error('GET returned 404'));
+
+    renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText('Workflow activity unavailable'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Remove workflow filter wf-missing',
+      }),
+    ).toBeEnabled();
+    expect(mockListRuns).not.toHaveBeenCalled();
+  });
+
+  it('keeps a workflow without a definition in an honest unavailable state', async () => {
+    mockSearch = '?workflowId=wf-draft-only';
+    mockGetWorkflowDetail.mockResolvedValue({
+      available: false,
+      scopeId: 'scope-alpha',
+      workflow: null,
+      source: null,
+    });
+
+    renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
+
+    expect(
+      await screen.findByText('Activity filtering is unavailable'),
+    ).toBeInTheDocument();
+    expect(mockListRuns).not.toHaveBeenCalled();
   });
 
   it('sends only URL-backed supported filters to the observatory API', async () => {
@@ -146,7 +217,7 @@ describe('Workflow Activity vNext Activity ledger', () => {
 
   it('restores search from the URL without sending it to the runs API', async () => {
     mockSearch =
-      '?q=customer&status=failed&origin=draft&definition=definition-alpha&workflowFilter=unavailable';
+      '?q=customer&status=failed&origin=draft&definition=definition-alpha';
 
     renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
 
@@ -168,7 +239,7 @@ describe('Workflow Activity vNext Activity ledger', () => {
 
     await waitFor(() =>
       expect(history.replace).toHaveBeenLastCalledWith(
-        '/scopes/scope-alpha/workflow-activity-vnext/activity?q=invoice&status=failed&origin=draft&definition=definition-alpha&workflowFilter=unavailable',
+        '/scopes/scope-alpha/workflow-activity-vnext/activity?q=invoice&status=failed&origin=draft&definition=definition-alpha',
       ),
     );
     expect(mockListRuns).toHaveBeenLastCalledWith('scope-alpha', {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx
@@ -1,8 +1,13 @@
-import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
+import {
+  CloseOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+} from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
 import { getLocale } from '@umijs/max';
-import { Alert, Button, Input, Select, Space } from 'antd';
+import { Button, Input, Select, Space } from 'antd';
 import React from 'react';
+import { scopesApi } from '@/shared/api/scopesApi';
 import {
   WorkflowActivityApiError,
   workflowActivityApi,
@@ -56,21 +61,67 @@ function failureTitle(error: unknown): string {
 
 const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const location = useConsoleLocation();
-  const initialParams = React.useMemo(
+  const params = React.useMemo(
     () => new URLSearchParams(location.search),
     [location.search],
   );
-  const [status, setStatus] = React.useState(
-    normalizeRunStatusFilter(initialParams.get('status')),
+  const rawStatus = params.get('status');
+  const status = normalizeRunStatusFilter(rawStatus);
+  const origin = params.get('origin') ?? '';
+  const definition = params.get('definition')?.trim() ?? '';
+  const workflowFilterPresent = params.has('workflowId');
+  const workflowId = params.get('workflowId')?.trim() ?? '';
+  const search = params.get('q') ?? '';
+
+  const replaceParams = React.useCallback(
+    (update: (next: URLSearchParams) => void) => {
+      const next = new URLSearchParams(location.search);
+      update(next);
+      const suffix = next.toString();
+      history.replace(`${location.pathname}${suffix ? `?${suffix}` : ''}`);
+    },
+    [location.pathname, location.search],
   );
-  const [origin, setOrigin] = React.useState(initialParams.get('origin') ?? '');
-  const [definition, setDefinition] = React.useState(
-    initialParams.get('definition') ?? '',
+  const replaceParam = React.useCallback(
+    (name: string, value: string) =>
+      replaceParams((next) => {
+        if (value) next.set(name, value);
+        else next.delete(name);
+      }),
+    [replaceParams],
   );
-  const [workflowFilter, setWorkflowFilter] = React.useState(
-    initialParams.get('workflowFilter') ?? '',
+  const clearWorkflowFilter = React.useCallback(
+    () =>
+      replaceParams((next) => {
+        next.delete('workflowId');
+        next.delete('definition');
+      }),
+    [replaceParams],
   );
-  const [search, setSearch] = React.useState(initialParams.get('q') ?? '');
+
+  React.useEffect(() => {
+    if (!rawStatus || status) return;
+    replaceParam('status', '');
+  }, [rawStatus, replaceParam, status]);
+
+  const workflow = useQuery({
+    queryKey: [
+      'workflow-activity-vnext',
+      'activity-workflow',
+      scopeId,
+      workflowId,
+    ],
+    queryFn: () => scopesApi.getWorkflowDetail(scopeId, workflowId),
+    enabled: workflowFilterPresent && Boolean(workflowId),
+    retry: false,
+  });
+  const resolvedDefinition =
+    workflow.data?.source?.definitionActorId.trim() ?? '';
+  const effectiveDefinition = workflowFilterPresent
+    ? resolvedDefinition
+    : definition;
+  const workflowFilterReady =
+    !workflowFilterPresent || Boolean(resolvedDefinition);
   const runs = useQuery({
     queryKey: [
       'workflow-activity-vnext',
@@ -78,37 +129,28 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       scopeId,
       status,
       origin,
-      definition,
+      effectiveDefinition,
     ],
     queryFn: () =>
       workflowActivityApi.listRuns(scopeId, {
         status: status || undefined,
         origins: origin ? [origin] : undefined,
-        definitionActorIds: definition ? [definition] : undefined,
+        definitionActorIds: effectiveDefinition
+          ? [effectiveDefinition]
+          : undefined,
         take: 100,
       }),
+    enabled: workflowFilterReady,
     retry: false,
   });
 
-  React.useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    setSearch(params.get('q') ?? '');
-    setStatus(normalizeRunStatusFilter(params.get('status')));
-    setOrigin(params.get('origin') ?? '');
-    setDefinition(params.get('definition') ?? '');
-    setWorkflowFilter(params.get('workflowFilter') ?? '');
-  }, [location.search]);
-
-  React.useEffect(() => {
-    const params = new URLSearchParams();
-    if (search.trim()) params.set('q', search.trim());
-    if (status) params.set('status', status);
-    if (origin) params.set('origin', origin);
-    if (definition) params.set('definition', definition);
-    if (workflowFilter) params.set('workflowFilter', workflowFilter);
-    const suffix = params.toString();
-    history.replace(`${location.pathname}${suffix ? `?${suffix}` : ''}`);
-  }, [definition, location.pathname, origin, search, status, workflowFilter]);
+  const refresh = () => {
+    if (workflowFilterPresent && !resolvedDefinition) {
+      if (workflowId) void workflow.refetch();
+      return;
+    }
+    void runs.refetch();
+  };
 
   const filtered = (runs.data ?? []).filter((run) => {
     const normalized = search.trim().toLowerCase();
@@ -128,24 +170,31 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         'Review recent workflow runs and open one for details.',
       )}
       headerActions={
-        <Button icon={<ReloadOutlined />} onClick={() => void runs.refetch()}>
+        <Button icon={<ReloadOutlined />} onClick={refresh}>
           {t('workflowActivityVNext.common.refresh', 'Refresh')}
         </Button>
       }
       scopeId={scopeId}
       title={t('workflowActivityVNext.activity.title', 'Activity')}
     >
-      {workflowFilter === 'unavailable' ? (
-        <Alert
-          closable
-          message={t(
-            'workflowActivityVNext.activity.workflowFilterUnavailable',
-            "This workflow can't be filtered yet. Showing all activity.",
-          )}
-          onClose={() => setWorkflowFilter('')}
-          showIcon
-          type="warning"
-        />
+      {workflowFilterPresent ? (
+        <Space wrap>
+          <Button
+            aria-label={t(
+              'workflowActivityVNext.activity.removeWorkflowFilterAria',
+              'Remove workflow filter {workflowId}',
+              { workflowId: workflowId || 'invalid' },
+            )}
+            icon={<CloseOutlined />}
+            onClick={clearWorkflowFilter}
+          >
+            {t(
+              'workflowActivityVNext.activity.workflowFilterLabel',
+              'Workflow: {workflowId}',
+              { workflowId: workflowId || 'Invalid' },
+            )}
+          </Button>
+        </Space>
       ) : null}
       <div className="wa-vnext__toolbar">
         <Input
@@ -155,7 +204,7 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
             'Search runs',
           )}
           className="wa-vnext__toolbar-search"
-          onChange={(event) => setSearch(event.target.value)}
+          onChange={(event) => replaceParam('q', event.target.value)}
           placeholder={t(
             'workflowActivityVNext.activity.search',
             'Search runs',
@@ -170,7 +219,7 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
               'workflowActivityVNext.activity.statusFilter',
               'Run status',
             )}
-            onChange={setStatus}
+            onChange={(value) => replaceParam('status', value)}
             options={[
               {
                 label: t(
@@ -205,7 +254,7 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
               'workflowActivityVNext.activity.originFilter',
               'Run source',
             )}
-            onChange={setOrigin}
+            onChange={(value) => replaceParam('origin', value)}
             options={[
               {
                 label: t(
@@ -249,8 +298,8 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
             ]}
             value={origin}
           />
-          {definition ? (
-            <Button onClick={() => setDefinition('')}>
+          {definition && !workflowFilterPresent ? (
+            <Button onClick={() => replaceParam('definition', '')}>
               {t(
                 'workflowActivityVNext.activity.clearWorkflowFilter',
                 'Show all workflows',
@@ -259,7 +308,75 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           ) : null}
         </Space>
       </div>
-      {runs.isPending ? (
+      {workflowFilterPresent && !workflowId ? (
+        <div className="wa-vnext__state" role="alert">
+          <div>
+            <h2>
+              {t(
+                'workflowActivityVNext.activity.workflowFilterInvalidTitle',
+                'Choose a workflow to filter Activity',
+              )}
+            </h2>
+            <p>
+              {t(
+                'workflowActivityVNext.activity.workflowFilterInvalidDescription',
+                'This Activity link does not contain a workflow identity.',
+              )}
+            </p>
+          </div>
+        </div>
+      ) : workflowFilterPresent && workflow.isPending ? (
+        <div aria-live="polite" className="wa-vnext__state">
+          <p>
+            {t(
+              'workflowActivityVNext.activity.workflowFilterLoading',
+              'Loading workflow activity…',
+            )}
+          </p>
+        </div>
+      ) : workflowFilterPresent && workflow.isError ? (
+        <div className="wa-vnext__state" role="alert">
+          <div>
+            <h2>
+              {t(
+                'workflowActivityVNext.activity.workflowFilterResolutionFailed',
+                'Workflow activity unavailable',
+              )}
+            </h2>
+            <p>
+              {t(
+                'workflowActivityVNext.activity.workflowFilterResolutionFailedDescription',
+                'Try again or remove the workflow filter.',
+              )}
+            </p>
+            <Button onClick={() => void workflow.refetch()}>
+              {t('workflowActivityVNext.common.retry', 'Retry')}
+            </Button>
+            <TechnicalDetails>
+              {workflow.error instanceof Error
+                ? workflow.error.message
+                : String(workflow.error)}
+            </TechnicalDetails>
+          </div>
+        </div>
+      ) : workflowFilterPresent && !resolvedDefinition ? (
+        <div className="wa-vnext__state">
+          <div>
+            <h2>
+              {t(
+                'workflowActivityVNext.activity.workflowFilterUnavailableTitle',
+                'Activity filtering is unavailable',
+              )}
+            </h2>
+            <p>
+              {t(
+                'workflowActivityVNext.activity.workflowFilterUnavailableDescription',
+                'No runs are shown because this workflow does not expose an Activity filter.',
+              )}
+            </p>
+          </div>
+        </div>
+      ) : runs.isPending ? (
         <div aria-live="polite" className="wa-vnext__state">
           <p>
             {t('workflowActivityVNext.activity.loading', 'Loading activity…')}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -354,7 +354,12 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(history.push).not.toHaveBeenCalled();
   });
 
-  it('renders authoritative draft and committed rows, searches, and navigates by the real workflow id', async () => {
+  it('opens row Activity with only the catalogue workflow id', async () => {
+    const rowIdentities = {
+      memberId: 'm-alpha',
+      publishedServiceId: 'svc-alpha',
+      workflowId: 'wf-alpha',
+    };
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([
       {
         workflowId: 'wf-draft-alpha',
@@ -372,27 +377,17 @@ describe('Workflow Activity vNext catalogue', () => {
     mockScopesApi.listWorkflows.mockResolvedValue([
       {
         scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
+        workflowId: rowIdentities.workflowId,
         displayName: 'Invoice review',
         serviceKey: '',
         workflowName: 'invoice_review',
-        actorId: 'summary-actor-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
+        actorId: 'summary-actor-alpha',
+        activeRevisionId: 'revision-alpha',
+        deploymentId: 'deployment-alpha',
         deploymentStatus: 'active',
         updatedAt: '2026-08-03T10:00:00Z',
       },
     ]);
-    mockScopesApi.getWorkflowDetail.mockResolvedValue({
-      available: true,
-      scopeId: 'scope-alpha',
-      workflow: null,
-      source: {
-        workflowYaml: '',
-        definitionActorId: 'definition-beta',
-        inlineWorkflowYamls: null,
-      },
-    });
 
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
@@ -415,21 +410,22 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(screen.queryByText('Support triage')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Activity' }));
-    await waitFor(() => {
-      expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledWith(
-        'scope-alpha',
-        'wf-committed-beta',
-      );
-      expect(history.push).toHaveBeenCalledWith(
-        '/scopes/scope-alpha/workflow-activity-vnext/activity?definition=definition-beta',
-      );
-    });
+    expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
+    expect(history.push).toHaveBeenCalledWith(
+      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-alpha',
+    );
+    expect(history.push).not.toHaveBeenCalledWith(
+      expect.stringContaining(rowIdentities.memberId),
+    );
+    expect(history.push).not.toHaveBeenCalledWith(
+      expect.stringContaining(rowIdentities.publishedServiceId),
+    );
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Open Invoice review' }),
     );
     expect(history.push).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-committed-beta',
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-alpha',
     );
   });
 
@@ -623,43 +619,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
   });
 
-  it('reports an Activity resolution request failure with a toast instead of a page alert', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'summary-actor-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-    mockScopesApi.getWorkflowDetail.mockRejectedValue(
-      new Error('GET returned 503'),
-    );
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    expect(await screen.findByText('Invoice review')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Activity' }));
-
-    await waitFor(() =>
-      expect(mockConsoleToast.error).toHaveBeenCalledWith(
-        "Activity couldn't be opened for this workflow",
-      ),
-    );
-    expect(
-      screen.queryByText("Activity couldn't be opened for this workflow"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText('GET returned 503')).not.toBeInTheDocument();
-  });
-
-  it('opens unfiltered Activity with an unavailable notice for a draft-only row', async () => {
+  it('deep-links draft-only row Activity with its workflow id', async () => {
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([
       {
         workflowId: 'wf-draft-alpha',
@@ -675,14 +635,13 @@ describe('Workflow Activity vNext catalogue', () => {
       },
     ]);
     mockScopesApi.listWorkflows.mockResolvedValue([]);
-
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     expect(await screen.findByText('Support triage')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Activity' }));
     expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
     expect(history.push).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowFilter=unavailable',
+      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-draft-alpha',
     );
   });
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -109,7 +109,6 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const [view, setView] = React.useState<WorkflowView>(
     readWorkflowView(initialParams),
   );
-  const [activityWorkflowId, setActivityWorkflowId] = React.useState('');
   const [renameTarget, setRenameTarget] = React.useState<WorkflowRow | null>(
     null,
   );
@@ -230,32 +229,11 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     void committed.refetch();
   };
 
-  const openActivity = async (row: WorkflowRow) => {
+  const openActivity = (row: WorkflowRow) => {
     const activityHref = buildWorkflowActivitySectionHref(scopeId, 'activity');
-    if (!row.hasCommittedSource) {
-      history.push(`${activityHref}?workflowFilter=unavailable`);
-      return;
-    }
-
-    setActivityWorkflowId(row.workflowId);
-    try {
-      const detail = await scopesApi.getWorkflowDetail(scopeId, row.workflowId);
-      const definitionActorId = detail.source?.definitionActorId.trim() ?? '';
-      history.push(
-        definitionActorId
-          ? `${activityHref}?definition=${encodeURIComponent(definitionActorId)}`
-          : `${activityHref}?workflowFilter=unavailable`,
-      );
-    } catch {
-      toast.error(
-        t(
-          'workflowActivityVNext.workflows.activityResolutionFailed',
-          "Activity couldn't be opened for this workflow",
-        ),
-      );
-    } finally {
-      setActivityWorkflowId('');
-    }
+    history.push(
+      `${activityHref}?workflowId=${encodeURIComponent(row.workflowId)}`,
+    );
   };
 
   const copyWorkflowReference = async (row: WorkflowRow) => {
@@ -653,18 +631,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                       >
                         {t('workflowActivityVNext.common.open', 'Open')}
                       </Button>
-                      <Button
-                        loading={activityWorkflowId === row.workflowId}
-                        onClick={() => void openActivity(row)}
-                        title={
-                          !row.hasCommittedSource
-                            ? t(
-                                'workflowActivityVNext.workflows.activityFilterUnavailable',
-                                "Activity filtering isn't available for this workflow yet.",
-                              )
-                            : undefined
-                        }
-                      >
+                      <Button onClick={() => openActivity(row)}>
                         {t(
                           'workflowActivityVNext.workflows.viewActivity',
                           'Activity',


### PR DESCRIPTION
## Problem

The row-level Activity action resolved or discarded Workflow context before navigation. Draft-only rows opened global Activity, and failed or missing filter resolution could therefore present unrelated Runs under a Workflow-specific action.

## Solution

- Deep-link every catalogue row with its explicit workflowId in the Activity URL.
- Keep that workflowId visible and removable in Activity.
- Resolve the URL workflowId through the scoped Workflow detail contract, then send only the returned definitionActorId through the supported observatory definition filter.
- Disable the Runs query while Workflow context is missing, invalid, unresolved, or unavailable so the page never falls back to global results.
- Keep memberId, workflowId, and publishedServiceId visibly distinct in regression fixtures.
- Update the normative vNext design and user-path contracts for URL restoration, clearing, and honest failure behavior.

## Impacted paths

- Workflow Activity vNext catalogue navigation
- Workflow Activity vNext Activity URL/filter/query states
- English and Chinese vNext messages
- Focused catalogue and Activity route integration tests
- Workflow Activity vNext design and user-path specifications

No backend files, dependencies, route configuration, or legacy surfaces changed.

## Backend contract dependency

The observatory list contract supports definitionActorId, not workflowId. Activity therefore resolves the URL workflowId through the existing scoped Workflow detail contract. A draft-only Workflow with no resolvable definition identity remains in an explicit unavailable state and does not query or show global Runs.

## Verification

- python3 /Users/abigaildeng/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext
  - Passed; selected 2 Jest files and 6 static-check files.
- pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
  - Passed: 2 suites, 78 tests.
- pnpm --dir apps/aevatar-console-web exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.tsx src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
  - Passed: 6 files.
- bash tools/ci/test_stability_guards.sh
  - Passed.
- bash tools/docs/lint.sh
  - Passed: 87 files, 0 errors.
- From apps/aevatar-console-web: python3 docs/design-baselines/workflow-activity-vnext/verify-baseline.py
  - Passed: declared SHA, byte-identical generator output, and 17/17 frames.
- git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD
  - Passed.

The complete frontend suite, full typecheck, and production build were not run locally under the incremental frontend policy. The analyzer exposed no reliable affected typecheck target; full verification is delegated to GitHub CI.

## Workflow Activity vNext baseline declaration

- Primary visual reference: apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/aevatar-workflow-activity-vnext.excalidraw
- Excalidraw SHA-256: 30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
- Normative contracts: 2026-08-04-workflow-activity-vnext-design.md and 2026-08-04-workflow-activity-vnext-user-paths.md
- Production data remains real-API-only. No prototype, fixture, browser-storage, timer, or fabricated fallback data was added.

Closes #3219


## Post-rebase CI follow-up verification

- Related and changed tests: `pnpm exec jest src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx src/pages/workflow-activity-vnext/index.test.tsx --runInBand` - passed 2 suites and 85 tests.
- Changed-file static checks: `pnpm exec biome check` on all 6 analyzer-selected frontend files - passed.
- Patch integrity: `git diff --check` - passed.
- Full frontend suite/typecheck/build: delegated to GitHub CI by the personal incremental frontend policy.