### PR TITLE
Improve editor save and publish readiness feedback

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -87,7 +87,13 @@ const workflowActivityVNextMessages = {
     'No additional approval is required.',
   'workflowActivityVNext.publish.approvalRequired':
     'Approval is required before this request can run.',
+  'workflowActivityVNext.publish.addExecutableStep':
+    'Add at least one executable step before publishing.',
+  'workflowActivityVNext.publish.applyNodeChanges':
+    'Apply or discard node configuration before publishing.',
   'workflowActivityVNext.publish.backToService': 'Back',
+  'workflowActivityVNext.publish.blocked': 'Publish blocked · {count} issues',
+  'workflowActivityVNext.publish.blockedOne': 'Publish blocked · 1 issue',
   'workflowActivityVNext.publish.checkAgain': 'Check again',
   'workflowActivityVNext.publish.delayed':
     'Publication is taking longer to appear',
@@ -110,6 +116,9 @@ const workflowActivityVNextMessages = {
     'The selected service is now using this workflow.',
   'workflowActivityVNext.publish.observingDescription':
     'Checking whether the selected service is ready.',
+  'workflowActivityVNext.publish.published': 'Published',
+  'workflowActivityVNext.publish.publishedServiceId': 'Published service ID',
+  'workflowActivityVNext.publish.publishing': 'Publishing',
   'workflowActivityVNext.publish.publishingTo': 'Publishing to {service}',
   'workflowActivityVNext.publish.reviewAgain': 'Review again',
   'workflowActivityVNext.publish.reviewAndPublish': 'Review and publish',
@@ -120,6 +129,9 @@ const workflowActivityVNextMessages = {
     'Preparing this workflow for review.',
   'workflowActivityVNext.publish.reviewUnavailable':
     "We couldn't prepare this workflow for publishing.",
+  'workflowActivityVNext.publish.readinessIssues': 'Publish readiness issues',
+  'workflowActivityVNext.publish.resolvePublication':
+    'Resolve the current publication status before publishing again.',
   'workflowActivityVNext.publish.risk': 'Impact',
   'workflowActivityVNext.publish.risk.destructive':
     'May delete or permanently change data',
@@ -137,6 +149,15 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.publish.submittingDescription':
     'Sending this workflow to the selected service.',
   'workflowActivityVNext.publish.title': 'Publish workflow',
+  'workflowActivityVNext.publish.waitForPublication':
+    'Wait for the current publication to finish.',
+  'workflowActivityVNext.publish.waitForEditorUpdate':
+    'Wait for the workflow step update to finish.',
+  'workflowActivityVNext.publish.waitForSave':
+    'Wait for workflow validation and saving to finish.',
+  'workflowActivityVNext.publish.waitForSavedDraft':
+    'Wait for the saved draft to become readable.',
+  'workflowActivityVNext.publish.workflowId': 'Workflow ID',
   'workflowActivityVNext.publish.unauthorizedDescription':
     'Sign in again to check this publication.',
   'workflowActivityVNext.editor.checkLatestStatus': 'Check latest status',
@@ -165,6 +186,8 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.editor.saveDelayed':
     'Save is taking longer than expected',
   'workflowActivityVNext.editor.saveFailed': "Workflow couldn't be saved",
+  'workflowActivityVNext.editor.saveStatusAria': 'Workflow save status',
+  'workflowActivityVNext.editor.saveStatusFailed': 'Save failed',
   'workflowActivityVNext.editor.saveOpenFailed':
     "Workflow was saved but couldn't be reopened",
   'workflowActivityVNext.editor.savingProgress': 'Saving workflow…',
@@ -172,6 +195,7 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.editor.saveLeave': 'Save and leave',
   'workflowActivityVNext.editor.saveSuccess': 'Workflow saved',
   'workflowActivityVNext.editor.saved': 'Saved',
+  'workflowActivityVNext.editor.savedAt': 'Saved at {updatedAt}',
   'workflowActivityVNext.editor.stay': 'Stay',
   'workflowActivityVNext.editor.streamEnded':
     'Live updates ended. Open Activity to check the latest status.',
@@ -185,7 +209,9 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.editor.unavailableGuidance':
     'Try again to reopen the workflow.',
   'workflowActivityVNext.editor.unsaved': 'Unsaved',
+  'workflowActivityVNext.editor.unsavedChanges': 'Unsaved changes',
   'workflowActivityVNext.editor.updatingNode': 'Updating node…',
+  'workflowActivityVNext.editor.validating': 'Validating workflow…',
   'workflowActivityVNext.editor.unsavedDescription':
     'Save your changes, discard them, or stay in the editor.',
   'workflowActivityVNext.editor.unsavedTitle': 'Unsaved workflow changes',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -87,7 +87,13 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.publish.accepted': '发布请求已接受',
     'workflowActivityVNext.publish.approvalNotRequired': '此请求无需额外审批。',
     'workflowActivityVNext.publish.approvalRequired': '此请求运行前需要审批。',
+    'workflowActivityVNext.publish.addExecutableStep':
+      '发布前请至少添加一个可执行步骤。',
+    'workflowActivityVNext.publish.applyNodeChanges':
+      '发布前请应用或放弃节点配置更改。',
     'workflowActivityVNext.publish.backToService': '返回',
+    'workflowActivityVNext.publish.blocked': '发布受阻 · {count} 个问题',
+    'workflowActivityVNext.publish.blockedOne': '发布受阻 · 1 个问题',
     'workflowActivityVNext.publish.checkAgain': '再次检查',
     'workflowActivityVNext.publish.delayed': '发布状态显示所需时间较长',
     'workflowActivityVNext.publish.delayedDescription':
@@ -108,6 +114,9 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
       '所选服务现在正在使用此工作流。',
     'workflowActivityVNext.publish.observingDescription':
       '正在检查所选服务是否已准备就绪。',
+    'workflowActivityVNext.publish.published': '已发布',
+    'workflowActivityVNext.publish.publishedServiceId': '已发布服务 ID',
+    'workflowActivityVNext.publish.publishing': '正在发布',
     'workflowActivityVNext.publish.publishingTo': '正在发布到 {service}',
     'workflowActivityVNext.publish.reviewAgain': '再次审核',
     'workflowActivityVNext.publish.reviewAndPublish': '审核并发布',
@@ -118,6 +127,9 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
       '正在准备此工作流以供审核。',
     'workflowActivityVNext.publish.reviewUnavailable':
       '暂时无法准备此工作流以供发布。',
+    'workflowActivityVNext.publish.readinessIssues': '发布就绪问题',
+    'workflowActivityVNext.publish.resolvePublication':
+      '再次发布前请先处理当前发布状态。',
     'workflowActivityVNext.publish.risk': '影响',
     'workflowActivityVNext.publish.risk.destructive':
       '可能删除数据或造成永久性更改',
@@ -134,6 +146,14 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.publish.submittingDescription':
       '正在将此工作流发送到所选服务。',
     'workflowActivityVNext.publish.title': '发布工作流',
+    'workflowActivityVNext.publish.waitForPublication':
+      '请等待当前发布流程完成。',
+    'workflowActivityVNext.publish.waitForEditorUpdate':
+      '请等待工作流步骤更新完成。',
+    'workflowActivityVNext.publish.waitForSave': '请等待工作流验证和保存完成。',
+    'workflowActivityVNext.publish.waitForSavedDraft':
+      '请等待已保存草稿变为可读取状态。',
+    'workflowActivityVNext.publish.workflowId': '工作流 ID',
     'workflowActivityVNext.publish.unauthorizedDescription':
       '请重新登录后检查此发布状态。',
     'workflowActivityVNext.editor.checkLatestStatus': '检查最新状态',
@@ -159,6 +179,8 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.editor.retryActivityObservation': '再次检查',
     'workflowActivityVNext.editor.saveDelayed': '保存时间比预期更长',
     'workflowActivityVNext.editor.saveFailed': '无法保存工作流',
+    'workflowActivityVNext.editor.saveStatusAria': '工作流保存状态',
+    'workflowActivityVNext.editor.saveStatusFailed': '保存失败',
     'workflowActivityVNext.editor.saveOpenFailed':
       '工作流已保存，但暂时无法重新打开',
     'workflowActivityVNext.editor.savingProgress': '正在保存工作流…',
@@ -166,6 +188,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.editor.saveLeave': '保存并离开',
     'workflowActivityVNext.editor.saveSuccess': '工作流已保存',
     'workflowActivityVNext.editor.saved': '已保存',
+    'workflowActivityVNext.editor.savedAt': '已保存于 {updatedAt}',
     'workflowActivityVNext.editor.stay': '留在此处',
     'workflowActivityVNext.editor.streamEnded':
       '实时更新已结束，请打开活动记录查看最新状态。',
@@ -177,7 +200,9 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.editor.unavailableDescription': '无法加载此工作流。',
     'workflowActivityVNext.editor.unavailableGuidance': '请重试打开此工作流。',
     'workflowActivityVNext.editor.unsaved': '未保存',
+    'workflowActivityVNext.editor.unsavedChanges': '有未保存的更改',
     'workflowActivityVNext.editor.updatingNode': '正在更新节点…',
+    'workflowActivityVNext.editor.validating': '正在验证工作流…',
     'workflowActivityVNext.editor.unsavedDescription':
       '保存更改、放弃更改，或留在编辑器。',
     'workflowActivityVNext.editor.unsavedTitle': '工作流有未保存更改',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
@@ -137,6 +137,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
   >([]);
   const [dirty, setDirty] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
+  const [validating, setValidating] = React.useState(false);
   const [structuralMutationPending, setStructuralMutationPending] =
     React.useState(false);
   const [structuralMutationError, setStructuralMutationError] =
@@ -360,6 +361,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       setFindings([]);
       setDirty(false);
       setSaving(false);
+      setValidating(false);
       setStructuralMutationPending(false);
       setStructuralMutationError('');
       setFailedNodeType(null);
@@ -405,6 +407,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       return false;
     savingRef.current = true;
     setSaving(true);
+    setValidating(true);
     setSaveError('');
     try {
       const parsedDocument = await parseCurrentYaml();
@@ -415,6 +418,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       setFindings(serialized.findings);
       if (hasBlockingFindings(serialized.document, serialized.findings))
         return false;
+      setValidating(false);
       const directoryId =
         workflow.directoryId ||
         workspace.data?.directories[0]?.directoryId ||
@@ -464,6 +468,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
     } finally {
       savingRef.current = false;
       setSaving(false);
+      setValidating(false);
     }
   }, [
     adoptReadableWorkflow,
@@ -782,6 +787,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
     save,
     saveError,
     saving,
+    validating,
     structuralMutationPending,
     sseRunId,
     selectedNodeId,

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
@@ -11,7 +11,7 @@ const receipt: WorkflowPublicationReceipt = {
   scopeId: 'scope-alpha',
   workflowId: 'wf-publication-alpha',
   revisionId: 'rev-publication-alpha',
-  serviceId: 'svc-publication-alpha',
+  publishedServiceId: 'svc-publication-alpha',
 };
 
 function workflowDetail(
@@ -78,7 +78,7 @@ function revisionCatalog(
 ): ScopeServiceRevisionCatalogSnapshot {
   return {
     scopeId: receipt.scopeId,
-    serviceId: receipt.serviceId,
+    serviceId: receipt.publishedServiceId,
     serviceKey: 'service-publication',
     displayName: 'Publication service',
     defaultServingRevisionId: receipt.revisionId,

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.ts
@@ -16,10 +16,10 @@ const DELAYED_WORKFLOW_CONFLICT_CODES = new Set([
 ]);
 
 export type WorkflowPublicationReceipt = {
+  readonly publishedServiceId: string;
   readonly scopeId: string;
   readonly workflowId: string;
   readonly revisionId: string;
-  readonly serviceId: string;
 };
 
 export type WorkflowPublicationObservationInput = {
@@ -126,7 +126,7 @@ function assertAcceptedCatalogIdentity(
 ): void {
   if (
     catalog.scopeId !== receipt.scopeId ||
-    catalog.serviceId !== receipt.serviceId
+    catalog.serviceId !== receipt.publishedServiceId
   ) {
     throw new Error(
       'The observed service catalog does not match the accepted service.',
@@ -160,7 +160,7 @@ function matchesAcceptedPublication(
     workflow.workflow?.scopeId === receipt.scopeId &&
     workflow.workflow?.workflowId === receipt.workflowId &&
     catalog.scopeId === receipt.scopeId &&
-    catalog.serviceId === receipt.serviceId &&
+    catalog.serviceId === receipt.publishedServiceId &&
     catalog.activeServingRevisionId === receipt.revisionId &&
     revision.revisionId === receipt.revisionId &&
     revision.implementationKind === 'workflow' &&
@@ -235,7 +235,10 @@ export async function observeWorkflowPublication(
 
     const [workflowResult, catalogResult] = await Promise.allSettled([
       input.readWorkflow(input.receipt.scopeId, input.receipt.workflowId),
-      input.readRevisions(input.receipt.scopeId, input.receipt.serviceId),
+      input.readRevisions(
+        input.receipt.scopeId,
+        input.receipt.publishedServiceId,
+      ),
     ]);
     const error = observationError(workflowResult, catalogResult);
     if (error) throw error;
@@ -319,7 +322,7 @@ export function useWorkflowPublication(
       receipt?.scopeId ?? '',
       receipt?.workflowId ?? '',
       receipt?.revisionId ?? '',
-      receipt?.serviceId ?? '',
+      receipt?.publishedServiceId ?? '',
     ],
     queryFn: () => {
       if (!receipt) {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1930,6 +1930,17 @@ describe('Workflow Activity vNext editor', () => {
       ),
     );
     expect(await screen.findByText('Workflow published')).toBeInTheDocument();
+    expect(screen.getByText('Workflow ID')).toBeInTheDocument();
+    expect(screen.getByText('wf-draft-alpha')).toBeInTheDocument();
+    expect(screen.getByText('Published service ID')).toBeInTheDocument();
+    expect(screen.getByText('svc-alpha')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Published' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(mockConsoleToast.success).not.toHaveBeenCalledWith(
+      'Workflow published',
+    );
   });
 
   it.each([
@@ -2141,6 +2152,77 @@ describe('Workflow Activity vNext editor', () => {
     });
   }
 
+  it('keeps every publish blocker focusable and links validation issues to their fields and steps', async () => {
+    mockStudioApi.getWorkflow.mockResolvedValue({
+      workflowId: 'wf-committed-source',
+      name: 'Committed source',
+      fileName: 'committed-source.yaml',
+      filePath: '',
+      directoryId: '',
+      directoryLabel: '',
+      yaml: 'name: committed_source\nroles: []\nsteps:\n  - id: step-root\n    type: llm_call\n',
+      updatedAtUtc: '2026-08-04T10:00:00Z',
+      document: {
+        name: 'committed_source',
+        roles: [],
+        steps: [{ id: 'step-root', type: 'llm_call' }],
+      },
+      draftExists: false,
+      findings: [
+        {
+          code: 'WORKFLOW_NAME_REQUIRED',
+          level: 'error',
+          message: 'Workflow name is required.',
+          path: '/name',
+        },
+        {
+          code: 'STEP_INSTRUCTION_REQUIRED',
+          level: 'error',
+          message: 'Step instruction is required.',
+          path: '/steps/0/parameters/prompt_prefix',
+        },
+      ],
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const publish = await screen.findByRole('button', {
+      name: 'Publish blocked · 3 issues',
+    });
+    expect(publish).toHaveAttribute('aria-disabled', 'true');
+    expect(publish).toBeEnabled();
+
+    fireEvent.click(publish);
+    expect(
+      screen.queryByRole('dialog', { name: 'Publish workflow' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.focus(publish);
+    const checklist = await screen.findByRole('region', {
+      name: 'Publish readiness issues',
+    });
+    expect(within(checklist).getAllByRole('listitem')).toHaveLength(3);
+
+    fireEvent.click(
+      within(checklist).getByRole('button', {
+        name: 'Workflow name is required.',
+      }),
+    );
+    expect(
+      screen.getByRole('textbox', { name: 'Workflow name' }),
+    ).toHaveFocus();
+
+    fireEvent.click(
+      within(checklist).getByRole('button', {
+        name: 'Step instruction is required.',
+      }),
+    );
+    expect(
+      await screen.findByRole('complementary', { name: 'Configure step-root' }),
+    ).toBeVisible();
+    expect(mockStudioApi.previewExplicitRequests).not.toHaveBeenCalled();
+  });
+
   it('retries a failed publication observation without sending a second POST', async () => {
     arrangeSavedDraftPublication();
     mockScopesApi.getWorkflowDetail
@@ -2228,7 +2310,9 @@ describe('Workflow Activity vNext editor', () => {
     expect(
       await screen.findByText("Publication couldn't be confirmed"),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Publish' })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Publish blocked · 1 issue' }),
+    ).toHaveAttribute('aria-disabled', 'true');
     fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
 
     await waitFor(() =>
@@ -2275,7 +2359,9 @@ describe('Workflow Activity vNext editor', () => {
     );
 
     expect(await screen.findByText(message)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Publish' })).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Publish blocked · 1 issue' }),
+    ).toHaveAttribute('aria-disabled', 'true');
     fireEvent.click(screen.getByRole('button', { name: 'Check again' }));
 
     await waitFor(() =>
@@ -2835,10 +2921,88 @@ describe('Workflow Activity vNext editor', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save workflow' }));
 
     await waitFor(() =>
-      expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow saved'),
+      expect(
+        screen.getByRole('status', { name: 'Workflow save status' }),
+      ).toHaveTextContent(/^Saved at /),
     );
-    expect(screen.queryByText('Workflow saved')).not.toBeInTheDocument();
+    expect(mockConsoleToast.success).not.toHaveBeenCalledWith('Workflow saved');
     expect(mockStudioApi.saveWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces one persistent save lifecycle without implying publication', async () => {
+    const parsedDocument = {
+      name: 'committed_source',
+      roles: [],
+      steps: [{ id: 'step-root', type: 'llm_call' }],
+    };
+    let resolveParse: (() => void) | undefined;
+    let resolveSave: (() => void) | undefined;
+    mockStudioApi.parseYaml.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveParse = () =>
+            resolve({ document: parsedDocument, findings: [] });
+        }),
+    );
+    mockStudioApi.serializeYaml.mockResolvedValue({
+      yaml: 'name: committed_source\nroles: []\nsteps:\n  - id: step-root\n    type: llm_call\n',
+      document: parsedDocument,
+      findings: [],
+    });
+    mockStudioApi.saveWorkflow.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = () =>
+            resolve({
+              kind: 'materialized',
+              workflow: {
+                workflowId: 'wf-draft-saved',
+                name: 'Updated source',
+                fileName: 'committed-source.yaml',
+                filePath: '/workflows/committed-source.yaml',
+                directoryId: 'directory-alpha',
+                directoryLabel: 'Workflows',
+                yaml: 'name: committed_source\nroles: []\nsteps:\n  - id: step-root\n    type: llm_call\n',
+                updatedAtUtc: '2026-08-04T10:05:00Z',
+                document: parsedDocument,
+                draftExists: true,
+                findings: [],
+              },
+            });
+        }),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const saveStatus = await screen.findByRole('status', {
+      name: 'Workflow save status',
+    });
+    expect(saveStatus).toHaveTextContent('Saved at 2026-08-04 10:00:00 UTC');
+    expect(saveStatus).not.toHaveTextContent('Published');
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'Updated source' },
+    });
+    expect(saveStatus).toHaveTextContent('Unsaved changes');
+    fireEvent.click(screen.getByRole('button', { name: 'Save workflow' }));
+    expect(saveStatus).toHaveTextContent('Validating workflow…');
+
+    await act(async () => {
+      resolveParse?.();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(mockStudioApi.saveWorkflow).toHaveBeenCalled());
+    expect(saveStatus).toHaveTextContent('Saving workflow…');
+
+    await act(async () => {
+      resolveSave?.();
+      await Promise.resolve();
+    });
+    expect(
+      await screen.findByText('Saved at 2026-08-04 10:05:00 UTC'),
+    ).toBeInTheDocument();
+    expect(mockConsoleToast.success).not.toHaveBeenCalledWith('Workflow saved');
+    expect(screen.queryByText('Published')).not.toBeInTheDocument();
   });
 
   it('keeps later edits while retrying a failed create receipt', async () => {
@@ -3118,6 +3282,9 @@ describe('Workflow Activity vNext editor', () => {
         'PUT /api/studio/workflows/wf-committed-source returned 500',
       ),
     ).not.toBeVisible();
+    expect(
+      screen.getByRole('status', { name: 'Workflow save status' }),
+    ).toHaveTextContent('Save failed');
   });
 
   it('puts editable node configuration first and keeps raw JSON advanced', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -185,6 +185,13 @@ export const workflowActivityVNextCss = `
 .wa-vnext__editor-toolbar > * { flex: 0 1 auto; min-width: 0; }
 .wa-vnext__editor-name { flex: 1 1 220px !important; max-width: 420px; min-width: 0; }
 .wa-vnext__editor-toolbar-meta { align-items: center; display: flex; flex: 0 1 auto; gap: 8px; min-width: 0; }
+.wa-vnext__publish-readiness { max-width: min(360px, calc(100vw - 32px)); }
+.wa-vnext__publish-readiness ul { display: grid; gap: 4px; list-style: none; margin: 0; padding: 0; }
+.wa-vnext__publish-readiness .ant-btn { height: auto; line-height: 1.35; padding: 4px 0; text-align: left; white-space: normal; }
+.wa-vnext__publication-identities { display: grid; gap: 6px; margin: 12px 0 0; }
+.wa-vnext__publication-identities > div { display: grid; gap: 2px; grid-template-columns: minmax(116px, max-content) minmax(0, 1fr); }
+.wa-vnext__publication-identities dt { color: var(--wa-muted); font-size: 11px; font-weight: 700; }
+.wa-vnext__publication-identities dd { font-family: var(--wa-font-mono); margin: 0; overflow-wrap: anywhere; }
 .wa-vnext__editor-mode-control { flex: 0 1 auto; min-width: 0; }
 .wa-vnext__editor-alerts { display: grid; gap: 6px; margin-bottom: 12px; }
 .wa-vnext__publish-review-item {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -17,7 +17,6 @@ import { getLocationSnapshot, history } from '@/shared/navigation/history';
 import { studioApi } from '@/shared/studio/api';
 import { createWorkflowRevisionIdentityCandidate } from '@/shared/studio/explicitRequestConfirmation';
 import type { StudioExplicitRequestPreview } from '@/shared/studio/models';
-import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import {
   getRunStatusPresentation,
   isRunStatusInProgress,
@@ -590,7 +589,6 @@ const WorkflowEditorPage: React.FC<{
   const publicationActionPending =
     publicationStage === 'reviewing' ||
     publicationStage === 'submitting' ||
-    publication.phase === 'accepted' ||
     publication.phase === 'observing';
   const canRetryPublicationObservation =
     publicationReceipt !== null &&

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -7,10 +7,11 @@ import {
   RocketOutlined,
   SaveOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Input, Modal, Segmented, Space } from 'antd';
+import { Alert, Button, Input, Modal, Popover, Segmented, Space } from 'antd';
 import React from 'react';
 import WorkflowStudioCanvasRegion from '@/pages/team-member-workflow-studio/components/WorkflowStudioCanvasRegion';
 import WorkflowStudioNodeLibrary from '@/pages/team-member-workflow-studio/components/WorkflowStudioNodeLibrary';
+import { formatUtcDateTime } from '@/shared/datetime/dateTime';
 import { t } from '@/shared/i18n/messages';
 import { getLocationSnapshot, history } from '@/shared/navigation/history';
 import { studioApi } from '@/shared/studio/api';
@@ -73,6 +74,12 @@ type PendingWorkflowPublication = {
   readonly workflowYaml: string;
 };
 
+type PublishReadinessIssue = {
+  readonly id: string;
+  readonly message: string;
+  readonly resolve: () => void;
+};
+
 function hasNonBlankIdentifier(value: unknown): value is string {
   return typeof value === 'string' && Boolean(value.trim());
 }
@@ -118,7 +125,6 @@ const WorkflowEditorPage: React.FC<{
   const activeScopeId = activeEditorRoute.scopeId;
   const activeWorkflowId = activeEditorRoute.workflowId;
   const editor = useWorkflowEditor(activeScopeId, activeWorkflowId);
-  const toast = useConsoleToast();
   const [mode, setMode] = React.useState<'canvas' | 'yaml'>('canvas');
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
   const [publishDialogOpen, setPublishDialogOpen] = React.useState(false);
@@ -134,9 +140,10 @@ const WorkflowEditorPage: React.FC<{
     React.useState<PendingNavigation | null>(null);
   const [hasUnappliedNodeChanges, setHasUnappliedNodeChanges] =
     React.useState(false);
+  const workflowNameRef = React.useRef<React.ElementRef<typeof Input>>(null);
+  const saveStatusRef = React.useRef<HTMLSpanElement>(null);
   const inspectorRef = React.useRef<WorkflowNodeInspectorHandle>(null);
   const publicationReviewGenerationRef = React.useRef(0);
-  const publicationToastRef = React.useRef('');
   const runRequested = new URLSearchParams(location.search).get('run') === '1';
   const editorWriteLocked = editor.saving || editor.structuralMutationPending;
   const publication = useWorkflowPublication(publicationReceipt);
@@ -185,21 +192,6 @@ const WorkflowEditorPage: React.FC<{
     previousPublicationRouteRef.current = publicationRouteKey;
     clearPublication();
   }, [clearPublication, publicationRouteKey]);
-
-  React.useEffect(() => {
-    if (publication.phase !== 'observed' || !publicationReceipt) return;
-    const receiptKey = [
-      publicationReceipt.scopeId,
-      publicationReceipt.workflowId,
-      publicationReceipt.revisionId,
-      publicationReceipt.serviceId,
-    ].join('\u0000');
-    if (publicationToastRef.current === receiptKey) return;
-    publicationToastRef.current = receiptKey;
-    toast.success(
-      t('workflowActivityVNext.publish.observed', 'Workflow published'),
-    );
-  }, [publication.phase, publicationReceipt, toast]);
 
   React.useEffect(() => {
     const incomingRouteTarget =
@@ -305,22 +297,12 @@ const WorkflowEditorPage: React.FC<{
   }, [editorWriteLocked, hasUnappliedNodeChanges]);
 
   const saveWorkflow = React.useCallback(async () => {
-    const saved = await editor.save();
-    if (saved) {
-      toast.success(
-        t('workflowActivityVNext.editor.saveSuccess', 'Workflow saved'),
-      );
-    }
-    return saved;
-  }, [editor.save, toast]);
+    return editor.save();
+  }, [editor.save]);
 
   const retryMaterialization = React.useCallback(async () => {
-    if (await editor.retryMaterialization()) {
-      toast.success(
-        t('workflowActivityVNext.editor.saveSuccess', 'Workflow saved'),
-      );
-    }
-  }, [editor.retryMaterialization, toast]);
+    await editor.retryMaterialization();
+  }, [editor.retryMaterialization]);
 
   const reviewPublication = React.useCallback(
     async (
@@ -443,8 +425,8 @@ const WorkflowEditorPage: React.FC<{
         }
 
         setPublicationReceipt({
+          publishedServiceId: binding.serviceId,
           scopeId: result.scopeId,
-          serviceId: binding.serviceId,
           revisionId: result.revisionId,
           workflowId: result.workflowId,
         });
@@ -608,21 +590,176 @@ const WorkflowEditorPage: React.FC<{
   const publicationActionPending =
     publicationStage === 'reviewing' ||
     publicationStage === 'submitting' ||
-    publicationObservationPending;
+    publication.phase === 'accepted' ||
+    publication.phase === 'observing';
   const canRetryPublicationObservation =
     publicationReceipt !== null &&
     (publication.phase === 'delayed' ||
       publication.phase === 'failed' ||
       publication.phase === 'unauthorized' ||
       publication.phase === 'forbidden');
+  const revealPublicationStatus = () => {
+    document
+      .getElementById('workflow-publication-status')
+      ?.scrollIntoView?.({ block: 'nearest' });
+  };
+  const blockingFindings = editor.findings.filter(
+    (finding) => String(finding.level).toLowerCase() === 'error',
+  );
+  const publishReadinessIssues: PublishReadinessIssue[] = [];
+  if (!editor.workflow.draftExists) {
+    publishReadinessIssues.push({
+      id: 'draft',
+      message: t(
+        'workflowActivityVNext.publish.saveBeforePublishing',
+        'Save this workflow before publishing.',
+      ),
+      resolve: () => void saveWorkflow(),
+    });
+  }
+  if (editor.dirty) {
+    publishReadinessIssues.push({
+      id: 'dirty',
+      message: t(
+        'workflowActivityVNext.publish.saveChangesBeforePublishing',
+        'Save your changes before publishing.',
+      ),
+      resolve: () => void saveWorkflow(),
+    });
+  }
+  if (hasUnappliedNodeChanges) {
+    publishReadinessIssues.push({
+      id: 'node-configuration',
+      message: t(
+        'workflowActivityVNext.publish.applyNodeChanges',
+        'Apply or discard node configuration before publishing.',
+      ),
+      resolve: () => setMode('canvas'),
+    });
+  }
+  for (const [findingIndex, finding] of blockingFindings.entries()) {
+    const stepMatch = finding.path?.match(/^\/steps\/(\d+)(?:\/|$)/);
+    const stepId = stepMatch
+      ? editor.document?.steps?.[Number(stepMatch[1])]?.id
+      : undefined;
+    publishReadinessIssues.push({
+      id: `finding-${finding.code}-${finding.path ?? findingIndex}`,
+      message: finding.message,
+      resolve: () => {
+        if (finding.path === '/name') {
+          workflowNameRef.current?.focus();
+          return;
+        }
+        if (stepId) {
+          setMode('canvas');
+          editor.selectNode(`step:${stepId}`);
+          return;
+        }
+        setMode('yaml');
+      },
+    });
+  }
+  if (!editor.document?.steps?.length && blockingFindings.length === 0) {
+    publishReadinessIssues.push({
+      id: 'steps',
+      message: t(
+        'workflowActivityVNext.publish.addExecutableStep',
+        'Add at least one executable step before publishing.',
+      ),
+      resolve: () => {
+        setMode('canvas');
+        setNodeLibraryOpen(true);
+      },
+    });
+  }
+  if (editor.validating || editor.saving) {
+    publishReadinessIssues.push({
+      id: 'save-in-progress',
+      message: t(
+        'workflowActivityVNext.publish.waitForSave',
+        'Wait for workflow validation and saving to finish.',
+      ),
+      resolve: () => saveStatusRef.current?.focus(),
+    });
+  } else if (editor.structuralMutationPending) {
+    publishReadinessIssues.push({
+      id: 'editor-update-in-progress',
+      message: t(
+        'workflowActivityVNext.publish.waitForEditorUpdate',
+        'Wait for the workflow step update to finish.',
+      ),
+      resolve: () => setMode('canvas'),
+    });
+  } else if (editor.receiptPending) {
+    publishReadinessIssues.push({
+      id: 'save-observation',
+      message: t(
+        'workflowActivityVNext.publish.waitForSavedDraft',
+        'Wait for the saved draft to become readable.',
+      ),
+      resolve: () => saveStatusRef.current?.focus(),
+    });
+  }
+  if (publicationActionPending) {
+    publishReadinessIssues.push({
+      id: 'publication-in-progress',
+      message: t(
+        'workflowActivityVNext.publish.waitForPublication',
+        'Wait for the current publication to finish.',
+      ),
+      resolve: revealPublicationStatus,
+    });
+  } else if (publicationObservationPending) {
+    publishReadinessIssues.push({
+      id: 'publication-unresolved',
+      message: t(
+        'workflowActivityVNext.publish.resolvePublication',
+        'Resolve the current publication status before publishing again.',
+      ),
+      resolve: revealPublicationStatus,
+    });
+  }
+  const publicationObserved = publication.phase === 'observed';
   const canPublish =
-    Boolean(editor.workflow.draftExists) &&
-    editor.canRun &&
-    !editor.dirty &&
-    !editorWriteLocked &&
-    !editor.receiptPending &&
-    !hasUnappliedNodeChanges &&
-    !publicationActionPending;
+    publishReadinessIssues.length === 0 && !publicationObserved;
+  const publishLabel = publicationObserved
+    ? t('workflowActivityVNext.publish.published', 'Published')
+    : publicationActionPending
+      ? t('workflowActivityVNext.publish.publishing', 'Publishing')
+      : publishReadinessIssues.length > 0
+        ? publishReadinessIssues.length === 1
+          ? t(
+              'workflowActivityVNext.publish.blockedOne',
+              'Publish blocked · 1 issue',
+            )
+          : t(
+              'workflowActivityVNext.publish.blocked',
+              'Publish blocked · {count} issues',
+              { count: publishReadinessIssues.length },
+            )
+        : t('workflowActivityVNext.editor.publish', 'Publish');
+  const saveStatus = editor.validating
+    ? t('workflowActivityVNext.editor.validating', 'Validating workflow…')
+    : editor.saving || editor.receiptPending
+      ? t('workflowActivityVNext.editor.savingProgress', 'Saving workflow…')
+      : editor.saveError
+        ? t('workflowActivityVNext.editor.saveStatusFailed', 'Save failed')
+        : editor.dirty
+          ? t('workflowActivityVNext.editor.unsavedChanges', 'Unsaved changes')
+          : t('workflowActivityVNext.editor.savedAt', 'Saved at {updatedAt}', {
+              updatedAt: formatUtcDateTime(editor.workflow.updatedAtUtc),
+            });
+  const publishButton = (
+    <Button
+      aria-disabled={!canPublish}
+      icon={<RocketOutlined />}
+      onClick={() => {
+        if (canPublish) setPublishDialogOpen(true);
+      }}
+    >
+      {publishLabel}
+    </Button>
+  );
   return (
     <WorkflowActivityVNextShell
       activeSection="workflows"
@@ -691,31 +828,34 @@ const WorkflowEditorPage: React.FC<{
           >
             {t('workflowActivityVNext.common.run', 'Run')}
           </Button>
-          <Button
-            disabled={!canPublish}
-            icon={<RocketOutlined />}
-            onClick={() => setPublishDialogOpen(true)}
-            title={
-              !editor.workflow.draftExists
-                ? t(
-                    'workflowActivityVNext.publish.saveBeforePublishing',
-                    'Save this workflow before publishing.',
-                  )
-                : editor.dirty
-                  ? t(
-                      'workflowActivityVNext.publish.saveChangesBeforePublishing',
-                      'Save your changes before publishing.',
-                    )
-                  : !editor.canRun
-                    ? t(
-                        'workflowActivityVNext.editor.runUnavailable',
-                        'Add at least one valid step before running.',
-                      )
-                    : undefined
-            }
-          >
-            {t('workflowActivityVNext.editor.publish', 'Publish')}
-          </Button>
+          {publishReadinessIssues.length > 0 ? (
+            <Popover
+              content={
+                <section
+                  aria-label={t(
+                    'workflowActivityVNext.publish.readinessIssues',
+                    'Publish readiness issues',
+                  )}
+                  className="wa-vnext__publish-readiness"
+                >
+                  <ul>
+                    {publishReadinessIssues.map((issue) => (
+                      <li key={issue.id}>
+                        <Button onClick={issue.resolve} type="link">
+                          {issue.message}
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              }
+              trigger={['hover', 'focus', 'click']}
+            >
+              {publishButton}
+            </Popover>
+          ) : (
+            publishButton
+          )}
         </>
       }
       onNavigate={requestNavigation}
@@ -731,17 +871,23 @@ const WorkflowEditorPage: React.FC<{
           className="wa-vnext__editor-name"
           disabled={editorWriteLocked}
           onChange={(event) => editor.updateTitle(event.target.value)}
+          ref={workflowNameRef}
           value={editor.workflowTitle}
         />
         <div className="wa-vnext__editor-toolbar-meta">
           <span
-            className={`wa-vnext__status wa-vnext__status--${editor.dirty ? 'pending' : 'succeeded'}`}
+            aria-atomic="true"
+            aria-label={t(
+              'workflowActivityVNext.editor.saveStatusAria',
+              'Workflow save status',
+            )}
+            aria-live="polite"
+            className={`wa-vnext__status wa-vnext__status--${editor.saveError ? 'failed' : editor.dirty || editor.validating || editor.saving || editor.receiptPending ? 'pending' : 'succeeded'}`}
+            ref={saveStatusRef}
+            role="status"
+            tabIndex={-1}
           >
-            {editor.structuralMutationPending
-              ? t('workflowActivityVNext.editor.updatingNode', 'Updating node…')
-              : editor.dirty
-                ? t('workflowActivityVNext.editor.unsaved', 'Unsaved')
-                : t('workflowActivityVNext.editor.saved', 'Saved')}
+            {saveStatus}
           </span>
           <Segmented
             aria-label={`${t('workflowActivityVNext.editor.canvas', 'Canvas')} / ${t(
@@ -909,6 +1055,28 @@ const WorkflowEditorPage: React.FC<{
                                 'workflowActivityVNext.publish.failedDescription',
                                 'Review the workflow or try publishing again.',
                               )}
+              {publicationPhase === 'observed' && publicationReceipt ? (
+                <dl className="wa-vnext__publication-identities">
+                  <div>
+                    <dt>
+                      {t(
+                        'workflowActivityVNext.publish.workflowId',
+                        'Workflow ID',
+                      )}
+                    </dt>
+                    <dd>{publicationReceipt.workflowId}</dd>
+                  </div>
+                  <div>
+                    <dt>
+                      {t(
+                        'workflowActivityVNext.publish.publishedServiceId',
+                        'Published service ID',
+                      )}
+                    </dt>
+                    <dd>{publicationReceipt.publishedServiceId}</dd>
+                  </div>
+                </dl>
+              ) : null}
               {publicationError || publication.error ? (
                 <TechnicalDetails>
                   {errorMessage(publicationError ?? publication.error)}
@@ -958,6 +1126,7 @@ const WorkflowEditorPage: React.FC<{
                               "Publication couldn't be confirmed",
                             )
           }
+          id="workflow-publication-status"
           showIcon
           type={
             publicationPhase === 'observed'


### PR DESCRIPTION
## Problem

The Workflow Activity vNext editor conflated draft persistence with publication readiness. Save completion was reduced to a transient toast, Publish hid all but one blocking reason behind a natively disabled button, and the observed publication state did not distinguish the draft workflow identity from the callable service identity.

## Solution

- Add one persistent, polite live save status for validating, saving, failed, dirty, and authoritatively saved states.
- Remove duplicate save and publish success toasts.
- Keep blocked Publish actions focusable with `aria-disabled` and expose every current blocker through a hover, focus, and click popover.
- Make readiness findings actionable by focusing the Workflow name, opening the exact step inspector, saving the draft, or opening the node library.
- Keep publication-in-progress, unresolved observation, unapplied configuration, and structural update states explicit.
- Rename the internal publication receipt identity to `publishedServiceId` and map it once from authoritative `binding.serviceId`.
- Show `workflowId` and `publishedServiceId` separately after publication is observed.
- Add English and Chinese copy, compact responsive checklist styles, and focused regression coverage.

## Impact paths

- Workflow Activity vNext editor save and publish controls.
- Publication observation receipt identity.
- Workflow Activity vNext English and Chinese messages.
- Focused editor route and publication observer tests.

## Validation

Change scope selected with:

```bash
python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext
```

Result: 8 changed frontend files, 6 source files, 2 changed test files, Jest runner selected.

```bash
pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
```

Result: 2 suites passed, 85 tests passed, 0 snapshots.

```bash
pnpm --dir apps/aevatar-console-web exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.ts src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
```

Result: 8 files checked, no fixes required.

```bash
bash tools/ci/test_stability_guards.sh
```

Result: passed.

```bash
python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py
```

Result: baseline passed; design SHA-256 and all 17 frames verified byte-identical.

```bash
git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD --check
```

Result: passed.

Per the frontend incremental validation policy, no full frontend test, lint, typecheck, or production build was run locally. No reliable affected-only typecheck is available; GitHub CI owns full frontend typecheck, suite, and build verification.

## Design baseline

Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py

## Contract dependency

The UI exposes `publishedServiceId` because `saveAndBindWorkflow` returns authoritative `binding.serviceId`. No backend change is required. If that contract stops returning the binding identity, publication must remain unresolved rather than infer a service identity from `workflowId`, revision, service key, or route state.

Closes #3221


## Post-rebase CI follow-up verification

- Related and changed tests: `pnpm exec jest src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts src/pages/workflow-activity-vnext/index.test.tsx --runInBand` - passed 2 suites and 92 tests.
- Changed-file static checks: `pnpm exec biome check` on all 8 analyzer-selected frontend files - passed.
- Patch integrity: `git diff --check` - passed.
- Full frontend suite/typecheck/build: delegated to GitHub CI by the personal incremental frontend policy.