### PR TITLE
Reject workflow artifacts needing admission rebind

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/WorkflowServiceArtifactReadiness.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/WorkflowServiceArtifactReadiness.cs
@@ -1,0 +1,31 @@
+using Aevatar.Workflow.Abstractions;
+
+namespace Aevatar.GAgentService.Abstractions.Services;
+
+public static class WorkflowServiceArtifactReadiness
+{
+    public static bool RequiresCapabilityAdmissionRebind(PreparedServiceRevisionArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        if (artifact.ImplementationKind != ServiceImplementationKind.Workflow)
+            return false;
+
+        if (artifact.DeploymentPlan?.PlanSpecCase != ServiceDeploymentPlan.PlanSpecOneofCase.WorkflowPlan)
+            return true;
+
+        var workflowPlan = artifact.DeploymentPlan.WorkflowPlan;
+        if (workflowPlan == null || workflowPlan.ExecutionMode == ExternalCapabilityExecutionMode.Unspecified)
+            return true;
+
+        var admissionPlan = workflowPlan.CapabilityAdmissionPlan;
+        if (admissionPlan == null)
+            return true;
+
+        return WorkflowCapabilityAdmissionPlanIntegrity.RequiresRebind(admissionPlan.SchemaVersion)
+               || !string.Equals(
+                   admissionPlan.SchemaVersion,
+                   WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion,
+                   StringComparison.Ordinal)
+               || admissionPlan.ExecutionMode == ExternalCapabilityExecutionMode.Unspecified;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/WorkflowServiceArtifactReadiness.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/WorkflowServiceArtifactReadiness.cs
@@ -14,8 +14,12 @@ public static class WorkflowServiceArtifactReadiness
             return true;
 
         var workflowPlan = artifact.DeploymentPlan.WorkflowPlan;
-        if (workflowPlan == null || workflowPlan.ExecutionMode == ExternalCapabilityExecutionMode.Unspecified)
+        if (workflowPlan == null ||
+            workflowPlan.ExecutionMode == ExternalCapabilityExecutionMode.Unspecified ||
+            !Enum.IsDefined(workflowPlan.ExecutionMode))
+        {
             return true;
+        }
 
         var admissionPlan = workflowPlan.CapabilityAdmissionPlan;
         if (admissionPlan == null)
@@ -26,6 +30,8 @@ public static class WorkflowServiceArtifactReadiness
                    admissionPlan.SchemaVersion,
                    WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion,
                    StringComparison.Ordinal)
-               || admissionPlan.ExecutionMode == ExternalCapabilityExecutionMode.Unspecified;
+               || admissionPlan.ExecutionMode == ExternalCapabilityExecutionMode.Unspecified
+               || !Enum.IsDefined(admissionPlan.ExecutionMode)
+               || workflowPlan.ExecutionMode != admissionPlan.ExecutionMode;
     }
 }

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -229,6 +229,14 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                 $"Revision '{revisionId}' already exists for service '{ServiceKeys.Build(identity)}'.");
         }
 
+        if (request.ImplementationKind == ScopeBindingImplementationKind.Workflow &&
+            existingRevision.PreparedArtifact != null &&
+            WorkflowServiceArtifactReadiness.RequiresCapabilityAdmissionRebind(existingRevision.PreparedArtifact))
+        {
+            throw new InvalidOperationException(
+                $"Revision '{revisionId}' already exists for service '{ServiceKeys.Build(identity)}' but its workflow capability admission plan requires rebind; publish a new revision id.");
+        }
+
         if (string.IsNullOrWhiteSpace(existingRevision.ArtifactHash))
             return false;
 

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingReadinessQueryService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingReadinessQueryService.cs
@@ -142,6 +142,21 @@ public sealed class ScopeBindingReadinessQueryService : IScopeBindingReadinessQu
                 ObservedAtUtc: observedAtUtc);
         }
 
+        if (WorkflowServiceArtifactReadiness.RequiresCapabilityAdmissionRebind(artifact!))
+        {
+            return new ScopeBindingReadinessSnapshot(
+                normalizedScopeId,
+                normalizedServiceId,
+                ScopeBindingReadinessStatus.InvocationCatalogNotReady,
+                ServiceCatalogVisible: true,
+                ServingSetVisible: true,
+                EligibleServingTargetVisible: true,
+                InvokeReady: false,
+                RevisionId: eligibleTarget.RevisionId,
+                DeploymentId: eligibleTarget.DeploymentId,
+                ObservedAtUtc: observedAtUtc);
+        }
+
         var invocationCatalog = await _invocationCatalogQueryReader.GetAsync(identity, ct).ConfigureAwait(false);
         if (!IsInvocationCatalogReady(invocationCatalog, serviceEndpointIds, eligibleTarget))
         {

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceInvocationResolutionService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceInvocationResolutionService.cs
@@ -48,6 +48,17 @@ public sealed class ServiceInvocationResolutionService : IServiceInvocationResol
             request.Identity,
             readiness.SelectedRevisionId,
             readiness);
+        if (WorkflowServiceArtifactReadiness.RequiresCapabilityAdmissionRebind(artifact))
+        {
+            throw CreateUnavailable(
+                readiness with
+                {
+                    UnavailableReason = ServiceInvokeUnavailableReason.PreparedArtifactIncompatible,
+                    ReadinessStatus = ServiceInvokeReadinessStatus.Unavailable,
+                },
+                $"Workflow service '{serviceKey}' endpoint '{request.EndpointId}' requires capability admission rebind before invoke.");
+        }
+
         var endpoint = artifact.Endpoints.FirstOrDefault(x =>
             string.Equals(x.EndpointId, request.EndpointId, StringComparison.Ordinal));
         if (endpoint == null)

--- a/src/platform/Aevatar.GAgentService.Core/Services/ServiceInvokeReadinessEvaluator.cs
+++ b/src/platform/Aevatar.GAgentService.Core/Services/ServiceInvokeReadinessEvaluator.cs
@@ -55,9 +55,10 @@ public sealed class ServiceInvokeReadinessEvaluator
         }
 
         if (revision.Spec?.ImplementationKind == ServiceImplementationKind.Workflow &&
-            !WorkflowServiceDeploymentPlanIntegrity.IsCompatible(
-                artifact,
-                selectedTarget.RevisionId))
+            (!WorkflowServiceDeploymentPlanIntegrity.IsCompatible(
+                 artifact,
+                 selectedTarget.RevisionId) ||
+             WorkflowServiceArtifactReadiness.RequiresCapabilityAdmissionRebind(artifact)))
         {
             return Unavailable(
                 endpointId,

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -1373,6 +1373,82 @@ public sealed class ScopeBindingCommandApplicationServiceTests
     }
 
     [Fact]
+    public async Task UpsertAsync_ShouldRejectExistingWorkflowReplay_WhenPreparedArtifactRequiresCapabilityAdmissionRebind()
+    {
+        const string revisionId = "rev-platform-bind-1";
+        const string workflowYaml = "name: main\nsteps:\n  - run: echo hello";
+        var commandPort = new RecordingServiceCommandPort();
+        var lifecyclePort = new FakeServiceLifecycleQueryPort(
+            new ServiceCatalogSnapshot(
+                "scope-a:default:default:default",
+                ScopeId,
+                DefaultOptions.ServiceAppId,
+                DefaultOptions.ServiceNamespace,
+                DefaultOptions.DefaultServiceId,
+                "main",
+                revisionId,
+                revisionId,
+                "dep-1",
+                "actor-1",
+                "Active",
+                [
+                    new ServiceEndpointSnapshot(
+                        "chat",
+                        "chat",
+                        ServiceEndpointKind.Chat.ToString(),
+                        GetTypeUrl(ChatRequestEvent.Descriptor),
+                        GetTypeUrl(ChatResponseEvent.Descriptor),
+                        "Workflow chat endpoint."),
+                ],
+                [],
+                DateTimeOffset.UtcNow),
+            new ServiceRevisionCatalogSnapshot(
+                "scope-a:default:default:default",
+                [
+                    new ServiceRevisionSnapshot(
+                        revisionId,
+                        ServiceImplementationKind.Workflow.ToString(),
+                        ServiceRevisionStatus.Published.ToString(),
+                        string.Empty,
+                        string.Empty,
+                        [],
+                        DateTimeOffset.UtcNow.AddHours(-1),
+                        DateTimeOffset.UtcNow.AddHours(-1),
+                        DateTimeOffset.UtcNow.AddHours(-1),
+                        null,
+                        null,
+                        CreateWorkflowArtifact(
+                            revisionId,
+                            "main",
+                            workflowYaml,
+                            WorkflowCapabilityAdmissionPlanIntegrity.LegacySchemaVersion)),
+                ],
+                DateTimeOffset.UtcNow));
+        var service = CreateService(
+            commandPort,
+            lifecyclePort,
+            new FakeScopeScriptQueryPort(),
+            new FakeScriptDefinitionSnapshotPort(),
+            new FakeWorkflowRunActorPort());
+
+        var act = () => service.UpsertAsync(new ScopeBindingUpsertRequest(
+            ScopeId,
+            ScopeBindingImplementationKind.Workflow,
+            Workflow: new ScopeBindingWorkflowSpec([
+                workflowYaml,
+            ]),
+            RevisionId: revisionId,
+            AllowExistingRevisionReplay: true,
+            ReplayRevisionId: revisionId));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*requires rebind*new revision id*");
+        commandPort.Calls.Should().ContainSingle(call => call.Method == "UpdateServiceAsync");
+        commandPort.Calls.Should().NotContain(call => call.Method == "PrepareRevisionAsync");
+        commandPort.Calls.Should().NotContain(call => call.Method == "PublishRevisionAsync");
+    }
+
+    [Fact]
     public async Task UpsertAsync_ShouldReplayExistingWorkflowRevision_WhenRevisionIsUnprepared()
     {
         const string revisionId = "rev-platform-bind-1";
@@ -2170,6 +2246,47 @@ public sealed class ScopeBindingCommandApplicationServiceTests
             .Assemble(artifact)
             .ArtifactHash;
     }
+
+    private static PreparedServiceRevisionArtifact CreateWorkflowArtifact(
+        string revisionId,
+        string workflowName,
+        string workflowYaml,
+        string admissionSchemaVersion) =>
+        new()
+        {
+            Identity = DefaultServiceIdentity(),
+            RevisionId = revisionId,
+            ImplementationKind = ServiceImplementationKind.Workflow,
+            Endpoints =
+            {
+                new ServiceEndpointDescriptor
+                {
+                    EndpointId = "chat",
+                    DisplayName = "chat",
+                    Kind = ServiceEndpointKind.Chat,
+                    RequestTypeUrl = GetTypeUrl(ChatRequestEvent.Descriptor),
+                    ResponseTypeUrl = GetTypeUrl(ChatResponseEvent.Descriptor),
+                    Description = "Workflow chat endpoint.",
+                },
+            },
+            DeploymentPlan = new ServiceDeploymentPlan
+            {
+                WorkflowPlan = new WorkflowServiceDeploymentPlan
+                {
+                    WorkflowName = workflowName,
+                    WorkflowYaml = workflowYaml,
+                    ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                    DefinitionActorId = DefaultOptions.BuildDefinitionActorIdPrefix(
+                        ScopeId,
+                        DefaultOptions.DefaultServiceId),
+                    CapabilityAdmissionPlan = new WorkflowCapabilityAdmissionPlan
+                    {
+                        SchemaVersion = admissionSchemaVersion,
+                        ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                    },
+                },
+            },
+        };
 
     private static string CreateStaticArtifactHash(
         string revisionId,

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -1372,8 +1372,19 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         commandPort.Calls.Should().Contain(call => call.Method == "ActivateServiceRevisionAsync");
     }
 
-    [Fact]
-    public async Task UpsertAsync_ShouldRejectExistingWorkflowReplay_WhenPreparedArtifactRequiresCapabilityAdmissionRebind()
+    [Theory]
+    [InlineData(
+        WorkflowCapabilityAdmissionPlanIntegrity.LegacySchemaVersion,
+        ExternalCapabilityExecutionMode.Interactive,
+        ExternalCapabilityExecutionMode.Interactive)]
+    [InlineData(
+        WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion,
+        ExternalCapabilityExecutionMode.Interactive,
+        ExternalCapabilityExecutionMode.Durable)]
+    public async Task UpsertAsync_ShouldRejectExistingWorkflowReplay_WhenPreparedArtifactRequiresCapabilityAdmissionRebind(
+        string admissionSchemaVersion,
+        ExternalCapabilityExecutionMode workflowExecutionMode,
+        ExternalCapabilityExecutionMode admissionExecutionMode)
     {
         const string revisionId = "rev-platform-bind-1";
         const string workflowYaml = "name: main\nsteps:\n  - run: echo hello";
@@ -1421,7 +1432,9 @@ public sealed class ScopeBindingCommandApplicationServiceTests
                             revisionId,
                             "main",
                             workflowYaml,
-                            WorkflowCapabilityAdmissionPlanIntegrity.LegacySchemaVersion)),
+                            admissionSchemaVersion,
+                            workflowExecutionMode,
+                            admissionExecutionMode)),
                 ],
                 DateTimeOffset.UtcNow));
         var service = CreateService(
@@ -2251,7 +2264,9 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         string revisionId,
         string workflowName,
         string workflowYaml,
-        string admissionSchemaVersion) =>
+        string admissionSchemaVersion,
+        ExternalCapabilityExecutionMode workflowExecutionMode,
+        ExternalCapabilityExecutionMode admissionExecutionMode) =>
         new()
         {
             Identity = DefaultServiceIdentity(),
@@ -2275,14 +2290,14 @@ public sealed class ScopeBindingCommandApplicationServiceTests
                 {
                     WorkflowName = workflowName,
                     WorkflowYaml = workflowYaml,
-                    ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                    ExecutionMode = workflowExecutionMode,
                     DefinitionActorId = DefaultOptions.BuildDefinitionActorIdPrefix(
                         ScopeId,
                         DefaultOptions.DefaultServiceId),
                     CapabilityAdmissionPlan = new WorkflowCapabilityAdmissionPlan
                     {
                         SchemaVersion = admissionSchemaVersion,
-                        ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                        ExecutionMode = admissionExecutionMode,
                     },
                 },
             },

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingReadinessQueryServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingReadinessQueryServiceTests.cs
@@ -3,6 +3,7 @@ using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Workflows;
+using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 
@@ -355,6 +356,43 @@ public sealed class ScopeBindingReadinessQueryServiceTests
     }
 
     [Fact]
+    public async Task GetReadinessAsync_WhenWorkflowArtifactHasLegacyAdmissionPlan_ShouldReturnRebindRequired()
+    {
+        var lifecyclePort = new FakeServiceLifecycleQueryPort
+        {
+            Service = CreateServiceSnapshot("service-a", activeRevisionId: "rev-ready", endpoints: [CreateServiceEndpoint("chat")]),
+        };
+        var servingPort = new FakeServiceServingQueryPort
+        {
+            ServingSet = CreateServingSet([
+                CreateTarget("rev-ready", ServiceServingState.Active, allocationWeight: 100, enabledEndpointIds: ["chat"]),
+            ]),
+            TrafficView = CreateTrafficView([
+                CreateTrafficEndpoint("chat", [CreateTrafficTarget("rev-ready", ServiceServingState.Active, allocationWeight: 100)]),
+            ]),
+        };
+        var revisionCatalogReader = CreateRevisionCatalogReader(preparedArtifacts: new Dictionary<string, PreparedServiceRevisionArtifact>(StringComparer.Ordinal)
+        {
+            ["rev-ready"] = CreateWorkflowArtifact(
+                "rev-ready",
+                WorkflowCapabilityAdmissionPlanIntegrity.LegacySchemaVersion,
+                ExternalCapabilityExecutionMode.Interactive),
+        });
+        var service = CreateService(lifecyclePort, servingPort, revisionCatalogReader);
+
+        var snapshot = await service.GetReadinessAsync(new ScopeBindingReadinessRequest(
+            "scope-a",
+            "service-a",
+            ExpectedRevisionId: "rev-ready",
+            ExpectedEndpointIds: ["chat"]));
+
+        snapshot.Status.Should().Be(ScopeBindingReadinessStatus.InvocationCatalogNotReady);
+        snapshot.InvokeReady.Should().BeFalse();
+        snapshot.RevisionId.Should().Be("rev-ready");
+        snapshot.DeploymentId.Should().Be("deployment-rev-ready");
+    }
+
+    [Fact]
     public async Task GetReadinessAsync_WhenTrafficViewHasStaleTargets_ShouldReturnTrafficViewTargetMissing()
     {
         var lifecyclePort = new FakeServiceLifecycleQueryPort
@@ -606,6 +644,48 @@ public sealed class ScopeBindingReadinessQueryServiceTests
             RequestTypeUrl = "type.googleapis.com/a.Request",
             ResponseTypeUrl = "type.googleapis.com/a.Response",
         }));
+        return artifact;
+    }
+
+    private static PreparedServiceRevisionArtifact CreateWorkflowArtifact(
+        string revisionId,
+        string schemaVersion,
+        ExternalCapabilityExecutionMode executionMode)
+    {
+        var artifact = new PreparedServiceRevisionArtifact
+        {
+            Identity = new ServiceIdentity
+            {
+                TenantId = "scope-a",
+                AppId = DefaultOptions.ServiceAppId,
+                Namespace = DefaultOptions.ServiceNamespace,
+                ServiceId = "service-a",
+            },
+            RevisionId = revisionId,
+            ImplementationKind = ServiceImplementationKind.Workflow,
+            DeploymentPlan = new ServiceDeploymentPlan
+            {
+                WorkflowPlan = new WorkflowServiceDeploymentPlan
+                {
+                    WorkflowName = "invoice_file_extract",
+                    WorkflowYaml = "name: invoice_file_extract\nsteps: []",
+                    ExecutionMode = executionMode,
+                    CapabilityAdmissionPlan = new WorkflowCapabilityAdmissionPlan
+                    {
+                        SchemaVersion = schemaVersion,
+                        ExecutionMode = executionMode,
+                    },
+                },
+            },
+        };
+        artifact.Endpoints.Add(new ServiceEndpointDescriptor
+        {
+            EndpointId = "chat",
+            DisplayName = "chat",
+            Kind = ServiceEndpointKind.Chat,
+            RequestTypeUrl = "type.googleapis.com/a.Request",
+            ResponseTypeUrl = "type.googleapis.com/a.Response",
+        });
         return artifact;
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingReadinessQueryServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingReadinessQueryServiceTests.cs
@@ -356,7 +356,7 @@ public sealed class ScopeBindingReadinessQueryServiceTests
     }
 
     [Fact]
-    public async Task GetReadinessAsync_WhenWorkflowArtifactHasLegacyAdmissionPlan_ShouldReturnRebindRequired()
+    public async Task GetReadinessAsync_WhenWorkflowArtifactHasLegacyAdmissionPlan_ShouldReturnInvocationCatalogNotReady()
     {
         var lifecyclePort = new FakeServiceLifecycleQueryPort
         {

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceInvocationResolutionServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceInvocationResolutionServiceTests.cs
@@ -4,6 +4,7 @@ using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Tests.TestSupport;
+using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 
@@ -203,6 +204,47 @@ public sealed class ServiceInvocationResolutionServiceTests
         ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactMissing);
     }
 
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectReadyReadModel_WhenWorkflowArtifactRequiresCapabilityAdmissionRebind()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
+        await revisionCatalog.UpsertRevisionAsync(
+            ServiceKeys.Build(identity),
+            "r1",
+            PreparedWorkflowArtifact(identity, "r1", WorkflowCapabilityAdmissionPlanIntegrity.LegacySchemaVersion));
+        var service = CreateService(
+            identity,
+            revisionCatalog,
+            readiness: Ready(identity, "chat", "r1", "dep-1", "actor-1"));
+
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
+
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactIncompatible);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectReadyReadModel_WhenWorkflowExecutionModeIsMissing()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
+        var artifact = PreparedWorkflowArtifact(identity, "r1", WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion);
+        artifact.DeploymentPlan.WorkflowPlan.ExecutionMode = ExternalCapabilityExecutionMode.Unspecified;
+        await revisionCatalog.UpsertRevisionAsync(ServiceKeys.Build(identity), "r1", artifact);
+        var service = CreateService(
+            identity,
+            revisionCatalog,
+            readiness: Ready(identity, "chat", "r1", "dep-1", "actor-1"));
+
+        var act = () => service.ResolveAsync(NewRequest(identity, "chat"));
+
+        var ex = await act.Should().ThrowAsync<ServiceInvokeReadinessException>();
+        ex.Which.Snapshot.ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        ex.Which.Snapshot.UnavailableReason.Should().Be(ServiceInvokeUnavailableReason.PreparedArtifactIncompatible);
+    }
+
     private static ServiceInvocationRequest NewRequest(ServiceIdentity identity, string endpointId) =>
         new()
         {
@@ -314,6 +356,35 @@ public sealed class ServiceInvocationResolutionServiceTests
             [],
             policyIds ?? [],
             DateTimeOffset.UtcNow);
+
+    private static PreparedServiceRevisionArtifact PreparedWorkflowArtifact(
+        ServiceIdentity identity,
+        string revisionId,
+        string schemaVersion)
+    {
+        var artifact = new PreparedServiceRevisionArtifact
+        {
+            Identity = identity.Clone(),
+            RevisionId = revisionId,
+            ImplementationKind = ServiceImplementationKind.Workflow,
+            DeploymentPlan = new ServiceDeploymentPlan
+            {
+                WorkflowPlan = new WorkflowServiceDeploymentPlan
+                {
+                    WorkflowName = "invoice_file_extract",
+                    WorkflowYaml = "name: invoice_file_extract\nsteps: []",
+                    ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                    CapabilityAdmissionPlan = new WorkflowCapabilityAdmissionPlan
+                    {
+                        SchemaVersion = schemaVersion,
+                        ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                    },
+                },
+            },
+        };
+        artifact.Endpoints.Add(GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat"));
+        return artifact;
+    }
 
     private sealed class RecordingCatalogQueryReader : IServiceCatalogQueryReader
     {

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceInvokeReadinessEvaluatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceInvokeReadinessEvaluatorTests.cs
@@ -133,6 +133,29 @@ public sealed class ServiceInvokeReadinessEvaluatorTests
     }
 
     [Fact]
+    public void Evaluate_ShouldReturnPreparedArtifactIncompatible_WhenWorkflowAdmissionPlanRequiresRebind()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var revision = PreparedWorkflowRevision(identity, "r1", "chat");
+        revision.PreparedArtifact.DeploymentPlan.WorkflowPlan.CapabilityAdmissionPlan.SchemaVersion =
+            WorkflowCapabilityAdmissionPlanIntegrity.LegacySchemaVersion;
+
+        var entries = _evaluator.Evaluate(
+            [GAgentServiceTestKit.CreateEndpointDescriptor(endpointId: "chat")],
+            [Target("dep-1", "r1", "actor-1", "chat")],
+            new Dictionary<string, ServiceRevisionRecordState>(StringComparer.Ordinal)
+            {
+                ["r1"] = revision,
+            });
+
+        entries.Should().ContainSingle();
+        entries[0].ReadinessStatus.Should().Be(ServiceInvokeReadinessStatus.Unavailable);
+        entries[0].UnavailableReason.Should()
+            .Be(ServiceInvokeUnavailableReason.PreparedArtifactIncompatible);
+        entries[0].SelectedRevisionId.Should().Be("r1");
+    }
+
+    [Fact]
     public void Evaluate_ShouldOnlyUseCanonicalStatusesAndReasons()
     {
         var statuses = Enum.GetNames<ServiceInvokeReadinessStatus>();
@@ -219,6 +242,7 @@ public sealed class ServiceInvokeReadinessEvaluatorTests
                         ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
                         CapabilityAdmissionPlan = new WorkflowCapabilityAdmissionPlan
                         {
+                            SchemaVersion = WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion,
                             ExecutionMode = ExternalCapabilityExecutionMode.Interactive,
                         },
                     },


### PR DESCRIPTION
## Summary
- Add a shared workflow artifact readiness check for missing workflow execution mode, missing/current-invalid admission plans, legacy admission schemas, undefined execution modes, and workflow/admission execution-mode drift that require rebind.
- Keep scope binding readiness and invocation resolution from reporting or using stale ready state for incompatible workflow artifacts.
- Reject existing workflow revision replay when the persisted prepared artifact requires capability admission rebind, forcing a new revision id instead of reusing the broken artifact.

## Issue
Fixes #3240

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "FullyQualifiedName~ServiceInvokeReadinessEvaluatorTests|FullyQualifiedName~ScopeBindingReadinessQueryServiceTests|FullyQualifiedName~ServiceInvocationResolutionServiceTests|FullyQualifiedName~ScopeBindingCommandApplicationServiceTests"` passed: 94 tests.
- [x] `PATH="/usr/bin:$PATH" bash tools/ci/test_stability_guards.sh` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)