### PR TITLE
Refine Workflow catalogue metadata hierarchy

### DIFF
--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-workflow-list-metadata.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-workflow-list-metadata.md
@@ -98,7 +98,7 @@ const workflowName = <span className="wa-vnext__title">{row.name}</span>;
         {row.description}
       </p>
     }
-    placement="rightTop"
+    placement="bottomLeft"
     trigger={['hover', 'focus']}
   >
     <button

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-workflow-list-metadata.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-workflow-list-metadata.md
@@ -1,0 +1,222 @@
+# Workflow List Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Workflow catalogue scan-friendly by separating lifecycle status and last update, moving descriptions into an accessible fixed-width popover, and removing technical scope and revision details from the primary list.
+
+**Architecture:** Keep the existing draft/committed merge and query behavior intact. Change only the `WorkflowRow` presentation mapping and table rendering in `WorkflowsPage.tsx`, add narrow table/popover styles in the existing vNext stylesheet, and add the new column and status locale strings to the existing locale dictionaries.
+
+**Tech Stack:** React 19, TypeScript, Ant Design 6 `Popover`, Jest, Testing Library, Biome.
+
+---
+
+## File Map
+
+- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`: user-observable regression coverage for list hierarchy, hidden technical values, and popover behavior.
+- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`: merged row model and four-column table rendering.
+- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts`: stable table column sizing, name trigger focus treatment, and fixed-width description content.
+- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`: English column and Published labels.
+- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`: Chinese column and Published labels.
+
+### Task 1: Lock The Correct Product Semantics With A Failing Test
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] **Step 1: Replace the old mixed-metadata assertion with the desired list behavior**
+
+Use distinct workflow, revision, service, scope, and ownership values. Assert the four column headers and row cell labels, then assert that ownership, scope, revision ID, and Created are absent. The key expectations are:
+
+```tsx
+expect(within(workflowTable).getAllByRole('columnheader')).toHaveLength(4);
+expect(within(workflowTable).getByRole('columnheader', { name: 'Status' })).toBeVisible();
+expect(
+  within(workflowTable).getByRole('columnheader', { name: 'Last updated' }),
+).toBeVisible();
+expect(within(apacRow).getByText('Published')).toBeVisible();
+expect(within(apacRow).queryByText('rev-support-apac-7')).not.toBeInTheDocument();
+expect(within(workflowTable).queryByText('scope-alpha')).not.toBeInTheDocument();
+expect(within(workflowTable).queryByText('APAC operations')).not.toBeInTheDocument();
+expect(within(workflowTable).queryByRole('columnheader', { name: 'Created' })).not.toBeInTheDocument();
+```
+
+- [ ] **Step 2: Assert description disclosure instead of default description rendering**
+
+Give the workflow-name trigger an accessible label such as `Description for Support triage`. Assert the description is absent initially, then use both pointer and keyboard interactions to disclose it. Verify the rendered content owns the fixed-width class:
+
+```tsx
+const descriptionTrigger = within(emeaRow).getByRole('button', {
+  name: 'Description for Support triage',
+});
+expect(screen.queryByText(emeaDescription)).not.toBeInTheDocument();
+fireEvent.mouseEnter(descriptionTrigger);
+const description = await screen.findByText(emeaDescription);
+expect(description).toHaveClass('wa-vnext__workflow-description');
+fireEvent.mouseLeave(descriptionTrigger);
+await waitFor(() => expect(screen.queryByText(emeaDescription)).not.toBeInTheDocument());
+fireEvent.focus(descriptionTrigger);
+expect(await screen.findByText(emeaDescription)).toBeVisible();
+```
+
+Add a committed-only workflow with no description and assert its name is not a description button.
+
+- [ ] **Step 3: Run the focused regression test and confirm RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest src/pages/workflow-activity-vnext/index.test.tsx --selectProjects jsdom --runInBand -t "separates workflow status"
+```
+
+Expected: FAIL because the current table has two headers, permanently renders descriptions, includes ownership and revision values, and has no Status or Last updated columns.
+
+### Task 2: Implement The Four-Column Catalogue
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts`
+- Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`
+- Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`
+
+- [ ] **Step 1: Remove ownership from the row presentation model**
+
+Delete `ownershipLabel` from `WorkflowRow` and from both row mappers. Keep `description`, `activeRevisionId`, and `updatedAtUtc` because they still drive search, popover content, status, and sorting.
+
+- [ ] **Step 2: Add the accessible description trigger**
+
+Import `Popover` and render it only for a trimmed non-empty description:
+
+```tsx
+const workflowName = <span className="wa-vnext__title">{row.name}</span>;
+
+{row.description.trim() ? (
+  <Popover
+    content={
+      <p className="wa-vnext__workflow-description">
+        {row.description}
+      </p>
+    }
+    placement="rightTop"
+    trigger={['hover', 'focus']}
+  >
+    <button
+      aria-label={t(
+        'workflowActivityVNext.workflows.descriptionAria',
+        'Description for {name}',
+        { name: row.name },
+      )}
+      className="wa-vnext__workflow-name-trigger"
+      type="button"
+    >
+      {workflowName}
+    </button>
+  </Popover>
+) : (
+  workflowName
+)}
+```
+
+The trigger is contextual and must not navigate or replace the explicit Open action.
+
+- [ ] **Step 3: Split status and update time into columns**
+
+Add `Status` and `Last updated` headers between Workflow and Actions. Render corresponding cells with matching `data-label` values. Status uses only `Published` or `Draft`; update time uses `formatDate(row.updatedAtUtc)` without an `Updated` prefix.
+
+- [ ] **Step 4: Add stable, viewport-safe styling**
+
+Define table width classes so the Workflow column owns remaining space and Status, Last updated, and Actions have stable widths. Add a native-looking name button reset with a visible focus outline. The popover description content must use:
+
+```css
+.wa-vnext__workflow-description {
+  margin: 0;
+  max-width: calc(100vw - 48px);
+  overflow-wrap: anywhere;
+  white-space: normal;
+  width: 320px;
+}
+```
+
+- [ ] **Step 5: Add locale keys and remove stale primary-list copy**
+
+Add English and Chinese values for `columnStatus`, `columnUpdated`, `publishedStatus`, and `descriptionAria`. Remove `publishedRevision`, `updatedContext`, and `workspaceOwner` only if no remaining references exist in the vNext area.
+
+- [ ] **Step 6: Run the focused test and confirm GREEN**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest src/pages/workflow-activity-vnext/index.test.tsx --selectProjects jsdom --runInBand -t "separates workflow status"
+```
+
+Expected: PASS for the new regression test.
+
+### Task 3: Focused Regression And Static Verification
+
+**Files:**
+
+- Verify all files listed in the File Map.
+
+- [ ] **Step 1: Run the frontend change scope analyzer**
+
+Run from the worktree root:
+
+```bash
+python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext
+```
+
+Record `relatedTests` and `staticCheckFiles`. Do not replace missing affected checks with a full suite.
+
+- [ ] **Step 2: Run the complete related page test file**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest src/pages/workflow-activity-vnext/index.test.tsx --selectProjects jsdom --runInBand
+```
+
+Expected: the Workflow Activity vNext test file passes with zero failures.
+
+- [ ] **Step 3: Run changed-file static checks only**
+
+Pass exactly the analyzer-reported frontend source, test, style, and locale files to Biome. Do not run package-wide lint, full typecheck, or production build. If no repository-native affected typecheck exists, record that GitHub CI owns type verification.
+
+- [ ] **Step 4: Review semantics and diff integrity**
+
+Run:
+
+```bash
+rg -n "publishedRevision|Published \{revision\}|updatedContext|ownershipLabel" apps/aevatar-console-web/src/pages/workflow-activity-vnext apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.*.ts
+git diff --check
+git diff --stat origin/feat/2026-08-04_workflow-activity-vnext...HEAD
+git status --short
+```
+
+Expected: no stale primary-list references, no whitespace errors, and only task-owned files changed.
+
+- [ ] **Step 5: Commit the implementation**
+
+Stage only the implementation, test, locale, style, and plan files, then commit:
+
+```bash
+git commit -m "Refine workflow list metadata hierarchy"
+```
+
+### Task 4: Deliver The Pull Request
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/2026-08-06_workflow-list-metadata
+```
+
+- [ ] **Step 2: Create a ready pull request**
+
+Create a PR targeting `feat/2026-08-04_workflow-activity-vnext`. Include the problem and solution, affected Workflow catalogue path, exact focused commands and results, and this statement:
+
+```text
+Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
+```
+
+Stop after reporting the ready PR URL. Do not wait for CI unless the user asks.

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-workflow-list-metadata-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-workflow-list-metadata-design.md
@@ -1,0 +1,71 @@
+# Workflow List Metadata Design
+
+## Product Mismatch
+
+The Workflow list currently gives draft descriptions, publication revision IDs, ownership labels, and update context the same visual priority as the workflow name. This makes internal scope and revision details look like primary product information, while users need to scan workflow identity, lifecycle status, and recency first.
+
+This is primarily a placement and prominence mismatch. The existing runtime and API semantics are sufficient for the requested UI change:
+
+- `description` is user-authored workflow purpose text.
+- `activeRevisionId` determines whether a workflow is published, but the identifier itself is diagnostic detail.
+- `directoryLabel` can resolve to a technical scope identifier and is not useful in the primary list.
+- `updatedAtUtc` is the authoritative last-update time.
+- No authoritative creation time exists in the current list contract.
+
+## Chosen Design
+
+Use a four-column catalogue:
+
+```text
+Workflow | Status | Last updated | Actions
+```
+
+The Workflow column shows only the workflow name. When a workflow has a non-empty description, its name becomes a keyboard-focusable description trigger. Hovering or focusing that trigger opens a fixed-width popover containing the full description. Workflows without descriptions remain plain text and do not expose an empty trigger or popover.
+
+The description popover uses a 320 px content width with a viewport-safe maximum width and normal wrapping. It is contextual supporting information, not part of the row's default reading order.
+
+The Status column contains one badge:
+
+- `Draft` when there is no active revision.
+- `Published` when an active revision exists.
+
+The active revision identifier is not rendered in the primary list. The list does not render ownership or scope labels. Workflow and service identifiers remain available only through the existing explicit copy-reference action and navigation contracts.
+
+The Last updated column renders the existing authoritative `updatedAtUtc` value with the established localized formatter. The UI does not add a Created column and does not derive a creation time from update time, file metadata, identifiers, or ordering.
+
+## Responsive And Accessible Behavior
+
+The existing horizontally scrollable table remains the layout owner. Column widths prioritize the workflow name, reserve stable space for status and last update, and keep Actions wide enough for the existing commands. On narrow screens, horizontal scrolling preserves the column relationships instead of collapsing unrelated facts into the Workflow cell.
+
+The description trigger supports both pointer hover and keyboard focus through the Ant Design popover behavior. Its focus treatment is visible, and the popover content wraps long descriptions without resizing the table row. No empty description surface is rendered.
+
+## Data Flow
+
+No API, model, or backend change is required.
+
+1. Draft and committed workflow sources continue to merge by `workflowId`.
+2. Draft descriptions continue to populate the merged row when available.
+3. `activeRevisionId` is converted to the user-facing status label only.
+4. `updatedAtUtc` continues to supply the localized last-update value.
+5. `directoryLabel` is no longer mapped into a user-visible row property.
+
+Search continues to match workflow name, description, and workflow ID even though descriptions and IDs are not permanently rendered. Sorting continues to use `updatedAtUtc` descending.
+
+## Error And Empty States
+
+Loading, partial-source failure, total failure, retry, empty, and filtered-empty states are unchanged. Missing or invalid update values continue to use the existing `Unavailable` behavior. A missing description simply disables the contextual description popover for that row.
+
+## Verification
+
+Focused page tests will assert that:
+
+- the table exposes Workflow, Status, Last updated, and Actions headers;
+- descriptions are absent from the default row content and appear through hover and keyboard focus;
+- the description popover has a fixed 320 px width and is not created for empty descriptions;
+- Published never exposes the active revision identifier;
+- ownership labels and the scope ID are absent from the workflow list;
+- the authoritative update value is rendered in the Last updated column;
+- no Created column or inferred creation value appears;
+- existing row actions, search behavior, and identity routing remain intact.
+
+Local verification remains limited to the Workflow Activity test file and changed-file static checks. The full frontend suite, typecheck, and production build are delegated to GitHub CI by the personal frontend workflow policy.

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -544,10 +544,13 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.allView': 'All workflows',
   'workflowActivityVNext.workflows.clearFilters': 'Clear filters',
   'workflowActivityVNext.workflows.columnActions': 'Actions',
+  'workflowActivityVNext.workflows.columnStatus': 'Status',
+  'workflowActivityVNext.workflows.columnUpdated': 'Last updated',
   'workflowActivityVNext.workflows.columnWorkflow': 'Workflow',
   'workflowActivityVNext.workflows.copyReference': 'Copy workflow reference',
   'workflowActivityVNext.workflows.description':
     'Create, edit, and run your workflows.',
+  'workflowActivityVNext.workflows.descriptionAria': 'Description for {name}',
   'workflowActivityVNext.workflows.draftsUnavailable':
     'Draft workflows unavailable',
   'workflowActivityVNext.workflows.draftsUnavailableDescription':
@@ -589,7 +592,7 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.viewFilter': 'Workflow view',
   'workflowActivityVNext.workflows.partialUnavailable':
     "Some workflows couldn't be loaded",
-  'workflowActivityVNext.workflows.publishedRevision': 'Published {revision}',
+  'workflowActivityVNext.workflows.publishedStatus': 'Published',
   'workflowActivityVNext.workflows.referenceCopied':
     'Workflow reference copied',
   'workflowActivityVNext.workflows.referenceCopyFailed':
@@ -600,9 +603,7 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.renameSave': 'Save name',
   'workflowActivityVNext.workflows.renameSuccess': 'Workflow renamed',
   'workflowActivityVNext.workflows.renameTitle': 'Rename workflow',
-  'workflowActivityVNext.workflows.updatedContext': 'Updated {updatedAt}',
   'workflowActivityVNext.workflows.viewActivity': 'Activity',
-  'workflowActivityVNext.workflows.workspaceOwner': 'Workspace',
 } as const;
 
 export default workflowActivityVNextMessages;

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -506,10 +506,13 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.allView': '全部工作流',
     'workflowActivityVNext.workflows.clearFilters': '清除筛选',
     'workflowActivityVNext.workflows.columnActions': '操作',
+    'workflowActivityVNext.workflows.columnStatus': '状态',
+    'workflowActivityVNext.workflows.columnUpdated': '最近更新',
     'workflowActivityVNext.workflows.columnWorkflow': '工作流',
     'workflowActivityVNext.workflows.copyReference': '复制工作流引用',
     'workflowActivityVNext.workflows.description':
       '创建、编辑并运行你的工作流。',
+    'workflowActivityVNext.workflows.descriptionAria': '{name} 的描述',
     'workflowActivityVNext.workflows.draftsUnavailable': '草稿工作流不可用',
     'workflowActivityVNext.workflows.draftsUnavailableDescription':
       '请重试加载草稿工作流。',
@@ -549,7 +552,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
       '请重试加载工作流。',
     'workflowActivityVNext.workflows.viewFilter': '工作流视图',
     'workflowActivityVNext.workflows.partialUnavailable': '部分工作流无法加载',
-    'workflowActivityVNext.workflows.publishedRevision': '已发布 {revision}',
+    'workflowActivityVNext.workflows.publishedStatus': '已发布',
     'workflowActivityVNext.workflows.referenceCopied': '已复制工作流引用',
     'workflowActivityVNext.workflows.referenceCopyFailed': '无法复制工作流引用',
     'workflowActivityVNext.workflows.rename': '重命名',
@@ -557,9 +560,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.renameSave': '保存名称',
     'workflowActivityVNext.workflows.renameSuccess': '工作流已重命名',
     'workflowActivityVNext.workflows.renameTitle': '重命名工作流',
-    'workflowActivityVNext.workflows.updatedContext': '更新于 {updatedAt}',
     'workflowActivityVNext.workflows.viewActivity': '活动',
-    'workflowActivityVNext.workflows.workspaceOwner': '工作区',
   };
 
 export default workflowActivityVNextMessages;

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -443,21 +443,23 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
-  it('distinguishes same-name workflows with purpose, publication state, ownership, and localized update context', async () => {
+  it('separates workflow status and last update while disclosing descriptions on demand', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, 'clipboard', {
       configurable: true,
       value: { writeText },
     });
+    const emeaDescription = 'Route urgent EMEA requests to the on-call queue';
+    const apacDescription = 'Escalate APAC billing requests to finance';
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([
       {
         workflowId: 'wf-support-emea',
         name: 'Support triage',
-        description: 'Route urgent EMEA requests to the on-call queue',
+        description: emeaDescription,
         fileName: 'support-emea.yaml',
         filePath: '/emea/support-emea.yaml',
         directoryId: 'directory-emea',
-        directoryLabel: 'EMEA operations',
+        directoryLabel: 'scope-alpha',
         stepCount: 3,
         hasLayout: true,
         updatedAtUtc: '2026-08-04T10:00:00Z',
@@ -467,11 +469,11 @@ describe('Workflow Activity vNext catalogue', () => {
         serviceKey: 'svc-support-apac',
         workflowId: 'wf-support-apac',
         name: 'Support triage',
-        description: 'Escalate APAC billing requests to finance',
+        description: apacDescription,
         fileName: 'support-apac.yaml',
         filePath: '/apac/support-apac.yaml',
         directoryId: 'directory-apac',
-        directoryLabel: 'APAC operations',
+        directoryLabel: 'scope-alpha',
         stepCount: 5,
         hasLayout: true,
         updatedAtUtc: '2026-08-05T11:30:00Z',
@@ -490,36 +492,99 @@ describe('Workflow Activity vNext catalogue', () => {
         deploymentStatus: 'active',
         updatedAt: '2026-08-05T11:30:00Z',
       },
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-nightly-reconciliation',
+        displayName: 'Nightly reconciliation',
+        serviceKey: 'svc-nightly-reconciliation',
+        workflowName: 'nightly_reconciliation',
+        actorId: 'definition-nightly-reconciliation',
+        activeRevisionId: 'rev-nightly-reconciliation-2',
+        deploymentId: 'deployment-nightly-reconciliation',
+        deploymentStatus: 'active',
+        updatedAt: '2026-08-03T09:15:00Z',
+      },
     ]);
 
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     const duplicateNames = await screen.findAllByText('Support triage');
     expect(duplicateNames).toHaveLength(2);
-    const emeaRow = screen
-      .getByText('Route urgent EMEA requests to the on-call queue')
-      .closest('tr');
-    const apacRow = screen
-      .getByText('Escalate APAC billing requests to finance')
+    const apacRow = duplicateNames[0].closest('tr');
+    const emeaRow = duplicateNames[1].closest('tr');
+    const noDescriptionRow = screen
+      .getByText('Nightly reconciliation')
       .closest('tr');
     expect(emeaRow).not.toBeNull();
     expect(apacRow).not.toBeNull();
+    expect(noDescriptionRow).not.toBeNull();
+
+    const workflowTable = screen.getByRole('table');
+    expect(within(workflowTable).getAllByRole('columnheader')).toHaveLength(4);
+    expect(
+      within(workflowTable).getByRole('columnheader', { name: 'Status' }),
+    ).toBeVisible();
+    expect(
+      within(workflowTable).getByRole('columnheader', {
+        name: 'Last updated',
+      }),
+    ).toBeVisible();
+    expect(
+      within(workflowTable).queryByRole('columnheader', { name: 'Created' }),
+    ).not.toBeInTheDocument();
+
     expect(within(emeaRow as HTMLElement).getByText('Draft')).toBeVisible();
+    expect(within(apacRow as HTMLElement).getByText('Published')).toBeVisible();
     expect(
-      within(emeaRow as HTMLElement).getByText(/EMEA operations/),
-    ).toBeVisible();
+      within(apacRow as HTMLElement).queryByText('rev-support-apac-7'),
+    ).not.toBeInTheDocument();
     expect(
-      within(apacRow as HTMLElement).getByText('Published rev-support-apac-7'),
-    ).toBeVisible();
-    expect(
-      within(apacRow as HTMLElement).getByText(/APAC operations/),
-    ).toBeVisible();
+      within(workflowTable).queryByText('scope-alpha'),
+    ).not.toBeInTheDocument();
     expect(
       within(apacRow as HTMLElement).queryByText('wf-support-apac'),
     ).not.toBeInTheDocument();
     expect(
       within(apacRow as HTMLElement).queryByText('svc-support-apac'),
     ).not.toBeInTheDocument();
+
+    const apacUpdatedAt = new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date('2026-08-05T11:30:00Z'));
+    expect(
+      within(apacRow as HTMLElement).getByText(apacUpdatedAt),
+    ).toBeVisible();
+    expect(
+      within(apacRow as HTMLElement)
+        .getByText(apacUpdatedAt)
+        .closest('td'),
+    ).toHaveAttribute('data-label', 'Last updated');
+
+    expect(screen.queryByText(emeaDescription)).not.toBeInTheDocument();
+    expect(screen.queryByText(apacDescription)).not.toBeInTheDocument();
+    const descriptionTriggers = within(workflowTable).getAllByRole('button', {
+      name: 'Description for Support triage',
+    });
+    expect(descriptionTriggers).toHaveLength(2);
+    expect(
+      within(noDescriptionRow as HTMLElement).queryByRole('button', {
+        name: 'Description for Nightly reconciliation',
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(descriptionTriggers[1]);
+    const disclosedDescription = await screen.findByText(emeaDescription);
+    await waitFor(() => expect(disclosedDescription).toBeVisible());
+    expect(disclosedDescription).toHaveClass('wa-vnext__workflow-description');
+    expect(disclosedDescription.closest('.ant-popover')).toHaveClass(
+      'ant-popover-placement-bottomLeft',
+    );
+
+    fireEvent.mouseLeave(descriptionTriggers[1]);
+    await waitFor(() => expect(disclosedDescription).not.toBeVisible());
+    fireEvent.focus(descriptionTriggers[1]);
+    await waitFor(() => expect(disclosedDescription).toBeVisible());
 
     fireEvent.click(
       within(apacRow as HTMLElement).getByRole('button', {
@@ -599,9 +664,10 @@ describe('Workflow Activity vNext catalogue', () => {
 
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
-    const apacRow = (
-      await screen.findByText('Escalate APAC billing requests')
-    ).closest('tr');
+    const [apacDescriptionTrigger] = await screen.findAllByRole('button', {
+      name: 'Description for Support triage',
+    });
+    const apacRow = apacDescriptionTrigger.closest('tr');
     fireEvent.click(
       within(apacRow as HTMLElement).getByRole('button', {
         name: 'More actions for Support triage',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -122,7 +122,7 @@ export const workflowActivityVNextCss = `
   overflow: auto;
   scrollbar-gutter: stable;
 }
-.wa-vnext__table { border-collapse: separate; border-spacing: 0; font-size: 12px; line-height: 17px; min-width: 720px; table-layout: fixed; width: 100%; }
+.wa-vnext__table { border-collapse: separate; border-spacing: 0; font-size: 12px; line-height: 17px; min-width: 900px; table-layout: fixed; width: 100%; }
 .wa-vnext__table th {
   background: var(--wa-subtle);
   border-bottom: 1px solid var(--wa-line);
@@ -141,6 +141,9 @@ export const workflowActivityVNextCss = `
 }
 .wa-vnext__table th:first-child { border-top-left-radius: 7px; }
 .wa-vnext__table th:last-child { border-top-right-radius: 7px; }
+.wa-vnext__table-column--status { width: 120px; }
+.wa-vnext__table-column--updated { width: 190px; }
+.wa-vnext__table-column--actions { width: 270px; }
 .wa-vnext__table td { border-bottom: 1px solid var(--wa-line); height: 76px; overflow-wrap: anywhere; padding: 10px 12px; vertical-align: middle; }
 .wa-vnext__table tr:last-child td { border-bottom: 0; }
 .wa-vnext__table tbody tr:hover { background: #f9fafb; }
@@ -148,8 +151,9 @@ export const workflowActivityVNextCss = `
 .wa-vnext__run-link { max-width: 100%; min-width: 0; overflow: hidden; }
 .wa-vnext__title { display: block; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wa-vnext__sub { color: var(--wa-muted); display: block; font-size: 12px; line-height: 17px; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.wa-vnext__workflow-context { align-items: center; color: var(--wa-muted); display: flex; flex-wrap: wrap; font-size: 11px; gap: 4px 7px; line-height: 16px; margin-top: 7px; }
-.wa-vnext__workflow-context .wa-vnext__status { min-height: 20px; }
+.wa-vnext__workflow-name-trigger { background: transparent; border: 0; color: inherit; cursor: help; display: block; font: inherit; margin: 0; max-width: 100%; padding: 0; text-align: left; }
+.wa-vnext__workflow-description-popover { max-width: calc(100vw - 48px); width: 320px; }
+.wa-vnext__workflow-description { margin: 0; max-width: 100%; overflow-wrap: anywhere; white-space: normal; }
 .wa-vnext__status { align-items: center; border: 1px solid currentColor; border-radius: 5px; display: inline-flex; font-size: 11px; font-weight: 600; gap: 6px; min-height: 24px; padding: 0 8px; white-space: nowrap; }
 .wa-vnext__status::before { background: currentColor; border-radius: 50%; content: ""; height: 6px; width: 6px; }
 .wa-vnext__status--draft { background: #f4f3ff; color: #6941c6; }

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -8,7 +8,16 @@ import {
   SearchOutlined,
 } from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Dropdown, Input, Modal, Select, Space, Tooltip } from 'antd';
+import {
+  Button,
+  Dropdown,
+  Input,
+  Modal,
+  Popover,
+  Select,
+  Space,
+  Tooltip,
+} from 'antd';
 import React from 'react';
 import { scopesApi } from '@/shared/api/scopesApi';
 import { t } from '@/shared/i18n/messages';
@@ -32,7 +41,6 @@ type WorkflowRow = {
   readonly hasCommittedSource: boolean;
   readonly hasDraftSource: boolean;
   readonly name: string;
-  readonly ownershipLabel: string;
   readonly stepCount?: number;
   readonly updatedAtUtc: string | null;
   readonly workflowId: string;
@@ -49,9 +57,6 @@ function toDraftRow(
     hasCommittedSource: Boolean(committed),
     hasDraftSource: true,
     name: item.name,
-    ownershipLabel:
-      item.directoryLabel.trim() ||
-      t('workflowActivityVNext.workflows.workspaceOwner', 'Workspace'),
     stepCount: item.stepCount,
     updatedAtUtc: item.updatedAtUtc,
     workflowId: item.workflowId,
@@ -65,10 +70,6 @@ function toCommittedRow(item: ScopeWorkflowSummary): WorkflowRow {
     hasCommittedSource: true,
     hasDraftSource: false,
     name: item.displayName || item.workflowName,
-    ownershipLabel: t(
-      'workflowActivityVNext.workflows.workspaceOwner',
-      'Workspace',
-    ),
     updatedAtUtc: item.updatedAt,
     workflowId: item.workflowId,
   };
@@ -555,7 +556,16 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                     'Workflow',
                   )}
                 </th>
-                <th>
+                <th className="wa-vnext__table-column--status">
+                  {t('workflowActivityVNext.workflows.columnStatus', 'Status')}
+                </th>
+                <th className="wa-vnext__table-column--updated">
+                  {t(
+                    'workflowActivityVNext.workflows.columnUpdated',
+                    'Last updated',
+                  )}
+                </th>
+                <th className="wa-vnext__table-column--actions">
                   {t(
                     'workflowActivityVNext.workflows.columnActions',
                     'Actions',
@@ -564,150 +574,185 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => (
-                <tr key={row.workflowId}>
-                  <td
-                    data-label={t(
-                      'workflowActivityVNext.workflows.columnWorkflow',
-                      'Workflow',
-                    )}
-                  >
-                    <span className="wa-vnext__title">{row.name}</span>
-                    {row.description ? (
-                      <span className="wa-vnext__sub">{row.description}</span>
-                    ) : null}
-                    <span className="wa-vnext__workflow-context">
+              {rows.map((row) => {
+                const description = row.description.trim();
+                const isPublished = Boolean(row.activeRevisionId);
+                const workflowName = (
+                  <span className="wa-vnext__title">{row.name}</span>
+                );
+
+                return (
+                  <tr key={row.workflowId}>
+                    <td
+                      data-label={t(
+                        'workflowActivityVNext.workflows.columnWorkflow',
+                        'Workflow',
+                      )}
+                    >
+                      {description ? (
+                        <Popover
+                          classNames={{
+                            container: 'wa-vnext__workflow-description-popover',
+                          }}
+                          content={
+                            <p className="wa-vnext__workflow-description">
+                              {description}
+                            </p>
+                          }
+                          destroyOnHidden
+                          placement="bottomLeft"
+                          trigger={['hover', 'focus']}
+                        >
+                          <button
+                            aria-label={t(
+                              'workflowActivityVNext.workflows.descriptionAria',
+                              'Description for {name}',
+                              { name: row.name },
+                            )}
+                            className="wa-vnext__workflow-name-trigger"
+                            type="button"
+                          >
+                            {workflowName}
+                          </button>
+                        </Popover>
+                      ) : (
+                        workflowName
+                      )}
+                    </td>
+                    <td
+                      data-label={t(
+                        'workflowActivityVNext.workflows.columnStatus',
+                        'Status',
+                      )}
+                    >
                       <span
                         className={`wa-vnext__status ${
-                          row.activeRevisionId
+                          isPublished
                             ? 'wa-vnext__status--committed'
                             : 'wa-vnext__status--draft'
                         }`}
                       >
-                        {row.activeRevisionId
+                        {isPublished
                           ? t(
-                              'workflowActivityVNext.workflows.publishedRevision',
-                              'Published {revision}',
-                              { revision: row.activeRevisionId },
+                              'workflowActivityVNext.workflows.publishedStatus',
+                              'Published',
                             )
                           : t(
                               'workflowActivityVNext.workflows.draftStatus',
                               'Draft',
                             )}
                       </span>
-                      <span aria-hidden="true">·</span>
-                      <span>{row.ownershipLabel}</span>
-                      <span aria-hidden="true">·</span>
-                      <span>
-                        {t(
-                          'workflowActivityVNext.workflows.updatedContext',
-                          'Updated {updatedAt}',
-                          { updatedAt: formatDate(row.updatedAtUtc) },
-                        )}
-                      </span>
-                    </span>
-                  </td>
-                  <td
-                    data-label={t(
-                      'workflowActivityVNext.workflows.columnActions',
-                      'Actions',
-                    )}
-                  >
-                    <Space>
-                      <Button
-                        aria-label={t(
-                          'workflowActivityVNext.workflows.openAria',
-                          'Open {name}',
-                          { name: row.name },
-                        )}
-                        onClick={() =>
-                          history.push(
-                            buildWorkflowActivityEditorHref(
-                              scopeId,
-                              row.workflowId,
-                            ),
-                          )
-                        }
-                      >
-                        {t('workflowActivityVNext.common.open', 'Open')}
-                      </Button>
-                      <Button onClick={() => openActivity(row)}>
-                        {t(
-                          'workflowActivityVNext.workflows.viewActivity',
-                          'Activity',
-                        )}
-                      </Button>
-                      {row.hasDraftSource ? (
-                        <Tooltip
-                          title={t(
-                            'workflowActivityVNext.workflows.deleteDraft',
-                            'Delete draft',
+                    </td>
+                    <td
+                      data-label={t(
+                        'workflowActivityVNext.workflows.columnUpdated',
+                        'Last updated',
+                      )}
+                    >
+                      {formatDate(row.updatedAtUtc)}
+                    </td>
+                    <td
+                      data-label={t(
+                        'workflowActivityVNext.workflows.columnActions',
+                        'Actions',
+                      )}
+                    >
+                      <Space>
+                        <Button
+                          aria-label={t(
+                            'workflowActivityVNext.workflows.openAria',
+                            'Open {name}',
+                            { name: row.name },
                           )}
+                          onClick={() =>
+                            history.push(
+                              buildWorkflowActivityEditorHref(
+                                scopeId,
+                                row.workflowId,
+                              ),
+                            )
+                          }
+                        >
+                          {t('workflowActivityVNext.common.open', 'Open')}
+                        </Button>
+                        <Button onClick={() => openActivity(row)}>
+                          {t(
+                            'workflowActivityVNext.workflows.viewActivity',
+                            'Activity',
+                          )}
+                        </Button>
+                        {row.hasDraftSource ? (
+                          <Tooltip
+                            title={t(
+                              'workflowActivityVNext.workflows.deleteDraft',
+                              'Delete draft',
+                            )}
+                          >
+                            <Button
+                              aria-label={t(
+                                'workflowActivityVNext.workflows.deleteAria',
+                                'Delete {name}',
+                                { name: row.name },
+                              )}
+                              danger
+                              icon={<DeleteOutlined />}
+                              onClick={() => {
+                                setDeleteTarget(row);
+                                setDeleteFailed(false);
+                                setDeleteSucceeded(false);
+                              }}
+                              type="text"
+                            />
+                          </Tooltip>
+                        ) : null}
+                        <Dropdown
+                          menu={{
+                            items: [
+                              ...(row.hasDraftSource
+                                ? [
+                                    {
+                                      icon: <EditOutlined />,
+                                      key: 'rename',
+                                      label: t(
+                                        'workflowActivityVNext.workflows.rename',
+                                        'Rename',
+                                      ),
+                                    },
+                                  ]
+                                : []),
+                              {
+                                icon: <CopyOutlined />,
+                                key: 'copy-reference',
+                                label: t(
+                                  'workflowActivityVNext.workflows.copyReference',
+                                  'Copy workflow reference',
+                                ),
+                              },
+                            ],
+                            onClick: ({ key }) => {
+                              if (key === 'rename') openRename(row);
+                              if (key === 'copy-reference')
+                                void copyWorkflowReference(row);
+                            },
+                          }}
+                          placement="bottomRight"
+                          trigger={['click']}
                         >
                           <Button
                             aria-label={t(
-                              'workflowActivityVNext.workflows.deleteAria',
-                              'Delete {name}',
+                              'workflowActivityVNext.workflows.moreActionsAria',
+                              'More actions for {name}',
                               { name: row.name },
                             )}
-                            danger
-                            icon={<DeleteOutlined />}
-                            onClick={() => {
-                              setDeleteTarget(row);
-                              setDeleteFailed(false);
-                              setDeleteSucceeded(false);
-                            }}
+                            icon={<MoreOutlined />}
                             type="text"
                           />
-                        </Tooltip>
-                      ) : null}
-                      <Dropdown
-                        menu={{
-                          items: [
-                            ...(row.hasDraftSource
-                              ? [
-                                  {
-                                    icon: <EditOutlined />,
-                                    key: 'rename',
-                                    label: t(
-                                      'workflowActivityVNext.workflows.rename',
-                                      'Rename',
-                                    ),
-                                  },
-                                ]
-                              : []),
-                            {
-                              icon: <CopyOutlined />,
-                              key: 'copy-reference',
-                              label: t(
-                                'workflowActivityVNext.workflows.copyReference',
-                                'Copy workflow reference',
-                              ),
-                            },
-                          ],
-                          onClick: ({ key }) => {
-                            if (key === 'rename') openRename(row);
-                            if (key === 'copy-reference')
-                              void copyWorkflowReference(row);
-                          },
-                        }}
-                        placement="bottomRight"
-                        trigger={['click']}
-                      >
-                        <Button
-                          aria-label={t(
-                            'workflowActivityVNext.workflows.moreActionsAria',
-                            'More actions for {name}',
-                            { name: row.name },
-                          )}
-                          icon={<MoreOutlined />}
-                          type="text"
-                        />
-                      </Dropdown>
-                    </Space>
-                  </td>
-                </tr>
-              ))}
+                        </Dropdown>
+                      </Space>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </TableScrollRegion>


### PR DESCRIPTION
## Problem

The Workflow Activity vNext catalogue mixed workflow descriptions, technical scope ownership, published revision IDs, status, and update context into the primary Workflow cell. That made duplicate workflows harder to scan and exposed identifiers that do not help users choose or manage a workflow.

The current API contract provides an authoritative update time but no authoritative creation time, so the UI must not fabricate a Created value.

## Solution

- Use the stable table hierarchy `Workflow | Status | Last updated | Actions`.
- Keep descriptions available through a fixed-width hover/focus popover instead of rendering them in every row.
- Show `Draft` or `Published` as a dedicated status without revision IDs.
- Remove scope ownership labels and scope IDs from the primary catalogue.
- Render the authoritative update timestamp in its own column.
- Add keyboard-accessible disclosure behavior and regression coverage, including narrow-viewport popover placement.

## Impact

Workflow Activity vNext catalogue only. Workflow identity, routing, filters, rename, copy-reference, delete, and Activity behavior remain unchanged.

## Local verification

- Scope analysis: `python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext`
- Related tests: `pnpm exec jest --findRelatedTests src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx --selectProjects jsdom --runInBand` — 94 suites and 1202 tests passed; the only failing assertion was the changed page test's stale description locator, which was corrected and rerun below.
- Changed test file: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --selectProjects jsdom --runInBand` — 1 suite passed, 83/83 tests passed.
- Changed-file static checks: `pnpm exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx` — 5 files checked, no fixes required.
- Diff validation: `git diff --check` — passed.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
