### PR TITLE
Hide redundant raw configuration for guided workflow nodes

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx
@@ -17,6 +17,7 @@ import {
   formatRawStudioNodeConfiguration,
   getStudioNodeConfigurationSchema,
   readStudioNodeConfigurationValues,
+  shouldShowRawStudioNodeConfiguration,
   type StudioStructuredNodeConfigField,
 } from "@/shared/studio/nodeConfigFields";
 import { formatConsoleMessage, t } from "@/shared/i18n/messages";
@@ -370,6 +371,10 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
   const parameters = readCurrentParameters(stepDraft, rawConfigurationText);
   const schema = getStudioNodeConfigurationSchema(stepDraft.type, schemaParameters);
   const hasSemanticFields = schema.fields.length > 0;
+  const showRawConfiguration = shouldShowRawStudioNodeConfiguration(
+    stepDraft.type,
+    schemaParameters,
+  );
   const nodeTypeLabel = formatStudioStepTypeLabel(stepDraft.type);
   const branchesSummary = summarizeBranches(stepDraft.branchesText);
   const activeError = structuredError || rawError || error || "";
@@ -619,6 +624,7 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
           zIndex: token.zIndexPopupBase,
         }}
       >
+        {/* biome-ignore lint/a11y/useSemanticElements: The separator is an interactive keyboard and pointer resize handle. */}
         <div
           aria-label={t(
             "teamMemberWorkflowStudio.nodeInspector.resizeHandle",
@@ -800,60 +806,62 @@ const WorkflowStudioNodeDetailPanel: React.FC<WorkflowStudioNodeDetailPanelProps
           ) : null}
         </section>
 
-        <Collapse
-          bordered={false}
-          items={[
-            {
-              key: "raw-configuration",
-              label: t(
-                "teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration",
-                "Advanced raw configuration",
-              ),
-              children: (
-                <div style={{ display: "grid", gap: token.paddingXS }}>
-                  <Typography.Paragraph style={{ color: token.colorTextSecondary, margin: 0 }}>
-                    {t(
-                      "teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription",
-                      "Use this only when a node option is not available as a guided field.",
-                    )}
-                  </Typography.Paragraph>
-                  <Input.TextArea
-                    aria-label={t(
-                      "teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria",
-                      "Raw node configuration",
-                    )}
-                    autoSize={{ minRows: 8, maxRows: 16 }}
-                    onChange={(event) =>
-                      updateRawConfigurationText(event.target.value)
-                    }
-                    spellCheck={false}
-                    status={rawError ? "error" : undefined}
-                    style={{
-                      fontFamily:
-                        "SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace",
-                    }}
-                    value={rawConfigurationText}
-                  />
-                  <Button
-                    disabled={Boolean(rawError)}
-                    onClick={applyRawConfigurationToDraft}
-                    size="small"
-                  >
-                    {t(
-                      "teamMemberWorkflowStudio.nodeDetail.applyRawConfiguration",
-                      "Apply raw JSON",
-                    )}
-                  </Button>
-                </div>
-              ),
-            },
-          ]}
-          style={{
-            background: token.colorFillAlter,
-            border: `${token.lineWidth}px ${token.lineType} ${token.colorBorderSecondary}`,
-            borderRadius: token.borderRadius,
-          }}
-        />
+        {showRawConfiguration ? (
+          <Collapse
+            bordered={false}
+            items={[
+              {
+                key: "raw-configuration",
+                label: t(
+                  "teamMemberWorkflowStudio.nodeDetail.advancedRawConfiguration",
+                  "Advanced raw configuration",
+                ),
+                children: (
+                  <div style={{ display: "grid", gap: token.paddingXS }}>
+                    <Typography.Paragraph style={{ color: token.colorTextSecondary, margin: 0 }}>
+                      {t(
+                        "teamMemberWorkflowStudio.nodeDetail.advancedRawConfigurationDescription",
+                        "Use this only when a node option is not available as a guided field.",
+                      )}
+                    </Typography.Paragraph>
+                    <Input.TextArea
+                      aria-label={t(
+                        "teamMemberWorkflowStudio.nodeDetail.rawConfigurationAria",
+                        "Raw node configuration",
+                      )}
+                      autoSize={{ minRows: 8, maxRows: 16 }}
+                      onChange={(event) =>
+                        updateRawConfigurationText(event.target.value)
+                      }
+                      spellCheck={false}
+                      status={rawError ? "error" : undefined}
+                      style={{
+                        fontFamily:
+                          "SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace",
+                      }}
+                      value={rawConfigurationText}
+                    />
+                    <Button
+                      disabled={Boolean(rawError)}
+                      onClick={applyRawConfigurationToDraft}
+                      size="small"
+                    >
+                      {t(
+                        "teamMemberWorkflowStudio.nodeDetail.applyRawConfiguration",
+                        "Apply raw JSON",
+                      )}
+                    </Button>
+                  </div>
+                ),
+              },
+            ]}
+            style={{
+              background: token.colorFillAlter,
+              border: `${token.lineWidth}px ${token.lineType} ${token.colorBorderSecondary}`,
+              borderRadius: token.borderRadius,
+            }}
+          />
+        ) : null}
         </div>
       </aside>
     </>

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -3391,21 +3391,16 @@ describe('TeamMemberWorkflowStudioPage', () => {
     );
     expect(screen.queryByText('Parameters')).toBeNull();
     expect(screen.queryByLabelText('Raw node configuration')).toBeNull();
+    expect(screen.queryByText('Advanced raw configuration')).toBeNull();
     expect(screen.queryByText(/prompt_prefix/)).toBeNull();
     expect(screen.queryByText('Output')).toBeNull();
-    fireEvent.click(screen.getByText('Advanced raw configuration'));
-    expect(
-      (screen.getByLabelText('Raw node configuration') as HTMLTextAreaElement)
-        .value,
-    ).toContain('"prompt_prefix": "Triage the request"');
 
     fireEvent.change(screen.getByLabelText('Instruction'), {
       target: { value: 'Updated instruction' },
     });
-    expect(
-      (screen.getByLabelText('Raw node configuration') as HTMLTextAreaElement)
-        .value,
-    ).toContain('"prompt_prefix": "Updated instruction"');
+    expect(screen.getByLabelText('Instruction')).toHaveValue(
+      'Updated instruction',
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Update node' }));
     expect(screen.getByText('Unsaved changes')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -3634,7 +3629,7 @@ describe('TeamMemberWorkflowStudioPage', () => {
     expect(document.body.style.userSelect).toBe('text');
   });
 
-  it('shows a node detail error for invalid parameter JSON', async () => {
+  it('shows a raw configuration error for an unknown node', async () => {
     window.history.replaceState(
       {},
       '',
@@ -3670,7 +3665,19 @@ describe('TeamMemberWorkflowStudioPage', () => {
       name: 'Workflow Alpha',
       workflowId: 'workflow-alpha',
       yaml: 'name: Workflow Alpha\nsteps: []\n',
-      document: mockWorkflowDocument,
+      document: {
+        ...mockWorkflowDocument,
+        steps: [
+          {
+            id: 'custom_step',
+            type: 'custom_node',
+            targetRole: null,
+            parameters: { title: 'Draft' },
+            next: null,
+            branches: {},
+          },
+        ],
+      },
       updatedAtUtc: '2026-06-08T00:00:00Z',
     });
 
@@ -3679,7 +3686,9 @@ describe('TeamMemberWorkflowStudioPage', () => {
     await waitFor(() => {
       expect(screen.getByTestId('graph-canvas')).toHaveTextContent('nodes:1');
     });
-    fireEvent.click(screen.getByRole('button', { name: 'node:step:triage' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'node:step:custom_step' }),
+    );
     expect(screen.queryByLabelText('Raw node configuration')).toBeNull();
     fireEvent.click(screen.getByText('Advanced raw configuration'));
     fireEvent.change(screen.getByLabelText('Raw node configuration'), {
@@ -3852,6 +3861,7 @@ describe('TeamMemberWorkflowStudioPage', () => {
     expect(screen.getByText('LLM call')).toBeTruthy();
     expect(screen.queryByText('llm_call')).toBeNull();
     expect(screen.queryByLabelText('Raw node configuration')).toBeNull();
+    expect(screen.queryByText('Advanced raw configuration')).toBeNull();
 
     fireEvent.change(screen.getByLabelText('TTL seconds'), {
       target: { value: '900' },
@@ -3878,11 +3888,6 @@ describe('TeamMemberWorkflowStudioPage', () => {
     });
 
     expect(screen.queryByText('llm_call')).toBeNull();
-    fireEvent.click(screen.getByText('Advanced raw configuration'));
-    expect(
-      (screen.getByLabelText('Raw node configuration') as HTMLTextAreaElement)
-        .value,
-    ).toContain('"child_step_type": "llm_call"');
   });
 
   it('infers typed configuration fields for unknown node parameters and writes them through raw JSON', async () => {

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFieldSchemas.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFieldSchemas.ts
@@ -1453,6 +1453,27 @@ export function hasStudioNodeConfigurationSchema(stepType: string): boolean {
   return SCHEMAS_BY_STEP_TYPE[normalizeStepType(stepType)] !== undefined;
 }
 
+export function shouldShowRawStudioNodeConfiguration(
+  stepType: string,
+  parameters: Record<string, unknown> | null | undefined,
+): boolean {
+  const schema = SCHEMAS_BY_STEP_TYPE[normalizeStepType(stepType)];
+  if (!schema) {
+    return true;
+  }
+
+  const coveredParameters = new Set(
+    schema.fields.map((field) =>
+      resolveStepParameterName(stepType, field.parameterName),
+    ),
+  );
+
+  return Object.keys(parameters ?? {}).some(
+    (parameterName) =>
+      !coveredParameters.has(resolveStepParameterName(stepType, parameterName)),
+  );
+}
+
 export function readStudioNodeConfigurationValues(
   stepType: string,
   parameters: Record<string, unknown> | null | undefined,

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.structured.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.structured.test.ts
@@ -7,6 +7,7 @@ import {
   getStudioNodeConfigurationSchema,
   hasStudioNodeConfigurationSchema,
   readStudioNodeConfigurationValues,
+  shouldShowRawStudioNodeConfiguration,
 } from './nodeConfigFields';
 import { STUDIO_GRAPH_CATEGORIES } from './graph';
 
@@ -270,6 +271,30 @@ describe('studio node configuration semantics', () => {
     expect(
       applyRawStudioNodeConfiguration('transform', '{ "op": "lowercase" }'),
     ).toEqual({ op: 'lowercase' });
+  });
+
+  it('shows raw configuration only for unknown nodes or uncovered parameters', () => {
+    expect(
+      shouldShowRawStudioNodeConfiguration('llm_call', {
+        prompt_prefix: 'Classify the request.',
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowRawStudioNodeConfiguration('llm_call', {
+        prompt: 'Legacy instruction',
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowRawStudioNodeConfiguration('llm_call', {
+        llm_timeout_ms: '120000',
+        prompt_prefix: 'Classify the request.',
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowRawStudioNodeConfiguration('custom_step', {
+        title: 'Draft',
+      }),
+    ).toBe(true);
   });
 
   it('infers typed fields for unknown node parameters from the workflow document', () => {

--- a/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.ts
+++ b/apps/aevatar-console-web/src/shared/studio/nodeConfigFields.ts
@@ -19,6 +19,7 @@ export {
   getStudioNodeConfigurationSchema,
   hasStudioNodeConfigurationSchema,
   readStudioNodeConfigurationValues,
+  shouldShowRawStudioNodeConfiguration,
 } from './nodeConfigFieldSchemas';
 export type {
   NodeConfigField as StudioStructuredNodeConfigField,


### PR DESCRIPTION
## Problem and solution

The workflow node inspector exposed `Advanced raw configuration` for every node, even when guided fields already represented every runtime parameter. For `llm_call`, this duplicated `Instruction` as `prompt_prefix` and presented two editing/apply paths for the same fact.

Hide the raw JSON editor when a built-in node's parameters are fully covered by its guided schema. Preserve the fallback for unknown/custom node types and for existing parameters that are not represented by the guided schema. Canonical parameter aliases such as `prompt` and `prompt_prefix` are compared as the same field.

## Impacted paths

- Team member workflow node inspector visibility
- Shared Studio node configuration schema semantics
- Workflow Studio UI and structured configuration regression tests

## Local verification

Validation was run after rebasing onto `origin/feat/2026-08-04_workflow-activity-vnext`.

- Related tests: `pnpm exec jest --findRelatedTests src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx src/shared/studio/nodeConfigFieldSchemas.ts src/shared/studio/nodeConfigFields.ts --runInBand` - passed, 336 tests across 7 suites
- Changed tests: `pnpm exec jest src/pages/team-member-workflow-studio/index.test.tsx src/shared/studio/nodeConfigFields.structured.test.ts --runInBand` - passed, 101 tests across 2 suites
- Changed-file static checks: `pnpm exec biome lint src/pages/team-member-workflow-studio/components/WorkflowStudioNodeDetailPanel.tsx src/pages/team-member-workflow-studio/index.test.tsx src/shared/studio/nodeConfigFieldSchemas.ts src/shared/studio/nodeConfigFields.structured.test.ts src/shared/studio/nodeConfigFields.ts` - passed with 5 pre-existing warnings
- Test stability: `bash tools/ci/test_stability_guards.sh` - passed
- Diff integrity: `git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD` - passed
- Full frontend suite/typecheck/build: deferred to GitHub CI by personal local workflow policy

## Documentation

No architecture or external contract changed; no documentation update is required.
