### PR TITLE
Expose NyxID inventory default LLM models

### DIFF
--- a/src/Aevatar.AI.ToolProviders.NyxId/LlmCatalog/NyxIdLlmServiceCatalogParser.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/LlmCatalog/NyxIdLlmServiceCatalogParser.cs
@@ -177,9 +177,20 @@ public static class NyxIdLlmServiceCatalogParser
         if (diagnostic?.ModelCatalog.Certainty == LLMModelCatalogCertainty.Unavailable)
             return diagnostic.ModelCatalog.Clone();
 
-        IReadOnlyList<string> models = diagnostic?.ModelCatalog.Certainty == LLMModelCatalogCertainty.Enumerated
-            ? diagnostic.ModelCatalog.ModelIds
-            : [inventoryService.DefaultModel];
+        IReadOnlyList<string> models;
+        if (diagnostic?.ModelCatalog.Certainty == LLMModelCatalogCertainty.Enumerated)
+        {
+            var reconciledModels = new SortedSet<string>(diagnostic.ModelCatalog.ModelIds, StringComparer.Ordinal)
+            {
+                inventoryService.DefaultModel,
+            };
+            models = reconciledModels.ToArray();
+        }
+        else
+        {
+            models = [inventoryService.DefaultModel];
+        }
+
         return BuildModelCatalog(models, inventoryService.DefaultModel, ReadyStatus, true);
     }
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/LlmCatalog/NyxIdLlmServiceCatalogParser.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/LlmCatalog/NyxIdLlmServiceCatalogParser.cs
@@ -159,16 +159,28 @@ public static class NyxIdLlmServiceCatalogParser
                 diagnostic?.DisplayName,
                 inventoryService.Slug),
             RouteValue: $"/api/v1/proxy/s/{inventoryService.Slug}",
-            ModelCatalog: diagnostic?.ModelCatalog.Clone() ?? BuildModelCatalog(
-                [],
-                null,
-                ReadyStatus,
-                allowed: true),
+            ModelCatalog: ComposeInventoryModelCatalog(diagnostic, inventoryService),
             Status: diagnostic?.Status ?? ReadyStatus,
             Source: NyxIdLlmProviderSource.UserService,
             Allowed: true,
             Description: null,
             Identity: InventoryIdentity(inventoryService));
+    }
+
+    private static LLMModelCatalog ComposeInventoryModelCatalog(
+        NyxIdLlmService? diagnostic,
+        NyxIdUserService inventoryService)
+    {
+        if (string.IsNullOrWhiteSpace(inventoryService.DefaultModel))
+            return diagnostic?.ModelCatalog.Clone() ?? NotVerifiableCatalog(LLMModelCatalogDiagnosticKind.NotPublished);
+
+        if (diagnostic?.ModelCatalog.Certainty == LLMModelCatalogCertainty.Unavailable)
+            return diagnostic.ModelCatalog.Clone();
+
+        IReadOnlyList<string> models = diagnostic?.ModelCatalog.Certainty == LLMModelCatalogCertainty.Enumerated
+            ? diagnostic.ModelCatalog.ModelIds
+            : [inventoryService.DefaultModel];
+        return BuildModelCatalog(models, inventoryService.DefaultModel, ReadyStatus, true);
     }
 
     private static bool IsEligible(NyxIdUserService service) =>

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs
@@ -66,7 +66,8 @@ public sealed record NyxIdUserService(
     string? Label,
     string? CatalogServiceName,
     bool IsActive,
-    NyxIdUserServiceCredentialSource CredentialSource);
+    NyxIdUserServiceCredentialSource CredentialSource,
+    string? DefaultModel = null);
 
 public sealed record NyxIdUserServices(IReadOnlyList<NyxIdUserService> Services);
 
@@ -275,7 +276,8 @@ public static class NyxIdApiAccessResponseParser
                 ParseCredentialSource(RequireProperty(
                     serviceElement,
                     "credential_source",
-                    JsonValueKind.Object))));
+                    JsonValueKind.Object)),
+                ReadOptionalString(serviceElement, "default_model", "defaultModel")));
         }
 
         return new NyxIdUserServices(services);
@@ -708,15 +710,29 @@ public static class NyxIdApiAccessResponseParser
         return true;
     }
 
-    private static string? ReadOptionalString(JsonElement root, string propertyName)
+    private static string? ReadOptionalString(JsonElement root, string propertyName, params string[] alternativePropertyNames)
     {
-        if (!root.TryGetProperty(propertyName, out var property) ||
-            property.ValueKind == JsonValueKind.Null)
+        if (TryReadOptionalString(root, propertyName, out var value))
+            return value;
+        foreach (var alternativePropertyName in alternativePropertyNames)
         {
-            return null;
+            if (TryReadOptionalString(root, alternativePropertyName, out value))
+                return value;
         }
+
+        return null;
+    }
+
+    private static bool TryReadOptionalString(JsonElement root, string propertyName, out string? value)
+    {
+        value = null;
+        if (!root.TryGetProperty(propertyName, out var property))
+            return false;
+        if (property.ValueKind == JsonValueKind.Null)
+            return true;
         RequireKind(property, JsonValueKind.String);
-        return property.GetString();
+        value = property.GetString();
+        return true;
     }
 
     private static string? ReadOptionalNormalizedString(JsonElement root, string propertyName)

--- a/test/Aevatar.AI.Tests/NyxIdApiAccessContractTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiAccessContractTests.cs
@@ -78,6 +78,7 @@ public sealed class NyxIdApiAccessContractTests
                   "catalog_service_name": "GitHub API",
                   "is_active": true,
                   "credential_source": { "type": "personal" },
+                  "default_model": "gpt-5.5",
                   "endpoint_id": "ignored"
                 },
                 {
@@ -85,6 +86,7 @@ public sealed class NyxIdApiAccessContractTests
                   "slug": "api-linear",
                   "label": null,
                   "is_active": false,
+                  "defaultModel": "claude-opus-4-6",
                   "credential_source": {
                     "type": "org",
                     "org_id": "org-alpha",
@@ -111,7 +113,8 @@ public sealed class NyxIdApiAccessContractTests
             "GitHub API",
             true,
             new NyxIdUserServiceCredentialSource(
-                NyxIdUserServiceCredentialSourceKind.Personal)));
+                NyxIdUserServiceCredentialSourceKind.Personal),
+            "gpt-5.5"));
         result.Value.Services[1].CredentialSource.Should().BeEquivalentTo(
             new NyxIdUserServiceCredentialSource(
                 NyxIdUserServiceCredentialSourceKind.Organization,
@@ -120,6 +123,7 @@ public sealed class NyxIdApiAccessContractTests
                 null,
                 NyxIdOrganizationRole.Admin,
                 true));
+        result.Value.Services[1].DefaultModel.Should().Be("claude-opus-4-6");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/NyxIdLlmServiceCatalogUserKeyMergeTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLlmServiceCatalogUserKeyMergeTests.cs
@@ -171,6 +171,32 @@ public sealed class NyxIdLlmServiceCatalogUserKeyMergeTests
     }
 
     [Fact]
+    public void ComposeUserServiceInventory_WithInventoryDefault_ShouldExposeModelCatalogDefault()
+    {
+        var result = NyxIdLlmServiceCatalogParser.ComposeUserServiceInventory(
+            new NyxIdLlmServicesResult([], null),
+            new NyxIdUserServices([Inventory("us-alpha", "chrono-llm", defaultModel: "gpt-5.5")]));
+
+        var catalog = result.Services.Should().ContainSingle().Subject.ModelCatalog;
+        catalog.Certainty.Should().Be(LLMModelCatalogCertainty.Enumerated);
+        catalog.DefaultModelId.Should().Be("gpt-5.5");
+        catalog.ModelIds.Should().Equal("gpt-5.5");
+    }
+
+    [Fact]
+    public void ComposeUserServiceInventory_WithUnavailableDiagnostic_ShouldNotExposeInventoryDefault()
+    {
+        var result = NyxIdLlmServiceCatalogParser.ComposeUserServiceInventory(
+            new NyxIdLlmServicesResult([NotConnectedProxyService()], null),
+            new NyxIdUserServices([Inventory("us-alpha", "chrono-llm", defaultModel: "gpt-5.5")]));
+
+        var catalog = result.Services.Should().ContainSingle().Subject.ModelCatalog;
+        catalog.Certainty.Should().Be(LLMModelCatalogCertainty.Unavailable);
+        catalog.DiagnosticKind.Should().Be(LLMModelCatalogDiagnosticKind.RouteNotReady);
+        catalog.DefaultModelId.Should().BeEmpty();
+    }
+
+    [Fact]
     public void ParseProvisionedService_ShouldKeepResponseIdDiagnosticOnly()
     {
         var service = NyxIdLlmServiceCatalogParser.ParseProvisionedService("""
@@ -295,7 +321,8 @@ public sealed class NyxIdLlmServiceCatalogUserKeyMergeTests
         string id,
         string slug,
         bool isActive = true,
-        bool? organizationAllowed = null) => new(
+        bool? organizationAllowed = null,
+        string? defaultModel = null) => new(
         Id: id,
         Slug: slug,
         Label: $"Inventory {id}",
@@ -309,7 +336,8 @@ public sealed class NyxIdLlmServiceCatalogUserKeyMergeTests
                 OrganizationRole: NyxIdOrganizationRole.Member,
                 Allowed: allowed)
             : new NyxIdUserServiceCredentialSource(
-                NyxIdUserServiceCredentialSourceKind.Personal));
+                NyxIdUserServiceCredentialSourceKind.Personal),
+        DefaultModel: defaultModel);
 
     [Fact]
     public void ActiveKeyReplacesNotConnectedProxyEntryAsSelectable()

--- a/test/Aevatar.Studio.Tests/NyxIdLlmServiceCatalogUserKeyMergeTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLlmServiceCatalogUserKeyMergeTests.cs
@@ -184,6 +184,28 @@ public sealed class NyxIdLlmServiceCatalogUserKeyMergeTests
     }
 
     [Fact]
+    public void ComposeUserServiceInventory_WithInventoryDefaultOutsideDiagnosticModels_ShouldReconcileModelCatalog()
+    {
+        var diagnostic = Diagnostic("diag-alpha", "chrono-llm") with
+        {
+            ModelCatalog = new LLMModelCatalog
+            {
+                Certainty = LLMModelCatalogCertainty.Enumerated,
+                DefaultModelId = "gpt-5.4",
+                ModelIds = { "gpt-5.4" },
+            },
+        };
+        var result = NyxIdLlmServiceCatalogParser.ComposeUserServiceInventory(
+            new NyxIdLlmServicesResult([diagnostic], null),
+            new NyxIdUserServices([Inventory("us-alpha", "chrono-llm", defaultModel: "gpt-5.5")]));
+
+        var catalog = result.Services.Should().ContainSingle().Subject.ModelCatalog;
+        catalog.Certainty.Should().Be(LLMModelCatalogCertainty.Enumerated);
+        catalog.DefaultModelId.Should().Be("gpt-5.5");
+        catalog.ModelIds.Should().Equal("gpt-5.4", "gpt-5.5");
+    }
+
+    [Fact]
     public void ComposeUserServiceInventory_WithUnavailableDiagnostic_ShouldNotExposeInventoryDefault()
     {
         var result = NyxIdLlmServiceCatalogParser.ComposeUserServiceInventory(

--- a/test/Aevatar.Studio.Tests/UserConfigControllerSettingsTests.cs
+++ b/test/Aevatar.Studio.Tests/UserConfigControllerSettingsTests.cs
@@ -29,7 +29,7 @@ public sealed class UserConfigControllerSettingsTests
                   "display_name": "OpenAI Work",
                   "route_value": "/api/v1/proxy/s/openai-work",
                   "default_model": "gpt-5.4",
-                  "models": ["gpt-5.4"],
+                  "models": ["gpt-5.4", "gpt-5.5"],
                   "status": "ready",
                   "source": "user",
                   "allowed": true
@@ -39,7 +39,7 @@ public sealed class UserConfigControllerSettingsTests
             """),
             (HttpStatusCode.OK, """{"keys":[]}"""),
             (HttpStatusCode.OK, """{"services":[]}"""))
-            .RespondToUserServicesWith(PersonalUserServicesJson("us-openai", "openai-work", "OpenAI Work"));
+            .RespondToUserServicesWith(PersonalUserServicesJson("us-openai", "openai-work", "OpenAI Work", "gpt-5.5"));
         var controller = CreateController(
             current: UserServiceConfig("gpt-5.4", "openai-work", "us-openai"),
             httpHandler: httpHandler,
@@ -59,7 +59,7 @@ public sealed class UserConfigControllerSettingsTests
         payload.RouteOptions.Should().Contain(option =>
             option.UserServiceId == "us-openai" &&
             option.Ready &&
-            option.ModelCatalog.DefaultModelId == "gpt-5.4");
+            option.ModelCatalog.DefaultModelId == "gpt-5.5");
         payload.RouteOptions.Should()
             .ContainSingle(option => option.RouteValue == UserConfigLlmRouteDefaults.Gateway)
             .Which.ModelCatalog.Certainty.Should().Be("unavailable");
@@ -846,20 +846,29 @@ public sealed class UserConfigControllerSettingsTests
         BuildNyxIdConfiguration(),
         NullLogger<NyxIdLlmCatalogHttpClient>.Instance);
 
-    private static string PersonalUserServicesJson(string id, string slug, string label) => $$"""
-        {
-          "services": [
-            {
-              "id": "{{id}}",
-              "slug": "{{slug}}",
-              "label": "{{label}}",
-              "catalog_service_name": "{{label}}",
-              "is_active": true,
-              "credential_source": { "type": "personal" }
-            }
-          ]
-        }
+    private static string PersonalUserServicesJson(string id, string slug, string label, string? defaultModel = null)
+    {
+        var defaultModelJson = string.IsNullOrWhiteSpace(defaultModel)
+            ? string.Empty
+            : $$""",
+              "default_model": "{{defaultModel}}"
         """;
+
+        return $$"""
+            {
+              "services": [
+                {
+                  "id": "{{id}}",
+                  "slug": "{{slug}}",
+                  "label": "{{label}}",
+                  "catalog_service_name": "{{label}}",
+                  "is_active": true,
+                  "credential_source": { "type": "personal" }{{defaultModelJson}}
+                }
+              ]
+            }
+            """;
+    }
 
     private static string SingleReadyServiceJson() => """
         {

--- a/test/Aevatar.Studio.Tests/UserConfigControllerSettingsTests.cs
+++ b/test/Aevatar.Studio.Tests/UserConfigControllerSettingsTests.cs
@@ -848,11 +848,23 @@ public sealed class UserConfigControllerSettingsTests
 
     private static string PersonalUserServicesJson(string id, string slug, string label, string? defaultModel = null)
     {
-        var defaultModelJson = string.IsNullOrWhiteSpace(defaultModel)
-            ? string.Empty
-            : $$""",
-              "default_model": "{{defaultModel}}"
-        """;
+        if (string.IsNullOrWhiteSpace(defaultModel))
+        {
+            return $$"""
+                {
+                  "services": [
+                    {
+                      "id": "{{id}}",
+                      "slug": "{{slug}}",
+                      "label": "{{label}}",
+                      "catalog_service_name": "{{label}}",
+                      "is_active": true,
+                      "credential_source": { "type": "personal" }
+                    }
+                  ]
+                }
+                """;
+        }
 
         return $$"""
             {
@@ -863,7 +875,8 @@ public sealed class UserConfigControllerSettingsTests
                   "label": "{{label}}",
                   "catalog_service_name": "{{label}}",
                   "is_active": true,
-                  "credential_source": { "type": "personal" }{{defaultModelJson}}
+                  "credential_source": { "type": "personal" },
+                  "default_model": "{{defaultModel}}"
                 }
               ]
             }


### PR DESCRIPTION
## Summary
- Parse `default_model`/`defaultModel` from NyxID `GET /api/v1/user-services` into the typed user-service inventory contract.
- Compose inventory-backed LLM route options so the existing `routeOptions[].modelCatalog.defaultModelId` field reflects the authoritative NyxID inventory default.
- Preserve unavailable catalog diagnostics without exposing defaults, and cover parser, catalog composition, and `/api/user-config/llm` response behavior.

## Test plan
- [x] `dotnet test /tmp/aevatar-issue-3230/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~NyxIdLlmServiceCatalogUserKeyMergeTests|FullyQualifiedName~UserConfigControllerSettingsTests"`
- [x] `git -C /tmp/aevatar-issue-3230 diff --check`
- [ ] `dotnet test /tmp/aevatar-issue-3230/test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~NyxIdApiAccessContractTests"` blocked: the project fails before the focused test with unrelated missing-reference errors across existing test files.
- [ ] `bash /tmp/aevatar-issue-3230/tools/ci/test_stability_guards.sh` blocked after initial guard checks by local Homebrew Python `pyexpat`/`libexpat` import failure.

Fixes #3230

🤖 Generated with [Claude Code](https://claude.com/claude-code)