### PR TITLE
Add scope workflow catalogue query

### DIFF
--- a/docs/canon/workflow-catalog-visibility.md
+++ b/docs/canon/workflow-catalog-visibility.md
@@ -58,3 +58,22 @@ Console Chat 的默认资源语义已经确定，不能再把公共模板目录�
 - Prompt 只负责选择正确工具，不承担鉴权。事实边界仍由 projection-backed query port、投影写入约束与 Host composition 强制保证。
 
 历史上已被错误物化进公共 catalog 的文档不在 query path 中修复。评估与清理必须走独立后台迁移，见 `docs/operations/2026-07-23-workflow-catalog-contamination-repair.md`。
+
+## Scope workflow catalogue query
+
+Console Workflow Activity vNext uses the scope-owned catalogue endpoint:
+
+`GET /api/scopes/{scopeId}/workflow-catalogue?view=all|drafts&query={text}&cursor={cursor}&take={take}`
+
+Contract:
+
+- `view=all` returns the deduplicated scope catalogue keyed by exact `workflowId`, preserving `hasDraftSource` and `hasCommittedSource` when both source read models contain the same workflow ID.
+- `view=drafts` returns only rows with an authoritative draft source, while still returning committed-source facts and capabilities when the same `workflowId` also has a committed workflow.
+- The backend applies scope authorization, view filtering, search, deterministic ordering, and cursor pagination in that order. Clients must not join draft/committed lists or filter an unbounded catalogue in memory.
+- Deterministic ordering is `updatedAtUtc DESC`, then `workflowId ASC` using ordinal comparison. `nextPageToken` is an opaque cursor token returned by the previous response.
+- Search trims and normalizes the query with Unicode FormKC. Empty, omitted, or whitespace-only `query` values are equivalent to no search filter and do not create a separate freshness domain.
+- Searchable fields are `name`, `description`, and `workflowId`. `name` and `description` use ordinal case-insensitive substring matching; `workflowId` supports exact or prefix matching only. Chinese and English text are both matched after the same normalization.
+- Query length after trimming/normalization is capped by the response `search.maximumQueryLength`; invalid cursor or overlong query returns `400`.
+- Rows expose typed capabilities for `open`, `activity`, `rename`, and `delete`. Unavailable actions carry a typed unavailable reason instead of requiring the client to infer from sources.
+- Rows keep `workflowId`, committed `actorId`, deployment/service IDs, and other identities separate. `workflowId` must not be reused as `memberId` or `publishedServiceId`.
+- `freshness.refreshWatermarkUtc` is the maximum source `UpdatedAt` observed from the materialized draft workspace and committed workflow read models used by the query. It is a refresh watermark, not a synthetic local `StateVersion++`.

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowCatalogueService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowCatalogueService.cs
@@ -1,0 +1,247 @@
+using System.Text;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application;
+
+public interface IAppScopedWorkflowCatalogueService
+{
+    Task<ScopeWorkflowCatalogueResponse> QueryAsync(
+        ScopeWorkflowCatalogueQuery query,
+        CancellationToken ct = default);
+}
+
+public sealed class AppScopedWorkflowCatalogueService : IAppScopedWorkflowCatalogueService
+{
+    private const int DefaultTake = 50;
+    private const int MaxTake = 100;
+    private const int MaxQueryLength = 128;
+
+    private static readonly ScopeWorkflowCatalogueSearchContract SearchContract = new(
+        ["name", "description", "workflowId"],
+        "Search normalizes text with Unicode FormKC and uses ordinal case-insensitive matching for name and description.",
+        "FormKC",
+        MaxQueryLength,
+        "An omitted, null, empty, or whitespace-only query is equivalent to no search filter.",
+        "workflowId participates only by exact match or ordinal case-insensitive prefix match.");
+
+    private readonly AppScopedWorkflowService _draftWorkflowService;
+    private readonly IScopeWorkflowQueryPort _committedWorkflowQueryPort;
+
+    public AppScopedWorkflowCatalogueService(
+        AppScopedWorkflowService draftWorkflowService,
+        IScopeWorkflowQueryPort committedWorkflowQueryPort)
+    {
+        _draftWorkflowService = draftWorkflowService ?? throw new ArgumentNullException(nameof(draftWorkflowService));
+        _committedWorkflowQueryPort = committedWorkflowQueryPort ?? throw new ArgumentNullException(nameof(committedWorkflowQueryPort));
+    }
+
+    public async Task<ScopeWorkflowCatalogueResponse> QueryAsync(
+        ScopeWorkflowCatalogueQuery query,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var scopeId = NormalizeRequired(query.ScopeId, nameof(query.ScopeId));
+        var normalizedSearch = NormalizeSearchQuery(query.Query);
+        var offset = ParseCursor(query.Cursor);
+        var take = NormalizeTake(query.Take);
+
+        var drafts = await _draftWorkflowService.ListDraftsAsync(scopeId, ct);
+        var committedWorkflows = await _committedWorkflowQueryPort.ListAsync(scopeId, ct);
+
+        var rows = BuildRows(scopeId, drafts, committedWorkflows)
+            .Where(row => query.View != ScopeWorkflowCatalogueView.Drafts || row.HasDraftSource)
+            .Where(row => Matches(row, normalizedSearch))
+            .OrderByDescending(static row => row.UpdatedAtUtc)
+            .ThenBy(static row => row.WorkflowId, StringComparer.Ordinal)
+            .ToList();
+
+        var page = rows.Skip(offset).Take(take).ToList();
+        var nextOffset = offset + page.Count;
+        var nextPageToken = nextOffset < rows.Count ? nextOffset.ToString(System.Globalization.CultureInfo.InvariantCulture) : null;
+        DateTimeOffset? watermark = rows.Count == 0 ? null : rows.Max(static row => row.SourceWatermarkUtc);
+
+        return new ScopeWorkflowCatalogueResponse(
+            page,
+            nextPageToken,
+            new ScopeWorkflowCatalogueFreshness(
+                watermark,
+                "Refresh watermark is the maximum source UpdatedAt observed across the materialized draft workspace and committed workflow read models used by this query; it is not a synthetic state version."),
+            SearchContract);
+    }
+
+    private static IReadOnlyList<ScopeWorkflowCatalogueRow> BuildRows(
+        string scopeId,
+        IReadOnlyList<WorkflowDraftSummary> drafts,
+        IReadOnlyList<ScopeWorkflowSummary> committedWorkflows)
+    {
+        var draftByWorkflowId = drafts
+            .GroupBy(static draft => draft.WorkflowId, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.OrderByDescending(static draft => draft.UpdatedAtUtc).First(),
+                StringComparer.Ordinal);
+        var committedByWorkflowId = committedWorkflows
+            .GroupBy(static workflow => workflow.WorkflowId, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.OrderByDescending(static workflow => workflow.UpdatedAt).First(),
+                StringComparer.Ordinal);
+
+        var workflowIds = new SortedSet<string>(draftByWorkflowId.Keys, StringComparer.Ordinal);
+        workflowIds.UnionWith(committedByWorkflowId.Keys);
+
+        var rows = new List<ScopeWorkflowCatalogueRow>(workflowIds.Count);
+        foreach (var workflowId in workflowIds)
+        {
+            draftByWorkflowId.TryGetValue(workflowId, out var draft);
+            committedByWorkflowId.TryGetValue(workflowId, out var committed);
+            rows.Add(BuildRow(scopeId, workflowId, draft, committed));
+        }
+
+        return rows;
+    }
+
+    private static ScopeWorkflowCatalogueRow BuildRow(
+        string scopeId,
+        string workflowId,
+        WorkflowDraftSummary? draft,
+        ScopeWorkflowSummary? committed)
+    {
+        var hasDraftSource = draft != null;
+        var hasCommittedSource = committed != null;
+        var updatedAtUtc = ResolveUpdatedAt(draft, committed);
+        var updatedAtSource = ResolveUpdatedAtSource(draft, committed);
+        var name = ResolveName(workflowId, draft, committed);
+        var description = draft?.Description ?? string.Empty;
+
+        return new ScopeWorkflowCatalogueRow(
+            scopeId,
+            workflowId,
+            name,
+            description,
+            hasDraftSource,
+            hasCommittedSource,
+            updatedAtUtc,
+            updatedAtSource,
+            BuildCapabilities(hasDraftSource, hasCommittedSource),
+            updatedAtUtc,
+            committed == null
+                ? null
+                : new ScopeWorkflowCatalogueCommittedFacts(
+                    committed.ServiceKey,
+                    committed.WorkflowName,
+                    committed.ActorId,
+                    committed.ActiveRevisionId,
+                    committed.DeploymentId,
+                    committed.DeploymentStatus));
+    }
+
+    private static ScopeWorkflowCatalogueRowCapabilities BuildCapabilities(bool hasDraftSource, bool hasCommittedSource) =>
+        new(
+            Open: new ScopeWorkflowCatalogueActionCapability(
+                hasDraftSource || hasCommittedSource,
+                hasDraftSource || hasCommittedSource ? null : "workflow_source_missing"),
+            Activity: new ScopeWorkflowCatalogueActionCapability(
+                hasCommittedSource,
+                hasCommittedSource ? null : "committed_source_missing"),
+            Rename: new ScopeWorkflowCatalogueActionCapability(
+                hasDraftSource,
+                hasDraftSource ? null : "draft_source_missing"),
+            Delete: new ScopeWorkflowCatalogueActionCapability(
+                hasDraftSource,
+                hasDraftSource ? null : "draft_source_missing"));
+
+    private static DateTimeOffset ResolveUpdatedAt(WorkflowDraftSummary? draft, ScopeWorkflowSummary? committed)
+    {
+        if (draft == null)
+            return committed!.UpdatedAt;
+        if (committed == null)
+            return draft.UpdatedAtUtc;
+
+        return draft.UpdatedAtUtc >= committed.UpdatedAt ? draft.UpdatedAtUtc : committed.UpdatedAt;
+    }
+
+    private static string ResolveUpdatedAtSource(WorkflowDraftSummary? draft, ScopeWorkflowSummary? committed)
+    {
+        if (draft == null)
+            return "committed";
+        if (committed == null)
+            return "draft";
+
+        return draft.UpdatedAtUtc >= committed.UpdatedAt ? "draft" : "committed";
+    }
+
+    private static string ResolveName(string workflowId, WorkflowDraftSummary? draft, ScopeWorkflowSummary? committed)
+    {
+        if (!string.IsNullOrWhiteSpace(draft?.Name))
+            return draft.Name.Trim();
+        if (!string.IsNullOrWhiteSpace(committed?.DisplayName))
+            return committed.DisplayName.Trim();
+        if (!string.IsNullOrWhiteSpace(committed?.WorkflowName))
+            return committed.WorkflowName.Trim();
+
+        return workflowId;
+    }
+
+    private static bool Matches(ScopeWorkflowCatalogueRow row, string normalizedSearch)
+    {
+        if (normalizedSearch.Length == 0)
+            return true;
+
+        return ContainsNormalized(row.Name, normalizedSearch) ||
+               ContainsNormalized(row.Description, normalizedSearch) ||
+               MatchesWorkflowId(row.WorkflowId, normalizedSearch);
+    }
+
+    private static bool ContainsNormalized(string value, string normalizedSearch) =>
+        NormalizeText(value).Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase);
+
+    private static bool MatchesWorkflowId(string workflowId, string normalizedSearch)
+    {
+        var normalizedWorkflowId = NormalizeText(workflowId);
+        return string.Equals(normalizedWorkflowId, normalizedSearch, StringComparison.OrdinalIgnoreCase) ||
+               normalizedWorkflowId.StartsWith(normalizedSearch, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeSearchQuery(string? query)
+    {
+        var normalized = NormalizeText(query ?? string.Empty).Trim();
+        if (normalized.Length > MaxQueryLength)
+            throw new InvalidOperationException($"query must be {MaxQueryLength} characters or fewer after trimming and normalization.");
+
+        return normalized;
+    }
+
+    private static string NormalizeText(string value) => value.Normalize(NormalizationForm.FormKC);
+
+    private static string NormalizeRequired(string value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+
+        return normalized;
+    }
+
+    private static int NormalizeTake(int take)
+    {
+        if (take <= 0)
+            return DefaultTake;
+
+        return Math.Min(take, MaxTake);
+    }
+
+    private static int ParseCursor(string? cursor)
+    {
+        if (string.IsNullOrWhiteSpace(cursor))
+            return 0;
+
+        if (!int.TryParse(cursor.Trim(), System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var offset) || offset < 0)
+            throw new InvalidOperationException("cursor must be a non-negative catalogue offset token returned by the previous response.");
+
+        return offset;
+    }
+}

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowCatalogueService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowCatalogueService.cs
@@ -27,14 +27,14 @@ public sealed class AppScopedWorkflowCatalogueService : IAppScopedWorkflowCatalo
         "workflowId participates only by exact match or ordinal case-insensitive prefix match.");
 
     private readonly AppScopedWorkflowService _draftWorkflowService;
-    private readonly IScopeWorkflowQueryPort _committedWorkflowQueryPort;
+    private readonly IScopeWorkflowCatalogueCommittedSourcePort _committedWorkflowSourcePort;
 
     public AppScopedWorkflowCatalogueService(
         AppScopedWorkflowService draftWorkflowService,
-        IScopeWorkflowQueryPort committedWorkflowQueryPort)
+        IScopeWorkflowCatalogueCommittedSourcePort committedWorkflowSourcePort)
     {
         _draftWorkflowService = draftWorkflowService ?? throw new ArgumentNullException(nameof(draftWorkflowService));
-        _committedWorkflowQueryPort = committedWorkflowQueryPort ?? throw new ArgumentNullException(nameof(committedWorkflowQueryPort));
+        _committedWorkflowSourcePort = committedWorkflowSourcePort ?? throw new ArgumentNullException(nameof(committedWorkflowSourcePort));
     }
 
     public async Task<ScopeWorkflowCatalogueResponse> QueryAsync(
@@ -49,9 +49,11 @@ public sealed class AppScopedWorkflowCatalogueService : IAppScopedWorkflowCatalo
         var take = NormalizeTake(query.Take);
 
         var drafts = await _draftWorkflowService.ListDraftsAsync(scopeId, ct);
-        var committedWorkflows = await _committedWorkflowQueryPort.ListAsync(scopeId, ct);
+        var committedWorkflows = await _committedWorkflowSourcePort.ListCatalogueAsync(scopeId, ct);
+        var sourceRows = BuildRows(scopeId, drafts, committedWorkflows);
+        DateTimeOffset? watermark = sourceRows.Count == 0 ? null : sourceRows.Max(static row => row.SourceWatermarkUtc);
 
-        var rows = BuildRows(scopeId, drafts, committedWorkflows)
+        var rows = sourceRows
             .Where(row => query.View != ScopeWorkflowCatalogueView.Drafts || row.HasDraftSource)
             .Where(row => Matches(row, normalizedSearch))
             .OrderByDescending(static row => row.UpdatedAtUtc)
@@ -61,7 +63,6 @@ public sealed class AppScopedWorkflowCatalogueService : IAppScopedWorkflowCatalo
         var page = rows.Skip(offset).Take(take).ToList();
         var nextOffset = offset + page.Count;
         var nextPageToken = nextOffset < rows.Count ? nextOffset.ToString(System.Globalization.CultureInfo.InvariantCulture) : null;
-        DateTimeOffset? watermark = rows.Count == 0 ? null : rows.Max(static row => row.SourceWatermarkUtc);
 
         return new ScopeWorkflowCatalogueResponse(
             page,

--- a/src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs
@@ -70,6 +70,68 @@ public sealed record WorkflowCommittedResponse(
     IReadOnlyList<ValidationFinding> Findings,
     DateTimeOffset? UpdatedAtUtc = null);
 
+public sealed record ScopeWorkflowCatalogueQuery(
+    string ScopeId,
+    ScopeWorkflowCatalogueView View = ScopeWorkflowCatalogueView.All,
+    string? Query = null,
+    string? Cursor = null,
+    int Take = 50);
+
+public enum ScopeWorkflowCatalogueView
+{
+    All = 0,
+    Drafts = 1,
+}
+
+public sealed record ScopeWorkflowCatalogueResponse(
+    IReadOnlyList<ScopeWorkflowCatalogueRow> Items,
+    string? NextPageToken,
+    ScopeWorkflowCatalogueFreshness Freshness,
+    ScopeWorkflowCatalogueSearchContract Search);
+
+public sealed record ScopeWorkflowCatalogueRow(
+    string ScopeId,
+    string WorkflowId,
+    string Name,
+    string Description,
+    bool HasDraftSource,
+    bool HasCommittedSource,
+    DateTimeOffset UpdatedAtUtc,
+    string UpdatedAtSource,
+    ScopeWorkflowCatalogueRowCapabilities Capabilities,
+    DateTimeOffset SourceWatermarkUtc,
+    ScopeWorkflowCatalogueCommittedFacts? Committed = null);
+
+public sealed record ScopeWorkflowCatalogueCommittedFacts(
+    string ServiceKey,
+    string WorkflowName,
+    string ActorId,
+    string ActiveRevisionId,
+    string DeploymentId,
+    string DeploymentStatus);
+
+public sealed record ScopeWorkflowCatalogueRowCapabilities(
+    ScopeWorkflowCatalogueActionCapability Open,
+    ScopeWorkflowCatalogueActionCapability Activity,
+    ScopeWorkflowCatalogueActionCapability Rename,
+    ScopeWorkflowCatalogueActionCapability Delete);
+
+public sealed record ScopeWorkflowCatalogueActionCapability(
+    bool Available,
+    string? UnavailableReason = null);
+
+public sealed record ScopeWorkflowCatalogueFreshness(
+    DateTimeOffset? RefreshWatermarkUtc,
+    string SourceVersionSemantics);
+
+public sealed record ScopeWorkflowCatalogueSearchContract(
+    IReadOnlyList<string> SearchableFields,
+    string CaseSemantics,
+    string UnicodeNormalization,
+    int MaximumQueryLength,
+    string EmptyQuerySemantics,
+    string WorkflowIdSemantics);
+
 public sealed record SaveWorkflowDraftRequest(
     string DirectoryId,
     string WorkflowName,

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ internal static class StudioHostingServiceCollectionExtensions
             sp.GetService<IStudioWorkspaceQueryPort>(),
             sp.GetService<IStudioWorkspaceCommandPort>(),
             sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<AppScopedWorkflowService>>()));
+        services.AddSingleton<IAppScopedWorkflowCatalogueService, AppScopedWorkflowCatalogueService>();
         services.TryAddSingleton<
             IStudioMemberWorkflowDraftProvisioningPort,
             StudioMemberWorkflowDraftProvisioningService>();

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowQueryPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowQueryPort.cs
@@ -21,3 +21,10 @@ public interface IScopeWorkflowQueryPort
         string actorId,
         CancellationToken ct = default);
 }
+
+public interface IScopeWorkflowCatalogueCommittedSourcePort
+{
+    Task<IReadOnlyList<ScopeWorkflowSummary>> ListCatalogueAsync(
+        string scopeId,
+        CancellationToken ct = default);
+}

--- a/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowQueryApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowQueryApplicationService.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Aevatar.GAgentService.Application.Workflows;
 
-public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPort
+public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPort, IScopeWorkflowCatalogueCommittedSourcePort
 {
     private readonly IServiceLifecycleQueryPort _serviceLifecycleQueryPort;
     private readonly IWorkflowActorBindingReader _workflowActorBindingReader;
@@ -32,11 +32,28 @@ public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPo
         CancellationToken ct = default)
     {
         var normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(scopeId, nameof(scopeId));
+        return await ListCoreAsync(normalizedScopeId, _options.ListTake, applyResultTake: true, ct);
+    }
+
+    public async Task<IReadOnlyList<ScopeWorkflowSummary>> ListCatalogueAsync(
+        string scopeId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(scopeId, nameof(scopeId));
+        return await ListCoreAsync(normalizedScopeId, int.MaxValue, applyResultTake: false, ct);
+    }
+
+    private async Task<IReadOnlyList<ScopeWorkflowSummary>> ListCoreAsync(
+        string normalizedScopeId,
+        int sourceTake,
+        bool applyResultTake,
+        CancellationToken ct)
+    {
         var services = await _serviceLifecycleQueryPort.ListServicesAsync(
             normalizedScopeId,
             ScopeWorkflowCapabilityOptions.NormalizeRequired(_options.ServiceAppId, nameof(_options.ServiceAppId)),
             ScopeWorkflowCapabilityOptions.NormalizeRequired(_options.ServiceNamespace, nameof(_options.ServiceNamespace)),
-            _options.ListTake,
+            sourceTake,
             ct);
 
         var summaries = new List<ScopeWorkflowSummary>(services.Count);
@@ -61,7 +78,7 @@ public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPo
 
         foreach (var source in _descriptorSources)
         {
-            var descriptors = await source.ListAsync(normalizedScopeId, _options.ListTake, ct);
+            var descriptors = await source.ListAsync(normalizedScopeId, sourceTake, ct);
             foreach (var descriptor in descriptors)
             {
                 var normalizedDescriptor = NormalizeDescriptor(normalizedScopeId, descriptor);
@@ -87,7 +104,7 @@ public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPo
             }
         }
 
-        return summaries
+        var workflows = summaries
             .GroupBy(static workflow => workflow.WorkflowId, StringComparer.Ordinal)
             .Where(static group => group
                 .Select(workflow => workflow.ServiceKey)
@@ -95,9 +112,9 @@ public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPo
                 .Take(2)
                 .Count() == 1)
             .Select(static group => group.OrderByDescending(workflow => workflow.UpdatedAt).First())
-            .OrderByDescending(static workflow => workflow.UpdatedAt)
-            .Take(_options.ListTake)
-            .ToArray();
+            .OrderByDescending(static workflow => workflow.UpdatedAt);
+
+        return (applyResultTake ? workflows.Take(_options.ListTake) : workflows).ToArray();
     }
 
     public async Task<ScopeWorkflowLookupResult> LookupByWorkflowIdAsync(

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -190,6 +190,7 @@ public static class ServiceCollectionExtensions
             .Bind(configuration.GetSection(ScopeWorkflowCapabilityOptions.SectionName));
         services.TryAddSingleton<ScopeWorkflowQueryApplicationService>();
         services.TryAddSingleton<IScopeWorkflowQueryPort>(sp => sp.GetRequiredService<ScopeWorkflowQueryApplicationService>());
+        services.TryAddSingleton<IScopeWorkflowCatalogueCommittedSourcePort>(sp => sp.GetRequiredService<ScopeWorkflowQueryApplicationService>());
         services.TryAddSingleton<IScopeWorkflowCommandPort, ScopeWorkflowCommandApplicationService>();
         services.TryAddSingleton<IScopeWorkflowSaveAndBindPort, ScopeWorkflowSaveAndBindApplicationService>();
         services.Replace(ServiceDescriptor.Singleton(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -45,9 +45,13 @@ public static class ScopeWorkflowEndpoints
         group.MapGet("/{scopeId}/workflows", HandleListWorkflowsAsync)
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);
-        group.MapGet("/{scopeId}/workflow-catalogue", HandleQueryWorkflowCatalogueAsync)
-            .Produces<ScopeWorkflowCatalogueResponse>(StatusCodes.Status200OK)
-            .Produces(StatusCodes.Status400BadRequest);
+        if (app.ServiceProvider.GetService<IAppScopedWorkflowCatalogueService>() != null)
+        {
+            group.MapGet("/{scopeId}/workflow-catalogue", HandleQueryWorkflowCatalogueAsync)
+                .Produces<ScopeWorkflowCatalogueResponse>(StatusCodes.Status200OK)
+                .Produces(StatusCodes.Status400BadRequest);
+        }
+
         group.MapGet("/{scopeId}/workflows/{workflowId}", HandleGetWorkflowDetailAsync)
             .Produces<ScopeWorkflowDetail>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
@@ -97,7 +101,7 @@ public static class ScopeWorkflowEndpoints
         string? view,
         string? query,
         string? cursor,
-        int take,
+        int? take,
         [FromServices] IAppScopedWorkflowCatalogueService catalogueService,
         CancellationToken ct)
         => await HandleQueryWorkflowCatalogueAsyncCore(http, scopeId, view, query, cursor, take, catalogueService, ct);
@@ -407,7 +411,7 @@ public static class ScopeWorkflowEndpoints
         string? view,
         string? query,
         string? cursor,
-        int take,
+        int? take,
         IAppScopedWorkflowCatalogueService catalogueService,
         CancellationToken ct)
     {
@@ -426,7 +430,7 @@ public static class ScopeWorkflowEndpoints
             }
 
             return Results.Ok(await catalogueService.QueryAsync(
-                new ScopeWorkflowCatalogueQuery(scopeId, catalogueView, query, cursor, take),
+                new ScopeWorkflowCatalogueQuery(scopeId, catalogueView, query, cursor, take ?? 0),
                 ct));
         }
         catch (InvalidOperationException ex)

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -9,7 +9,9 @@ using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Workflows;
 using Aevatar.GAgentService.Hosting.Sse;
+using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.ExternalCapabilities;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -42,6 +44,9 @@ public static class ScopeWorkflowEndpoints
             .Produces(StatusCodes.Status400BadRequest);
         group.MapGet("/{scopeId}/workflows", HandleListWorkflowsAsync)
             .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest);
+        group.MapGet("/{scopeId}/workflow-catalogue", HandleQueryWorkflowCatalogueAsync)
+            .Produces<ScopeWorkflowCatalogueResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);
         group.MapGet("/{scopeId}/workflows/{workflowId}", HandleGetWorkflowDetailAsync)
             .Produces<ScopeWorkflowDetail>(StatusCodes.Status200OK)
@@ -85,6 +90,17 @@ public static class ScopeWorkflowEndpoints
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
         => await HandleListWorkflowsAsyncCore(http, scopeId, includeSource, workflowQueryPort, workflowActorBindingReader, revisionCatalogReader, options, ct);
+
+    internal static async Task<IResult> HandleQueryWorkflowCatalogueAsync(
+        HttpContext http,
+        string scopeId,
+        string? view,
+        string? query,
+        string? cursor,
+        int take,
+        [FromServices] IAppScopedWorkflowCatalogueService catalogueService,
+        CancellationToken ct)
+        => await HandleQueryWorkflowCatalogueAsyncCore(http, scopeId, view, query, cursor, take, catalogueService, ct);
 
     internal static async Task<IResult> HandleGetWorkflowDetailAsync(
         HttpContext http,
@@ -380,6 +396,44 @@ public static class ScopeWorkflowEndpoints
             return Results.BadRequest(new
             {
                 code = "INVALID_USER_WORKFLOW_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleQueryWorkflowCatalogueAsyncCore(
+        HttpContext http,
+        string scopeId,
+        string? view,
+        string? query,
+        string? cursor,
+        int take,
+        IAppScopedWorkflowCatalogueService catalogueService,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (!TryParseCatalogueView(view, out var catalogueView))
+            {
+                return Results.BadRequest(new
+                {
+                    code = "INVALID_WORKFLOW_CATALOGUE_REQUEST",
+                    message = "view must be either 'all' or 'drafts'.",
+                });
+            }
+
+            return Results.Ok(await catalogueService.QueryAsync(
+                new ScopeWorkflowCatalogueQuery(scopeId, catalogueView, query, cursor, take),
+                ct));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_WORKFLOW_CATALOGUE_REQUEST",
                 message = ex.Message,
             });
         }
@@ -788,6 +842,26 @@ public static class ScopeWorkflowEndpoints
                 "USER_WORKFLOW_NOT_READY",
                 $"Workflow '{workflowId}' is not ready to run for scope '{scopeId}'."),
         };
+
+    internal static bool TryParseCatalogueView(
+        string? rawValue,
+        out ScopeWorkflowCatalogueView view)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue) || string.Equals(rawValue, "all", StringComparison.OrdinalIgnoreCase))
+        {
+            view = ScopeWorkflowCatalogueView.All;
+            return true;
+        }
+
+        if (string.Equals(rawValue, "drafts", StringComparison.OrdinalIgnoreCase))
+        {
+            view = ScopeWorkflowCatalogueView.Drafts;
+            return true;
+        }
+
+        view = ScopeWorkflowCatalogueView.All;
+        return false;
+    }
 
     internal static bool TryParseEventFormat(
         string? rawValue,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -11,7 +11,9 @@ using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Endpoints;
+using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Workflow.Abstractions;
@@ -534,6 +536,67 @@ public sealed class ScopeWorkflowEndpointsTests
         http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         body.Should().Contain("\"workflowId\":\"approval\"");
         body.Should().Contain("\"source\":{\"workflowYaml\":\"name: approval\\nsteps: []\\n\"");
+    }
+
+    [Fact]
+    public async Task HandleQueryWorkflowCatalogueAsync_ShouldDelegateServerSideFilterQuery()
+    {
+        var http = CreateHttpContext();
+        var catalogueService = new RecordingWorkflowCatalogueService
+        {
+            Response = new ScopeWorkflowCatalogueResponse(
+                [
+                    new ScopeWorkflowCatalogueRow(
+                        "user-1",
+                        "wf-alpha",
+                        "审批 Workflow",
+                        "draft description",
+                        true,
+                        false,
+                        DateTimeOffset.Parse("2026-08-04T00:00:00Z"),
+                        "draft",
+                        new ScopeWorkflowCatalogueRowCapabilities(
+                            new ScopeWorkflowCatalogueActionCapability(true),
+                            new ScopeWorkflowCatalogueActionCapability(false, "No committed workflow source."),
+                            new ScopeWorkflowCatalogueActionCapability(true),
+                            new ScopeWorkflowCatalogueActionCapability(true)),
+                        DateTimeOffset.Parse("2026-08-04T00:00:00Z")),
+                ],
+                "next-token",
+                new ScopeWorkflowCatalogueFreshness(
+                    DateTimeOffset.Parse("2026-08-04T00:00:00Z"),
+                    "max_source_updated_at_utc"),
+                new ScopeWorkflowCatalogueSearchContract(
+                    ["workflowId", "name", "description"],
+                    "ordinal_ignore_case",
+                    "FormKC",
+                    128,
+                    "matches_all_after_view_filter",
+                    "exact_or_prefix")),
+        };
+
+        var result = await ScopeWorkflowEndpoints.HandleQueryWorkflowCatalogueAsync(
+            http,
+            "user-1",
+            view: "drafts",
+            query: "审批",
+            cursor: "2",
+            take: 25,
+            catalogueService,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        catalogueService.Query.Should().NotBeNull();
+        catalogueService.Query!.ScopeId.Should().Be("user-1");
+        catalogueService.Query.View.Should().Be(ScopeWorkflowCatalogueView.Drafts);
+        catalogueService.Query.Query.Should().Be("审批");
+        catalogueService.Query.Cursor.Should().Be("2");
+        catalogueService.Query.Take.Should().Be(25);
+        body.Should().Contain("\"workflowId\":\"wf-alpha\"");
+        body.Should().Contain("\"nextPageToken\":\"next-token\"");
     }
 
     [Fact]
@@ -1395,6 +1458,31 @@ public sealed class ScopeWorkflowEndpointsTests
         public Task<UserConfig> GetAsync(UserConfigResourceKey resource, CancellationToken ct = default) => GetAsync(ct);
     }
 
+    private sealed class RecordingWorkflowCatalogueService : IAppScopedWorkflowCatalogueService
+    {
+        public ScopeWorkflowCatalogueQuery? Query { get; private set; }
+
+        public ScopeWorkflowCatalogueResponse Response { get; init; } = new(
+            [],
+            null,
+            new ScopeWorkflowCatalogueFreshness(null, "max_source_updated_at_utc"),
+            new ScopeWorkflowCatalogueSearchContract(
+                ["workflowId", "name", "description"],
+                "ordinal_ignore_case",
+                "FormKC",
+                128,
+                "matches_all_after_view_filter",
+                "exact_or_prefix"));
+
+        public Task<ScopeWorkflowCatalogueResponse> QueryAsync(
+            ScopeWorkflowCatalogueQuery query,
+            CancellationToken ct = default)
+        {
+            Query = query;
+            return Task.FromResult(Response);
+        }
+    }
+
     private sealed class ThrowingUserConfigStore : IUserConfigQueryPort
     {
         public Task<UserConfig> GetAsync(CancellationToken ct = default) => throw new HttpRequestException("config backend unavailable");
@@ -1480,7 +1568,7 @@ public sealed class ScopeWorkflowEndpointsTests
         public Dictionary<string, WorkflowActorBinding> Bindings { get; } = new(StringComparer.Ordinal);
 
         public Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default) =>
-            Task.FromResult(Bindings.TryGetValue(actorId, out var binding)
+            Task.FromResult<WorkflowActorBinding?>(Bindings.TryGetValue(actorId, out var binding)
                 ? binding
                 : new WorkflowActorBinding(
                     WorkflowActorKind.Definition,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -600,6 +600,89 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleQueryWorkflowCatalogueAsync_ShouldUseDefaultTakeWhenQueryOmitsTake()
+    {
+        var http = CreateHttpContext();
+        var catalogueService = new RecordingWorkflowCatalogueService();
+
+        var result = await ScopeWorkflowEndpoints.HandleQueryWorkflowCatalogueAsync(
+            http,
+            "user-1",
+            view: null,
+            query: null,
+            cursor: null,
+            take: null,
+            catalogueService,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        catalogueService.Query.Should().NotBeNull();
+        catalogueService.Query!.Take.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ListCatalogueAsync_ShouldRequestUncappedCommittedSourceRows()
+    {
+        var queryPort = new FakeServiceLifecycleQueryPort
+        {
+            ListServicesResult =
+            [
+                new ServiceCatalogSnapshot(
+                    "tenant-a:workflow-app:user:token:approval",
+                    "tenant-a",
+                    "workflow-app",
+                    "user:user-1-token",
+                    "approval",
+                    "Approval",
+                    "rev-1",
+                    "rev-1",
+                    "dep-1",
+                    "definition-actor-1",
+                    "active",
+                    [],
+                    [],
+                    DateTimeOffset.Parse("2026-08-01T00:00:00Z")),
+                new ServiceCatalogSnapshot(
+                    "tenant-a:workflow-app:user:token:billing",
+                    "tenant-a",
+                    "workflow-app",
+                    "user:user-1-token",
+                    "billing",
+                    "Billing",
+                    "rev-2",
+                    "rev-2",
+                    "dep-2",
+                    "definition-actor-2",
+                    "active",
+                    [],
+                    [],
+                    DateTimeOffset.Parse("2026-08-02T00:00:00Z")),
+            ],
+        };
+        var service = new ScopeWorkflowQueryApplicationService(
+            queryPort,
+            new FakeWorkflowActorBindingReader(),
+            Options.Create(new ScopeWorkflowCapabilityOptions
+            {
+                ServiceAppId = "default",
+                ServiceNamespace = "default",
+                DefinitionActorIdPrefix = "scope-workflow",
+                ListTake = 1,
+            }));
+
+        var legacyList = await service.ListAsync("user-1", CancellationToken.None);
+        queryPort.LastListRequest!.Take.Should().Be(1);
+        legacyList.Should().ContainSingle();
+
+        var catalogueList = await service.ListCatalogueAsync("user-1", CancellationToken.None);
+
+        queryPort.LastListRequest!.Take.Should().Be(int.MaxValue);
+        catalogueList.Select(static item => item.WorkflowId).Should().Equal("billing", "approval");
+    }
+
+    [Fact]
     public async Task HandleRunWorkflowStreamAsync_ShouldDelegateToWorkflowChatPipeline_WhenOwnershipMatches()
     {
         var queryPort = new FakeServiceLifecycleQueryPort

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowCatalogueServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowCatalogueServiceTests.cs
@@ -1,0 +1,252 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.Studio.Application;
+using Aevatar.Studio.Application.Studio;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Studio.Tests.Shared;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class AppScopedWorkflowCatalogueServiceTests
+{
+    private const string ScopeId = "scope-alpha";
+
+    [Fact]
+    public async Task QueryAsync_ShouldMergeDraftOnlyCommittedOnlyAndOverlappingRowsByWorkflowId()
+    {
+        var service = CreateService(
+            [
+                Draft("wf-alpha", "Draft Alpha", "draft alpha description", DateTimeOffset.Parse("2026-08-01T00:00:00Z")),
+                Draft("wf-overlap", "Draft Overlap", "draft overlap description", DateTimeOffset.Parse("2026-08-03T00:00:00Z")),
+            ],
+            [
+                Committed("wf-beta", "Committed Beta", "m-beta", "svc-beta", DateTimeOffset.Parse("2026-08-02T00:00:00Z")),
+                Committed("wf-overlap", "Committed Overlap", "m-overlap", "svc-overlap", DateTimeOffset.Parse("2026-08-04T00:00:00Z")),
+            ]);
+
+        var response = await service.QueryAsync(new ScopeWorkflowCatalogueQuery(ScopeId));
+
+        response.Items.Select(static item => item.WorkflowId).Should().Equal("wf-overlap", "wf-beta", "wf-alpha");
+        var overlap = response.Items[0];
+        overlap.HasDraftSource.Should().BeTrue();
+        overlap.HasCommittedSource.Should().BeTrue();
+        overlap.Name.Should().Be("Draft Overlap");
+        overlap.Description.Should().Be("draft overlap description");
+        overlap.UpdatedAtSource.Should().Be("committed");
+        overlap.Capabilities.Open.Available.Should().BeTrue();
+        overlap.Capabilities.Activity.Available.Should().BeTrue();
+        overlap.Capabilities.Rename.Available.Should().BeTrue();
+        overlap.Capabilities.Delete.Available.Should().BeTrue();
+        overlap.Committed.Should().NotBeNull();
+        overlap.Committed!.ActorId.Should().Be("m-overlap");
+        overlap.Committed.DeploymentId.Should().Be("svc-overlap");
+        response.Freshness.RefreshWatermarkUtc.Should().Be(DateTimeOffset.Parse("2026-08-04T00:00:00Z"));
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithDraftView_ShouldReturnDraftSubsetWithCommittedFacts()
+    {
+        var service = CreateService(
+            [
+                Draft("wf-alpha", "Draft Alpha", "draft alpha description", DateTimeOffset.Parse("2026-08-01T00:00:00Z")),
+                Draft("wf-overlap", "Draft Overlap", "draft overlap description", DateTimeOffset.Parse("2026-08-03T00:00:00Z")),
+            ],
+            [
+                Committed("wf-beta", "Committed Beta", "m-beta", "svc-beta", DateTimeOffset.Parse("2026-08-02T00:00:00Z")),
+                Committed("wf-overlap", "Committed Overlap", "m-overlap", "svc-overlap", DateTimeOffset.Parse("2026-08-04T00:00:00Z")),
+            ]);
+
+        var response = await service.QueryAsync(new ScopeWorkflowCatalogueQuery(
+            ScopeId,
+            ScopeWorkflowCatalogueView.Drafts));
+
+        response.Items.Select(static item => item.WorkflowId).Should().Equal("wf-overlap", "wf-alpha");
+        response.Items[0].HasCommittedSource.Should().BeTrue();
+        response.Items[0].Capabilities.Activity.Available.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task QueryAsync_ShouldSearchNameDescriptionChineseTextAndWorkflowIdPrefix()
+    {
+        var service = CreateService(
+            [
+                Draft("wf-alpha", "Alpha Draft", "Handles 审批 flow", DateTimeOffset.Parse("2026-08-01T00:00:00Z")),
+                Draft("wf-gamma", "Gamma Draft", "Other", DateTimeOffset.Parse("2026-08-02T00:00:00Z")),
+            ],
+            [
+                Committed("wf-beta", "Billing Review", "m-beta", "svc-beta", DateTimeOffset.Parse("2026-08-03T00:00:00Z")),
+            ]);
+
+        (await service.QueryAsync(new ScopeWorkflowCatalogueQuery(ScopeId, Query: "alpha")))
+            .Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-alpha");
+        (await service.QueryAsync(new ScopeWorkflowCatalogueQuery(ScopeId, Query: "审批")))
+            .Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-alpha");
+        (await service.QueryAsync(new ScopeWorkflowCatalogueQuery(ScopeId, Query: "WF-B")))
+            .Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-beta");
+        (await service.QueryAsync(new ScopeWorkflowCatalogueQuery(ScopeId, Query: "missing")))
+            .Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task QueryAsync_ShouldSearchBeforeCursorPagination()
+    {
+        var service = CreateService(
+            [
+                Draft("wf-alpha", "Searchable Alpha", "same", DateTimeOffset.Parse("2026-08-01T00:00:00Z")),
+                Draft("wf-beta", "Searchable Beta", "same", DateTimeOffset.Parse("2026-08-02T00:00:00Z")),
+                Draft("wf-gamma", "Other", "same", DateTimeOffset.Parse("2026-08-03T00:00:00Z")),
+            ],
+            []);
+
+        var firstPage = await service.QueryAsync(new ScopeWorkflowCatalogueQuery(
+            ScopeId,
+            Query: "searchable",
+            Take: 1));
+        var secondPage = await service.QueryAsync(new ScopeWorkflowCatalogueQuery(
+            ScopeId,
+            Query: "searchable",
+            Cursor: firstPage.NextPageToken,
+            Take: 1));
+
+        firstPage.Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-beta");
+        firstPage.NextPageToken.Should().Be("1");
+        secondPage.Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-alpha");
+        secondPage.NextPageToken.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithDraftViewAndSearch_ShouldSearchOnlyDraftSubset()
+    {
+        var service = CreateService(
+            [Draft("wf-alpha", "Draft Alpha", "", DateTimeOffset.Parse("2026-08-01T00:00:00Z"))],
+            [Committed("wf-beta", "Draft Alpha", "m-beta", "svc-beta", DateTimeOffset.Parse("2026-08-02T00:00:00Z"))]);
+
+        var response = await service.QueryAsync(new ScopeWorkflowCatalogueQuery(
+            ScopeId,
+            ScopeWorkflowCatalogueView.Drafts,
+            Query: "Draft Alpha"));
+
+        response.Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-alpha");
+    }
+
+    private static AppScopedWorkflowCatalogueService CreateService(
+        IReadOnlyList<StudioWorkflowDraftRecord> drafts,
+        IReadOnlyList<ScopeWorkflowSummary> committedWorkflows)
+    {
+        var workspacePort = new RecordingStudioWorkspacePorts(drafts.Select(static draft => new ScopedDraft(ScopeId, draft)));
+        var draftService = new AppScopedWorkflowService(
+            new StubWorkflowYamlDocumentService(),
+            new StubWorkflowDefinitionParser(),
+            workspacePort,
+            workspaceCommandPort: null);
+        return new AppScopedWorkflowCatalogueService(
+            draftService,
+            new StubScopeWorkflowQueryPort(committedWorkflows));
+    }
+
+    private static StudioWorkflowDraftRecord Draft(
+        string workflowId,
+        string name,
+        string description,
+        DateTimeOffset updatedAtUtc) =>
+        new(
+            workflowId,
+            name,
+            $"{workflowId}.yaml",
+            $"scope://{ScopeId}/{workflowId}.yaml",
+            $"scope:{ScopeId}",
+            ScopeId,
+            $"name: {name}\ndescription: {description}\nsteps: []\n",
+            Layout: null,
+            updatedAtUtc,
+            updatedAtUtc,
+            1);
+
+    private static ScopeWorkflowSummary Committed(
+        string workflowId,
+        string displayName,
+        string memberId,
+        string publishedServiceId,
+        DateTimeOffset updatedAtUtc) =>
+        new(
+            ScopeId,
+            workflowId,
+            displayName,
+            ServiceKeys.Build(ScopeId, "workflow-app", "user:scope-alpha-token", publishedServiceId),
+            displayName,
+            memberId,
+            "rev-alpha",
+            publishedServiceId,
+            ServiceDeploymentStatus.Active.ToString(),
+            updatedAtUtc);
+
+    private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
+    {
+        public WorkflowParseResult Parse(string yaml)
+        {
+            var document = new WorkflowDocument
+            {
+                Name = ReadScalar(yaml, "name") ?? "workflow",
+                Description = ReadScalar(yaml, "description") ?? string.Empty,
+            };
+            return new WorkflowParseResult(document, []);
+        }
+
+        public string Serialize(WorkflowDocument document) =>
+            $"name: {document.Name}\ndescription: {document.Description}\nsteps: []\n";
+
+        private static string? ReadScalar(string yaml, string key)
+        {
+            foreach (var line in yaml.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                var prefix = $"{key}:";
+                if (trimmed.StartsWith(prefix, StringComparison.Ordinal))
+                    return trimmed[prefix.Length..].Trim();
+            }
+
+            return null;
+        }
+    }
+
+    private sealed class StubWorkflowDefinitionParser : IWorkflowDefinitionParser
+    {
+        public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
+            string workflowYaml,
+            CancellationToken ct = default) =>
+            Task.FromResult(WorkflowYamlParseResult.Success("workflow"));
+
+        public Task<WorkflowInlineYamlBundleParseResult> ParseInlineWorkflowBundleAsync(
+            IReadOnlyList<WorkflowChatInlineYamlDocument> inlineWorkflowDocuments,
+            CancellationToken ct = default) =>
+            Task.FromResult(WorkflowInlineYamlBundleParseResult.Success(
+                "workflow",
+                string.Empty,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+    }
+
+    private sealed class StubScopeWorkflowQueryPort(IReadOnlyList<ScopeWorkflowSummary> workflows) : IScopeWorkflowQueryPort
+    {
+        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default)
+        {
+            scopeId.Should().Be(ScopeId);
+            return Task.FromResult(workflows);
+        }
+
+        public Task<ScopeWorkflowLookupResult> LookupByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(string scopeId, string actorId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowCatalogueServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowCatalogueServiceTests.cs
@@ -136,6 +136,22 @@ public sealed class AppScopedWorkflowCatalogueServiceTests
         response.Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-alpha");
     }
 
+    [Fact]
+    public async Task QueryAsync_ShouldReportSourceWatermarkBeforeViewAndSearchFiltering()
+    {
+        var service = CreateService(
+            [Draft("wf-alpha", "Draft Alpha", "", DateTimeOffset.Parse("2026-08-01T00:00:00Z"))],
+            [Committed("wf-beta", "Committed Beta", "m-beta", "svc-beta", DateTimeOffset.Parse("2026-08-05T00:00:00Z"))]);
+
+        var response = await service.QueryAsync(new ScopeWorkflowCatalogueQuery(
+            ScopeId,
+            ScopeWorkflowCatalogueView.Drafts,
+            Query: "Draft Alpha"));
+
+        response.Items.Should().ContainSingle().Which.WorkflowId.Should().Be("wf-alpha");
+        response.Freshness.RefreshWatermarkUtc.Should().Be(DateTimeOffset.Parse("2026-08-05T00:00:00Z"));
+    }
+
     private static AppScopedWorkflowCatalogueService CreateService(
         IReadOnlyList<StudioWorkflowDraftRecord> drafts,
         IReadOnlyList<ScopeWorkflowSummary> committedWorkflows)
@@ -148,7 +164,7 @@ public sealed class AppScopedWorkflowCatalogueServiceTests
             workspaceCommandPort: null);
         return new AppScopedWorkflowCatalogueService(
             draftService,
-            new StubScopeWorkflowQueryPort(committedWorkflows));
+            new StubScopeWorkflowCatalogueCommittedSourcePort(committedWorkflows));
     }
 
     private static StudioWorkflowDraftRecord Draft(
@@ -232,21 +248,12 @@ public sealed class AppScopedWorkflowCatalogueServiceTests
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
     }
 
-    private sealed class StubScopeWorkflowQueryPort(IReadOnlyList<ScopeWorkflowSummary> workflows) : IScopeWorkflowQueryPort
+    private sealed class StubScopeWorkflowCatalogueCommittedSourcePort(IReadOnlyList<ScopeWorkflowSummary> workflows) : IScopeWorkflowCatalogueCommittedSourcePort
     {
-        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default)
+        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListCatalogueAsync(string scopeId, CancellationToken ct = default)
         {
             scopeId.Should().Be(ScopeId);
             return Task.FromResult(workflows);
         }
-
-        public Task<ScopeWorkflowLookupResult> LookupByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(string scopeId, string actorId, CancellationToken ct = default) =>
-            throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary
- Add a backend-owned scope workflow catalogue query contract for Workflow Activity vNext.
- Merge draft and committed workflow read-model rows by exact workflowId, with server-side view filtering, search, deterministic ordering, cursor pagination, capabilities, committed facts, and freshness watermark.
- Expose `GET /api/scopes/{scopeId}/workflow-catalogue` and document client/server ownership semantics.

## Test plan
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter AppScopedWorkflowCatalogueServiceTests`
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter HandleQueryWorkflowCatalogueAsync_ShouldDelegateServerSideFilterQuery`
- [x] `bash tools/ci/query_projection_priming_guard.sh`
- [x] `bash tools/ci/workflow_catalog_query_port_guard.sh`
- [ ] `bash tools/ci/test_stability_guards.sh` stopped in `project_reference_layer_guard.py` because local Homebrew Python cannot import `pyexpat` (`Symbol not found: _XML_SetAllocTrackerActivationThreshold`). Earlier guard steps in the script passed.
- [ ] `bash tools/ci/architecture_guards.sh` stopped at the same local Python `pyexpat` import failure after earlier architecture sub-guards passed.

Closes #3249

🤖 Generated with [Claude Code](https://claude.com/claude-code)