### PR TITLE
Use toast for transient frontend errors

### DIFF
--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -1702,7 +1702,7 @@ const enUSMessages = {
   'pages.studio.bind.studiomemberbindpanel.run.completed': 'Run completed',
   'pages.studio.bind.studiomemberbindpanel.service.ready': 'Service ready',
   'pages.studio.bind.studiomemberbindpanel.smoke.test.request.failed':
-    'Could not complete the smoke test. Review the result and try again.',
+    'Could not complete the smoke test. Try again.',
   'pages.studio.studiobuildpanels.command.accepted': 'command: accepted',
   'pages.studio.studiobuildpanels.current.run.ready': 'current run: ready',
   'pages.studio.studiobuildpanels.events.count': 'events: {count}',
@@ -1768,6 +1768,30 @@ const enUSMessages = {
     'YAML copied to clipboard.',
   'pages.workflows.workflowyamlviewer.failed.to.copy.yaml':
     'Failed to copy YAML.',
+  'pages.chat.chatadvancedconsole.timelineActionFailed':
+    'Run action could not be completed. Try again.',
+  'pages.deployments.index.actionFailed':
+    'Deployment action could not be completed. Try again.',
+  'pages.gagents.index.bindingActionFailed':
+    'Binding action could not be completed. Try again.',
+  'pages.gagents.index.registryActionFailed':
+    'Actor registry action could not be completed. Try again.',
+  'pages.governance.governanceworkbench.actionFailed':
+    'Governance action could not be completed. Try again.',
+  'pages.studio.bind.studiomemberbindpanel.bindingActionFailed':
+    'Binding action could not be completed. Try again.',
+  'pages.studio.studiobuildpanels.workflowSaveFailed':
+    'Could not save workflow. Try again.',
+  'pages.studio.studiofilesdetailpane.connectorSaveFailed':
+    'Could not save connector catalog. Try again.',
+  'pages.studio.studiofilesdetailpane.conversationDeleteFailed':
+    'Could not delete conversation. Try again.',
+  'pages.studio.studiofilesdetailpane.roleSaveFailed':
+    'Could not save role catalog. Try again.',
+  'pages.studio.studioinspectorpane.nodeActionFailed':
+    'Could not apply node changes. Try again.',
+  'pages.studio.studioworkbenchsections.executionActionFailed':
+    'Execution action could not be completed. Try again.',
 };
 
 export default enUSMessages;

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -1607,7 +1607,7 @@ const zhCNMessages = {
   'pages.studio.bind.studiomemberbindpanel.run.completed': 'Run completed',
   'pages.studio.bind.studiomemberbindpanel.service.ready': 'Service ready',
   'pages.studio.bind.studiomemberbindpanel.smoke.test.request.failed':
-    '无法完成冒烟测试。请查看结果后重试。',
+    '无法完成冒烟测试，请重试。',
   'pages.studio.studiobuildpanels.command.accepted': 'command: accepted',
   'pages.studio.studiobuildpanels.current.run.ready': 'current run: ready',
   'pages.studio.studiobuildpanels.events.count': 'events: {count}',
@@ -1669,6 +1669,28 @@ const zhCNMessages = {
   'pages.studio.studiomemberinvokepanel.copyFailed': '无法复制该内容。',
   'pages.workflows.workflowyamlviewer.copy.success': 'YAML 已复制到剪贴板。',
   'pages.workflows.workflowyamlviewer.failed.to.copy.yaml': '复制 YAML 失败。',
+  'pages.chat.chatadvancedconsole.timelineActionFailed':
+    '无法完成运行操作，请重试。',
+  'pages.deployments.index.actionFailed': '无法完成部署操作，请重试。',
+  'pages.gagents.index.bindingActionFailed': '无法完成绑定操作，请重试。',
+  'pages.gagents.index.registryActionFailed':
+    '无法完成 Actor 注册表操作，请重试。',
+  'pages.governance.governanceworkbench.actionFailed':
+    '无法完成治理操作，请重试。',
+  'pages.studio.bind.studiomemberbindpanel.bindingActionFailed':
+    '无法完成绑定操作，请重试。',
+  'pages.studio.studiobuildpanels.workflowSaveFailed':
+    '无法保存工作流，请重试。',
+  'pages.studio.studiofilesdetailpane.connectorSaveFailed':
+    '无法保存连接器目录，请重试。',
+  'pages.studio.studiofilesdetailpane.conversationDeleteFailed':
+    '无法删除会话，请重试。',
+  'pages.studio.studiofilesdetailpane.roleSaveFailed':
+    '无法保存角色目录，请重试。',
+  'pages.studio.studioinspectorpane.nodeActionFailed':
+    '无法应用节点更改，请重试。',
+  'pages.studio.studioworkbenchsections.executionActionFailed':
+    '无法完成运行操作，请重试。',
 };
 
 export default zhCNMessages;

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -75,6 +75,7 @@ import {
   type AevatarThemeSurfaceToken,
 } from '@/shared/ui/aevatarWorkbench';
 import ConsoleMenuPageShell from '@/shared/ui/ConsoleMenuPageShell';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import {
   cardStackStyle,
   summaryFieldLabelStyle,
@@ -2116,15 +2117,16 @@ const DeploymentsPage: React.FC = () => {
       title="Deployments"
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-        {notice ? (
-          <Alert
-            closable
-            message={notice.message}
-            showIcon
-            type={notice.tone}
-            onClose={() => setNotice(null)}
-          />
-        ) : null}
+        <ConsoleOperationNotice
+          errorMessage={t(
+            'pages.deployments.index.actionFailed',
+            'Deployment action could not be completed. Try again.',
+          )}
+          notice={
+            notice ? { message: notice.message, type: notice.tone } : null
+          }
+          onClose={() => setNotice(null)}
+        />
 
         <DeploymentsScopeCard
           draft={draft}

--- a/apps/aevatar-console-web/src/pages/chat/chatAdvancedConsole.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatAdvancedConsole.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/shared/runs/scopeConsole";
 import { studioApi } from "@/shared/studio/api";
 import { AevatarContextDrawer } from "@/shared/ui/aevatarPageShells";
+import { useConsoleToast } from "@/shared/ui/ConsoleToast";
 import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
   AEVATAR_INTERACTIVE_CHIP_CLASS,
@@ -467,8 +468,8 @@ export function ChatAdvancedConsole({
   );
   const [timelineActionInput, setTimelineActionInput] = useState("");
   const [timelineActionLoading, setTimelineActionLoading] = useState(false);
-  const [timelineActionError, setTimelineActionError] = useState("");
   const [timelineActionNotice, setTimelineActionNotice] = useState("");
+  const toast = useConsoleToast();
 
   const [executeServiceId, setExecuteServiceId] = useState(defaultServiceId || "");
   const [executeEndpointId, setExecuteEndpointId] = useState("chat");
@@ -758,7 +759,6 @@ export function ChatAdvancedConsole({
   }, [timelineRows]);
 
   useEffect(() => {
-    setTimelineActionError("");
     setTimelineActionInput("");
     setTimelineActionNotice("");
   }, [timelineBlockingSummary?.kind, timelineBlockingSummary?.stepId]);
@@ -1078,7 +1078,6 @@ export function ChatAdvancedConsole({
       }
 
       setTimelineActionLoading(true);
-      setTimelineActionError("");
       setTimelineActionNotice("");
 
       try {
@@ -1156,7 +1155,12 @@ export function ChatAdvancedConsole({
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        setTimelineActionError(errorMessage);
+        toast.error(
+          t(
+            "pages.chat.chatadvancedconsole.timelineActionFailed",
+            "Run action could not be completed. Try again.",
+          ),
+        );
         onTimelineActionResult?.({
           action,
           actorId: effectiveTimelineActorId,
@@ -2391,10 +2395,6 @@ export function ChatAdvancedConsole({
                   {!executeRunId || !effectiveTimelineServiceId ? (
                     <Typography.Text type="secondary">
                       {t("pages.chat.chatadvancedconsole.run.actions.become.available.after", "Run actions become available after the console has a run ID and service context.")}</Typography.Text>
-                  ) : null}
-
-                  {timelineActionError ? (
-                    <Alert showIcon title={timelineActionError} type="error" />
                   ) : null}
 
                   {timelineActionNotice ? (

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -7,6 +7,13 @@ import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
 import { chatHistoryApi } from "./chatHistoryApi";
 import ChatPage, { hydrateStoredMessages } from "./index";
 
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
 jest.mock("@/shared/auth/fetch", () => ({
   authFetch: jest.fn(),
 }));
@@ -43,6 +50,10 @@ jest.mock("@/shared/navigation/history", () => ({
   history: {
     push: jest.fn(),
   },
+}));
+
+jest.mock("@/shared/ui/ConsoleToast", () => ({
+  useConsoleToast: () => mockConsoleToast,
 }));
 
 jest.mock("@/shared/studio/api", () => ({
@@ -1922,7 +1933,7 @@ describe("ChatPage server-backed history", () => {
     ).toBeTruthy();
   });
 
-  it("keeps history visible when deletion fails", async () => {
+  it("reports deletion failures with a toast and keeps history visible", async () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
@@ -1937,8 +1948,13 @@ describe("ChatPage server-backed history", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
-    expect(await screen.findByText("Conversation could not be deleted")).toBeTruthy();
-    expect(screen.getByText("Delete request failed")).toBeTruthy();
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "Conversation could not be deleted",
+      ),
+    );
+    expect(screen.queryByText("Conversation could not be deleted")).toBeNull();
+    expect(screen.queryByText("Delete request failed")).toBeNull();
     expect(screen.getByRole("button", { name: "Server conversation" })).toBeTruthy();
   });
 

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -30,6 +30,7 @@ import React, {
 } from "react";
 import { studioApi } from "@/shared/studio/api";
 import { AevatarPageShell } from "@/shared/ui/aevatarPageShells";
+import { useConsoleToast } from "@/shared/ui/ConsoleToast";
 import { resolveStudioScopeContext } from "../scopes/components/resolvedScope";
 import {
   applyRuntimeEvent,
@@ -609,6 +610,7 @@ function formatTurnCount(count: number): string {
 }
 
 const ChatPage: React.FC = () => {
+  const toast = useConsoleToast();
   const { token } = theme.useToken();
   const queryClient = useQueryClient();
   const activeConversationRef = useRef<ConversationState | null>(null);
@@ -626,7 +628,6 @@ const ChatPage: React.FC = () => {
   const [conversationStateScopeId, setConversationStateScopeId] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<ConversationMeta | null>(null);
   const [deletingConversation, setDeletingConversation] = useState(false);
-  const [deleteError, setDeleteError] = useState("");
   const [deletedConversationIds, setDeletedConversationIds] = useState<
     ReadonlySet<string>
   >(() => new Set());
@@ -800,7 +801,6 @@ const ChatPage: React.FC = () => {
     setConversationStateScopeId(scopeId);
     setActiveConversation(null);
     setDeleteTarget(null);
-    setDeleteError("");
     setDeletingConversation(false);
     setDeletedConversationIds(new Set());
     setPendingConversations(new Map());
@@ -965,7 +965,6 @@ const ChatPage: React.FC = () => {
       return;
     }
 
-    setDeleteError("");
     setDeletingConversation(true);
     const deleteScopeEpoch = scopeEpochRef.current;
     try {
@@ -994,17 +993,22 @@ const ChatPage: React.FC = () => {
       }
       setDeleteTarget(null);
       await queryClient.invalidateQueries({ queryKey: ["chat-history", scopeId] });
-    } catch (error) {
+    } catch {
       if (scopeEpochRef.current !== deleteScopeEpoch) {
         return;
       }
-      setDeleteError(errorMessage(error));
+      toast.error(
+        t(
+          "pages.chat.index.deleteChatFailed",
+          "Conversation could not be deleted",
+        ),
+      );
     } finally {
       if (scopeEpochRef.current === deleteScopeEpoch) {
         setDeletingConversation(false);
       }
     }
-  }, [deleteTarget, deletingConversation, isStreaming, queryClient, scopeId]);
+  }, [deleteTarget, deletingConversation, isStreaming, queryClient, scopeId, toast]);
 
   const reconcileConversation = useCallback(
     (conversation: ConversationState) => {
@@ -1918,7 +1922,6 @@ const ChatPage: React.FC = () => {
                       disabled={isStreaming}
                       icon={<DeleteOutlined />}
                       onClick={() => {
-                        setDeleteError("");
                         setDeleteTarget(conversation);
                       }}
                       style={{ minHeight: 40, minWidth: 40 }}
@@ -2324,7 +2327,6 @@ const ChatPage: React.FC = () => {
         onCancel={() => {
           if (!deletingConversation) {
             setDeleteTarget(null);
-            setDeleteError("");
           }
         }}
         onOk={() => void handleDeleteConversation()}
@@ -2339,17 +2341,6 @@ const ChatPage: React.FC = () => {
             { title: deleteTarget?.title || "" }
           )}
         </Typography.Paragraph>
-        {deleteError ? (
-          <Alert
-            description={deleteError}
-            message={t(
-              "pages.chat.index.deleteChatFailed",
-              "Conversation could not be deleted"
-            )}
-            showIcon
-            type="error"
-          />
-        ) : null}
       </Modal>
     </AevatarPageShell>
   );

--- a/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
@@ -488,9 +488,14 @@ describe("GAgentsPage", () => {
 
     expect(
       await screen.findByText(
-        "Acknowledge the replacement impact before publishing a new binding revision."
+        "Binding action could not be completed. Try again."
       )
     ).toBeTruthy();
+    expect(
+      screen.queryByText(
+        "Acknowledge the replacement impact before publishing a new binding revision."
+      )
+    ).toBeNull();
     expect(mockedRuntimeGAgentApi.bindScopeGAgent).not.toHaveBeenCalled();
 
     fireEvent.click(

--- a/apps/aevatar-console-web/src/pages/gagents/index.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.tsx
@@ -59,6 +59,7 @@ import {
   AevatarWorkbenchLayout,
 } from '@/shared/ui/aevatarPageShells';
 import { describeError } from '@/shared/ui/errorText';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import { getUserFacingIdentifierLabel } from '@/shared/ui/userFacingIdentifiers';
 import { resolveStudioScopeContext } from '@/pages/scopes/components/resolvedScope';
 import { t } from "@/shared/i18n/messages";
@@ -1756,15 +1757,14 @@ const GAgentsPage: React.FC = () => {
       title={t("pages.gagents.index.actor.registry", "Actor Registry")}
     >
       <Space orientation="vertical" size={12} style={{ width: '100%' }}>
-        {registryNotice ? (
-          <Alert
-            closable
-            onClose={() => setRegistryNotice(null)}
-            showIcon
-            title={registryNotice.message}
-            type={registryNotice.type}
-          />
-        ) : null}
+        <ConsoleOperationNotice
+          errorMessage={t(
+            'pages.gagents.index.registryActionFailed',
+            'Actor registry action could not be completed. Try again.',
+          )}
+          notice={registryNotice}
+          onClose={() => setRegistryNotice(null)}
+        />
 
         {gAgentActorsQuery.error ? (
           <Alert
@@ -2197,7 +2197,7 @@ const GAgentsPage: React.FC = () => {
                         <Space orientation="vertical" size={12} style={{ width: '100%' }}>
                           {bindingDraft.endpoints.map((endpoint, index) => (
                             <div
-                              key={`binding-endpoint-${index}`}
+                              key={endpoint.endpointId}
                               style={{
                                 ...summaryMetricStyle,
                                 display: 'flex',
@@ -2704,15 +2704,14 @@ const GAgentsPage: React.FC = () => {
       }}
     >
       {selectedTypePanel}
-      {bindingNotice ? (
-        <Alert
-          closable
-          onClose={() => setBindingNotice(null)}
-          showIcon
-          type={bindingNotice.type}
-          title={bindingNotice.message}
-        />
-      ) : null}
+      <ConsoleOperationNotice
+        errorMessage={t(
+          'pages.gagents.index.bindingActionFailed',
+          'Binding action could not be completed. Try again.',
+        )}
+        notice={bindingNotice}
+        onClose={() => setBindingNotice(null)}
+      />
       <Tabs
         activeKey={activeWorkbenchTab}
         items={workbenchTabs}

--- a/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
+++ b/apps/aevatar-console-web/src/pages/governance/components/GovernanceWorkbench.tsx
@@ -46,6 +46,7 @@ import {
 import { AevatarCompactText } from "@/shared/ui/compactText";
 import type { AevatarBreadcrumbItem } from "@/shared/ui/aevatarPageShells";
 import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
+import ConsoleOperationNotice from "@/shared/ui/ConsoleOperationNotice";
 import GovernanceAuditTimeline, {
   type GovernanceAuditEvent,
 } from "./GovernanceAuditTimeline";
@@ -1992,15 +1993,16 @@ const GovernanceWorkbench: React.FC = () => {
       title="Governance"
     >
       <div style={buildAevatarViewportStyle(surfaceToken)}>
-        {notice ? (
-          <Alert
-            closable
-            message={notice.message}
-            showIcon
-            type={notice.tone}
-            onClose={() => setNotice(null)}
-          />
-        ) : null}
+        <ConsoleOperationNotice
+          errorMessage={t(
+            "pages.governance.governanceworkbench.actionFailed",
+            "Governance action could not be completed. Try again.",
+          )}
+          notice={
+            notice ? { message: notice.message, type: notice.tone } : null
+          }
+          onClose={() => setNotice(null)}
+        />
         {commandReceipt && commandReceiptObservation ? (
           <Alert
             closable

--- a/apps/aevatar-console-web/src/pages/settings/accountContent.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/accountContent.tsx
@@ -4,7 +4,7 @@ import {
   UserOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Alert, Avatar, Button, Empty, Space, Typography, theme } from "antd";
+import { Avatar, Button, Empty, Space, Typography, theme } from "antd";
 import React, { useMemo, useState } from "react";
 import {
   NyxIDAuthClient,
@@ -18,6 +18,7 @@ import {
 import { studioApi } from "@/shared/studio/api";
 import { AevatarCompactText } from "@/shared/ui/compactText";
 import { AevatarPanel } from "@/shared/ui/aevatarPageShells";
+import { useConsoleToast } from "@/shared/ui/ConsoleToast";
 import {
   summaryFieldGridStyle,
   summaryMetricGridStyle,
@@ -60,11 +61,9 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
   const settingsPanelStyle = buildSettingsPanelStyle(token);
   const authSession = useMemo(() => loadRestorableAuthSession(), []);
   const authConfig = useMemo(() => getNyxIDRuntimeConfig(), []);
+  const toast = useConsoleToast();
   const [serviceAccessReviewPending, setServiceAccessReviewPending] =
     useState(false);
-  const [serviceAccessReviewError, setServiceAccessReviewError] = useState<
-    string | undefined
-  >(undefined);
   const authMeQuery = useQuery({
     queryKey: ["settings", "auth-me"],
     queryFn: () => studioApi.getAuthSession(),
@@ -116,7 +115,6 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
   const startServiceAccessReview = async () => {
     try {
       setServiceAccessReviewPending(true);
-      setServiceAccessReviewError(undefined);
       const client = new NyxIDAuthClient(authConfig);
       await client.loginWithRedirect({
         flow: "serviceAccessReview",
@@ -124,7 +122,12 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
       });
     } catch {
       setServiceAccessReviewPending(false);
-      setServiceAccessReviewError(t("pages.settings.accountcontent.service.access.review.start.failed", "Could not start service access review. Try again."));
+      toast.error(
+        t(
+          "pages.settings.accountcontent.service.access.review.start.failed",
+          "Could not start service access review. Try again.",
+        ),
+      );
     }
   };
 
@@ -246,9 +249,6 @@ const AccountSettingsContent: React.FC<AccountSettingsContentProps> = ({
               value={t("pages.settings.accountcontent.browser.token.refresh.disabled", "Disabled")}
             />
           </div>
-          {serviceAccessReviewError ? (
-            <Alert message={serviceAccessReviewError} role="alert" showIcon type="error" />
-          ) : null}
         </Space>
       </AevatarPanel>
     </>

--- a/apps/aevatar-console-web/src/pages/settings/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.test.tsx
@@ -7,6 +7,13 @@ import {
 } from "../../../tests/reactQueryTestUtils";
 import SettingsPage from "./index";
 
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
 jest.mock("@/shared/studio/api", () => ({
   studioApi: {
     getAuthSession: jest.fn(),
@@ -14,6 +21,10 @@ jest.mock("@/shared/studio/api", () => ({
     getUserLlmSettings: jest.fn(),
     saveUserLlmSettings: jest.fn(),
   },
+}));
+
+jest.mock("@/shared/ui/ConsoleToast", () => ({
+  useConsoleToast: () => mockConsoleToast,
 }));
 
 const { studioApi: mockStudioApi } = jest.requireMock(
@@ -446,7 +457,7 @@ describe("SettingsPage", () => {
     );
   });
 
-  it("keeps service access review retryable when redirect setup fails", async () => {
+  it("reports service access review failures with a toast and keeps retry available", async () => {
     persistAuthSession({
       tokens: { accessToken: "token", tokenType: "Bearer", expiresIn: 3600, expiresAt: Date.now() + 60_000 },
       user: { sub: "user-123", name: "Ada Lovelace" },
@@ -463,12 +474,38 @@ describe("SettingsPage", () => {
     renderWithQueryClient(React.createElement(SettingsPage));
     const manageButton = await screen.findByRole("button", { name: "Manage service access" });
     fireEvent.click(manageButton);
-    expect(await screen.findByRole("alert")).toHaveTextContent("Could not start service access review. Try again.");
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "Could not start service access review. Try again.",
+      ),
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
     await waitFor(() => expect(manageButton).not.toHaveClass("ant-btn-loading"));
     fireEvent.click(manageButton);
     await waitFor(() => expect(assign).toHaveBeenCalledTimes(2));
     expect(screen.queryByRole("alert")).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a current settings save failure with a toast", async () => {
+    mockStudioApi.saveUserLlmSettings.mockRejectedValue(
+      new Error("PUT /api/settings returned 500"),
+    );
+    renderWithQueryClient(React.createElement(SettingsPage));
+
+    fireEvent.mouseDown(
+      await screen.findByRole("combobox", { name: "Default model" }),
+    );
+    fireEvent.click(screen.getByRole("option", { name: "gpt-4o" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save config" }));
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "Settings could not be saved. Try again.",
+      ),
+    );
+    expect(screen.queryByText("Save failed")).toBeNull();
+    expect(screen.queryByText("PUT /api/settings returned 500")).toBeNull();
   });
 
   it("hides service access review when the user is signed out", async () => {

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/shared/ui/compactText";
 import { describeError } from "@/shared/ui/errorText";
 import { AevatarPanel } from "@/shared/ui/aevatarPageShells";
+import { useConsoleToast } from "@/shared/ui/ConsoleToast";
 import { codeBlockStyle } from "@/shared/ui/proComponents";
 import AccountSettingsContent from "./accountContent";
 import {
@@ -449,6 +450,7 @@ const ConnectedProviderChip: React.FC<{
 };
 
 const SettingsPage: React.FC = () => {
+  const toast = useConsoleToast();
   const locationSnapshot = React.useSyncExternalStore(
     subscribeToLocationChanges,
     getLocationSnapshot,
@@ -494,6 +496,15 @@ const SettingsPage: React.FC = () => {
   const draft = draftState.value;
   const pendingSave = draftState.pendingSave;
   const saveError = draftState.saveError;
+  React.useEffect(() => {
+    if (!saveError) return;
+    toast.error(
+      t(
+        "pages.settings.index.save.failed.toast",
+        "Settings could not be saved. Try again.",
+      ),
+    );
+  }, [saveError, toast]);
   const draftDirty = React.useMemo(
     () => !draftsEqual(draft, draftState.baseline),
     [draft, draftState.baseline],
@@ -1275,15 +1286,6 @@ const SettingsPage: React.FC = () => {
               />
             ) : null}
 
-            {saveError ? (
-              <Alert
-                message={t("pages.settings.index.save.failed", "Save failed")}
-                description={saveError}
-                showIcon
-                type="error"
-              />
-            ) : null}
-
             {pendingSave && pendingSave.phase !== "saving" ? (
               <Alert
                 action={
@@ -1680,7 +1682,6 @@ const SettingsPage: React.FC = () => {
       selectionStatus,
       selectionSelectOptions,
       routeSummaryLabel,
-      saveError,
       settingsPanelStyle,
       summaryGridStyle,
       technicalPreviewRows,

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -627,8 +627,8 @@ describe('StudioWorkflowBuildPanel', () => {
       );
     });
     expect(
-      screen.getByText('The workflow adapter rejected this node.'),
-    ).toBeInTheDocument();
+      screen.queryByText('The workflow adapter rejected this node.'),
+    ).not.toBeInTheDocument();
   });
 
   it('keeps the Script bind CTA stable and uses the dry-run panel as the run entry', () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -71,6 +71,7 @@ import type {
   ScriptValidationResult,
 } from '@/shared/studio/scriptsModels';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import { describeError } from '@/shared/ui/errorText';
 import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
@@ -1232,9 +1233,7 @@ export const StudioWorkflowBuildPanel: React.FC<
       try {
         await onInsertStep(stepType);
         setStepTypePickerOpen(false);
-      } catch (error) {
-        const visibleMessage = describeError(error);
-        setStepMutationError(visibleMessage);
+      } catch {
         toast.error(workflowActionFailure);
       } finally {
         stepMutationPendingRef.current = false;
@@ -1264,9 +1263,7 @@ export const StudioWorkflowBuildPanel: React.FC<
     setStepMutationError('');
     try {
       await onApplyStepDraft(currentStepDraft);
-    } catch (error) {
-      const visibleMessage = describeError(error);
-      setStepMutationError(visibleMessage);
+    } catch {
       toast.error(workflowActionFailure);
     } finally {
       stepMutationPendingRef.current = false;
@@ -1313,9 +1310,7 @@ export const StudioWorkflowBuildPanel: React.FC<
     setStepMutationError('');
     try {
       await onRemoveSelectedStep();
-    } catch (error) {
-      const visibleMessage = describeError(error);
-      setStepMutationError(visibleMessage);
+    } catch {
       toast.error(workflowActionFailure);
     } finally {
       stepMutationPendingRef.current = false;
@@ -1337,9 +1332,7 @@ export const StudioWorkflowBuildPanel: React.FC<
       setStepMutationError('');
       try {
         await onDeleteWorkflowNodes(normalizedNodeIds);
-      } catch (error) {
-        const visibleMessage = describeError(error);
-        setStepMutationError(visibleMessage);
+      } catch {
         toast.error(workflowActionFailure);
       } finally {
         stepMutationPendingRef.current = false;
@@ -1434,19 +1427,13 @@ export const StudioWorkflowBuildPanel: React.FC<
             </Button>
           </Space>
         </div>
-        {saveNotice ? (
-          <Alert
-            message={saveNotice.message}
-            showIcon
-            type={
-              saveNotice.type === 'success'
-                ? 'success'
-                : saveNotice.type === 'info'
-                  ? 'info'
-                  : 'error'
-            }
-          />
-        ) : null}
+        <ConsoleOperationNotice
+          errorMessage={t(
+            'pages.studio.studiobuildpanels.workflowSaveFailed',
+            'Could not save workflow. Try again.',
+          )}
+          notice={saveNotice}
+        />
       </div>
 
       <div

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioExecutionPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioExecutionPage.test.tsx
@@ -3,6 +3,17 @@ import { setLocale } from '@umijs/max';
 import React from 'react';
 import { StudioExecutionPage } from './StudioWorkbenchSections';
 
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
+jest.mock('@/shared/ui/ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
+}));
+
 jest.mock('@/shared/graphs/GraphCanvas', () => ({
   __esModule: true,
   default: () => {
@@ -128,6 +139,7 @@ function createBaseProps(overrides = {}) {
 
 describe('StudioExecutionPage', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     setLocale('zh-CN', false);
   });
 
@@ -165,7 +177,9 @@ describe('StudioExecutionPage', () => {
     expect(screen.getByText('人工回放')).toBeInTheDocument();
     expect(screen.getByText('观察事实')).toBeInTheDocument();
     expect(screen.getByText('运行中')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '停止运行' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '停止运行' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('执行日志')).toBeInTheDocument();
     expect(screen.getByLabelText('选择运行记录')).toBeInTheDocument();
     expect(screen.getByText('Graph canvas')).toBeInTheDocument();
@@ -178,24 +192,26 @@ describe('StudioExecutionPage', () => {
       value: { writeText },
     });
 
-    render(
-      React.createElement(StudioExecutionPage, createBaseProps() as any),
-    );
+    render(React.createElement(StudioExecutionPage, createBaseProps() as any));
 
     expect(screen.queryByText('Actor ID')).toBeNull();
     expect(screen.queryByText('actor-1')).toBeNull();
-    expect(screen.queryByRole('button', { name: '复制 Actor ID。' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: '复制 Actor ID。' }),
+    ).toBeNull();
     expect(writeText).not.toHaveBeenCalled();
   });
 
   it('surfaces approval playback details from the selected execution trace', () => {
-    render(
-      React.createElement(StudioExecutionPage, createBaseProps() as any),
-    );
+    render(React.createElement(StudioExecutionPage, createBaseProps() as any));
 
-    expect(screen.getAllByText('triage waiting for approval').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('triage waiting for approval').length,
+    ).toBeGreaterThan(0);
     expect(screen.getAllByText('triage approved').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Need L2 approval before refund.').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Need L2 approval before refund.').length,
+    ).toBeGreaterThan(0);
   });
 
   it('allows sending a signal when the selected run is waiting on wait_signal', async () => {
@@ -317,5 +333,28 @@ describe('StudioExecutionPage', () => {
     );
 
     expect(screen.getByText('Select a member to observe.')).toBeInTheDocument();
+  });
+
+  it('reports execution action failures with a safe toast', async () => {
+    render(
+      React.createElement(
+        StudioExecutionPage,
+        createBaseProps({
+          executionNotice: {
+            message: 'POST /api/runs/stop returned 500',
+            type: 'error',
+          },
+        }) as any,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        '无法完成运行操作，请重试。',
+      );
+    });
+    expect(
+      screen.queryByText('POST /api/runs/stop returned 500'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
@@ -23,6 +23,7 @@ import type {
   StudioWorkflowSummary,
 } from '@/shared/studio/models';
 import type { ScopedScriptDetail } from '@/shared/studio/scriptsModels';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import { describeError } from '@/shared/ui/errorText';
 import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
@@ -1093,9 +1094,13 @@ const StudioFilesDetailPane: React.FC<Props> = ({
           </div>
         </div>
 
-        {roleNotice ? (
-          <Alert type={roleNotice.type} showIcon message={roleNotice.message} />
-        ) : null}
+        <ConsoleOperationNotice
+          errorMessage={t(
+            'pages.studio.studiofilesdetailpane.roleSaveFailed',
+            'Could not save role catalog. Try again.',
+          )}
+          notice={roleNotice}
+        />
 
         {roles.isError ? (
           <Alert
@@ -1423,13 +1428,13 @@ const StudioFilesDetailPane: React.FC<Props> = ({
           </div>
         </div>
 
-        {connectorNotice ? (
-          <Alert
-            type={connectorNotice.type}
-            showIcon
-            message={connectorNotice.message}
-          />
-        ) : null}
+        <ConsoleOperationNotice
+          errorMessage={t(
+            'pages.studio.studiofilesdetailpane.connectorSaveFailed',
+            'Could not save connector catalog. Try again.',
+          )}
+          notice={connectorNotice}
+        />
 
         {connectors.isError ? (
           <Alert
@@ -2254,9 +2259,13 @@ const StudioFilesDetailPane: React.FC<Props> = ({
             />
           ) : null}
 
-          {chatNotice ? (
-            <Alert type={chatNotice.type} showIcon message={chatNotice.message} />
-          ) : null}
+          <ConsoleOperationNotice
+            errorMessage={t(
+              'pages.studio.studiofilesdetailpane.conversationDeleteFailed',
+              'Could not delete conversation. Try again.',
+            )}
+            notice={chatNotice}
+          />
 
           {selectedConversationMessages.isLoading ? (
             <div style={emptyCardStyle}>{t("pages.studio.studiofilesdetailpane.loading.conversation", "Loading conversation...")}</div>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.test.tsx
@@ -1,20 +1,19 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
-import type { StudioNodeInspectorDraft } from '@/shared/studio/document';
-import type {
-  StudioGraphRole,
-  StudioGraphStep,
-} from '@/shared/studio/graph';
-import type {
-  StudioConnectorDefinition,
-  StudioRoleDefinition,
-  StudioValidationFinding,
-} from '@/shared/studio/models';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
 import StudioInspectorPane from './StudioInspectorPane';
 
-type InspectorProps = React.ComponentProps<typeof StudioInspectorPane>;
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
 
-const workflowRole: StudioGraphRole = {
+jest.mock('@/shared/ui/ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
+}));
+
+const workflowRole = {
   id: 'assistant',
   name: 'Assistant',
   provider: 'openai',
@@ -23,7 +22,7 @@ const workflowRole: StudioGraphRole = {
   connectors: ['search'],
 };
 
-const workflowStep: StudioGraphStep = {
+const workflowStep = {
   id: 'review_step',
   type: 'connector_call',
   targetRole: 'assistant',
@@ -32,7 +31,7 @@ const workflowStep: StudioGraphStep = {
   branches: { retry: 'retry_step' },
 };
 
-const connector: StudioConnectorDefinition = {
+const connector = {
   name: 'search',
   type: 'http',
   enabled: true,
@@ -40,7 +39,7 @@ const connector: StudioConnectorDefinition = {
   retry: 0,
 };
 
-const savedRole: StudioRoleDefinition = {
+const savedRole = {
   id: 'assistant_catalog',
   name: 'Catalog assistant',
   provider: 'openai',
@@ -49,10 +48,8 @@ const savedRole: StudioRoleDefinition = {
   connectors: ['search'],
 };
 
-function createBaseProps(
-  overrides: Partial<InspectorProps> = {},
-): InspectorProps {
-  const nodeInspectorDraft: StudioNodeInspectorDraft = {
+function createBaseProps(overrides = {}) {
+  const nodeInspectorDraft = {
     kind: 'step',
     id: 'review_step',
     type: 'connector_call',
@@ -81,7 +78,8 @@ function createBaseProps(
     validationFindings: [],
     parsedWorkflowName: 'studio_demo',
     activeWorkflowName: 'studio_demo',
-    activeWorkflowDescription: 'A demo workflow used for Studio inspector tests.',
+    activeWorkflowDescription:
+      'A demo workflow used for Studio inspector tests.',
     onSetInspectorTab: jest.fn(),
     onSetDraftYaml: jest.fn(),
     onValidateDraft: jest.fn(),
@@ -100,8 +98,12 @@ function createBaseProps(
 }
 
 describe('StudioInspectorPane', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders the YAML summary and validation digest', () => {
-    const validationFindings: StudioValidationFinding[] = [
+    const validationFindings = [
       {
         level: 'warning',
         path: '/steps/0',
@@ -125,7 +127,9 @@ describe('StudioInspectorPane', () => {
         'Edit the source document directly, then validate it before saving or running.',
       ),
     ).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Show help' }).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('button', { name: 'Show help' }).length,
+    ).toBeGreaterThan(0);
     expect(screen.getByText('Validation digest')).toBeInTheDocument();
     expect(screen.getByText('1 validation finding(s)')).toBeInTheDocument();
     expect(screen.getByText('Parsed workflow')).toBeInTheDocument();
@@ -197,11 +201,40 @@ describe('StudioInspectorPane', () => {
       />,
     );
 
-    expect(screen.getByText('Unexpected end of JSON input')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Apply node changes' })).toBeDisabled();
+    expect(
+      screen.getByText('Unexpected end of JSON input'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Apply node changes' }),
+    ).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Apply node changes' }));
 
     expect(onApplyNodeChanges).not.toHaveBeenCalled();
+  });
+
+  it('reports node action failures with a safe toast', async () => {
+    render(
+      <StudioInspectorPane
+        {...createBaseProps({
+          inspectorNotice: {
+            message: 'PATCH /api/studio/node returned 500',
+            type: 'error',
+          },
+          inspectorTab: 'node',
+          selectedGraphStep: workflowStep,
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockConsoleToast.error).toHaveBeenCalledTimes(1);
+    });
+    expect(mockConsoleToast.error).not.toHaveBeenCalledWith(
+      'PATCH /api/studio/node returned 500',
+    );
+    expect(
+      screen.queryByText('PATCH /api/studio/node returned 500'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioInspectorPane.tsx
@@ -34,6 +34,7 @@ import {
   summaryMetricValueStyle,
 } from '@/shared/ui/proComponents';
 import { AevatarHelpTooltip } from '@/shared/ui/aevatarPageShells';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import { t } from "@/shared/i18n/messages";
 
 type StudioInspectorTab = 'node' | 'roles' | 'yaml';
@@ -446,16 +447,12 @@ function renderInspectorNotice(
   }
 
   return (
-    <NoticePanel
-      type={inspectorNotice.type}
-      title={
-        inspectorNotice.type === 'success'
-          ? 'Node changes applied'
-          : inspectorNotice.type === 'warning'
-            ? 'Node changes applied with warnings'
-            : 'Node changes failed'
-      }
-      description={inspectorNotice.message}
+    <ConsoleOperationNotice
+      errorMessage={t(
+        'pages.studio.studioinspectorpane.nodeActionFailed',
+        'Could not apply node changes. Try again.',
+      )}
+      notice={inspectorNotice}
     />
   );
 }

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -45,6 +45,7 @@ import {
   fillCardStyle,
 } from '@/shared/ui/proComponents';
 import { AevatarPanel, AevatarStatusTag } from '@/shared/ui/aevatarPageShells';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import { describeError } from '@/shared/ui/errorText';
 import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
@@ -1620,7 +1621,7 @@ export const StudioExecutionPage: React.FC<StudioExecutionPageProps> = ({
       type: 'error',
     });
   }
-  if (executionNotice) {
+  if (executionNotice && executionNotice.type !== 'error') {
     compactNotices.push({
       description: executionNotice.message,
       title:
@@ -1649,11 +1650,20 @@ export const StudioExecutionPage: React.FC<StudioExecutionPageProps> = ({
 
   return (
     <div style={cardStackStyle}>
+      <ConsoleOperationNotice
+        errorMessage={t(
+          'pages.studio.studioworkbenchsections.executionActionFailed',
+          'Execution action could not be completed. Try again.',
+        )}
+        notice={
+          executionNotice?.type === 'error' ? executionNotice : null
+        }
+      />
       {compactNotices.length > 0 ? (
         <div style={studioCompactNoticeStackStyle}>
-          {compactNotices.map((notice, index) => (
+          {compactNotices.map((notice) => (
             <StudioCompactNotice
-              key={`${notice.type}-${index}`}
+              key={String(notice.title)}
               {...notice}
             />
           ))}

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -1134,8 +1134,15 @@ describe('StudioMemberBindPanel', () => {
   });
 
   it('explains that a smoke test failure is scoped to the contract check', async () => {
-    (runtimeRunsApi.streamChat as jest.Mock).mockRejectedValueOnce(
-      new Error('Backend rejected the smoke prompt.'),
+    (parseBackendSSEStream as jest.Mock).mockImplementationOnce(
+      async function* () {
+        yield {
+          type: 'RUN_ERROR',
+          code: 'ERR_RUNTIME',
+          message: 'The workflow run failed.',
+          runId: 'run-1',
+        };
+      },
     );
 
     renderWithQueryClient(
@@ -1256,15 +1263,15 @@ describe('StudioMemberBindPanel', () => {
 
     await waitFor(() => {
       expect(mockConsoleToast.error).toHaveBeenCalledWith(
-        'Could not complete the smoke test. Review the result and try again.',
+        'Could not complete the smoke test. Try again.',
       );
     });
     expect(mockConsoleToast.error).not.toHaveBeenCalledWith(
       'Backend rejected the smoke prompt.',
     );
     expect(
-      await screen.findByText('Backend rejected the smoke prompt.'),
-    ).toBeTruthy();
+      screen.queryByText('Backend rejected the smoke prompt.'),
+    ).not.toBeInTheDocument();
   });
 
   it('clears the previous member bind notice when the bind candidate changes', async () => {
@@ -1341,5 +1348,45 @@ describe('StudioMemberBindPanel', () => {
         'joker binding request was accepted. Studio will show the published contract after the run completes.',
       ),
     ).toBeNull();
+  });
+
+  it('reports pending bind failures with a safe toast', async () => {
+    const handleBindPendingCandidate = jest
+      .fn()
+      .mockRejectedValue(new Error('POST /api/studio/bind returned 500'));
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        scopeId: 'scope-1',
+        pendingBindingCandidate: {
+          kind: 'workflow',
+          displayName: 'draft1',
+          description: 'Publish the current workflow revision first.',
+          actionLabel: 'Bind current revision',
+        },
+        onBindPendingCandidate: handleBindPendingCandidate,
+        services: [],
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Bind current revision' }),
+    );
+
+    await waitFor(() => {
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Binding action could not be completed. Try again.',
+      );
+    });
+    expect(
+      screen.queryByText('POST /api/studio/bind returned 500'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -46,6 +46,7 @@ import {
   type StudioMemberBindingRunStatusResponse,
 } from '@/shared/studio/models';
 import { AevatarPanel, AevatarStatusTag } from '@/shared/ui/aevatarPageShells';
+import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { AEVATAR_INTERACTIVE_CHIP_CLASS } from '@/shared/ui/interactionStandards';
 import { getUserFacingIdentifierLabel } from '@/shared/ui/userFacingIdentifiers';
@@ -1059,19 +1060,12 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
         ),
         status: 'success',
       });
-    } catch (error) {
-      setSmokeTestResult({
-        error: error instanceof Error ? error.message : String(error),
-        eventCount: 0,
-        latencyMs: Date.now() - startedAt,
-        responseSummary: '',
-        runId: '',
-        status: 'error',
-      });
+    } catch {
+      setSmokeTestResult(createIdleSmokeTestResult());
       toast.error(
         t(
           'pages.studio.bind.studiomemberbindpanel.smoke.test.request.failed',
-          'Could not complete the smoke test. Review the result and try again.',
+          'Could not complete the smoke test. Try again.',
         ),
       );
     }
@@ -1290,13 +1284,14 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
               <Typography.Text type="secondary">
                 {pendingBindingCandidate.description}
               </Typography.Text>
-              {pendingBindNotice ? (
-                <Alert
-                  showIcon
-                  message={pendingBindNotice.message}
-                  type={pendingBindNotice.type}
-                />
-              ) : null}
+              <ConsoleOperationNotice
+                errorMessage={t(
+                  'pages.studio.bind.studiomemberbindpanel.bindingActionFailed',
+                  'Binding action could not be completed. Try again.',
+                )}
+                notice={pendingBindNotice}
+                onClose={() => setPendingBindNotice(null)}
+              />
               {currentBindingRunNotice ? (
                 <Alert
                   showIcon

--- a/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerDetailPane.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerDetailPane.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import ExplorerDetailPane from './ExplorerDetailPane';
+
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
+jest.mock('@/shared/ui/ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
+}));
+
+function renderPane(
+  overrides: {
+    readonly onDeleteFile?: (key: string) => Promise<void>;
+    readonly onSaveFile?: (key: string, content: string) => Promise<void>;
+  } = {},
+) {
+  return render(
+    <ExplorerDetailPane
+      content="original"
+      contentErrorMessage={null}
+      contentLoading={false}
+      errorMessage={null}
+      onDeleteFile={overrides.onDeleteFile}
+      onOpenScriptInStudio={jest.fn()}
+      onOpenWorkflowInStudio={jest.fn()}
+      onSaveFile={overrides.onSaveFile}
+      scopeId="scope-alpha"
+      selectedEntry={{
+        key: 'configs/app.txt',
+        name: 'app.txt',
+        type: 'config',
+      }}
+    />,
+  );
+}
+
+describe('ExplorerDetailPane operation feedback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports save failures with a toast without exposing raw details', async () => {
+    const onSaveFile = jest
+      .fn()
+      .mockRejectedValue(new Error('PUT /api/explorer returned 500'));
+    renderPane({ onSaveFile });
+
+    fireEvent.change(screen.getByLabelText('Explorer file editor'), {
+      target: { value: 'changed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Could not save file. Try again.',
+      ),
+    );
+    expect(screen.queryByText('Could not save file')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('PUT /api/explorer returned 500'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reports delete failures with a toast and keeps the retry action', async () => {
+    const onDeleteFile = jest
+      .fn()
+      .mockRejectedValue(new Error('DELETE /api/explorer returned 500'));
+    renderPane({ onDeleteFile });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete now' }));
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Could not delete file. Try again.',
+      ),
+    );
+    expect(screen.queryByText('Could not delete file')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('DELETE /api/explorer returned 500'),
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Delete now/ })).toBeEnabled(),
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/explorer/ExplorerDetailPane.tsx
@@ -1,6 +1,7 @@
 import { Alert, Button, Input, Space, Spin, Tag, Typography } from "antd";
 import React from "react";
 import type { ExplorerManifestEntry } from "@/shared/api/explorerApi";
+import { useConsoleToast } from "@/shared/ui/ConsoleToast";
 import ExplorerContentView from "./ExplorerContentView";
 import { t } from "@/shared/i18n/messages";
 
@@ -116,9 +117,8 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
   scopeId,
   selectedEntry,
 }) => {
+  const toast = useConsoleToast();
   const [draft, setDraft] = React.useState("");
-  const [saveError, setSaveError] = React.useState<string | null>(null);
-  const [deleteError, setDeleteError] = React.useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [isSaving, setIsSaving] = React.useState(false);
   const [isDeleting, setIsDeleting] = React.useState(false);
@@ -139,8 +139,6 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
   }, [isDirty, onDirtyStateChange]);
 
   React.useEffect(() => {
-    setSaveError(null);
-    setDeleteError(null);
     setConfirmDelete(false);
     setDraft(content ?? "");
     if (selectedEntry?.type === "chat-history") {
@@ -259,7 +257,6 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
               <Button
                 onClick={() => {
                   setDraft(content ?? "");
-                  setSaveError(null);
                 }}
                 disabled={!isDirty || isSaving || isDeleting}
               >
@@ -273,13 +270,15 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
                     return;
                   }
 
-                  setSaveError(null);
                   setIsSaving(true);
                   try {
                     await onSaveFile(selectedEntry.key, draft);
-                  } catch (error) {
-                    setSaveError(
-                      error instanceof Error ? error.message : "Failed to save explorer file."
+                  } catch {
+                    toast.error(
+                      t(
+                        "pages.studio.explorer.explorerdetailpane.could.not.save.file.toast",
+                        "Could not save file. Try again.",
+                      ),
                     );
                   } finally {
                     setIsSaving(false);
@@ -292,7 +291,6 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
                 loading={isDeleting}
                 disabled={isSaving || !onDeleteFile}
                 onClick={() => {
-                  setDeleteError(null);
                   setConfirmDelete(true);
                 }}
               >
@@ -323,14 +321,16 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
                       return;
                     }
 
-                    setDeleteError(null);
                     setIsDeleting(true);
                     try {
                       await onDeleteFile(selectedEntry.key);
                       setConfirmDelete(false);
-                    } catch (error) {
-                      setDeleteError(
-                        error instanceof Error ? error.message : "Failed to delete explorer file."
+                    } catch {
+                      toast.error(
+                        t(
+                          "pages.studio.explorer.explorerdetailpane.could.not.delete.file.toast",
+                          "Could not delete file. Try again.",
+                        ),
                       );
                     } finally {
                       setIsDeleting(false);
@@ -340,17 +340,6 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
                   {t("pages.studio.explorer.explorerdetailpane.delete.now", "Delete now")}</Button>
               </Space>
             }
-          />
-        ) : null}
-        {saveError ? (
-          <Alert type="error" showIcon message={t("pages.studio.explorer.explorerdetailpane.could.not.save.file", "Could not save file")} description={saveError} />
-        ) : null}
-        {deleteError ? (
-          <Alert
-            type="error"
-            showIcon
-            message={t("pages.studio.explorer.explorerdetailpane.could.not.delete.file", "Could not delete file")}
-            description={deleteError}
           />
         ) : null}
       </div>
@@ -377,7 +366,6 @@ const ExplorerDetailPane: React.FC<ExplorerDetailPaneProps> = ({
               value={draft}
               onChange={(event) => {
                 setDraft(event.target.value);
-                setSaveError(null);
               }}
             />
           ) : (

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/hooks/useTeamMemberWorkflowStudio.ts
@@ -269,8 +269,6 @@ type TeamMemberWorkflowStudioState = {
   readonly save: () => void;
   readonly savePending: boolean;
   readonly savePlaceholderReason: string;
-  readonly workflowActionError: string;
-  readonly clearWorkflowActionError: () => void;
   readonly draftRunPanelOpen: boolean;
   readonly selectedEdgeId: string;
   readonly selectedNodeId: string;
@@ -1184,7 +1182,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     React.useState<StudioMemberBindingRunStatusResponse | null>(null);
   const [publishError, setPublishError] = React.useState('');
   const [publishErrorVisible, setPublishErrorVisible] = React.useState(true);
-  const [workflowActionError, setWorkflowActionError] = React.useState('');
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
   const [draftRunPanelOpen, setDraftRunPanelOpen] = React.useState(false);
   const [yamlPanelOpen, setYamlPanelOpen] = React.useState(false);
@@ -1768,21 +1765,12 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       return saveOutcome;
     },
     onError: () => {
-      setWorkflowActionError(
-        t(
-          'teamMemberWorkflowStudio.alerts.draftSaveFailed.description',
-          "We couldn't save the workflow draft. Review your changes and try again.",
-        ),
-      );
       toast.error(
         t(
           'teamMemberWorkflowStudio.toast.draftSaveFailed',
           'Could not save the workflow draft. Review the details and try again.',
         ),
       );
-    },
-    onMutate: () => {
-      setWorkflowActionError('');
     },
     onSuccess: (saveOutcome, variables) => {
       markSavedDraft(
@@ -1815,12 +1803,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       if (
         !(error instanceof PublishWorkflowStatusError && !error.showAsError)
       ) {
-        setWorkflowActionError(
-          t(
-            'teamMemberWorkflowStudio.alerts.saveAndPublishFailed.description',
-            "We couldn't validate and publish the workflow. Review the workflow and try again.",
-          ),
-        );
         toast.error(
           t(
             'teamMemberWorkflowStudio.toast.saveAndPublishFailed',
@@ -1828,9 +1810,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
           ),
         );
       }
-    },
-    onMutate: () => {
-      setWorkflowActionError('');
     },
     onSuccess: ({ materializedWorkflow, savedDraft }, variables) => {
       markSavedDraft(savedDraft, ['published'], variables.draftRevision);
@@ -1958,17 +1937,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
     onError: (error) => {
       const memberLinkPending =
         error instanceof CreatedWorkflowMemberLinkPendingError;
-      setWorkflowActionError(
-        memberLinkPending
-          ? t(
-              'teamMemberWorkflowStudio.alerts.memberLinkFailed.description',
-              "We couldn't finish linking the workflow member. Your draft is still available. Save again to retry.",
-            )
-          : t(
-              'teamMemberWorkflowStudio.alerts.memberCreateFailed.description',
-              "We couldn't create the workflow member. Review your changes and try again.",
-            ),
-      );
       toast.error(
         memberLinkPending
           ? t(
@@ -1980,9 +1948,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
               'Could not create the workflow member. Review the details and try again.',
             ),
       );
-    },
-    onMutate: () => {
-      setWorkflowActionError('');
     },
     onSuccess: ({ memberId, savedDraft, workflowId }) => {
       setPendingCreatedWorkflowMemberLink(null);
@@ -2080,21 +2045,12 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       };
     },
     onError: () => {
-      setWorkflowActionError(
-        t(
-          'teamMemberWorkflowStudio.alerts.draftSaveFailed.description',
-          "We couldn't save the workflow draft. Review your changes and try again.",
-        ),
-      );
       toast.error(
         t(
           'teamMemberWorkflowStudio.toast.draftSaveFailed',
           'Could not save the workflow draft. Review the details and try again.',
         ),
       );
-    },
-    onMutate: () => {
-      setWorkflowActionError('');
     },
     onSuccess: ({ savedDraft, workflowId }) => {
       cacheSavedWorkflowDraft(savedDraft);
@@ -3616,8 +3572,6 @@ export function useTeamMemberWorkflowStudio(): TeamMemberWorkflowStudioState {
       createWorkflowMemberMutation.isPending ||
       createUnlinkedMemberDraftMutation.isPending,
     savePlaceholderReason,
-    workflowActionError,
-    clearWorkflowActionError: () => setWorkflowActionError(''),
     draftRunPanelOpen,
     selectedEdgeId,
     selectedNodeId,

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -1135,10 +1135,10 @@ describe('TeamMemberWorkflowStudioPage', () => {
     );
     expect(message.error).not.toHaveBeenCalled();
     expect(
-      await screen.findByText(
+      screen.queryByText(
         "We couldn't create the workflow member. Review your changes and try again.",
       ),
-    ).toBeTruthy();
+    ).toBeNull();
   });
 
   it('waits for a newly created workflow member to materialize before linking the draft', async () => {
@@ -1265,14 +1265,16 @@ describe('TeamMemberWorkflowStudioPage', () => {
     const saveButton = screen.getByRole('button', { name: 'Save' });
     fireEvent.click(saveButton);
 
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Could not finish linking the workflow member. Save again to retry.',
+      ),
+    );
     expect(
-      await screen.findByText(
+      screen.queryByText(
         "We couldn't finish linking the workflow member. Your draft is still available. Save again to retry.",
       ),
-    ).toBeTruthy();
-    expect(mockConsoleToast.error).toHaveBeenCalledWith(
-      'Could not finish linking the workflow member. Save again to retry.',
-    );
+    ).toBeNull();
     expect(studioApi.saveWorkflow).toHaveBeenCalledTimes(1);
     expect(studioApi.createMember).toHaveBeenCalledTimes(1);
     expect(studioApi.updateMemberImplementationRef).not.toHaveBeenCalled();
@@ -7471,12 +7473,13 @@ describe('TeamMemberWorkflowStudioPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          "We couldn't validate and publish the workflow. Review the workflow and try again.",
-        ),
-      ).toBeTruthy();
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Could not save and publish the workflow. Review the details and try again.',
+      );
     });
+    expect(
+      screen.queryByText('Latest workflow preview failed.'),
+    ).not.toBeInTheDocument();
     expect(studioApi.previewExplicitRequests).toHaveBeenCalledWith({
       executionMode: 'interactive',
       inlineWorkflowYamls: {},

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -309,19 +309,6 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
           type="error"
         />
       ) : null}
-      {studio.workflowActionError ? (
-        <Alert
-          banner
-          closable
-          description={studio.workflowActionError}
-          message={t(
-            'teamMemberWorkflowStudio.alerts.actionError.title',
-            'Workflow changes need attention',
-          )}
-          onClose={studio.clearWorkflowActionError}
-          type="error"
-        />
-      ) : null}
       <section
         ref={editorRegionRef}
         style={{

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
@@ -26,7 +26,7 @@ type ShellProps = {
   } | null;
   readonly activeSection: WorkflowActivitySection;
   readonly children: React.ReactNode;
-  readonly description: string;
+  readonly description?: string;
   readonly footer?: React.ReactNode;
   readonly headerActions?: React.ReactNode;
   readonly onNavigate?: (target: string) => void;
@@ -126,7 +126,7 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
       <header className="wa-vnext__header">
         <div className="wa-vnext__heading-copy">
           <h1>{title}</h1>
-          <p>{description}</p>
+          {description ? <p>{description}</p> : null}
         </div>
         {headerActions ? (
           <div className="wa-vnext__header-actions">{headerActions}</div>

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
@@ -249,7 +249,7 @@ describe('Workflow Activity vNext run detail recovery', () => {
     expect(screen.queryByText(/state version/i)).not.toBeInTheDocument();
   });
 
-  it("keeps a retry failure's server detail out of the confirmation message", async () => {
+  it('reports a retry failure with a toast and keeps server detail out of the page', async () => {
     mockWorkflowActivityApi.forkRun.mockRejectedValue(
       new Error('POST /api/workflow/runs/fork returned 503'),
     );
@@ -263,14 +263,17 @@ describe('Workflow Activity vNext run detail recovery', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Confirm retry' }));
 
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "The new run couldn't be started",
+      ),
+    );
     expect(
-      (await screen.findAllByText("The new run couldn't be started")).length,
-    ).toBeGreaterThan(0);
-    for (const detail of screen.getAllByText(
-      'POST /api/workflow/runs/fork returned 503',
-    )) {
-      expect(detail).not.toBeVisible();
-    }
+      screen.queryByText("The new run couldn't be started"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('POST /api/workflow/runs/fork returned 503'),
+    ).not.toBeInTheDocument();
   });
 
   it('keeps committed detail visible and disables run again when graph evidence fails', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.tsx
@@ -131,7 +131,6 @@ const RunDetailPage: React.FC<{
     retry: false,
   });
   const [forking, setForking] = React.useState(false);
-  const [forkError, setForkError] = React.useState('');
   const [receipt, setReceipt] =
     React.useState<WorkflowRunForkAcceptedReceipt | null>(null);
   const [pendingRecovery, setPendingRecovery] = React.useState<{
@@ -200,7 +199,6 @@ const RunDetailPage: React.FC<{
   const fork = async (startAtStepId: string): Promise<boolean> => {
     if (forking) return false;
     setForking(true);
-    setForkError('');
     try {
       setReceipt(
         await workflowActivityApi.forkRun({
@@ -210,8 +208,13 @@ const RunDetailPage: React.FC<{
         }),
       );
       return true;
-    } catch (error) {
-      setForkError(errorMessage(error));
+    } catch {
+      toast.error(
+        t(
+          'workflowActivityVNext.run.startFailed',
+          "The new run couldn't be started",
+        ),
+      );
       return false;
     } finally {
       setForking(false);
@@ -365,17 +368,6 @@ const RunDetailPage: React.FC<{
           </Button>
         </Space>
       </div>
-      {forkError ? (
-        <Alert
-          description={<TechnicalDetails>{forkError}</TechnicalDetails>}
-          message={t(
-            'workflowActivityVNext.run.startFailed',
-            "The new run couldn't be started",
-          )}
-          showIcon
-          type="error"
-        />
-      ) : null}
       {receipt ? (
         <Alert
           action={
@@ -925,17 +917,6 @@ const RunDetailPage: React.FC<{
             },
           ]}
         />
-        {forkError ? (
-          <Alert
-            description={<TechnicalDetails>{forkError}</TechnicalDetails>}
-            message={t(
-              'workflowActivityVNext.run.startFailed',
-              "The new run couldn't be started",
-            )}
-            showIcon
-            type="error"
-          />
-        ) : null}
       </Modal>
     </WorkflowActivityVNextShell>
   );

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1810,6 +1810,17 @@ describe('Workflow Activity vNext editor', () => {
 
   afterEach(() => cleanupTestQueryClients());
 
+  it('keeps the editor header focused on the workflow name', async () => {
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(
+      await screen.findByDisplayValue('Committed source'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Build, test, and refine this workflow.'),
+    ).not.toBeInTheDocument();
+  });
+
   it('requires an explicitly selected real scope service before publishing a saved workflow', async () => {
     mockLocation =
       '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-draft-alpha';
@@ -3406,7 +3417,7 @@ describe('Workflow Activity vNext editor', () => {
     expect(mockRuntimeRunsApi.streamDraftRun).not.toHaveBeenCalled();
   });
 
-  it("keeps a save failure's server detail out of the primary editor message", async () => {
+  it('reports a save failure with a toast instead of a page alert', async () => {
     mockStudioApi.saveWorkflow.mockRejectedValue(
       new Error('PUT /api/studio/workflows/wf-committed-source returned 500'),
     );
@@ -3421,14 +3432,19 @@ describe('Workflow Activity vNext editor', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save workflow' }));
 
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "Workflow couldn't be saved",
+      ),
+    );
     expect(
-      await screen.findByText("Workflow couldn't be saved"),
-    ).toBeInTheDocument();
+      screen.queryByText("Workflow couldn't be saved"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         'PUT /api/studio/workflows/wf-committed-source returned 500',
       ),
-    ).not.toBeVisible();
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('status', { name: 'Workflow save status' }),
     ).toHaveTextContent('Save failed');

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1,6 +1,7 @@
 import {
   act,
   fireEvent,
+  render,
   screen,
   waitFor,
   within,
@@ -3726,7 +3727,7 @@ describe('Workflow Activity vNext editor', () => {
     );
   });
 
-  it('keeps a failed node insertion visible and retryable', async () => {
+  it('reports a failed node insertion with a retryable toast', async () => {
     const serializeFailure = new Error(
       'POST /api/editor/serialize-yaml returned 500',
     );
@@ -3745,17 +3746,25 @@ describe('Workflow Activity vNext editor', () => {
       await screen.findByRole('button', { name: 'Insert LLM call node' }),
     );
 
-    expect(await screen.findByText("Couldn't add node")).toBeVisible();
-    expect(screen.getByText(serializeFailure.message)).not.toBeVisible();
-    expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled();
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledTimes(1),
+    );
+    expect(screen.queryByText("Couldn't add node")).not.toBeInTheDocument();
+    expect(screen.queryByText(serializeFailure.message)).not.toBeInTheDocument();
+    const [content] = mockConsoleToast.error.mock.calls[0];
+    const toastContent = render(content).container;
+    expect(
+      within(toastContent).getByText("Couldn't add node"),
+    ).toBeVisible();
+    const retryButton = within(toastContent).getByRole('button', {
+      name: 'Retry',
+    });
+    expect(retryButton).toBeEnabled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    fireEvent.click(retryButton);
 
     await waitFor(() =>
       expect(mockStudioApi.serializeYaml).toHaveBeenCalledTimes(2),
-    );
-    await waitFor(() =>
-      expect(screen.queryByText("Couldn't add node")).not.toBeInTheDocument(),
     );
   });
 
@@ -4731,7 +4740,7 @@ describe('Workflow Activity vNext creation', () => {
     expect(screen.queryByText('scope-alpha')).not.toBeInTheDocument();
   });
 
-  it('clears a submission failure when changing creation methods', async () => {
+  it('reports a submission failure with a toast and keeps method changes usable', async () => {
     mockStudioApi.authorWorkflow.mockRejectedValue(
       new Error('LLM service rejected the request'),
     );
@@ -4747,9 +4756,17 @@ describe('Workflow Activity vNext creation', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Generate and open' }));
 
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "Workflow couldn't be created",
+      ),
+    );
     expect(
-      await screen.findByText("Workflow couldn't be created"),
-    ).toBeInTheDocument();
+      screen.queryByText("Workflow couldn't be created"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('LLM service rejected the request'),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Change method' }));
     fireEvent.click(screen.getByRole('button', { name: 'Start blank' }));
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import AccountPanel from './AccountPanel';
+
+const mockLoginWithRedirect = jest.fn();
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
+jest.mock('@/shared/auth/client', () => ({
+  NyxIDAuthClient: jest.fn().mockImplementation(() => ({
+    loginWithRedirect: mockLoginWithRedirect,
+  })),
+}));
+
+jest.mock('@/shared/ui/ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
+}));
+
+const identity = {
+  displayName: { kind: 'value', value: 'Ada Lovelace' },
+  email: { kind: 'value', value: 'ada@example.com' },
+  expiry: { kind: 'value', value: 'Aug 7, 2026' },
+  picture: null,
+  provider: { kind: 'value', value: 'NyxID' },
+  scope: { kind: 'value', value: 'scope-alpha' },
+  sessionState: 'active',
+  support: {
+    groups: [],
+    roles: [],
+    subject: 'user-alpha',
+  },
+} as const;
+
+describe('Workflow Activity vNext account panel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports service access review failures with a toast', async () => {
+    mockLoginWithRedirect.mockRejectedValue(
+      new Error('authorization endpoint unavailable'),
+    );
+
+    render(
+      <AccountPanel
+        identity={identity}
+        onRefresh={jest.fn()}
+        returnTo="/scopes/scope-alpha/workflow-activity-vnext/settings"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Manage service access' }),
+    );
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Could not start service access review. Try again.',
+      ),
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Manage service access' }),
+    ).not.toHaveClass('ant-btn-loading');
+  });
+});

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/AccountPanel.tsx
@@ -5,7 +5,7 @@ import {
   SafetyCertificateOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import { Alert, Avatar, Button, Descriptions, Space, Typography } from 'antd';
+import { Avatar, Button, Descriptions, Space, Typography } from 'antd';
 import React from 'react';
 import { NyxIDAuthClient } from '@/shared/auth/client';
 import { getNyxIDRuntimeConfig } from '@/shared/auth/config';
@@ -16,6 +16,7 @@ import {
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
 import { AevatarCompactText } from '@/shared/ui/compactText';
+import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import TechnicalDetails from '../TechnicalDetails';
 import type { AccountField, AccountIdentity } from './accountIdentity';
 
@@ -57,8 +58,8 @@ const AccountPanel: React.FC<AccountPanelProps> = ({
   onRefresh,
   returnTo,
 }) => {
+  const toast = useConsoleToast();
   const [reviewPending, setReviewPending] = React.useState(false);
-  const [reviewError, setReviewError] = React.useState('');
   const recoverable =
     identity.sessionState === 'expired' || identity.sessionState === 'invalid';
   const displayName = accountFieldValue(identity.displayName);
@@ -76,14 +77,13 @@ const AccountPanel: React.FC<AccountPanelProps> = ({
   const reviewServiceAccess = async () => {
     try {
       setReviewPending(true);
-      setReviewError('');
       await new NyxIDAuthClient(getNyxIDRuntimeConfig()).loginWithRedirect({
         flow: 'serviceAccessReview',
         returnTo,
       });
     } catch {
       setReviewPending(false);
-      setReviewError(
+      toast.error(
         t(
           'workflowActivityVNext.settings.serviceAccessFailed',
           'Could not start service access review. Try again.',
@@ -172,10 +172,6 @@ const AccountPanel: React.FC<AccountPanelProps> = ({
           </>
         )}
       </Space>
-
-      {reviewError ? (
-        <Alert message={reviewError} role="alert" showIcon type="error" />
-      ) : null}
 
       <TechnicalDetails
         summary={t(

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
@@ -298,7 +298,9 @@ describe('New workflow save-target recovery', () => {
     expect(
       await screen.findByText("Workflow couldn't be created"),
     ).toBeVisible();
-    expect(screen.getByText('Generation unavailable')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Generation unavailable'),
+    ).not.toBeInTheDocument();
     expect(description).toHaveValue('Summarize this week');
     expect(mockStudioApi.createWorkflowDraft).not.toHaveBeenCalled();
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
@@ -12,6 +12,7 @@ import { scopesApi } from '@/shared/api/scopesApi';
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
+import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import type {
   StudioValidationFinding,
   StudioWorkflowSaveResult,
@@ -94,6 +95,7 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
   >([]);
   const [submitting, setSubmitting] = React.useState(false);
   const [failure, setFailure] = React.useState('');
+  const toast = useConsoleToast();
   const materialization = useDraftMaterialization(scopeId);
   const workspace = useQuery({
     queryKey: ['workflow-activity-vnext', 'workspace', scopeId],
@@ -123,6 +125,16 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
     }
     setDirectoryId(workspace.data.directories[0]?.directoryId ?? '');
   }, [directoryId, workspace.data]);
+
+  React.useEffect(() => {
+    if (!failure) return;
+    toast.error(
+      t(
+        'workflowActivityVNext.new.createFailed',
+        "Workflow couldn't be created",
+      ),
+    );
+  }, [failure, toast]);
 
   const navigateToWorkflow = React.useCallback(
     (workflowId: string) =>
@@ -613,17 +625,6 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                   />
                 ))}
               </div>
-            ) : null}
-            {failure ? (
-              <Alert
-                description={<TechnicalDetails>{failure}</TechnicalDetails>}
-                message={t(
-                  'workflowActivityVNext.new.createFailed',
-                  "Workflow couldn't be created",
-                )}
-                showIcon
-                type="error"
-              />
             ) : null}
             {materialization.phase !== 'idle' && materialization.receipt ? (
               <div

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -17,6 +17,7 @@ import { getLocationSnapshot, history } from '@/shared/navigation/history';
 import { studioApi } from '@/shared/studio/api';
 import { createWorkflowRevisionIdentityCandidate } from '@/shared/studio/explicitRequestConfirmation';
 import type { StudioExplicitRequestPreview } from '@/shared/studio/models';
+import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import {
   getRunStatusPresentation,
   isRunStatusInProgress,
@@ -124,6 +125,7 @@ const WorkflowEditorPage: React.FC<{
   const activeScopeId = activeEditorRoute.scopeId;
   const activeWorkflowId = activeEditorRoute.workflowId;
   const editor = useWorkflowEditor(activeScopeId, activeWorkflowId);
+  const toast = useConsoleToast();
   const [mode, setMode] = React.useState<'canvas' | 'yaml'>('canvas');
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
   const [publishDialogOpen, setPublishDialogOpen] = React.useState(false);
@@ -298,6 +300,16 @@ const WorkflowEditorPage: React.FC<{
   const saveWorkflow = React.useCallback(async () => {
     return editor.save();
   }, [editor.save]);
+
+  React.useEffect(() => {
+    if (!editor.saveError) return;
+    toast.error(
+      t(
+        'workflowActivityVNext.editor.saveFailed',
+        "Workflow couldn't be saved",
+      ),
+    );
+  }, [editor.saveError, toast]);
 
   const retryMaterialization = React.useCallback(async () => {
     await editor.retryMaterialization();
@@ -761,10 +773,6 @@ const WorkflowEditorPage: React.FC<{
   return (
     <WorkflowActivityVNextShell
       activeSection="workflows"
-      description={t(
-        'workflowActivityVNext.editor.description',
-        'Build, test, and refine this workflow.',
-      )}
       headerActions={
         <>
           <Button
@@ -911,17 +919,6 @@ const WorkflowEditorPage: React.FC<{
           />
         </div>
       </div>
-      {editor.saveError ? (
-        <Alert
-          description={<TechnicalDetails>{editor.saveError}</TechnicalDetails>}
-          message={t(
-            'workflowActivityVNext.editor.saveFailed',
-            "Workflow couldn't be saved",
-          )}
-          showIcon
-          type="error"
-        />
-      ) : null}
       {editor.nodeInsertionError ? (
         <Alert
           action={

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -311,6 +311,27 @@ const WorkflowEditorPage: React.FC<{
     );
   }, [editor.saveError, toast]);
 
+  React.useEffect(() => {
+    if (!editor.nodeInsertionError) return;
+    toast.error(
+      <Space size="small">
+        <span>
+          {t(
+            'workflowActivityVNext.editor.addNodeFailed',
+            "Couldn't add node",
+          )}
+        </span>
+        <Button
+          onClick={() => void editor.retryNodeInsertion()}
+          size="small"
+          type="link"
+        >
+          {t('workflowActivityVNext.common.retry', 'Retry')}
+        </Button>
+      </Space>,
+    );
+  }, [editor.nodeInsertionError, editor.retryNodeInsertion, toast]);
+
   const retryMaterialization = React.useCallback(async () => {
     await editor.retryMaterialization();
   }, [editor.retryMaterialization]);
@@ -919,27 +940,6 @@ const WorkflowEditorPage: React.FC<{
           />
         </div>
       </div>
-      {editor.nodeInsertionError ? (
-        <Alert
-          action={
-            <Button
-              disabled={editorWriteLocked}
-              onClick={() => void editor.retryNodeInsertion()}
-            >
-              {t('workflowActivityVNext.common.retry', 'Retry')}
-            </Button>
-          }
-          description={
-            <TechnicalDetails>{editor.nodeInsertionError}</TechnicalDetails>
-          }
-          message={t(
-            'workflowActivityVNext.editor.addNodeFailed',
-            "Couldn't add node",
-          )}
-          showIcon
-          type="error"
-        />
-      ) : null}
       {editor.materialization.phase !== 'idle' &&
       editor.materialization.receipt ? (
         <Alert

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowPublishDialog.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowPublishDialog.test.tsx
@@ -10,10 +10,21 @@ import { scopeRuntimeApi } from '@/shared/api/scopeRuntimeApi';
 import { renderWithQueryClient } from '../../../../tests/reactQueryTestUtils';
 import WorkflowPublishDialog from './WorkflowPublishDialog';
 
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
 jest.mock('@/shared/api/scopeRuntimeApi', () => ({
   scopeRuntimeApi: {
     listServices: jest.fn(),
   },
+}));
+
+jest.mock('@/shared/ui/ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
 }));
 
 const mockListServices = scopeRuntimeApi.listServices as jest.Mock;
@@ -111,7 +122,45 @@ function startReview(dialog: HTMLElement): void {
 
 describe('WorkflowPublishDialog', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockListServices.mockResolvedValue([service]);
+  });
+
+  it('reports a review failure with a toast instead of an inline error', async () => {
+    const onReview = jest.fn().mockRejectedValue(
+      new Error('POST /api/studio/publication-review returned 500'),
+    );
+
+    renderDialog({
+      onPublish: jest.fn(async () => undefined),
+      onReview,
+      onReturnToSelection: jest.fn(),
+    });
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Publish workflow',
+    });
+    await selectService(dialog);
+    startReview(dialog);
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        "We couldn't prepare this workflow for publishing.",
+      ),
+    );
+    expect(
+      within(dialog).queryByText(
+        "We couldn't prepare this workflow for publishing.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).queryByText(
+        'POST /api/studio/publication-review returned 500',
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(dialog).getByRole('button', { name: 'Review and publish' }),
+    ).toBeEnabled();
   });
 
   it('keeps the final publish action unavailable while preparing the review', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowPublishDialog.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowPublishDialog.tsx
@@ -3,6 +3,7 @@ import { Alert, Button, Modal, Select, Space, Typography } from 'antd';
 import React from 'react';
 import { scopeRuntimeApi } from '@/shared/api/scopeRuntimeApi';
 import { t } from '@/shared/i18n/messages';
+import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import type {
   StudioExplicitRequestConfirmation,
   StudioExplicitRequestPreview,
@@ -92,7 +93,7 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
   const [selectedServiceId, setSelectedServiceId] = React.useState('');
   const [stage, setStage] = React.useState<PublicationStage>('selecting');
   const [review, setReview] = React.useState<PublicationReview | null>(null);
-  const [actionError, setActionError] = React.useState<unknown>(null);
+  const toast = useConsoleToast();
   const reviewGenerationRef = React.useRef(0);
   const servicesQuery = useQuery({
     enabled: open && Boolean(normalizedScopeId),
@@ -117,7 +118,6 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
     setSelectedServiceId('');
     setStage('selecting');
     setReview(null);
-    setActionError(null);
   }, [open, selectedServiceIsAvailable]);
 
   const servicesStatus = errorStatus(servicesQuery.error);
@@ -135,14 +135,12 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
     reviewGenerationRef.current += 1;
     setStage('selecting');
     setReview(null);
-    setActionError(null);
     onReturnToSelection();
   }, [onReturnToSelection]);
 
   const handleReview = React.useCallback(async () => {
     if (!canReview) return;
     const generation = ++reviewGenerationRef.current;
-    setActionError(null);
     setReview(null);
     setStage('preparing');
     try {
@@ -161,14 +159,13 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
       setStage('reviewing');
     } catch (error) {
       if (generation !== reviewGenerationRef.current) return;
-      setActionError(error);
+      toast.error(errorCopy(error));
       setStage('selecting');
     }
-  }, [canReview, onReview, selectedServiceId]);
+  }, [canReview, onReview, selectedServiceId, toast]);
 
   const handlePublish = React.useCallback(async () => {
     if (!review || stage !== 'reviewing') return;
-    setActionError(null);
     setStage('submitting');
     try {
       const confirmations = review.preview.items.map((item) => ({
@@ -184,10 +181,10 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
         serviceId: review.serviceId,
       });
     } catch (error) {
-      setActionError(error);
+      toast.error(errorCopy(error));
       setStage('reviewing');
     }
-  }, [onPublish, review, stage]);
+  }, [onPublish, review, stage, toast]);
 
   const close = React.useCallback(() => {
     if (stage === 'submitting') return;
@@ -226,21 +223,6 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
     />
   ) : null;
 
-  const actionErrorAlert = actionError ? (
-    <Alert
-      action={
-        stage === 'selecting' && selectedServiceId ? (
-          <Button onClick={() => void handleReview()}>
-            {t('workflowActivityVNext.publish.reviewAgain', 'Review again')}
-          </Button>
-        ) : undefined
-      }
-      message={errorCopy(actionError)}
-      showIcon
-      type="error"
-    />
-  ) : null;
-
   const selectionContent = (
     <>
       <Typography.Paragraph>
@@ -259,7 +241,6 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
         </Typography.Text>
       ) : null}
       {serviceErrorAlert}
-      {actionErrorAlert}
       {hasNoServices ? (
         <Alert
           action={
@@ -282,7 +263,6 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
             reviewGenerationRef.current += 1;
             setSelectedServiceId(value);
             setReview(null);
-            setActionError(null);
           }}
           options={services.map((service) => ({
             label: service.displayName,
@@ -362,7 +342,6 @@ const WorkflowPublishDialog: React.FC<WorkflowPublishDialogProps> = ({
           </div>
         ))
       )}
-      {actionErrorAlert}
     </>
   ) : null;
 

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleOperationNotice.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleOperationNotice.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import ConsoleOperationNotice from './ConsoleOperationNotice';
+
+const mockConsoleToast = {
+  error: jest.fn(),
+  info: jest.fn(),
+  success: jest.fn(),
+  warning: jest.fn(),
+};
+
+jest.mock('./ConsoleToast', () => ({
+  useConsoleToast: () => mockConsoleToast,
+}));
+
+describe('ConsoleOperationNotice', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes errors to a safe toast without rendering the raw notice', async () => {
+    const onClose = jest.fn();
+    render(
+      <ConsoleOperationNotice
+        errorMessage="Action could not be completed. Try again."
+        notice={{
+          message: 'POST /api/action returned 500',
+          type: 'error',
+        }}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Action could not be completed. Try again.',
+      ),
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('POST /api/action returned 500'),
+    ).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps non-error operation notices visible', () => {
+    render(
+      <ConsoleOperationNotice
+        errorMessage="Action could not be completed. Try again."
+        notice={{ message: 'Action accepted', type: 'success' }}
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Action accepted');
+    expect(mockConsoleToast.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleOperationNotice.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleOperationNotice.tsx
@@ -1,0 +1,48 @@
+import { Alert } from 'antd';
+import * as React from 'react';
+import { useConsoleToast } from './ConsoleToast';
+
+export type ConsoleOperationNoticeValue = {
+  readonly message: string;
+  readonly type: 'error' | 'info' | 'success' | 'warning';
+};
+
+type ConsoleOperationNoticeProps = {
+  readonly errorMessage: string;
+  readonly notice: ConsoleOperationNoticeValue | null | undefined;
+  readonly onClose?: () => void;
+};
+
+const ConsoleOperationNotice: React.FC<ConsoleOperationNoticeProps> = ({
+  errorMessage,
+  notice,
+  onClose,
+}) => {
+  const toast = useConsoleToast();
+  const shownErrorRef = React.useRef<ConsoleOperationNoticeValue | null>(null);
+
+  React.useEffect(() => {
+    if (notice?.type !== 'error') {
+      shownErrorRef.current = null;
+      return;
+    }
+    if (shownErrorRef.current === notice) return;
+    shownErrorRef.current = notice;
+    toast.error(errorMessage);
+    onClose?.();
+  }, [errorMessage, notice, onClose, toast]);
+
+  if (!notice || notice.type === 'error') return null;
+
+  return (
+    <Alert
+      closable={Boolean(onClose)}
+      message={notice.message}
+      onClose={onClose}
+      showIcon
+      type={notice.type}
+    />
+  );
+};
+
+export default ConsoleOperationNotice;


### PR DESCRIPTION
## Problem

Transient action and API failures were still rendered as persistent inline Alerts across several frontend surfaces, sometimes exposing raw backend details such as endpoint paths or HTTP failures.

## Solution

- Add a shared `ConsoleOperationNotice` that routes error notices to safe localized toasts while preserving non-error notices inline.
- Replace transient inline action errors across Workflow Activity, Studio, Chat, Settings, Deployments, Governance, and GAgent surfaces.
- Remove raw backend details and obsolete duplicate error state.
- Keep query/loading, validation, committed run, binding, and materialization states persistent.
- Add focused regression coverage and English/Chinese safe-toast copy.

## Impact paths

- `apps/aevatar-console-web/src/shared/ui/ConsoleOperationNotice.tsx`
- Workflow Activity vNext editor, creation, publish, run detail, and settings
- Studio build, files, explorer, bind, inspector, and execution surfaces
- Chat, Settings, Deployments, Governance, and GAgent pages
- Team member workflow studio hook and page

## Local verification

- Dependency-related Jest coverage included 20 related suites. Seventeen passed in the grouped run; two stale inline-error assertions were updated, and those cases plus two long-run timeout cases all passed on direct focused reruns.
- The explicit changed-test batch covered 12 suites. All affected cases passed after obsolete inline-error expectations were updated.
- Additional focused Workflow Activity, GAgent, Studio bind, inspector, execution, and team workflow tests passed.
- Changed-file lint: `pnpm --dir apps/aevatar-console-web exec biome lint <39 explicit changed files>` passed with five pre-existing warnings.
- Selected-file formatting: `pnpm --dir apps/aevatar-console-web exec biome format <10 explicit files>` passed.
- Test stability: `bash tools/ci/test_stability_guards.sh` passed.
- Patch integrity: `git diff --check` passed before commit.
- Conflict resolution: merged `origin/feat/2026-08-04_workflow-activity-vnext` at `70ddb63e1`.
- Conflict-focused test: `pnpm exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx` passed 1 suite and 12 tests.
- Dependency-related test: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx --runInBand` passed 2 suites and 101 tests.
- Conflict-file static checks: `pnpm exec biome lint ...` and `pnpm exec biome format ...` passed for `NewWorkflowPage.tsx` and its test.
- A repository-native affected TypeScript target is unavailable, so local typecheck was skipped.
- Full frontend suite/build is delegated to GitHub CI by personal local workflow policy.

## Documentation

No architecture or API contract documentation changes are required. This change standardizes presentation behavior for existing frontend failures.