### PR TITLE
Restore workflow name in Describe creation

### DIFF
--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-new-workflow-creation-ux.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-new-workflow-creation-ux.md
@@ -234,7 +234,9 @@ it('generates, validates, creates, and opens a described workflow with one actio
   renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
 
   fireEvent.click(await screen.findByRole('button', { name: 'Describe' }));
-  expect(screen.queryByLabelText('Workflow name')).not.toBeInTheDocument();
+  fireEvent.change(screen.getByLabelText('Workflow name'), {
+    target: { value: 'Weekly feedback' },
+  });
   expect(screen.queryByLabelText('Generated YAML')).not.toBeInTheDocument();
   fireEvent.change(screen.getByLabelText('What should this workflow do?'), {
     target: { value: 'Summarize weekly customer feedback' },
@@ -247,7 +249,7 @@ it('generates, validates, creates, and opens a described workflow with one actio
     expect.objectContaining({ onText: expect.any(Function) }),
   );
   expect(mockStudioApi.createWorkflowDraft).toHaveBeenCalledWith(
-    expect.objectContaining({ workflowName: 'weekly_feedback' }),
+    expect.objectContaining({ workflowName: 'Weekly feedback' }),
   );
   expect(history.push).toHaveBeenCalledWith(
     '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-created-alpha',
@@ -285,12 +287,7 @@ const createFromDescription = async () => {
     const parsed = await studioApi.parseYaml({ yaml: generated });
     setFindings(parsed.findings);
     if (hasBlockingFindings(parsed.document, parsed.findings)) return;
-    const generatedName = String(parsed.document?.name ?? '').trim();
-    if (!generatedName) {
-      setFailure(t('workflowActivityVNext.new.generatedNameMissing', 'The generated workflow has no name. Try describing it again.'));
-      return;
-    }
-    await persist(generated, generatedName, { manageSubmitting: false });
+    await persist(generated, name.trim(), { manageSubmitting: false });
   } catch (error) {
     setFailure(errorMessage(error));
   } finally {
@@ -304,8 +301,8 @@ and create. Keep the materialized/accepted handling in `finishSave` unchanged.
 
 - [ ] **Step 4: Render the focused Describe surface**
 
-Use `Describe your workflow`, the supporting sentence, a labeled textarea, and
-one primary button:
+Use `Describe your workflow`, the supporting sentence, a Workflow name input,
+a labeled textarea, and one primary button:
 
 ```tsx
 <label className="wa-vnext__creation-field">
@@ -409,11 +406,13 @@ Expected: FAIL on old name fields and old action labels.
 - [ ] **Step 3: Implement method-specific name derivation**
 
 - Blank continues to require `Workflow name` and uses `Create and open`.
+- Describe requires `Workflow name`, uses it independently of the generated
+  YAML document name, and completes through `Generate and open`.
 - Import parses first, rejects a missing parsed name with localized actionable
   copy, then persists using that parsed name and `Import and open`.
 - Template copies the selected YAML, parses it, and persists with the localized
   display name `${templateName} copy` through `Use template and open`.
-- Describe, Import, and Template do not render the shared Workflow name field.
+- Import and Template do not render the shared Workflow name field.
 
 Keep the server parser call for template YAML so backend field naming and
 validation remain authoritative.
@@ -463,8 +462,6 @@ Use equivalent English and Chinese product copy for:
 'workflowActivityVNext.new.importAndOpen': 'Import and open',
 'workflowActivityVNext.new.templateAndOpen': 'Use template and open',
 'workflowActivityVNext.new.directory': 'Save to',
-'workflowActivityVNext.new.generatedNameMissing':
-  'The generated workflow has no name. Try describing it again.',
 'workflowActivityVNext.new.importedNameMissing':
   'The imported workflow needs a name before it can be created.',
 ```

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-new-workflow-creation-ux-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-new-workflow-creation-ux-design.md
@@ -48,20 +48,23 @@ error and never overwrites the existing draft.
 
 ### Describe
 
-Describe is a focused single-input flow:
+Describe is a focused two-input flow with one final action:
 
 - heading: `Describe your workflow`;
+- field label: `Workflow name`;
 - field label: `What should this workflow do?`;
 - supporting copy explains that the generated steps can be reviewed in the
   editor;
 - one primary action: `Generate and open`.
 
 The action calls the real generator, parses and validates the returned YAML,
-derives the workflow name from the parsed document, creates the draft, waits
-for the exact draft to become readable when creation is accepted, and opens
-the editor. The page does not expose generated YAML or require a second create
-confirmation. Generator, parse, validation, create, and materialization
-failures preserve the prompt and identify the failed stage in product terms.
+uses the user-provided Workflow name for the draft display name and filename,
+creates the draft, waits for the exact draft to become readable when creation
+is accepted, and opens the editor. The generated YAML document name remains an
+independent document field. The page does not expose generated YAML or require
+a second create confirmation. Generator, parse, validation, create, and
+materialization failures preserve both inputs and identify the failed stage in
+product terms.
 
 ### Other Creation Methods
 
@@ -70,7 +73,7 @@ provide, then use one final action.
 
 | Method | Visible input | Name source | Primary action |
 | --- | --- | --- | --- |
-| Describe | Natural-language workflow outcome | Parsed generator result | Generate and open |
+| Describe | Workflow name and natural-language workflow outcome | User input | Generate and open |
 | Start blank | Workflow name | User input | Create and open |
 | Import YAML | Workflow YAML | Parsed YAML document | Import and open |
 | Use template | Bundled template selection and concise preview | Template name, made independent for the new draft | Use template and open |
@@ -83,17 +86,17 @@ details. Creation does not add a second editor.
 
 ### Focused Prompt
 
-Show one task-specific input and one action. Derive the name for generated,
-imported, and template workflows; ask for a name only when starting blank.
-This is the selected approach because it minimizes decisions without hiding a
-decision the user can actually make.
+Show only task-specific inputs and one final action. Describe and Start blank
+ask for the user-controlled display name; Import and Template derive their
+names from their respective sources. This is the selected approach because it
+keeps the flow direct without hiding a decision the user can actually make.
 
-### Optional Name Before Generation
+### Derived Name For Describe
 
-Keep an optional name above the Describe prompt. This gives early naming
-control but duplicates a value the generator already supplies and weakens the
-primary hierarchy. It is rejected for Describe; naming remains available in
-the editor.
+Derive the draft display name from generated YAML and ask only for the outcome.
+This is rejected because the generated document name is not a substitute for
+the user's intended Workflow display name. Describe therefore requires an
+explicit name before generation.
 
 ### Guided Wizard
 
@@ -187,14 +190,16 @@ The owning route integration test will protect these observable risks:
    create request.
 2. Multiple returned directories render `Save to` and the selected value is
    used in the create request.
-3. Describe exposes `What should this workflow do?` and one action that calls
-   generator, parser, draft create, then opens the materialized workflow.
+3. Describe requires both `Workflow name` and `What should this workflow do?`,
+   then exposes one action that calls generator, parser, draft create, and opens
+   the materialized workflow using the user-provided display name.
 4. File-name resolution chooses the first available suffix within the selected
    directory without changing the Workflow display name.
 5. Import derives the name from parsed YAML and creates without a separate
    workflow-name field.
-6. Generator or create failure preserves the prompt; switching methods clears
-   stale failure output.
+6. Generator or create failure preserves the Workflow name and prompt;
+   switching methods clears stale failure output without discarding shared
+   name input.
 7. Accepted draft creation preserves the existing observe-and-retry contract
    and never resubmits create during readiness retry.
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -4726,6 +4726,9 @@ describe('Workflow Activity vNext creation', () => {
     });
     await waitFor(() => expect(describeButton).toBeEnabled());
     fireEvent.click(describeButton);
+    fireEvent.change(screen.getByLabelText('Workflow name'), {
+      target: { value: 'Weekly review' },
+    });
     fireEvent.change(screen.getByLabelText('What should this workflow do?'), {
       target: { value: 'Summarize this week' },
     });
@@ -4740,7 +4743,7 @@ describe('Workflow Activity vNext creation', () => {
     expect(
       screen.queryByText("Workflow couldn't be created"),
     ).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Workflow name')).toHaveValue('');
+    expect(screen.getByLabelText('Workflow name')).toHaveValue('Weekly review');
   });
 
   it('keeps bundled template version metadata out of the primary interface', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
@@ -246,19 +246,25 @@ describe('New workflow save-target recovery', () => {
     renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Describe' }));
-    expect(screen.queryByLabelText('Workflow name')).not.toBeInTheDocument();
+    const workflowName = screen.getByLabelText('Workflow name');
     expect(screen.queryByLabelText('Generated YAML')).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('What should this workflow do?'), {
       target: { value: 'Summarize this week' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Generate and open' }));
+    const generateAndOpen = screen.getByRole('button', {
+      name: 'Generate and open',
+    });
+    expect(generateAndOpen).toBeDisabled();
+    fireEvent.change(workflowName, { target: { value: 'Weekly review' } });
+    expect(generateAndOpen).toBeEnabled();
+    fireEvent.click(generateAndOpen);
 
     await waitFor(() =>
       expect(mockStudioApi.createWorkflowDraft).toHaveBeenCalledWith({
         directoryId: 'directory-alpha',
         fileName: 'weekly-review.yaml',
         scopeId: 'scope-alpha',
-        workflowName: 'weekly_review',
+        workflowName: 'Weekly review',
         yaml: generatedYaml,
       }),
     );
@@ -274,7 +280,7 @@ describe('New workflow save-target recovery', () => {
     );
   });
 
-  it('preserves the description and retries generation without an earlier save', async () => {
+  it('preserves the name and description and retries generation without an earlier save', async () => {
     const generatedYaml = 'name: weekly_review\nroles: []\nsteps: []\n';
     mockStudioApi.getWorkspaceSettings.mockResolvedValue(readyWorkspace);
     mockStudioApi.authorWorkflow
@@ -289,7 +295,11 @@ describe('New workflow save-target recovery', () => {
     renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Describe' }));
+    const workflowName = screen.getByLabelText('Workflow name');
     const description = screen.getByLabelText('What should this workflow do?');
+    fireEvent.change(workflowName, {
+      target: { value: 'Weekly review' },
+    });
     fireEvent.change(description, {
       target: { value: 'Summarize this week' },
     });
@@ -299,12 +309,16 @@ describe('New workflow save-target recovery', () => {
       await screen.findByText("Workflow couldn't be created"),
     ).toBeVisible();
     expect(screen.getByText('Generation unavailable')).toBeInTheDocument();
+    expect(workflowName).toHaveValue('Weekly review');
     expect(description).toHaveValue('Summarize this week');
     expect(mockStudioApi.createWorkflowDraft).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Generate and open' }));
     await waitFor(() =>
       expect(mockStudioApi.createWorkflowDraft).toHaveBeenCalledTimes(1),
+    );
+    expect(mockStudioApi.createWorkflowDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowName: 'Weekly review' }),
     );
   });
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
@@ -207,7 +207,8 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
   };
 
   const generateAndOpen = async () => {
-    if (!prompt.trim() || submitting) return;
+    const workflowName = name.trim();
+    if (!workflowName || !prompt.trim() || submitting) return;
     setSubmitting(true);
     setFailure('');
     setFindings([]);
@@ -219,8 +220,6 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
       const parsed = await studioApi.parseYaml({ yaml: generated });
       setFindings(parsed.findings);
       if (hasBlockingFindings(parsed.document, parsed.findings)) return;
-      const workflowName = String(parsed.document?.name ?? '').trim();
-      if (!workflowName) return;
       await persistDraft(generated, workflowName);
     } catch (error) {
       setFailure(errorMessage(error));
@@ -433,7 +432,7 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                 />
               </div>
             ) : null}
-            {mode === 'blank' ? (
+            {mode === 'blank' || mode === 'describe' ? (
               <div className="wa-vnext__creation-field">
                 <span>
                   {t('workflowActivityVNext.new.name', 'Workflow name')}
@@ -480,7 +479,9 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                 </div>
                 <div className="wa-vnext__creation-actions">
                   <Button
-                    disabled={!prompt.trim() || saveTargetUnavailable}
+                    disabled={
+                      !name.trim() || !prompt.trim() || saveTargetUnavailable
+                    }
                     loading={submitting}
                     onClick={() => void generateAndOpen()}
                     type="primary"


### PR DESCRIPTION
## Problem

Describe creation omitted the user-controlled Workflow name and derived the draft name from generated YAML. That removed an expected creation input and conflated the draft display name with the YAML document name.

## Solution

- Restore the required `Workflow name` input for Describe.
- Keep `What should this workflow do?` as the generation prompt.
- Use the user-entered name for the draft display name and filename while preserving the single `Generate and open` pipeline.
- Preserve both inputs across generation failures and creation-method changes.
- Keep the single implicit workspace hidden.
- Update the focused product specification and implementation plan.

## Impact

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx`
- Focused creation tests in `NewWorkflowPage.test.tsx` and `index.test.tsx`
- Workflow creation UX specification and plan

## Local verification

- Related tests: `pnpm --dir apps/aevatar-console-web exec jest --findRelatedTests src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx --runInBand` - 95 passed
- Changed tests: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx src/pages/workflow-activity-vnext/index.test.tsx` - 95 passed
- Changed-file static checks: `pnpm --dir apps/aevatar-console-web exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx` - passed
- Stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Documentation lint: `bash tools/docs/lint.sh` - passed
- Whitespace validation: `git diff --check` - passed
- Authenticated browser smoke test: confirmed one Workflow name field, one outcome field, one Generate and open action, required-field button state, and hidden single workspace selector
- A reliable affected typecheck target is unavailable, so local typecheck was skipped.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.