### PR TITLE
Fix Add node sequential placement

### DIFF
--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-add-node-sequential-link.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-add-node-sequential-link.md
@@ -1,0 +1,400 @@
+# Add Node Sequential Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Workflow Activity vNext Add node extend the current flow with explicit sequential transitions instead of appending a disconnected step that triggers `implicit_next` warnings.
+
+**Architecture:** Add one pure document-normalization helper beside the existing insertion helpers, then compose it into only the Workflow Activity vNext `addNode` callback. The helper materializes runtime-defined adjacent ordering without changing explicit or branched transitions; `insertStepByType` remains responsible for rewiring the chosen predecessor and preserving its former successor.
+
+**Tech Stack:** React, TypeScript, Jest, Testing Library, pnpm.
+
+---
+
+## File Map
+
+- Create `apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-add-node-sequential-link.md`: executable TDD and delivery plan.
+- Modify `apps/aevatar-console-web/src/shared/studio/document.ts`: export a pure helper that turns eligible adjacent implicit transitions into explicit `next` values.
+- Modify `apps/aevatar-console-web/src/shared/studio/document.test.ts`: cover chain materialization, explicit and branched preservation, terminal behavior, and immutability.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts`: normalize the document, resolve the insertion predecessor, and pass it to `insertStepByType`.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`: exercise Add node through the page UI for append and selected-middle insertion.
+- Existing `apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-add-node-sequential-link-design.md`: approved behavior contract; no implementation edits expected.
+
+### Task 1: Specify The Pure Transition Materializer
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/shared/studio/document.test.ts`
+- Test: `apps/aevatar-console-web/src/shared/studio/document.test.ts`
+
+- [ ] **Step 1: Import the new helper and write the failing chain test**
+
+Add `materializeImplicitSequentialTransitions` to the import from `./document`, then add a test with three ordered steps: an implicit first step, a second step with an explicit successor, and a terminal third step. Assert that the first gains `next: 'review_step'`, the explicit second successor remains unchanged, and the input object still equals a deep snapshot.
+
+```ts
+it('materializes only eligible implicit sequential transitions without mutating the document', () => {
+  const document: StudioWorkflowDocument = {
+    name: 'workspace-demo',
+    roles: [],
+    steps: [
+      { id: 'draft_step', type: 'llm_call', next: null, branches: {} },
+      {
+        id: 'review_step',
+        type: 'human_approval',
+        next: 'publish_step',
+        branches: {},
+      },
+      { id: 'publish_step', type: 'emit', next: null, branches: {} },
+    ],
+  };
+  const snapshot = structuredClone(document);
+
+  const result = materializeImplicitSequentialTransitions(document);
+
+  expect(result.steps?.map((step) => step.next)).toEqual([
+    'review_step',
+    'publish_step',
+    null,
+  ]);
+  expect(document).toEqual(snapshot);
+  expect(result).not.toBe(document);
+});
+```
+
+- [ ] **Step 2: Write the failing branched and terminal test**
+
+Add a case where the first step has `branches: { approved: 'publish_step' }` and no `next`, followed by a second step. Assert the first step still has no linear successor and its branch remains byte-for-byte equivalent. In the same test group, assert empty and single-step documents keep no synthesized transition.
+
+```ts
+it('preserves branched transitions and terminal documents', () => {
+  const branched = materializeImplicitSequentialTransitions({
+    name: 'branched',
+    roles: [],
+    steps: [
+      {
+        id: 'approval_step',
+        type: 'human_approval',
+        next: null,
+        branches: { approved: 'publish_step' },
+      },
+      { id: 'publish_step', type: 'emit', next: null, branches: {} },
+    ],
+  });
+
+  expect(branched.steps?.[0]).toEqual(
+    expect.objectContaining({
+      next: null,
+      branches: { approved: 'publish_step' },
+    }),
+  );
+  expect(materializeImplicitSequentialTransitions({ steps: [] }).steps).toEqual([]);
+  expect(
+    materializeImplicitSequentialTransitions({
+      steps: [{ id: 'only_step', type: 'llm_call', next: null, branches: {} }],
+    }).steps?.[0]?.next,
+  ).toBeNull();
+
+  const firstInsertion = insertStepByType(
+    materializeImplicitSequentialTransitions({ steps: [] }),
+    'assign',
+  );
+  expect(firstInsertion.document.steps).toEqual([
+    expect.objectContaining({ id: 'assign_step', next: null }),
+  ]);
+});
+```
+
+- [ ] **Step 3: Run the exact helper tests and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/shared/studio/document.test.ts --testNamePattern 'materializes only eligible implicit sequential transitions|preserves branched transitions and terminal documents'
+```
+
+Expected: FAIL because `materializeImplicitSequentialTransitions` is not exported or defined.
+
+- [ ] **Step 4: Commit the failing tests only**
+
+```bash
+git add apps/aevatar-console-web/src/shared/studio/document.test.ts
+git commit -m "Test implicit workflow transition materialization"
+```
+
+### Task 2: Implement The Pure Transition Materializer
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/shared/studio/document.ts`
+- Test: `apps/aevatar-console-web/src/shared/studio/document.test.ts`
+
+- [ ] **Step 1: Implement the minimal pure helper**
+
+Place the exported helper before `insertStepByType`. Clone every step, inspect every non-final step, and only set `next` when the current `next` normalizes empty, the branch map has no entries, and the following sibling has a normalized ID.
+
+```ts
+export function materializeImplicitSequentialTransitions(
+  document: StudioWorkflowDocument,
+): StudioWorkflowDocument {
+  const steps = Array.isArray(document.steps) ? document.steps : [];
+  const nextSteps = steps.map((entry, index) => {
+    const step = { ...entry } as StudioWorkflowStepDocument;
+    const followingStepId = normalizeString(steps[index + 1]?.id);
+    const hasBranches = Object.keys(step.branches ?? {}).length > 0;
+
+    if (
+      index < steps.length - 1 &&
+      !normalizeString(step.next) &&
+      !hasBranches &&
+      followingStepId
+    ) {
+      return { ...step, next: followingStepId } satisfies StudioWorkflowStepDocument;
+    }
+
+    return step;
+  });
+
+  return { ...document, steps: nextSteps };
+}
+```
+
+- [ ] **Step 2: Run the exact helper tests and verify GREEN**
+
+Run the command from Task 1 Step 3.
+
+Expected: PASS for both focused tests.
+
+- [ ] **Step 3: Run all shared document helper tests**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/shared/studio/document.test.ts
+```
+
+Expected: all tests in `document.test.ts` pass.
+
+- [ ] **Step 4: Commit the helper implementation**
+
+```bash
+git add apps/aevatar-console-web/src/shared/studio/document.ts
+git commit -m "Materialize implicit workflow transitions"
+```
+
+### Task 3: Specify Add Node Placement Through The Page
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+- Test: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] **Step 1: Write the failing no-selection append test**
+
+Arrange `getWorkflow` with two implicit steps, make `serializeYaml` return its submitted document, click `Add node`, then `Insert Assign node`. Assert the serialized steps are `draft_step -> review_step -> assign_step`, with the inserted step terminal.
+
+```ts
+it('adds a node after the final step and materializes the existing implicit chain', async () => {
+  const document = {
+    name: 'committed_source',
+    roles: [],
+    steps: [
+      { id: 'draft_step', type: 'llm_call', next: null, branches: {} },
+      { id: 'review_step', type: 'human_approval', next: null, branches: {} },
+    ],
+  };
+  mockStudioApi.getWorkflow.mockResolvedValue({
+    workflowId: 'wf-committed-source',
+    name: 'Committed source',
+    fileName: 'committed-source.yaml',
+    filePath: '',
+    directoryId: '',
+    directoryLabel: '',
+    yaml: 'name: committed_source\nroles: []\nsteps: []\n',
+    updatedAtUtc: '2026-08-04T10:00:00Z',
+    document,
+    draftExists: false,
+    findings: [],
+  });
+  mockStudioApi.serializeYaml.mockImplementation(async ({ document: submitted }) => ({
+    yaml: 'serialized',
+    document: submitted,
+    findings: [],
+  }));
+
+  renderWithQueryClient(<WorkflowActivityVNextPage />);
+  fireEvent.click(await screen.findByRole('button', { name: 'Add node' }));
+  fireEvent.click(await screen.findByRole('button', { name: 'Insert Assign node' }));
+
+  await waitFor(() => expect(mockStudioApi.serializeYaml).toHaveBeenCalledTimes(1));
+  expect(mockStudioApi.serializeYaml.mock.calls[0][0].document.steps).toEqual([
+    expect.objectContaining({ id: 'draft_step', next: 'review_step' }),
+    expect.objectContaining({ id: 'review_step', next: 'assign_step' }),
+    expect.objectContaining({ id: 'assign_step', next: null }),
+  ]);
+});
+```
+
+- [ ] **Step 2: Write the failing selected-middle insertion test**
+
+Arrange an explicit three-step chain, click `Select step:review_step`, then use Add node to insert Assign. Assert serialization receives `draft_step -> review_step -> assign_step -> publish_step` and all unaffected transitions remain intact.
+
+```ts
+expect(mockStudioApi.serializeYaml.mock.calls[0][0].document.steps).toEqual([
+  expect.objectContaining({ id: 'draft_step', next: 'review_step' }),
+  expect.objectContaining({ id: 'review_step', next: 'assign_step' }),
+  expect.objectContaining({ id: 'assign_step', next: 'publish_step' }),
+  expect.objectContaining({ id: 'publish_step', next: null }),
+]);
+```
+
+- [ ] **Step 3: Run the exact page tests and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx --testNamePattern 'adds a node after the final step and materializes the existing implicit chain|inserts a node after the selected middle step and preserves its successor'
+```
+
+Expected: FAIL because the current callback appends without `afterStepId` and does not materialize existing adjacency.
+
+- [ ] **Step 4: Commit the failing page tests only**
+
+```bash
+git add apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+git commit -m "Test Add node sequential placement"
+```
+
+### Task 4: Wire Explicit Placement Into Workflow Activity vNext
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts`
+- Test: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] **Step 1: Import the materializer**
+
+```ts
+import {
+  applyStepInspectorDraft,
+  createStepInspectorDraft,
+  insertStepByType,
+  materializeImplicitSequentialTransitions,
+} from '@/shared/studio/document';
+```
+
+- [ ] **Step 2: Normalize the document and resolve the predecessor**
+
+Inside `addNode`, after obtaining `current`, materialize its implicit adjacency. Resolve a selected step only when `selectedNodeId` has the `step:` prefix; otherwise use the last step with a non-empty ID.
+
+```ts
+const explicitDocument = materializeImplicitSequentialTransitions(current);
+const selectedStepId = selectedNodeId.startsWith('step:')
+  ? selectedNodeId.slice('step:'.length).trim()
+  : '';
+const finalStepId = [...(explicitDocument.steps ?? [])]
+  .reverse()
+  .map((step) => String(step.id ?? '').trim())
+  .find(Boolean);
+const inserted = insertStepByType(explicitDocument, stepType, {
+  afterStepId: selectedStepId || finalStepId || null,
+});
+```
+
+Do not add warning filtering. Keep the existing serialization request, generation guard, selection update, retry state, and local-edit marking unchanged.
+
+- [ ] **Step 3: Add the selection dependency**
+
+```ts
+[document, markLocalEdit, parseCurrentYaml, selectedNodeId]
+```
+
+- [ ] **Step 4: Run the exact page tests and verify GREEN**
+
+Run the command from Task 3 Step 3.
+
+Expected: both new tests pass.
+
+- [ ] **Step 5: Run the existing insertion regression tests**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx --testNamePattern 'waits for a node insertion to finish before allowing a competing save|locks structural editing while a save is still in flight|keeps a failed node insertion visible and retryable'
+```
+
+Expected: all three existing insertion lifecycle tests pass.
+
+- [ ] **Step 6: Commit the vNext wiring**
+
+```bash
+git add apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
+git commit -m "Fix Add node sequential placement"
+```
+
+### Task 5: Focused Validation And Pull Request
+
+**Files:**
+
+- Verify all task files listed above.
+- Do not run package-wide test, lint, typecheck, or build commands locally.
+
+- [ ] **Step 1: Analyze the frontend change scope**
+
+```bash
+python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext
+```
+
+Expected: frontend-only scope limited to the Workflow Activity vNext editor, shared Studio document helper, focused tests, and docs.
+
+- [ ] **Step 2: Read the framework command guidance selected by the analyzer**
+
+Read `~/.codex/skills/frontend-incremental-pr/references/framework-commands.md` and select only changed-file static checks supported by this project. If no reliable affected typecheck exists, skip local typecheck and state that GitHub CI owns full verification.
+
+- [ ] **Step 3: Run focused tests together**
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/shared/studio/document.test.ts src/pages/workflow-activity-vnext/index.test.tsx
+```
+
+Expected: both changed test files pass.
+
+- [ ] **Step 4: Run mandatory test and baseline guards**
+
+```bash
+bash tools/ci/test_stability_guards.sh
+python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py
+git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD
+```
+
+Expected: all commands exit 0 and the baseline digest remains unchanged.
+
+- [ ] **Step 5: Review the complete diff and repository state**
+
+```bash
+git status --short --branch
+git diff --stat origin/feat/2026-08-04_workflow-activity-vnext...HEAD
+git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD -- apps/aevatar-console-web/src/shared/studio/document.ts apps/aevatar-console-web/src/shared/studio/document.test.ts apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-add-node-sequential-link-design.md apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-add-node-sequential-link.md
+```
+
+Expected: no unrelated file changes, no generated artifacts, and the implementation matches the approved design.
+
+- [ ] **Step 6: Commit the implementation plan and any final focused corrections**
+
+```bash
+git add apps/aevatar-console-web/docs/superpowers/plans/2026-08-06-add-node-sequential-link.md
+git commit -m "Document Add node implementation plan"
+```
+
+- [ ] **Step 7: Push and open the pull request against the required base**
+
+```bash
+git push -u origin fix/2026-08-06_add-node-sequential-link
+gh pr create --base feat/2026-08-04_workflow-activity-vnext --head fix/2026-08-06_add-node-sequential-link --title "Fix Add node sequential placement" --body-file <prepared-pr-body>
+```
+
+The PR body must include the root cause, explicit transition solution, affected paths, exact focused commands and results, unchanged vNext design baseline declaration, and this statement:
+
+```text
+Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
+```
+
+Do not wait for CI after the PR is created unless the user asks.

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-add-node-sequential-link-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-06-add-node-sequential-link-design.md
@@ -1,0 +1,136 @@
+# Add Node Sequential Link Design
+
+## Status
+
+Approved for implementation on 2026-08-06.
+
+Implementation branch: `fix/2026-08-06_add-node-sequential-link`.
+
+Base branch: `feat/2026-08-04_workflow-activity-vnext` at
+`121f0132f1191206aaffdaf71d189840c41d7c5e`.
+
+## Problem
+
+Workflow Activity vNext appends a selected node type by calling
+`insertStepByType` without an insertion source. The helper therefore adds the
+new step to the document array without updating a predecessor's `next` field.
+The canvas renders only explicit `next` and `branches` edges, while the runtime
+still permits adjacent steps to execute through implicit sequential ordering.
+
+After insertion, the serialize endpoint validates the complete document and
+returns `implicit_next` warnings for every non-terminal step that still relies
+on array order. This makes the Add node action appear to have introduced an
+error and leaves the newly added node visually disconnected.
+
+## Product Contract
+
+`Add node` extends the current executable flow; it does not create an
+unconnected step by default.
+
+- When a step is selected, insert the new step immediately after it.
+- When no step is selected, append the new step after the final document step.
+- If the selected step already has an explicit linear successor, preserve that
+  successor as the inserted step's `next` target.
+- Before insertion, materialize existing implicit sequential transitions that
+  are already defined by adjacent document order: a non-final step with no
+  `next` and no branches points to the following step.
+- Do not synthesize a linear transition for a step that owns branches.
+- Preserve every existing explicit `next` and branch target.
+- Keep a truly empty workflow behavior unchanged: its first node has no
+  predecessor and remains the terminal step.
+- The inserted node becomes selected so its configuration surface opens as it
+  does today.
+
+## State Transition
+
+Given this implicit document:
+
+```text
+create_weekly_report, transform_step
+```
+
+adding `assign_step` without a selected node produces:
+
+```text
+create_weekly_report.next = transform_step
+transform_step.next = assign_step
+assign_step.next = null
+```
+
+Given an explicit chain and a selected middle step:
+
+```text
+draft.next = review
+review.next = publish
+```
+
+adding `assign_step` after `review` produces:
+
+```text
+draft.next = review
+review.next = assign_step
+assign_step.next = publish
+```
+
+## Implementation Boundary
+
+Keep the change frontend-only.
+
+1. Add a pure document helper that materializes only runtime-defined implicit
+   sequential transitions without altering explicit or branched transitions.
+2. Update the vNext editor insertion path to apply that helper and pass the
+   selected step ID, or the final step ID when no step is selected, to
+   `insertStepByType`.
+3. Keep serialization as the server-authoritative validation boundary. Do not
+   filter or suppress returned findings.
+4. Do not change backend validation, runtime semantics, graph rendering, or
+   the Team Member Workflow Studio behavior in this fix.
+
+## Failure And Concurrency
+
+The existing structural-mutation generation guard remains authoritative.
+Materialization and insertion happen in memory before the single serialize
+request. A failed or stale serialize response does not update the current
+document. Retry repeats the same deterministic insertion intent against the
+still-current document.
+
+## Verification
+
+Add focused coverage for:
+
+- materializing adjacent implicit transitions while preserving explicit and
+  branched transitions;
+- adding a node with no selected step after the final step and sending a fully
+  explicit linear chain to serialization;
+- inserting after a selected middle step while preserving its former
+  successor;
+- keeping first-node insertion valid for an empty document.
+
+Run only the changed test files and changed-file static checks. The complete
+frontend suite, typecheck, and production build remain delegated to GitHub CI
+under the personal incremental frontend policy.
+
+## Design Baseline
+
+```text
+Design baseline:
+  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
+Primary design:
+  aevatar-workflow-activity-vnext.excalidraw
+Design SHA-256:
+  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
+Contract specification:
+  apps/aevatar-console-web/docs/superpowers/specs/
+  2026-08-04-workflow-activity-vnext-design.md
+User paths:
+  apps/aevatar-console-web/docs/superpowers/specs/
+  2026-08-04-workflow-activity-vnext-user-paths.md
+Authentication and localization:
+  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
+  presentation may change, behavior may not.
+Production data source:
+  Real APIs and API-acknowledged user actions only; no mock fallback.
+Baseline integrity:
+  python3 apps/aevatar-console-web/docs/design-baselines/
+  workflow-activity-vnext/verify-baseline.py
+```

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
@@ -10,6 +10,7 @@ import {
   applyStepInspectorDraft,
   createStepInspectorDraft,
   insertStepByType,
+  materializeImplicitSequentialTransitions,
 } from '@/shared/studio/document';
 import {
   buildStudioGraphElements,
@@ -497,7 +498,17 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
         const current = document ?? (await parseCurrentYaml());
         if (!current || generation !== structuralMutationGenerationRef.current)
           return false;
-        const inserted = insertStepByType(current, stepType);
+        const explicitDocument = materializeImplicitSequentialTransitions(current);
+        const selectedStepId = selectedNodeId.startsWith('step:')
+          ? selectedNodeId.slice('step:'.length).trim()
+          : '';
+        const finalStepId = [...(explicitDocument.steps ?? [])]
+          .reverse()
+          .map((step) => String(step.id ?? '').trim())
+          .find(Boolean);
+        const inserted = insertStepByType(explicitDocument, stepType, {
+          afterStepId: selectedStepId || finalStepId || null,
+        });
         const serialized = await studioApi.serializeYaml({
           document: inserted.document,
         });
@@ -522,7 +533,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
         }
       }
     },
-    [document, markLocalEdit, parseCurrentYaml],
+    [document, markLocalEdit, parseCurrentYaml, selectedNodeId],
   );
 
   const retryNodeInsertion = React.useCallback(

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -4099,6 +4099,130 @@ describe('Workflow Activity vNext editor', () => {
     );
   });
 
+  it('adds a node after the final step and materializes the existing implicit chain', async () => {
+    const document = {
+      name: 'committed_source',
+      roles: [],
+      steps: [
+        {
+          id: 'draft_step',
+          type: 'llm_call',
+          next: null,
+          branches: {},
+        },
+        {
+          id: 'review_step',
+          type: 'human_approval',
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+    mockStudioApi.getWorkflow.mockResolvedValue({
+      workflowId: 'wf-committed-source',
+      name: 'Committed source',
+      fileName: 'committed-source.yaml',
+      filePath: '',
+      directoryId: '',
+      directoryLabel: '',
+      yaml: 'name: committed_source\nroles: []\nsteps: []\n',
+      updatedAtUtc: '2026-08-04T10:00:00Z',
+      document,
+      draftExists: false,
+      findings: [],
+    });
+    mockStudioApi.serializeYaml.mockImplementation(
+      async ({ document: submittedDocument }) => ({
+        yaml: 'serialized',
+        document: submittedDocument,
+        findings: [],
+      }),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add node' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Insert Assign node' }),
+    );
+
+    await waitFor(() =>
+      expect(mockStudioApi.serializeYaml).toHaveBeenCalledTimes(1),
+    );
+    expect(mockStudioApi.serializeYaml.mock.calls[0][0].document.steps).toEqual([
+      expect.objectContaining({ id: 'draft_step', next: 'review_step' }),
+      expect.objectContaining({ id: 'review_step', next: 'assign_step' }),
+      expect.objectContaining({ id: 'assign_step', next: null }),
+    ]);
+  });
+
+  it('inserts a node after the selected middle step and preserves its successor', async () => {
+    const document = {
+      name: 'committed_source',
+      roles: [],
+      steps: [
+        {
+          id: 'draft_step',
+          type: 'llm_call',
+          next: 'review_step',
+          branches: {},
+        },
+        {
+          id: 'review_step',
+          type: 'human_approval',
+          next: 'publish_step',
+          branches: {},
+        },
+        {
+          id: 'publish_step',
+          type: 'emit',
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+    mockStudioApi.getWorkflow.mockResolvedValue({
+      workflowId: 'wf-committed-source',
+      name: 'Committed source',
+      fileName: 'committed-source.yaml',
+      filePath: '',
+      directoryId: '',
+      directoryLabel: '',
+      yaml: 'name: committed_source\nroles: []\nsteps: []\n',
+      updatedAtUtc: '2026-08-04T10:00:00Z',
+      document,
+      draftExists: false,
+      findings: [],
+    });
+    mockStudioApi.serializeYaml.mockImplementation(
+      async ({ document: submittedDocument }) => ({
+        yaml: 'serialized',
+        document: submittedDocument,
+        findings: [],
+      }),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Select step:review_step' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add node' }));
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Insert Assign node' }),
+    );
+
+    await waitFor(() =>
+      expect(mockStudioApi.serializeYaml).toHaveBeenCalledTimes(1),
+    );
+    expect(mockStudioApi.serializeYaml.mock.calls[0][0].document.steps).toEqual([
+      expect.objectContaining({ id: 'draft_step', next: 'review_step' }),
+      expect.objectContaining({ id: 'review_step', next: 'assign_step' }),
+      expect.objectContaining({ id: 'assign_step', next: 'publish_step' }),
+      expect.objectContaining({ id: 'publish_step', next: null }),
+    ]);
+  });
+
   it('locks structural editing while a save is still in flight', async () => {
     let resolveSave: ((result: unknown) => void) | undefined;
     mockStudioApi.saveWorkflow.mockImplementationOnce(

--- a/apps/aevatar-console-web/src/shared/studio/document.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.test.ts
@@ -4,6 +4,7 @@ import {
   connectStepToTarget,
   insertStepAfter,
   insertStepByType,
+  materializeImplicitSequentialTransitions,
   parseInspectorBranches,
   parseInspectorParameters,
   removeStep,
@@ -14,6 +15,95 @@ import {
 import type { StudioWorkflowDocument } from './models';
 
 describe('studio document helpers', () => {
+  it('materializes only eligible implicit sequential transitions without mutating the document', () => {
+    const document: StudioWorkflowDocument = {
+      name: 'workspace-demo',
+      roles: [],
+      steps: [
+        {
+          id: 'draft_step',
+          type: 'llm_call',
+          next: null,
+          branches: {},
+        },
+        {
+          id: 'review_step',
+          type: 'human_approval',
+          next: 'publish_step',
+          branches: {},
+        },
+        {
+          id: 'publish_step',
+          type: 'emit',
+          next: null,
+          branches: {},
+        },
+      ],
+    };
+    const snapshot = structuredClone(document);
+
+    const result = materializeImplicitSequentialTransitions(document);
+
+    expect(result.steps?.map((step) => step.next)).toEqual([
+      'review_step',
+      'publish_step',
+      null,
+    ]);
+    expect(document).toEqual(snapshot);
+    expect(result).not.toBe(document);
+  });
+
+  it('preserves branched transitions and terminal documents', () => {
+    const branched = materializeImplicitSequentialTransitions({
+      name: 'branched',
+      roles: [],
+      steps: [
+        {
+          id: 'approval_step',
+          type: 'human_approval',
+          next: null,
+          branches: { approved: 'publish_step' },
+        },
+        {
+          id: 'publish_step',
+          type: 'emit',
+          next: null,
+          branches: {},
+        },
+      ],
+    });
+
+    expect(branched.steps?.[0]).toEqual(
+      expect.objectContaining({
+        next: null,
+        branches: { approved: 'publish_step' },
+      }),
+    );
+    expect(
+      materializeImplicitSequentialTransitions({ steps: [] }).steps,
+    ).toEqual([]);
+    expect(
+      materializeImplicitSequentialTransitions({
+        steps: [
+          {
+            id: 'only_step',
+            type: 'llm_call',
+            next: null,
+            branches: {},
+          },
+        ],
+      }).steps?.[0]?.next,
+    ).toBeNull();
+
+    const firstInsertion = insertStepByType(
+      materializeImplicitSequentialTransitions({ steps: [] }),
+      'assign',
+    );
+    expect(firstInsertion.document.steps).toEqual([
+      expect.objectContaining({ id: 'assign_step', next: null }),
+    ]);
+  });
+
   it('creates inserted step ids from product names instead of backend step type ids', () => {
     const document: StudioWorkflowDocument = {
       name: 'workspace-demo',

--- a/apps/aevatar-console-web/src/shared/studio/document.ts
+++ b/apps/aevatar-console-web/src/shared/studio/document.ts
@@ -466,6 +466,36 @@ export function insertStepAfter(
   };
 }
 
+export function materializeImplicitSequentialTransitions(
+  document: StudioWorkflowDocument,
+): StudioWorkflowDocument {
+  const steps = Array.isArray(document.steps) ? document.steps : [];
+  const nextSteps = steps.map((entry, index) => {
+    const step = { ...entry } as StudioWorkflowStepDocument;
+    const followingStepId = normalizeString(steps[index + 1]?.id);
+    const hasBranches = Object.keys(step.branches ?? {}).length > 0;
+
+    if (
+      index < steps.length - 1 &&
+      !normalizeString(step.next) &&
+      !hasBranches &&
+      followingStepId
+    ) {
+      return {
+        ...step,
+        next: followingStepId,
+      } satisfies StudioWorkflowStepDocument;
+    }
+
+    return step;
+  });
+
+  return {
+    ...document,
+    steps: nextSteps,
+  };
+}
+
 export function insertStepByType(
   document: StudioWorkflowDocument,
   stepType: string,


### PR DESCRIPTION
## Problem

Workflow Activity vNext called `insertStepByType` without an insertion predecessor. Add node therefore appended a disconnected step, left existing adjacent ordering implicit, and surfaced backend `implicit_next` warnings after serialization.

## Solution

- Materialize only eligible adjacent implicit transitions before insertion: non-terminal steps with no explicit `next` and no branches.
- Insert after the selected step, or after the final valid step when nothing is selected.
- Reuse the existing insertion helper to preserve a selected step's former explicit successor.
- Keep explicit `next` values, branch targets, terminal behavior, server validation findings, backend semantics, graph rendering, and Team Member Workflow Studio unchanged.
- Add pure document coverage plus route-level Add node coverage through accessible UI interactions.

## Impacted paths

- `apps/aevatar-console-web/src/shared/studio/document.ts`
- `apps/aevatar-console-web/src/shared/studio/document.test.ts`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
- Focused design and implementation documents under `apps/aevatar-console-web/docs/superpowers/`

## Verification

Passed:

```bash
pnpm --dir apps/aevatar-console-web exec jest \
  --runInBand \
  --runTestsByPath \
  src/shared/studio/document.test.ts \
  src/pages/workflow-activity-vnext/index.test.tsx
```

Result: 2 suites passed, 107 tests passed, 0 failures.

Dependency-discovery preflight:

```bash
pnpm --dir apps/aevatar-console-web exec jest \
  --listTests \
  --findRelatedTests \
  src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts \
  src/shared/studio/document.ts
```

Result: selected 8 test files, including task-external Team Member Workflow Studio and Studio domains. The related-test execution was intentionally rejected under `docs/testing-policy.md` fan-out guard; the two changed/directly-related test files above were run explicitly instead.

Passed changed-file static checks:

```bash
pnpm --dir apps/aevatar-console-web exec biome lint \
  src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts \
  src/pages/workflow-activity-vnext/index.test.tsx \
  src/shared/studio/document.test.ts \
  src/shared/studio/document.ts
```

Passed repository guards:

```bash
bash tools/ci/test_stability_guards.sh
python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py
git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD
```

Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.

Local full TypeScript checking was also skipped because no reliable affected-only project typecheck is available; GitHub CI owns full type verification.

## Design baseline

```text
Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py
```
