### PR TITLE
Standardize Workflow Activity failure toasts

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
@@ -344,7 +344,7 @@ describe('Workflow Activity vNext run detail recovery', () => {
     );
     const [content, options] = mockConsoleToast.error.mock.calls[0];
     expect(options).toEqual({
-      duration: 0,
+      duration: 8,
       key: 'run-failure:run-source-alpha:access_denied',
     });
     const toastContent = render(content).container;

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
@@ -11,7 +11,7 @@ describe('Workflow Activity run failure presentation', () => {
       { status: 401, message: 'Your session expired.' },
       'session_expired',
       'error',
-      0,
+      8,
     ],
     [
       {
@@ -21,13 +21,13 @@ describe('Workflow Activity run failure presentation', () => {
       },
       'access_denied',
       'error',
-      0,
+      8,
     ],
     [
       { status: 429, message: 'Too many requests.', retryAfterSeconds: 12 },
       'rate_limited',
       'warning',
-      0,
+      8,
     ],
     [
       {
@@ -37,13 +37,13 @@ describe('Workflow Activity run failure presentation', () => {
       },
       'invalid_input',
       'warning',
-      0,
+      8,
     ],
     [
       { status: 404, message: 'The run was not found.' },
       'resource_missing',
       'error',
-      5,
+      8,
     ],
     [
       {
@@ -53,13 +53,13 @@ describe('Workflow Activity run failure presentation', () => {
       },
       'state_conflict',
       'warning',
-      0,
+      8,
     ],
     [
       { status: 504, message: 'The provider timed out.' },
       'timeout_or_offline',
       'warning',
-      5,
+      8,
     ],
     [
       {
@@ -69,13 +69,13 @@ describe('Workflow Activity run failure presentation', () => {
       },
       'upstream_unavailable',
       'error',
-      5,
+      8,
     ],
     [
       { code: 'RUN_CANCELLED', message: 'Cancelled by the user.' },
       'cancelled',
       'info',
-      3,
+      8,
     ],
     [
       {
@@ -85,13 +85,13 @@ describe('Workflow Activity run failure presentation', () => {
       },
       'internal_failure',
       'error',
-      0,
+      8,
     ],
     [
       { status: 418, code: 'UNRECOGNIZED_CODE', message: '' },
       'internal_failure',
       'error',
-      0,
+      8,
     ],
   ] as const)('classifies %p as %s', (evidence, category, intent, duration) => {
     expect(classifyRunFailure(evidence)).toMatchObject({
@@ -116,9 +116,15 @@ describe('Workflow Activity run failure presentation', () => {
       />,
     );
 
-    expect(
-      screen.getByText('Try again after the quota window resets.'),
-    ).toBeVisible();
+    const message = screen.getByText(
+      'Try again after the quota window resets.',
+    );
+    const guidance = screen.getByText(
+      'Wait for the quota window to reset before trying again.',
+    );
+    expect(message).toBeVisible();
+    expect(message.closest('.ant-typography')).toBeVisible();
+    expect(guidance).toHaveClass('ant-typography-secondary');
     expect(screen.getByText('Try again in 12 seconds.')).toBeVisible();
     const action = screen.getByRole('button', { name: 'Retry' });
     action.focus();

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx
@@ -1,4 +1,4 @@
-import { Button, Space } from 'antd';
+import { Button, Space, Typography } from 'antd';
 import React from 'react';
 import { t } from '@/shared/i18n/messages';
 
@@ -49,6 +49,8 @@ type CategoryDefinition = Omit<
 > & {
   readonly fallbackMessage: string;
 };
+
+const RUN_FAILURE_TOAST_DURATION_SECONDS = 8;
 
 function normalizeCode(value: string | undefined): string {
   return value?.trim().toUpperCase() ?? '';
@@ -114,7 +116,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Sign in again',
         ),
         category,
-        duration: 0,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.sessionExpired',
           'Your session has expired.',
@@ -133,7 +135,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Choose allowed service',
         ),
         category,
-        duration: 0,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.accessDenied',
           'You do not have access to use this service or model.',
@@ -149,7 +151,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
         action: 'retry',
         actionLabel: t('workflowActivityVNext.common.retry', 'Retry'),
         category,
-        duration: 0,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.rateLimited',
           'This request was rate limited.',
@@ -168,7 +170,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Review input',
         ),
         category,
-        duration: 0,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.invalidInput',
           'The input or workflow definition needs attention.',
@@ -187,7 +189,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Back to Activity',
         ),
         category,
-        duration: 5,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.resourceMissing',
           'This run is no longer available.',
@@ -206,7 +208,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Reload latest',
         ),
         category,
-        duration: 0,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.stateConflict',
           'This run changed since it was loaded.',
@@ -222,7 +224,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
         action: 'retry',
         actionLabel: t('workflowActivityVNext.common.retry', 'Retry'),
         category,
-        duration: 5,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.timeoutOrOffline',
           'The request timed out or the connection was interrupted.',
@@ -238,7 +240,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
         action: 'retry',
         actionLabel: t('workflowActivityVNext.common.retry', 'Retry'),
         category,
-        duration: 5,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.upstreamUnavailable',
           'The selected service is temporarily unavailable.',
@@ -257,7 +259,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Open Activity',
         ),
         category,
-        duration: 3,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.cancelled',
           'Run cancelled.',
@@ -276,7 +278,7 @@ function definitionFor(category: RunFailureCategory): CategoryDefinition {
           'Reload latest',
         ),
         category,
-        duration: 0,
+        duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
         fallbackMessage: t(
           'workflowActivityVNext.failure.internal',
           'The request could not be completed.',
@@ -317,17 +319,27 @@ export const RunFailureToastContent: React.FC<{
 }> = ({ onAction, presentation }) => {
   const correlationId = presentation.correlationId;
   return (
-    <div>
-      <div>{presentation.message}</div>
-      <div>{presentation.guidance}</div>
+    <div
+      style={{
+        alignItems: 'flex-start',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        textAlign: 'left',
+      }}
+    >
+      <Typography.Text strong>{presentation.message}</Typography.Text>
+      <Typography.Text type="secondary">
+        {presentation.guidance}
+      </Typography.Text>
       {presentation.retryAfterSeconds !== undefined ? (
-        <div>
+        <Typography.Text type="secondary">
           {t(
             'workflowActivityVNext.failure.retryAfter',
             'Try again in {seconds} seconds.',
             { seconds: presentation.retryAfterSeconds },
           )}
-        </div>
+        </Typography.Text>
       ) : null}
       <Space size="small" wrap>
         {onAction ? (

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+import { App } from 'antd';
+import type { NotificationInstance } from 'antd/es/notification/interface';
+import React from 'react';
+import { useConsoleToast } from './ConsoleToast';
+
+function createNotificationStub(): jest.Mocked<NotificationInstance> {
+  return {
+    destroy: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    open: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+  };
+}
+
+describe('ConsoleToast', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens a compact dismissible top-right error notification', () => {
+    const notification = createNotificationStub();
+    const onClose = jest.fn();
+    const content = <span>Request failed</span>;
+    jest.spyOn(App, 'useApp').mockReturnValue({
+      notification,
+    } as ReturnType<typeof App.useApp>);
+
+    const { result } = renderHook(() => useConsoleToast());
+    act(() => {
+      result.current.error(content, {
+        duration: 8,
+        key: 'request-failure',
+        onClose,
+      });
+    });
+
+    expect(notification.error).toHaveBeenCalledTimes(1);
+    const config = notification.error.mock.calls[0][0];
+    expect(config).toMatchObject({
+      className: 'aevatar-console-toast',
+      closable: true,
+      duration: 8,
+      key: 'request-failure',
+      onClose,
+      pauseOnHover: true,
+      placement: 'topRight',
+      role: 'alert',
+    });
+    expect(config.title).toBe(content);
+    expect(config.styles).toMatchObject({
+      root: {
+        maxWidth: 'calc(100vw - 32px)',
+        width: 360,
+      },
+      title: {
+        marginBottom: 0,
+      },
+    });
+  });
+
+  it('uses status semantics and the short default for success', () => {
+    const notification = createNotificationStub();
+    jest.spyOn(App, 'useApp').mockReturnValue({
+      notification,
+    } as ReturnType<typeof App.useApp>);
+
+    const { result } = renderHook(() => useConsoleToast());
+    act(() => {
+      result.current.success('Saved');
+    });
+
+    expect(notification.success).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 3, role: 'status' }),
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx
@@ -1,9 +1,23 @@
-import { App } from 'antd';
-import type { ArgsProps, MessageInstance } from 'antd/es/message/interface';
+import { App, theme } from 'antd';
+import type {
+  ArgsProps,
+  NotificationInstance,
+} from 'antd/es/notification/interface';
 import React from 'react';
 
 type ConsoleToastOptions = Pick<ArgsProps, 'duration' | 'key' | 'onClose'>;
 type ConsoleToastIntent = 'error' | 'info' | 'success' | 'warning';
+
+type ConsoleToastSurfaceToken = Pick<
+  ReturnType<typeof theme.useToken>['token'],
+  | 'borderRadiusLG'
+  | 'boxShadowSecondary'
+  | 'colorBorderSecondary'
+  | 'fontSize'
+  | 'lineHeight'
+  | 'padding'
+  | 'paddingSM'
+>;
 
 export type ConsoleToastApi = {
   readonly [Intent in ConsoleToastIntent]: (
@@ -19,17 +33,40 @@ const TOAST_DURATION: Readonly<Record<ConsoleToastIntent, number>> = {
   warning: 5,
 };
 
-function createConsoleToastApi(messageApi: MessageInstance): ConsoleToastApi {
+function createConsoleToastApi(
+  notificationApi: NotificationInstance,
+  token: ConsoleToastSurfaceToken,
+): ConsoleToastApi {
   const show = (
     intent: ConsoleToastIntent,
     content: React.ReactNode,
     options?: ConsoleToastOptions,
   ) => {
-    void messageApi[intent]({
-      content,
+    notificationApi[intent]({
+      className: 'aevatar-console-toast',
+      closable: true,
       duration: options?.duration ?? TOAST_DURATION[intent],
       key: options?.key,
       onClose: options?.onClose,
+      pauseOnHover: true,
+      placement: 'topRight',
+      role: intent === 'error' || intent === 'warning' ? 'alert' : 'status',
+      styles: {
+        root: {
+          border: `1px solid ${token.colorBorderSecondary}`,
+          borderRadius: token.borderRadiusLG,
+          boxShadow: token.boxShadowSecondary,
+          maxWidth: 'calc(100vw - 32px)',
+          padding: `${token.paddingSM}px ${token.padding}px`,
+          width: 360,
+        },
+        title: {
+          fontSize: token.fontSize,
+          lineHeight: token.lineHeight,
+          marginBottom: 0,
+        },
+      },
+      title: content,
     });
   };
 
@@ -50,6 +87,10 @@ export const ConsoleToastProvider: React.FC<{
 );
 
 export function useConsoleToast(): ConsoleToastApi {
-  const { message } = App.useApp();
-  return React.useMemo(() => createConsoleToastApi(message), [message]);
+  const { notification } = App.useApp();
+  const { token } = theme.useToken();
+  return React.useMemo(
+    () => createConsoleToastApi(notification, token),
+    [notification, token],
+  );
 }

--- a/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
+++ b/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
@@ -423,7 +423,7 @@ git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD -- \
 
 Expected: only the toast design, plan, shared adapter, failure presentation, and their tests are present.
 
-- [ ] **Step 6: Push and create the focused pull request**
+- [x] **Step 6: Push and create the focused pull request**
 
 ```bash
 git push -u origin fix/2026-08-06_standardize-failure-toast

--- a/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
+++ b/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
@@ -236,6 +236,7 @@ git commit -m "Standardize console toast notifications"
 **Files:**
 - Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx`
 - Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx`
 
 - [x] **Step 1: Write the failing duration and hierarchy expectations**
 
@@ -337,7 +338,7 @@ pnpm exec jest src/pages/workflow-activity-vnext/activity/runFailurePresentation
 
 Expected: PASS with 13 tests and 0 failures.
 
-- [ ] **Step 5: Commit the failure policy**
+- [x] **Step 5: Commit the failure policy**
 
 ```bash
 git add \
@@ -351,7 +352,7 @@ git commit -m "Refine workflow failure toast presentation"
 **Files:**
 - Verify all files changed on the branch.
 
-- [ ] **Step 1: Analyze the affected frontend scope**
+- [x] **Step 1: Analyze the affected frontend scope**
 
 From the repository root:
 
@@ -361,9 +362,9 @@ python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py
   --base origin/feat/2026-08-04_workflow-activity-vnext
 ```
 
-Expected: Jest is the affected runner; the two changed production files and two changed test files are listed as frontend scope.
+Expected: Jest is the affected runner; the two changed production files and three changed test files are listed as frontend scope.
 
-- [ ] **Step 2: Run dependency-related tests for changed production files**
+- [x] **Step 2: Run dependency-related tests for changed production files**
 
 From `apps/aevatar-console-web`, using the analyzer's changed source list:
 
@@ -376,18 +377,19 @@ pnpm exec jest --findRelatedTests \
 
 Expected: all dependency-related tests selected by Jest pass. Do not replace this command with the full frontend suite.
 
-- [ ] **Step 3: Run the changed test files explicitly**
+- [x] **Step 3: Run the changed test files explicitly**
 
 ```bash
 pnpm exec jest \
   src/shared/ui/ConsoleToast.test.tsx \
   src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx \
+  src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx \
   --runInBand
 ```
 
 Expected: both changed test suites pass.
 
-- [ ] **Step 4: Run required test and changed-file static guards**
+- [x] **Step 4: Run required test and changed-file static guards**
 
 From the repository root:
 
@@ -397,7 +399,8 @@ pnpm --dir apps/aevatar-console-web exec biome check \
   src/shared/ui/ConsoleToast.tsx \
   src/shared/ui/ConsoleToast.test.tsx \
   src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx \
-  src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+  src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx \
+  src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
 ```
 
 Expected: the stability guard and Biome checks pass. Skip local full typecheck and build; GitHub CI owns them.
@@ -414,7 +417,8 @@ git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD -- \
   apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx \
   apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx \
   apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx \
-  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx
 ```
 
 Expected: only the toast design, plan, shared adapter, failure presentation, and their tests are present.
@@ -430,7 +434,7 @@ gh pr create \
   --body-file /tmp/standardize-failure-toast-pr.md
 ```
 
-The pull request body must contain the problem and selected solution, the six changed paths, the exact focused verification commands and results, and this statement:
+The pull request body must contain the problem and selected solution, the seven changed paths, the exact focused verification commands and results, and this statement:
 
 ```markdown
 - Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

--- a/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
+++ b/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
@@ -16,7 +16,7 @@
 - Create: `apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx`
 - Modify: `apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx`
 
-- [ ] **Step 1: Write the failing shared-adapter test**
+- [x] **Step 1: Write the failing shared-adapter test**
 
 Create `ConsoleToast.test.tsx` with a typed notification stub. The first test must call the public hook and prove that an error is sent to the top-right notification API with a close control, hover pause, the supplied duration/key/callback, and compact token-backed surface styles.
 
@@ -102,7 +102,7 @@ describe('ConsoleToast', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run from `apps/aevatar-console-web`:
 
@@ -112,7 +112,7 @@ pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand
 
 Expected: FAIL because `ConsoleToast` still calls the message instance and never calls `notification.error`.
 
-- [ ] **Step 3: Implement the notification adapter**
+- [x] **Step 3: Implement the notification adapter**
 
 Replace the message types with notification types, read `notification` and theme tokens from the existing Ant Design contexts, and keep the public toast methods unchanged.
 
@@ -215,7 +215,7 @@ export function useConsoleToast(): ConsoleToastApi {
 }
 ```
 
-- [ ] **Step 4: Run the test and verify GREEN**
+- [x] **Step 4: Run the test and verify GREEN**
 
 ```bash
 pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand
@@ -223,7 +223,7 @@ pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand
 
 Expected: PASS with 2 tests and 0 failures.
 
-- [ ] **Step 5: Commit the shared adapter**
+- [x] **Step 5: Commit the shared adapter**
 
 ```bash
 git add apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx \

--- a/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
+++ b/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
@@ -387,7 +387,7 @@ pnpm exec jest \
   --runInBand
 ```
 
-Expected: both changed test suites pass.
+Expected: all three changed test suites pass.
 
 - [x] **Step 4: Run required test and changed-file static guards**
 
@@ -405,7 +405,7 @@ pnpm --dir apps/aevatar-console-web exec biome check \
 
 Expected: the stability guard and Biome checks pass. Skip local full typecheck and build; GitHub CI owns them.
 
-- [ ] **Step 5: Review the complete task diff**
+- [x] **Step 5: Review the complete task diff**
 
 ```bash
 git status --short

--- a/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
+++ b/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
@@ -237,7 +237,7 @@ git commit -m "Standardize console toast notifications"
 - Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx`
 - Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx`
 
-- [ ] **Step 1: Write the failing duration and hierarchy expectations**
+- [x] **Step 1: Write the failing duration and hierarchy expectations**
 
 Change every expected duration in the classification table to `8`. Extend the accessible-action test with explicit compact hierarchy expectations:
 
@@ -251,7 +251,7 @@ expect(message).toHaveClass('ant-typography');
 expect(guidance).toHaveClass('ant-typography-secondary');
 ```
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 ```bash
 pnpm exec jest src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx --runInBand
@@ -259,7 +259,7 @@ pnpm exec jest src/pages/workflow-activity-vnext/activity/runFailurePresentation
 
 Expected: FAIL because current categories still use `0`, `3`, or `5` seconds and the guidance is a plain `div`.
 
-- [ ] **Step 3: Implement one failure duration and token-backed hierarchy**
+- [x] **Step 3: Implement one failure duration and token-backed hierarchy**
 
 Import `Typography`, define one duration constant, replace every category-specific duration with it, and render message/guidance/retry timing with Ant Design typography.
 
@@ -329,7 +329,7 @@ export const RunFailureToastContent: React.FC<{
 };
 ```
 
-- [ ] **Step 4: Run the failure-presentation test and verify GREEN**
+- [x] **Step 4: Run the failure-presentation test and verify GREEN**
 
 ```bash
 pnpm exec jest src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx --runInBand

--- a/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
+++ b/docs/superpowers/plans/2026-08-06-standardize-failure-toast.md
@@ -1,0 +1,439 @@
+# Standardized Failure Toast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render Aevatar failure toasts as compact, dismissible top-right notifications that pause on hover and close automatically after eight seconds.
+
+**Architecture:** Keep `ConsoleToast` as the single shared toast API and replace its Ant Design `message` adapter with the context-bound `notification` adapter. Keep business failure classification in `runFailurePresentation`, where every typed failure receives the approved eight-second duration and the existing content is reorganized into a token-backed compact hierarchy.
+
+**Tech Stack:** React 19, TypeScript, Ant Design 6 `App`/`notification`/`Typography`, Jest 29, Testing Library, Biome
+
+---
+
+### Task 1: Route the shared toast API through Ant Design notification
+
+**Files:**
+- Create: `apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx`
+- Modify: `apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx`
+
+- [ ] **Step 1: Write the failing shared-adapter test**
+
+Create `ConsoleToast.test.tsx` with a typed notification stub. The first test must call the public hook and prove that an error is sent to the top-right notification API with a close control, hover pause, the supplied duration/key/callback, and compact token-backed surface styles.
+
+```tsx
+import { act, renderHook } from '@testing-library/react';
+import { App } from 'antd';
+import type { NotificationInstance } from 'antd/es/notification/interface';
+import React from 'react';
+import { useConsoleToast } from './ConsoleToast';
+
+function createNotificationStub(): jest.Mocked<NotificationInstance> {
+  return {
+    destroy: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    open: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+  };
+}
+
+describe('ConsoleToast', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens a compact dismissible top-right error notification', () => {
+    const notification = createNotificationStub();
+    const onClose = jest.fn();
+    const content = <span>Request failed</span>;
+    jest.spyOn(App, 'useApp').mockReturnValue({
+      notification,
+    } as ReturnType<typeof App.useApp>);
+
+    const { result } = renderHook(() => useConsoleToast());
+    act(() => {
+      result.current.error(content, {
+        duration: 8,
+        key: 'request-failure',
+        onClose,
+      });
+    });
+
+    expect(notification.error).toHaveBeenCalledTimes(1);
+    const config = notification.error.mock.calls[0][0];
+    expect(config).toMatchObject({
+      className: 'aevatar-console-toast',
+      closable: true,
+      duration: 8,
+      key: 'request-failure',
+      onClose,
+      pauseOnHover: true,
+      placement: 'topRight',
+      role: 'alert',
+    });
+    expect(config.title).toBe(content);
+    expect(config.styles).toMatchObject({
+      root: {
+        maxWidth: 'calc(100vw - 32px)',
+        width: 360,
+      },
+      title: {
+        marginBottom: 0,
+      },
+    });
+  });
+
+  it('uses status semantics and the short default for success', () => {
+    const notification = createNotificationStub();
+    jest.spyOn(App, 'useApp').mockReturnValue({
+      notification,
+    } as ReturnType<typeof App.useApp>);
+
+    const { result } = renderHook(() => useConsoleToast());
+    act(() => {
+      result.current.success('Saved');
+    });
+
+    expect(notification.success).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 3, role: 'status' }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run from `apps/aevatar-console-web`:
+
+```bash
+pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand
+```
+
+Expected: FAIL because `ConsoleToast` still calls the message instance and never calls `notification.error`.
+
+- [ ] **Step 3: Implement the notification adapter**
+
+Replace the message types with notification types, read `notification` and theme tokens from the existing Ant Design contexts, and keep the public toast methods unchanged.
+
+```tsx
+import { App, theme } from 'antd';
+import type {
+  ArgsProps,
+  NotificationInstance,
+} from 'antd/es/notification/interface';
+import React from 'react';
+
+type ConsoleToastOptions = Pick<ArgsProps, 'duration' | 'key' | 'onClose'>;
+type ConsoleToastIntent = 'error' | 'info' | 'success' | 'warning';
+
+type ConsoleToastSurfaceToken = Pick<
+  ReturnType<typeof theme.useToken>['token'],
+  | 'borderRadiusLG'
+  | 'boxShadowSecondary'
+  | 'colorBorderSecondary'
+  | 'fontSize'
+  | 'lineHeight'
+  | 'padding'
+  | 'paddingSM'
+>;
+
+export type ConsoleToastApi = {
+  readonly [Intent in ConsoleToastIntent]: (
+    content: React.ReactNode,
+    options?: ConsoleToastOptions,
+  ) => void;
+};
+
+const TOAST_DURATION: Readonly<Record<ConsoleToastIntent, number>> = {
+  error: 5,
+  info: 3,
+  success: 3,
+  warning: 5,
+};
+
+function createConsoleToastApi(
+  notificationApi: NotificationInstance,
+  token: ConsoleToastSurfaceToken,
+): ConsoleToastApi {
+  const show = (
+    intent: ConsoleToastIntent,
+    content: React.ReactNode,
+    options?: ConsoleToastOptions,
+  ) => {
+    notificationApi[intent]({
+      className: 'aevatar-console-toast',
+      closable: true,
+      duration: options?.duration ?? TOAST_DURATION[intent],
+      key: options?.key,
+      onClose: options?.onClose,
+      pauseOnHover: true,
+      placement: 'topRight',
+      role: intent === 'error' || intent === 'warning' ? 'alert' : 'status',
+      styles: {
+        root: {
+          border: `1px solid ${token.colorBorderSecondary}`,
+          borderRadius: token.borderRadiusLG,
+          boxShadow: token.boxShadowSecondary,
+          maxWidth: 'calc(100vw - 32px)',
+          padding: `${token.paddingSM}px ${token.padding}px`,
+          width: 360,
+        },
+        title: {
+          fontSize: token.fontSize,
+          lineHeight: token.lineHeight,
+          marginBottom: 0,
+        },
+      },
+      title: content,
+    });
+  };
+
+  return {
+    error: (content, options) => show('error', content, options),
+    info: (content, options) => show('info', content, options),
+    success: (content, options) => show('success', content, options),
+    warning: (content, options) => show('warning', content, options),
+  };
+}
+
+export const ConsoleToastProvider: React.FC<{
+  readonly children: React.ReactNode;
+}> = ({ children }) => (
+  <App component="div" style={{ display: 'contents' }}>
+    {children}
+  </App>
+);
+
+export function useConsoleToast(): ConsoleToastApi {
+  const { notification } = App.useApp();
+  const { token } = theme.useToken();
+  return React.useMemo(
+    () => createConsoleToastApi(notification, token),
+    [notification, token],
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+```bash
+pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand
+```
+
+Expected: PASS with 2 tests and 0 failures.
+
+- [ ] **Step 5: Commit the shared adapter**
+
+```bash
+git add apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx \
+  apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
+git commit -m "Standardize console toast notifications"
+```
+
+### Task 2: Apply the approved failure hierarchy and eight-second duration
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx`
+
+- [ ] **Step 1: Write the failing duration and hierarchy expectations**
+
+Change every expected duration in the classification table to `8`. Extend the accessible-action test with explicit compact hierarchy expectations:
+
+```tsx
+const message = screen.getByText('Try again after the quota window resets.');
+const guidance = screen.getByText(
+  'Wait for the quota window to reset before trying again.',
+);
+expect(message).toBeVisible();
+expect(message).toHaveClass('ant-typography');
+expect(guidance).toHaveClass('ant-typography-secondary');
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+```bash
+pnpm exec jest src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx --runInBand
+```
+
+Expected: FAIL because current categories still use `0`, `3`, or `5` seconds and the guidance is a plain `div`.
+
+- [ ] **Step 3: Implement one failure duration and token-backed hierarchy**
+
+Import `Typography`, define one duration constant, replace every category-specific duration with it, and render message/guidance/retry timing with Ant Design typography.
+
+```tsx
+import { Button, Space, Typography } from 'antd';
+
+const RUN_FAILURE_TOAST_DURATION_SECONDS = 8;
+
+// In every category definition:
+duration: RUN_FAILURE_TOAST_DURATION_SECONDS,
+
+export const RunFailureToastContent: React.FC<{
+  readonly onAction?: (action: RunFailureAction) => void;
+  readonly presentation: RunFailurePresentation;
+}> = ({ onAction, presentation }) => {
+  const correlationId = presentation.correlationId;
+  return (
+    <div
+      style={{
+        alignItems: 'flex-start',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        textAlign: 'left',
+      }}
+    >
+      <Typography.Text strong>{presentation.message}</Typography.Text>
+      <Typography.Text type="secondary">
+        {presentation.guidance}
+      </Typography.Text>
+      {presentation.retryAfterSeconds !== undefined ? (
+        <Typography.Text type="secondary">
+          {t(
+            'workflowActivityVNext.failure.retryAfter',
+            'Try again in {seconds} seconds.',
+            { seconds: presentation.retryAfterSeconds },
+          )}
+        </Typography.Text>
+      ) : null}
+      <Space size="small" wrap>
+        {onAction ? (
+          <Button
+            onClick={() => onAction(presentation.action)}
+            size="small"
+            type="link"
+          >
+            {presentation.actionLabel}
+          </Button>
+        ) : null}
+        {correlationId ? (
+          <Button
+            onClick={() => {
+              void navigator.clipboard?.writeText(correlationId);
+            }}
+            size="small"
+            type="link"
+          >
+            {t(
+              'workflowActivityVNext.failure.copyTrackingId',
+              'Copy tracking ID',
+            )}
+          </Button>
+        ) : null}
+      </Space>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run the failure-presentation test and verify GREEN**
+
+```bash
+pnpm exec jest src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx --runInBand
+```
+
+Expected: PASS with 13 tests and 0 failures.
+
+- [ ] **Step 5: Commit the failure policy**
+
+```bash
+git add \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+git commit -m "Refine workflow failure toast presentation"
+```
+
+### Task 3: Run focused verification and deliver the pull request
+
+**Files:**
+- Verify all files changed on the branch.
+
+- [ ] **Step 1: Analyze the affected frontend scope**
+
+From the repository root:
+
+```bash
+python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py \
+  --repo . \
+  --base origin/feat/2026-08-04_workflow-activity-vnext
+```
+
+Expected: Jest is the affected runner; the two changed production files and two changed test files are listed as frontend scope.
+
+- [ ] **Step 2: Run dependency-related tests for changed production files**
+
+From `apps/aevatar-console-web`, using the analyzer's changed source list:
+
+```bash
+pnpm exec jest --findRelatedTests \
+  src/shared/ui/ConsoleToast.tsx \
+  src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx \
+  --runInBand
+```
+
+Expected: all dependency-related tests selected by Jest pass. Do not replace this command with the full frontend suite.
+
+- [ ] **Step 3: Run the changed test files explicitly**
+
+```bash
+pnpm exec jest \
+  src/shared/ui/ConsoleToast.test.tsx \
+  src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx \
+  --runInBand
+```
+
+Expected: both changed test suites pass.
+
+- [ ] **Step 4: Run required test and changed-file static guards**
+
+From the repository root:
+
+```bash
+bash tools/ci/test_stability_guards.sh
+pnpm --dir apps/aevatar-console-web exec biome check \
+  src/shared/ui/ConsoleToast.tsx \
+  src/shared/ui/ConsoleToast.test.tsx \
+  src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx \
+  src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+```
+
+Expected: the stability guard and Biome checks pass. Skip local full typecheck and build; GitHub CI owns them.
+
+- [ ] **Step 5: Review the complete task diff**
+
+```bash
+git status --short
+git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD
+git diff --stat origin/feat/2026-08-04_workflow-activity-vnext...HEAD
+git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD -- \
+  docs/superpowers/specs/2026-08-06-standardize-failure-toast-design.md \
+  docs/superpowers/plans/2026-08-06-standardize-failure-toast.md \
+  apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx \
+  apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx
+```
+
+Expected: only the toast design, plan, shared adapter, failure presentation, and their tests are present.
+
+- [ ] **Step 6: Push and create the focused pull request**
+
+```bash
+git push -u origin fix/2026-08-06_standardize-failure-toast
+gh pr create \
+  --base feat/2026-08-04_workflow-activity-vnext \
+  --head fix/2026-08-06_standardize-failure-toast \
+  --title "Standardize Workflow Activity failure toasts" \
+  --body-file /tmp/standardize-failure-toast-pr.md
+```
+
+The pull request body must contain the problem and selected solution, the six changed paths, the exact focused verification commands and results, and this statement:
+
+```markdown
+- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
+```
+
+Stop after reporting the PR URL. Do not wait for CI unless the user asks.

--- a/docs/superpowers/specs/2026-08-06-standardize-failure-toast-design.md
+++ b/docs/superpowers/specs/2026-08-06-standardize-failure-toast-design.md
@@ -1,0 +1,101 @@
+# Standardized Failure Toast Design
+
+## Context
+
+Workflow Activity vNext routes typed backend failures through the shared
+`ConsoleToast` API. The API currently delegates to Ant Design `message`, which
+renders a wide top-center surface without a visible dismiss control. Actionable
+failure content can contain a title, guidance, and recovery actions, so the
+result obscures page context and does not follow the console's notification
+layout.
+
+The failure presentation already owns typed category, intent, recovery action,
+tracking ID, and deduplication data. This change must preserve those semantics
+and adjust only toast presentation and timing.
+
+## Selected Approach
+
+Keep `ConsoleToast` as the single application-level API, but render it through
+Ant Design `notification` instead of `message`. Notification supplies the
+required top-right placement, visible close control, hover-paused timer,
+stacking, and accessible dismissal behavior without introducing a second toast
+system or custom timer registry.
+
+The public `toast.error/info/success/warning` methods and the existing `key`,
+`duration`, and `onClose` options remain stable. Existing callers do not manage
+notification lifecycle or depend on Ant Design internals.
+
+## Visual Design
+
+The notification uses the compact information hierarchy selected from the
+approved visual comparison and the top-right placement selected from the
+alternative layout:
+
+- a semantic status icon appears at the leading edge;
+- the primary message is the first, strongest line;
+- guidance and optional retry timing use secondary text;
+- recovery and tracking-ID actions remain in a compact action row;
+- the close icon occupies a separate top-right control and never competes with
+  recovery actions;
+- the desktop surface is approximately 360 pixels wide;
+- the mobile surface is constrained to the viewport with 16-pixel side margins;
+- spacing, radius, border, shadow, and colors use existing Aevatar and Ant
+  Design tokens rather than page-local hard-coded styling.
+
+## Behavior
+
+Workflow Activity failure notifications close automatically after eight
+seconds. Hovering pauses the timer, and the close control dismisses the
+notification immediately. Ant Design notification owns both behaviors.
+
+All typed run-failure categories use the same eight-second duration, including
+warning- and information-toned failures. Ordinary success and informational
+toasts outside this failure flow retain their shorter shared defaults.
+
+Existing notification keys continue to deduplicate repeated failures. Existing
+actions such as `Reload latest`, `Retry`, `Sign in again`, and `Copy tracking
+ID` retain their current callbacks and identity semantics.
+
+## Component Boundaries
+
+`ConsoleToast` owns the Ant Design notification adapter, placement, dismiss
+behavior, intent mapping, and shared visual class. It does not classify business
+failures.
+
+`runFailurePresentation` continues to classify typed API and committed-run
+evidence, produce user-safe copy, and expose recovery actions. It changes only
+the duration policy from category-specific persistent or short-lived values to
+the approved eight-second failure duration.
+
+Workflow Activity pages continue to call the shared toast API with a stable key
+and the existing `RunFailureToastContent`. They do not add local portals,
+timers, or close state.
+
+## Accessibility
+
+The notification keeps Ant Design's accessible status announcement and close
+button. The close control has an accessible name and supports keyboard
+activation. Recovery actions remain real buttons with visible labels and native
+focus behavior. Information is not communicated by color alone because each
+notification combines intent, icon, text, and labeled actions.
+
+## Verification
+
+Test-driven implementation will add focused tests before production changes.
+The shared toast adapter tests will prove that notification receives the
+top-right placement, visible close control, hover pause, semantic intent,
+duration, key, and close callback. Failure-presentation tests will prove that
+all typed failure categories use eight seconds while action and tracking-ID
+behavior remains intact.
+
+Local verification is limited to dependency-related Jest tests, explicit new or
+changed test files, the frontend test-stability guard, and changed-file Biome
+checks. Full frontend test, typecheck, and production build remain delegated to
+GitHub CI by the personal frontend workflow policy.
+
+## Delivery
+
+The change is delivered as a focused follow-up pull request from
+`fix/2026-08-06_standardize-failure-toast` into
+`feat/2026-08-04_workflow-activity-vnext`. The pull request includes the exact
+focused validation commands and does not include unrelated frontend changes.


### PR DESCRIPTION
## Problem and solution

Failure feedback used the transient Ant Design message surface, which produced a nonstandard presentation without an explicit close control. Workflow Activity failures also mixed permanent and short lifetimes and rendered message/guidance with a flat hierarchy.

This PR keeps `ConsoleToast` as the single shared API while moving its adapter to context-bound Ant Design notifications. Toasts now appear at the top right, are always closable, pause on hover, use a compact token-backed 360px surface with a mobile max width, and expose alert/status semantics. Workflow Activity failures use the approved eight-second lifetime and a primary-message/secondary-guidance hierarchy while preserving recovery actions and tracking ID copy.

## Affected paths

- `apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx`
- `apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx`
- `docs/superpowers/specs/2026-08-06-standardize-failure-toast-design.md`
- `docs/superpowers/plans/2026-08-06-standardize-failure-toast.md`

## Focused verification

- `python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext`: Jest selected; two source files, three test files, and five static-check files identified.
- `pnpm exec jest --findRelatedTests src/shared/ui/ConsoleToast.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx --runInBand`: 46 suites passed, 788 tests passed, 0 failures.
- `pnpm exec jest src/shared/ui/ConsoleToast.test.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx --runInBand`: 3 suites passed, 23 tests passed, 0 failures.
- `bash tools/ci/test_stability_guards.sh`: passed.
- `pnpm --dir apps/aevatar-console-web exec biome check src/shared/ui/ConsoleToast.tsx src/shared/ui/ConsoleToast.test.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.tsx src/pages/workflow-activity-vnext/activity/runFailurePresentation.test.tsx src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx`: checked 5 files, no fixes or errors.
- `git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD`: passed.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

## Visual verification

- The configured local app compiled and listened on `http://localhost:53878`, but the in-app browser remained on its earlier connection-refused interstitial and security policy blocked navigation back to the local URL. The failed tab and temporary dev server were cleaned up, so browser visual verification is explicitly not claimed.
