### PR TITLE
Add skeletons to Workflow Activity vNext lists

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
@@ -86,6 +86,37 @@ describe('Workflow Activity vNext Activity ledger', () => {
 
   afterEach(() => cleanupTestQueryClients());
 
+  it('renders the activity table skeleton while the run list is loading', () => {
+    mockListRuns.mockImplementation(() => new Promise(() => {}));
+
+    renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('data-variant', 'table');
+    expect(screen.getAllByTestId('aevatar-content-skeleton-cell')).toHaveLength(
+      16,
+    );
+    expect(screen.getByText('Loading activity…')).toHaveClass(
+      'aevatar-loading-visually-hidden',
+    );
+    expect(
+      screen.getByRole('searchbox', { name: 'Search runs' }),
+    ).toBeEnabled();
+    expect(screen.queryByText('No runs yet')).not.toBeInTheDocument();
+  });
+
+  it('renders the activity table skeleton while resolving a workflow filter', () => {
+    mockSearch = '?workflowId=wf-alpha';
+    mockGetWorkflowDetail.mockImplementation(() => new Promise(() => {}));
+
+    renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />);
+
+    expect(screen.getByRole('status')).toHaveAttribute('data-variant', 'table');
+    expect(screen.getByText('Loading workflow activity…')).toHaveClass(
+      'aevatar-loading-visually-hidden',
+    );
+    expect(mockListRuns).not.toHaveBeenCalled();
+  });
+
   it('restores a visible workflow filter from the URL and removes it back to global Activity', async () => {
     mockSearch = '?workflowId=wf-alpha';
     mockGetWorkflowDetail.mockResolvedValue({

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/shared/api/workflowActivityApi';
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
+import AevatarContentSkeleton from '@/shared/ui/AevatarContentSkeleton';
 import { useConsoleLocation } from '../hooks/useConsoleLocation';
 import { buildWorkflowActivityRunHref } from '../navigation';
 import TableScrollRegion from '../TableScrollRegion';
@@ -326,14 +327,16 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           </div>
         </div>
       ) : workflowFilterPresent && workflow.isPending ? (
-        <div aria-live="polite" className="wa-vnext__state">
-          <p>
-            {t(
-              'workflowActivityVNext.activity.workflowFilterLoading',
-              'Loading workflow activity…',
-            )}
-          </p>
-        </div>
+        <AevatarContentSkeleton
+          ariaLabel={t(
+            'workflowActivityVNext.activity.workflowFilterLoading',
+            'Loading workflow activity…',
+          )}
+          columnWidths={['minmax(240px, 1fr)', 120, 120, 190]}
+          rows={4}
+          tableMinWidth={900}
+          variant="table"
+        />
       ) : workflowFilterPresent && workflow.isError ? (
         <div className="wa-vnext__state" role="alert">
           <div>
@@ -377,11 +380,16 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           </div>
         </div>
       ) : runs.isPending ? (
-        <div aria-live="polite" className="wa-vnext__state">
-          <p>
-            {t('workflowActivityVNext.activity.loading', 'Loading activity…')}
-          </p>
-        </div>
+        <AevatarContentSkeleton
+          ariaLabel={t(
+            'workflowActivityVNext.activity.loading',
+            'Loading activity…',
+          )}
+          columnWidths={['minmax(240px, 1fr)', 120, 120, 190]}
+          rows={4}
+          tableMinWidth={900}
+          variant="table"
+        />
       ) : runs.isError ? (
         <div className="wa-vnext__state" role="alert">
           <div>

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -434,7 +434,14 @@ describe('Workflow Activity vNext catalogue', () => {
 
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
-    expect(screen.getByText('Loading workflows')).toBeInTheDocument();
+    const workflowSkeleton = screen.getByRole('status');
+    expect(workflowSkeleton).toHaveAttribute('data-variant', 'table');
+    expect(screen.getAllByTestId('aevatar-content-skeleton-cell')).toHaveLength(
+      16,
+    );
+    expect(screen.getByText('Loading workflows')).toHaveClass(
+      'aevatar-loading-visually-hidden',
+    );
     expect(await screen.findByText('Support triage')).toBeInTheDocument();
     expect(screen.getByText('Invoice review')).toBeInTheDocument();
 
@@ -1403,7 +1410,10 @@ describe('Workflow Activity vNext catalogue', () => {
     await waitFor(() =>
       expect(mockStudioApi.listWorkflowDrafts).toHaveBeenCalledTimes(1),
     );
-    expect(screen.getByText('Loading workflows')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute('data-variant', 'table');
+    expect(screen.getByText('Loading workflows')).toHaveClass(
+      'aevatar-loading-visually-hidden',
+    );
     expect(
       screen.queryByText("Some workflows couldn't be loaded"),
     ).not.toBeInTheDocument();

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/shared/runs/scopeConsole';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
 import type { StudioWorkflowDraftSummary } from '@/shared/studio/models';
+import AevatarContentSkeleton from '@/shared/ui/AevatarContentSkeleton';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from '@/shared/ui/interactionStandards';
 import { useConsoleLocation } from '../hooks/useConsoleLocation';
@@ -557,11 +558,16 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       </div>
 
       {loading ? (
-        <div aria-live="polite" className="wa-vnext__state">
-          <p>
-            {t('workflowActivityVNext.workflows.loading', 'Loading workflows')}
-          </p>
-        </div>
+        <AevatarContentSkeleton
+          ariaLabel={t(
+            'workflowActivityVNext.workflows.loading',
+            'Loading workflows',
+          )}
+          columnWidths={['minmax(240px, 1fr)', 120, 190, 270]}
+          rows={4}
+          tableMinWidth={900}
+          variant="table"
+        />
       ) : view === 'drafts' && drafts.isError ? (
         <div className="wa-vnext__state" role="alert">
           <div>


### PR DESCRIPTION
## Problem and solution

PR #3272 added the shared skeleton system and was merged into `feat/2026-08-04_workflow-activity-vnext`, but its page integrations targeted the legacy console surfaces. The actual Workflow Activity vNext Workflows and Activity pages therefore kept their plain loading panels.

This follow-up integrates the existing `AevatarContentSkeleton` into:

- the vNext Workflows primary catalogue while draft and committed sources are initially loading
- the vNext Activity run ledger while runs are initially loading
- the Activity workflow-filter resolution state that blocks the same primary ledger

Both skeletons use four columns and a `900px` minimum width to match the settled vNext tables. Existing headers, filters, actions, error states, empty states, populated tables, query behavior, and background-refetch behavior are unchanged.

## Impacted paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx`
- focused regression coverage in the corresponding vNext Jest suites

## Local verification

- Changed test files: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx --runInBand` - 2 suites passed, 106 tests passed
- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/activity/ActivityPage.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx --runInBand` - 2 suites passed, 106 tests passed
- Stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Changed-file static checks: Biome passed for `ActivityPage.test.tsx`, `ActivityPage.tsx`, and `WorkflowsPage.tsx`
- Four-file Biome check reports one pre-existing formatting issue in unchanged `index.test.tsx` lines 4276-4430; the current diff only changes lines near 437 and 1406, so unrelated formatting churn was not included
- Whitespace validation: `git diff --check` - passed
- A reliable affected-only typecheck target is unavailable, so local typecheck was skipped
- Full frontend suite, typecheck, and production build are delegated to GitHub CI by personal local workflow policy

## Preview verification

A separate local origin reached the NyxID login page because authentication storage is origin-specific. The intended vNext screen could not be rendered with an authenticated session there, so no visual-preview claim is made and the temporary preview server was stopped.