### PR TITLE
Separate Workflow rename, draft delete, and archive actions

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/workflowOperationalUnits.test.ts
+++ b/apps/aevatar-console-web/src/pages/teams/workflowOperationalUnits.test.ts
@@ -9,6 +9,7 @@ describe("workflowOperationalUnits", () => {
     {
       scopeId: "scope-a",
       workflowId: "wf-alpha",
+      publishedServiceId: "svc-alpha",
       displayName: "Customer Support Triage",
       serviceKey: "scope-a:alpha",
       workflowName: "customer-support-triage",
@@ -21,6 +22,7 @@ describe("workflowOperationalUnits", () => {
     {
       scopeId: "scope-a",
       workflowId: "wf-draft",
+      publishedServiceId: "svc-draft",
       displayName: "Draft Team",
       serviceKey: "",
       workflowName: "draft-team",
@@ -166,6 +168,7 @@ describe("workflowOperationalUnits", () => {
         {
           scopeId: "scope-a",
           workflowId: "wf-healthy",
+          publishedServiceId: "svc-healthy",
           displayName: "Healthy Team",
           serviceKey: "scope-a:healthy",
           workflowName: "healthy-team",

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
@@ -27,6 +27,7 @@ function workflowDetail(
     workflow: {
       scopeId,
       workflowId,
+      publishedServiceId: receipt.publishedServiceId,
       displayName: 'Publication workflow',
       serviceKey: 'workflow-publication',
       workflowName: 'Publication workflow',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -174,6 +174,7 @@ jest.mock('@/shared/studio/api', () => ({
     getWorkflow: jest.fn(),
     getWorkflowDraft: jest.fn(),
     getWorkflowDraftFile: jest.fn(),
+    listMembers: jest.fn(),
     listWorkflowDrafts: jest.fn(),
     parseYaml: jest.fn(),
     previewExplicitRequests: jest.fn(),
@@ -181,6 +182,7 @@ jest.mock('@/shared/studio/api', () => ({
     saveAndBindWorkflow: jest.fn(),
     saveUserLlmSettings: jest.fn(),
     serializeYaml: jest.fn(),
+    updateMemberDisplayName: jest.fn(),
     updateWorkflowDraft: jest.fn(),
   },
 }));
@@ -304,6 +306,7 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   getWorkflow: jest.Mock;
   getWorkflowDraft: jest.Mock;
   getWorkflowDraftFile: jest.Mock;
+  listMembers: jest.Mock;
   listWorkflowDrafts: jest.Mock;
   parseYaml: jest.Mock;
   previewExplicitRequests: jest.Mock;
@@ -311,6 +314,7 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   saveAndBindWorkflow: jest.Mock;
   saveUserLlmSettings: jest.Mock;
   serializeYaml: jest.Mock;
+  updateMemberDisplayName: jest.Mock;
   updateWorkflowDraft: jest.Mock;
 };
 const mockCreateWorkflowRevisionIdentityCandidate = jest.requireMock(
@@ -354,6 +358,16 @@ describe('Workflow Activity vNext catalogue', () => {
       targetActorId: 'deployment-manager-alpha',
       commandId: 'cmd-archive-alpha',
       correlationId: 'corr-archive-alpha',
+    });
+    mockStudioApi.listMembers.mockResolvedValue({
+      scopeId: 'scope-alpha',
+      members: [],
+      nextPageToken: null,
+    });
+    mockStudioApi.updateMemberDisplayName.mockResolvedValue({
+      status: 'accepted',
+      scopeId: 'scope-alpha',
+      memberId: 'm-alpha',
     });
   });
 
@@ -847,6 +861,74 @@ describe('Workflow Activity vNext catalogue', () => {
     );
     expect(await screen.findByText('APAC support triage')).toBeVisible();
     expect(mockStudioApi.getWorkflowDraft).toHaveBeenCalledTimes(3);
+    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
+  });
+
+  it('renames a published-only member through its explicit workflow binding identity', async () => {
+    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
+    mockStudioApi.listMembers.mockResolvedValue({
+      scopeId: 'scope-alpha',
+      members: [
+        {
+          memberId: 'm-alpha',
+          scopeId: 'scope-alpha',
+          displayName: 'Published workflow',
+          description: '',
+          implementationKind: 'workflow',
+          implementationRef: {
+            implementationKind: 'workflow',
+            workflowId: 'wf-alpha',
+          },
+          lifecycleStage: 'bind_ready',
+          publishedServiceId: 'svc-alpha',
+          lastBoundRevisionId: 'rev-alpha',
+          teamId: 't-alpha',
+          createdAt: '2026-08-06T09:00:00Z',
+          updatedAt: '2026-08-06T10:00:00Z',
+        },
+      ],
+      nextPageToken: null,
+    });
+    mockScopesApi.listWorkflows.mockResolvedValue([
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-alpha',
+        displayName: 'Published workflow',
+        serviceKey: 'scope-alpha:default:default:svc-alpha',
+        workflowName: 'published_workflow',
+        actorId: 'actor-alpha',
+        activeRevisionId: 'rev-alpha',
+        deploymentId: 'dep-alpha',
+        deploymentStatus: 'Active',
+        updatedAt: '2026-08-06T10:00:00Z',
+      },
+    ]);
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const publishedRow = (
+      await screen.findByText('Published workflow')
+    ).closest('tr');
+    fireEvent.click(
+      within(publishedRow as HTMLElement).getByRole('button', {
+        name: 'More actions for Published workflow in Workspace',
+      }),
+    );
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'Published workflow renamed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+
+    await waitFor(() =>
+      expect(mockStudioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+        scopeId: 'scope-alpha',
+        memberId: 'm-alpha',
+        displayName: 'Published workflow renamed',
+      }),
+    );
+    expect(mockStudioApi.getWorkflowDraft).not.toHaveBeenCalled();
+    expect(await screen.findByText('Published workflow renamed')).toBeVisible();
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
   });
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -866,7 +866,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
   });
 
-  it('renames a published-only member through its explicit workflow binding identity', async () => {
+  it('renames a published-only member through its explicit published service identity', async () => {
     const memberSummary = {
       memberId: 'm-alpha',
       scopeId: 'scope-alpha',
@@ -901,7 +901,8 @@ describe('Workflow Activity vNext catalogue', () => {
     mockScopesApi.listWorkflows.mockResolvedValue([
       {
         scopeId: 'scope-alpha',
-        workflowId: 'wf-alpha',
+        workflowId: 'legacy-catalogue-row-alpha',
+        publishedServiceId: 'svc-alpha',
         displayName: 'Published workflow',
         serviceKey: 'scope-alpha:default:default:svc-alpha',
         workflowName: 'published_workflow',
@@ -942,6 +943,69 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockStudioApi.getWorkflowDraft).not.toHaveBeenCalled();
     expect(await screen.findByText('Published workflow renamed')).toBeVisible();
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
+  });
+
+  it('does not infer a published member from workflow identity when service identity disagrees', async () => {
+    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
+    mockStudioApi.listMembers.mockResolvedValue({
+      scopeId: 'scope-alpha',
+      members: [
+        {
+          memberId: 'm-alpha',
+          scopeId: 'scope-alpha',
+          displayName: 'Different published member',
+          description: '',
+          implementationKind: 'workflow',
+          implementationRef: {
+            implementationKind: 'workflow',
+            workflowId: 'wf-alpha',
+          },
+          lifecycleStage: 'bind_ready',
+          publishedServiceId: 'svc-other',
+          lastBoundRevisionId: 'rev-alpha',
+          teamId: 't-alpha',
+          createdAt: '2026-08-06T09:00:00Z',
+          updatedAt: '2026-08-06T10:00:00Z',
+        },
+      ],
+      nextPageToken: null,
+    });
+    mockScopesApi.listWorkflows.mockResolvedValue([
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-alpha',
+        publishedServiceId: 'svc-alpha',
+        displayName: 'Published workflow without resolved owner',
+        serviceKey: 'scope-alpha:default:default:svc-alpha',
+        workflowName: 'published_workflow',
+        actorId: 'actor-alpha',
+        activeRevisionId: 'rev-alpha',
+        deploymentId: 'dep-alpha',
+        deploymentStatus: 'Active',
+        updatedAt: '2026-08-06T10:00:00Z',
+      },
+    ]);
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const publishedRow = (
+      await screen.findByText('Published workflow without resolved owner')
+    ).closest('tr');
+    fireEvent.click(
+      within(publishedRow as HTMLElement).getByRole('button', {
+        name: 'More actions for Published workflow without resolved owner in Workspace',
+      }),
+    );
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'Rename' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Copy workflow reference' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Archive' }),
+    ).toBeInTheDocument();
   });
 
   it('renames both authorities when a published member still has an editable draft', async () => {
@@ -1012,6 +1076,7 @@ describe('Workflow Activity vNext catalogue', () => {
       {
         scopeId: 'scope-alpha',
         workflowId: 'wf-alpha',
+        publishedServiceId: 'svc-alpha',
         displayName: 'Published workflow',
         serviceKey: 'scope-alpha:studio:default:svc-alpha',
         workflowName: 'published_workflow',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -169,6 +169,7 @@ jest.mock('@/shared/studio/api', () => ({
     deleteWorkflowDraft: jest.fn(),
     getWorkspaceSettings: jest.fn(),
     getAuthSession: jest.fn(),
+    getMember: jest.fn(),
     getUserConfigRuntime: jest.fn(),
     getUserLlmSettings: jest.fn(),
     getWorkflow: jest.fn(),
@@ -301,6 +302,7 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   deleteWorkflowDraft: jest.Mock;
   getWorkspaceSettings: jest.Mock;
   getAuthSession: jest.Mock;
+  getMember: jest.Mock;
   getUserConfigRuntime: jest.Mock;
   getUserLlmSettings: jest.Mock;
   getWorkflow: jest.Mock;
@@ -865,30 +867,37 @@ describe('Workflow Activity vNext catalogue', () => {
   });
 
   it('renames a published-only member through its explicit workflow binding identity', async () => {
+    const memberSummary = {
+      memberId: 'm-alpha',
+      scopeId: 'scope-alpha',
+      displayName: 'Published workflow',
+      description: '',
+      implementationKind: 'workflow',
+      implementationRef: {
+        implementationKind: 'workflow',
+        workflowId: 'wf-alpha',
+      },
+      lifecycleStage: 'bind_ready',
+      publishedServiceId: 'svc-alpha',
+      lastBoundRevisionId: 'rev-alpha',
+      teamId: 't-alpha',
+      createdAt: '2026-08-06T09:00:00Z',
+      updatedAt: '2026-08-06T10:00:00Z',
+    };
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
     mockStudioApi.listMembers.mockResolvedValue({
       scopeId: 'scope-alpha',
-      members: [
-        {
-          memberId: 'm-alpha',
-          scopeId: 'scope-alpha',
-          displayName: 'Published workflow',
-          description: '',
-          implementationKind: 'workflow',
-          implementationRef: {
-            implementationKind: 'workflow',
-            workflowId: 'wf-alpha',
-          },
-          lifecycleStage: 'bind_ready',
-          publishedServiceId: 'svc-alpha',
-          lastBoundRevisionId: 'rev-alpha',
-          teamId: 't-alpha',
-          createdAt: '2026-08-06T09:00:00Z',
-          updatedAt: '2026-08-06T10:00:00Z',
-        },
-      ],
+      members: [memberSummary],
       nextPageToken: null,
     });
+    mockStudioApi.getMember
+      .mockResolvedValueOnce({ summary: memberSummary })
+      .mockResolvedValueOnce({
+        summary: {
+          ...memberSummary,
+          displayName: 'Published workflow renamed',
+        },
+      });
     mockScopesApi.listWorkflows.mockResolvedValue([
       {
         scopeId: 'scope-alpha',
@@ -927,7 +936,128 @@ describe('Workflow Activity vNext catalogue', () => {
         displayName: 'Published workflow renamed',
       }),
     );
+    await waitFor(() =>
+      expect(mockStudioApi.getMember).toHaveBeenCalledTimes(2),
+    );
     expect(mockStudioApi.getWorkflowDraft).not.toHaveBeenCalled();
+    expect(await screen.findByText('Published workflow renamed')).toBeVisible();
+    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
+  });
+
+  it('renames both authorities when a published member still has an editable draft', async () => {
+    const memberSummary = {
+      memberId: 'm-alpha',
+      scopeId: 'scope-alpha',
+      displayName: 'Published workflow',
+      description: '',
+      implementationKind: 'workflow',
+      implementationRef: {
+        implementationKind: 'workflow',
+        workflowId: 'wf-alpha',
+      },
+      lifecycleStage: 'bind_ready',
+      publishedServiceId: 'svc-alpha',
+      lastBoundRevisionId: 'rev-alpha',
+      teamId: 't-alpha',
+      createdAt: '2026-08-06T09:00:00Z',
+      updatedAt: '2026-08-06T10:00:00Z',
+    };
+    const draft = {
+      workflowId: 'wf-alpha',
+      name: 'Published workflow',
+      description: '',
+      fileName: 'published.yaml',
+      filePath: '/published.yaml',
+      directoryId: 'directory-alpha',
+      directoryLabel: 'Workflows',
+      stepCount: 1,
+      hasLayout: true,
+      updatedAtUtc: '2026-08-06T10:00:00Z',
+      yaml: 'name: Published workflow\nsteps: []\n',
+      layout: { nodes: [] },
+    };
+    const renamedDraft = {
+      ...draft,
+      name: 'Published workflow renamed',
+      yaml: 'name: Published workflow renamed\nsteps: []\n',
+    };
+    mockStudioApi.listWorkflowDrafts
+      .mockResolvedValueOnce([draft])
+      .mockResolvedValue([renamedDraft]);
+    mockStudioApi.listMembers.mockResolvedValue({
+      scopeId: 'scope-alpha',
+      members: [memberSummary],
+      nextPageToken: null,
+    });
+    mockStudioApi.getWorkflowDraft
+      .mockResolvedValueOnce(draft)
+      .mockResolvedValue(renamedDraft);
+    mockStudioApi.parseYaml.mockResolvedValue({
+      document: { name: 'Published workflow', steps: [] },
+    });
+    mockStudioApi.serializeYaml.mockResolvedValue({
+      document: { name: 'Published workflow renamed', steps: [] },
+      yaml: renamedDraft.yaml,
+    });
+    mockStudioApi.updateWorkflowDraft.mockResolvedValue(renamedDraft);
+    mockStudioApi.getMember
+      .mockResolvedValueOnce({ summary: memberSummary })
+      .mockResolvedValueOnce({
+        summary: {
+          ...memberSummary,
+          displayName: 'Published workflow renamed',
+        },
+      });
+    mockScopesApi.listWorkflows.mockResolvedValue([
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-alpha',
+        displayName: 'Published workflow',
+        serviceKey: 'scope-alpha:studio:default:svc-alpha',
+        workflowName: 'published_workflow',
+        actorId: 'actor-alpha',
+        activeRevisionId: 'rev-alpha',
+        deploymentId: 'dep-alpha',
+        deploymentStatus: 'Active',
+        updatedAt: '2026-08-06T10:00:00Z',
+      },
+    ]);
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const publishedRow = (
+      await screen.findByText('Published workflow')
+    ).closest('tr');
+    fireEvent.click(
+      within(publishedRow as HTMLElement).getByRole('button', {
+        name: 'More actions for Published workflow in Workflows',
+      }),
+    );
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'Published workflow renamed' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+
+    await waitFor(() =>
+      expect(mockStudioApi.updateWorkflowDraft).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scopeId: 'scope-alpha',
+          workflowId: 'wf-alpha',
+          workflowName: 'Published workflow renamed',
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockStudioApi.updateMemberDisplayName).toHaveBeenCalledWith({
+        scopeId: 'scope-alpha',
+        memberId: 'm-alpha',
+        displayName: 'Published workflow renamed',
+      }),
+    );
+    await waitFor(() =>
+      expect(mockStudioApi.getMember).toHaveBeenCalledTimes(2),
+    );
     expect(await screen.findByText('Published workflow renamed')).toBeVisible();
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
   });

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -691,8 +691,8 @@ describe('Workflow Activity vNext catalogue', () => {
       }),
     );
     expect(
-      await screen.findByRole('menuitem', { name: 'Rename' }),
-    ).toBeInTheDocument();
+      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
+    ).toEqual(['Copy workflow reference', 'Archive']);
     fireEvent.click(
       screen.getByRole('menuitem', { name: 'Copy workflow reference' }),
     );
@@ -837,7 +837,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
   });
 
-  it('keeps archived workflows out of Active and offers Archive for active published rows', async () => {
+  it('keeps archived workflows out of Active and scopes published rows to published actions', async () => {
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([
       {
         workflowId: 'wf-draft-alpha',
@@ -850,6 +850,18 @@ describe('Workflow Activity vNext catalogue', () => {
         stepCount: 1,
         hasLayout: true,
         updatedAtUtc: '2026-08-06T09:00:00Z',
+      },
+      {
+        workflowId: 'wf-active-alpha',
+        name: 'Active workflow',
+        description: 'Editable source for the published workflow',
+        fileName: 'active.yaml',
+        filePath: '/active.yaml',
+        directoryId: 'directory-alpha',
+        directoryLabel: 'Workflows',
+        stepCount: 2,
+        hasLayout: true,
+        updatedAtUtc: '2026-08-06T11:00:00Z',
       },
     ]);
     mockScopesApi.listWorkflows.mockResolvedValue([
@@ -889,12 +901,12 @@ describe('Workflow Activity vNext catalogue', () => {
     const activeActions = within(
       activeName.closest('tr') as HTMLElement,
     ).getByRole('button', {
-      name: 'More actions for Active workflow in Workspace',
+      name: 'More actions for Active workflow in Workflows',
     });
     fireEvent.click(activeActions);
     expect(
-      await screen.findByRole('menuitem', { name: 'Archive' }),
-    ).toBeInTheDocument();
+      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
+    ).toEqual(['Copy workflow reference', 'Archive']);
   });
 
   it('restores the Archived view without offering Archive again', async () => {
@@ -1271,6 +1283,8 @@ describe('Workflow Activity vNext catalogue', () => {
   });
 
   it('deletes only the editable draft and refreshes authoritative draft membership', async () => {
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=drafts';
     let draftRows = [
       {
         workflowId: 'wf-draft-alpha',
@@ -1329,14 +1343,8 @@ describe('Workflow Activity vNext catalogue', () => {
     await waitFor(() =>
       expect(mockStudioApi.listWorkflowDrafts).toHaveBeenCalledTimes(2),
     );
-    expect(
-      await screen.findByText('Committed support source'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'More actions for Committed support source in Workspace',
-      }),
-    ).toBeEnabled();
+    expect(screen.queryByText('Support triage')).not.toBeInTheDocument();
+    expect(mockServicesApi.deactivateDeployment).not.toHaveBeenCalled();
   });
 
   it('keeps the draft and offers retry when deletion fails', async () => {
@@ -1575,6 +1583,16 @@ describe('Workflow Activity vNext catalogue', () => {
       screen.getByRole('searchbox', { name: 'Search workflows' }),
     ).toHaveValue('support');
     expect(screen.getByText('Drafts')).toBeInTheDocument();
+
+    const draftActions = within(
+      screen.getByText('Support triage').closest('tr') as HTMLElement,
+    ).getByRole('button', {
+      name: 'More actions for Support triage in Workflows',
+    });
+    fireEvent.click(draftActions);
+    expect(
+      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
+    ).toEqual(['Rename', 'Copy workflow reference', 'Delete draft']);
 
     fireEvent.mouseDown(
       screen.getByRole('combobox', { name: 'Workflow view' }),

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -692,7 +692,7 @@ describe('Workflow Activity vNext catalogue', () => {
     );
     expect(
       (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Copy workflow reference', 'Archive']);
+    ).toEqual(['Rename', 'Copy workflow reference', 'Archive']);
     fireEvent.click(
       screen.getByRole('menuitem', { name: 'Copy workflow reference' }),
     );
@@ -743,7 +743,20 @@ describe('Workflow Activity vNext catalogue', () => {
           : draft,
       ),
     );
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
+    mockScopesApi.listWorkflows.mockResolvedValue([
+      {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-support-apac',
+        displayName: 'Support triage',
+        serviceKey: 'scope-alpha:default:default:svc-support-apac',
+        workflowName: 'support_triage',
+        actorId: 'actor-support-apac',
+        activeRevisionId: 'rev-support-apac',
+        deploymentId: 'dep-support-apac',
+        deploymentStatus: 'Active',
+        updatedAt: '2026-08-05T11:29:00Z',
+      },
+    ]);
     mockStudioApi.getWorkflowDraft.mockImplementation(async () => {
       if (pendingName && postUpdateReads++ > 0) {
         authoritativeName = pendingName;
@@ -837,7 +850,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
   });
 
-  it('keeps archived workflows out of Active and scopes published rows to published actions', async () => {
+  it('keeps archived workflows out of Active and keeps rename on published rows with editable drafts', async () => {
     mockStudioApi.listWorkflowDrafts.mockResolvedValue([
       {
         workflowId: 'wf-draft-alpha',
@@ -906,7 +919,7 @@ describe('Workflow Activity vNext catalogue', () => {
     fireEvent.click(activeActions);
     expect(
       (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Copy workflow reference', 'Archive']);
+    ).toEqual(['Rename', 'Copy workflow reference', 'Archive']);
   });
 
   it('restores the Archived view without offering Archive again', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -734,7 +734,8 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 const description = row.description.trim();
                 const isArchived = isWorkflowArchived(row);
                 const isPublished = Boolean(row.activeRevisionId);
-                const showDraftActions =
+                const showRenameAction = row.hasDraftSource;
+                const showDeleteDraftAction =
                   row.hasDraftSource && (view === 'drafts' || !isPublished);
                 const showArchiveAction =
                   view !== 'drafts' && canArchiveWorkflow(row);
@@ -864,7 +865,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                         <Dropdown
                           menu={{
                             items: [
-                              ...(showDraftActions
+                              ...(showRenameAction
                                 ? [
                                     {
                                       icon: <EditOutlined />,
@@ -884,10 +885,10 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                                   'Copy workflow reference',
                                 ),
                               },
-                              ...(showDraftActions || showArchiveAction
+                              ...(showDeleteDraftAction || showArchiveAction
                                 ? [{ type: 'divider' as const }]
                                 : []),
-                              ...(showDraftActions
+                              ...(showDeleteDraftAction
                                 ? [
                                     {
                                       danger: true,

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -22,7 +22,11 @@ import {
   scopeServiceNamespace,
 } from '@/shared/runs/scopeConsole';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
-import type { StudioWorkflowDraftSummary } from '@/shared/studio/models';
+import type {
+  StudioMemberRoster,
+  StudioMemberSummary,
+  StudioWorkflowDraftSummary,
+} from '@/shared/studio/models';
 import AevatarContentSkeleton from '@/shared/ui/AevatarContentSkeleton';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from '@/shared/ui/interactionStandards';
@@ -48,6 +52,7 @@ type WorkflowRow = {
   readonly description: string;
   readonly hasCommittedSource: boolean;
   readonly hasDraftSource: boolean;
+  readonly memberId: string;
   readonly name: string;
   readonly ownershipLabel: string;
   readonly stepCount?: number;
@@ -67,6 +72,7 @@ function toDraftRow(
     deploymentStatus: committed?.deploymentStatus ?? '',
     hasCommittedSource: Boolean(committed),
     hasDraftSource: true,
+    memberId: committed?.memberId ?? '',
     name: item.name,
     ownershipLabel:
       item.directoryLabel.trim() ||
@@ -77,7 +83,10 @@ function toDraftRow(
   };
 }
 
-function toCommittedRow(item: ScopeWorkflowSummary): WorkflowRow {
+function toCommittedRow(
+  item: ScopeWorkflowSummary,
+  member?: StudioMemberSummary,
+): WorkflowRow {
   return {
     activeRevisionId: item.activeRevisionId.trim(),
     description: '',
@@ -85,7 +94,8 @@ function toCommittedRow(item: ScopeWorkflowSummary): WorkflowRow {
     deploymentStatus: item.deploymentStatus.trim(),
     hasCommittedSource: true,
     hasDraftSource: false,
-    name: item.displayName || item.workflowName,
+    memberId: member?.memberId.trim() ?? '',
+    name: member?.displayName.trim() || item.displayName || item.workflowName,
     ownershipLabel: t(
       'workflowActivityVNext.workflows.workspaceOwner',
       'Workspace',
@@ -179,6 +189,11 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     queryFn: () => scopesApi.listWorkflows(scopeId),
     retry: false,
   });
+  const members = useQuery({
+    queryKey: ['workflow-activity-vnext', 'members', scopeId],
+    queryFn: () => studioApi.listMembers(scopeId),
+    retry: false,
+  });
 
   React.useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -199,10 +214,33 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     () => new Set((drafts.data ?? []).map((item) => item.workflowId)),
     [drafts.data],
   );
+  const membersByWorkflowId = React.useMemo(() => {
+    const resolved = new Map<string, StudioMemberSummary | null>();
+    for (const member of members.data?.members ?? []) {
+      if (
+        member.implementationKind !== 'workflow' ||
+        member.implementationRef?.implementationKind !== 'workflow'
+      )
+        continue;
+      const boundWorkflowId = member.implementationRef.workflowId?.trim() ?? '';
+      if (!boundWorkflowId) continue;
+      resolved.set(
+        boundWorkflowId,
+        resolved.has(boundWorkflowId) ? null : member,
+      );
+    }
+    return resolved;
+  }, [members.data]);
   const rows = React.useMemo(() => {
     const merged = new Map<string, WorkflowRow>();
     for (const item of committed.data ?? [])
-      merged.set(item.workflowId, toCommittedRow(item));
+      merged.set(
+        item.workflowId,
+        toCommittedRow(
+          item,
+          membersByWorkflowId.get(item.workflowId) ?? undefined,
+        ),
+      );
     for (const item of drafts.data ?? [])
       merged.set(
         item.workflowId,
@@ -227,7 +265,14 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           Date.parse(right.updatedAtUtc ?? '') -
           Date.parse(left.updatedAtUtc ?? ''),
       );
-  }, [committed.data, draftWorkflowIds, drafts.data, query, view]);
+  }, [
+    committed.data,
+    draftWorkflowIds,
+    drafts.data,
+    membersByWorkflowId,
+    query,
+    view,
+  ]);
   const totalFailure = drafts.isError && committed.isError;
   const filtersActive = Boolean(query.trim()) || view !== 'active';
   const renameDuplicates = React.useMemo(() => {
@@ -278,6 +323,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const retry = () => {
     void drafts.refetch();
     void committed.refetch();
+    void members.refetch();
   };
 
   const copyWorkflowReference = async (row: WorkflowRow) => {
@@ -317,39 +363,63 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     if (!renameTarget || !workflowName || renaming) return;
     setRenaming(true);
     try {
-      const draft = await studioApi.getWorkflowDraft(
-        renameTarget.workflowId,
-        scopeId,
-      );
-      const parsed = await studioApi.parseYaml({ yaml: draft.yaml });
-      if (!parsed.document)
-        throw new Error('Workflow YAML could not be parsed');
-      const serialized = await studioApi.serializeYaml({
-        document: {
-          ...parsed.document,
-          name: workflowName,
-        },
-      });
-      await studioApi.updateWorkflowDraft({
-        directoryId: draft.directoryId,
-        fileName: draft.fileName,
-        layout: draft.layout,
-        scopeId,
-        workflowId: renameTarget.workflowId,
-        workflowName,
-        yaml: serialized.yaml,
-      });
-      const observation = await observeDraftMaterialization({
-        workflowId: renameTarget.workflowId,
-        read: (workflowId) => studioApi.getWorkflowDraft(workflowId, scopeId),
-        isNotFound: (candidate) => isStudioApiStatus(candidate, 404),
-        isObserved: (candidate) => candidate.name.trim() === workflowName,
-      });
-      if (observation.kind === 'delayed') {
-        throw new Error('Workflow rename was not observed');
+      if (renameTarget.hasDraftSource) {
+        const draft = await studioApi.getWorkflowDraft(
+          renameTarget.workflowId,
+          scopeId,
+        );
+        const parsed = await studioApi.parseYaml({ yaml: draft.yaml });
+        if (!parsed.document)
+          throw new Error('Workflow YAML could not be parsed');
+        const serialized = await studioApi.serializeYaml({
+          document: {
+            ...parsed.document,
+            name: workflowName,
+          },
+        });
+        await studioApi.updateWorkflowDraft({
+          directoryId: draft.directoryId,
+          fileName: draft.fileName,
+          layout: draft.layout,
+          scopeId,
+          workflowId: renameTarget.workflowId,
+          workflowName,
+          yaml: serialized.yaml,
+        });
+        const observation = await observeDraftMaterialization({
+          workflowId: renameTarget.workflowId,
+          read: (workflowId) => studioApi.getWorkflowDraft(workflowId, scopeId),
+          isNotFound: (candidate) => isStudioApiStatus(candidate, 404),
+          isObserved: (candidate) => candidate.name.trim() === workflowName,
+        });
+        if (observation.kind === 'delayed') {
+          throw new Error('Workflow rename was not observed');
+        }
+        const refreshed = await drafts.refetch();
+        if (refreshed.isError) throw refreshed.error;
+      } else if (renameTarget.memberId) {
+        await studioApi.updateMemberDisplayName({
+          scopeId,
+          memberId: renameTarget.memberId,
+          displayName: workflowName,
+        });
+        queryClient.setQueryData<StudioMemberRoster | undefined>(
+          ['workflow-activity-vnext', 'members', scopeId],
+          (current) =>
+            current
+              ? {
+                  ...current,
+                  members: current.members.map((member) =>
+                    member.memberId === renameTarget.memberId
+                      ? { ...member, displayName: workflowName }
+                      : member,
+                  ),
+                }
+              : current,
+        );
+      } else {
+        throw new Error('Workflow has no rename authority');
       }
-      const refreshed = await drafts.refetch();
-      if (refreshed.isError) throw refreshed.error;
       setRenameTarget(null);
       setRenameName('');
       toast.success(
@@ -734,7 +804,8 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 const description = row.description.trim();
                 const isArchived = isWorkflowArchived(row);
                 const isPublished = Boolean(row.activeRevisionId);
-                const showRenameAction = row.hasDraftSource;
+                const showRenameAction =
+                  row.hasDraftSource || Boolean(row.memberId);
                 const showDeleteDraftAction =
                   row.hasDraftSource && (view === 'drafts' || !isPublished);
                 const showArchiveAction =

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -363,6 +363,10 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     if (!renameTarget || !workflowName || renaming) return;
     setRenaming(true);
     try {
+      if (!renameTarget.hasDraftSource && !renameTarget.memberId) {
+        throw new Error('Workflow has no rename authority');
+      }
+
       if (renameTarget.hasDraftSource) {
         const draft = await studioApi.getWorkflowDraft(
           renameTarget.workflowId,
@@ -397,12 +401,24 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         }
         const refreshed = await drafts.refetch();
         if (refreshed.isError) throw refreshed.error;
-      } else if (renameTarget.memberId) {
+      }
+
+      if (renameTarget.memberId) {
         await studioApi.updateMemberDisplayName({
           scopeId,
           memberId: renameTarget.memberId,
           displayName: workflowName,
         });
+        const observation = await observeDraftMaterialization({
+          workflowId: renameTarget.memberId,
+          read: (memberId) => studioApi.getMember(scopeId, memberId),
+          isNotFound: (candidate) => isStudioApiStatus(candidate, 404),
+          isObserved: (candidate) =>
+            candidate.summary.displayName.trim() === workflowName,
+        });
+        if (observation.kind === 'delayed') {
+          throw new Error('Member rename was not observed');
+        }
         queryClient.setQueryData<StudioMemberRoster | undefined>(
           ['workflow-activity-vnext', 'members', scopeId],
           (current) =>
@@ -411,14 +427,12 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                   ...current,
                   members: current.members.map((member) =>
                     member.memberId === renameTarget.memberId
-                      ? { ...member, displayName: workflowName }
+                      ? observation.workflow.summary
                       : member,
                   ),
                 }
               : current,
         );
-      } else {
-        throw new Error('Workflow has no rename authority');
       }
       setRenameTarget(null);
       setRenameName('');

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -734,6 +734,10 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 const description = row.description.trim();
                 const isArchived = isWorkflowArchived(row);
                 const isPublished = Boolean(row.activeRevisionId);
+                const showDraftActions =
+                  row.hasDraftSource && (view === 'drafts' || !isPublished);
+                const showArchiveAction =
+                  view !== 'drafts' && canArchiveWorkflow(row);
                 const workflowName = (
                   <span className="wa-vnext__title">{row.name}</span>
                 );
@@ -860,7 +864,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                         <Dropdown
                           menu={{
                             items: [
-                              ...(row.hasDraftSource
+                              ...(showDraftActions
                                 ? [
                                     {
                                       icon: <EditOutlined />,
@@ -880,10 +884,10 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                                   'Copy workflow reference',
                                 ),
                               },
-                              ...(row.hasDraftSource || canArchiveWorkflow(row)
+                              ...(showDraftActions || showArchiveAction
                                 ? [{ type: 'divider' as const }]
                                 : []),
-                              ...(row.hasDraftSource
+                              ...(showDraftActions
                                 ? [
                                     {
                                       danger: true,
@@ -896,7 +900,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                                     },
                                   ]
                                 : []),
-                              ...(canArchiveWorkflow(row)
+                              ...(showArchiveAction
                                 ? [
                                     {
                                       danger: true,

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -214,33 +214,40 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     () => new Set((drafts.data ?? []).map((item) => item.workflowId)),
     [drafts.data],
   );
-  const membersByWorkflowId = React.useMemo(() => {
-    const resolved = new Map<string, StudioMemberSummary | null>();
+  const memberIndexes = React.useMemo(() => {
+    const byPublishedServiceId = new Map<string, StudioMemberSummary | null>();
+    const byWorkflowId = new Map<string, StudioMemberSummary | null>();
     for (const member of members.data?.members ?? []) {
       if (
         member.implementationKind !== 'workflow' ||
         member.implementationRef?.implementationKind !== 'workflow'
       )
         continue;
+      const publishedServiceId = member.publishedServiceId.trim();
+      if (publishedServiceId) {
+        byPublishedServiceId.set(
+          publishedServiceId,
+          byPublishedServiceId.has(publishedServiceId) ? null : member,
+        );
+      }
       const boundWorkflowId = member.implementationRef.workflowId?.trim() ?? '';
       if (!boundWorkflowId) continue;
-      resolved.set(
+      byWorkflowId.set(
         boundWorkflowId,
-        resolved.has(boundWorkflowId) ? null : member,
+        byWorkflowId.has(boundWorkflowId) ? null : member,
       );
     }
-    return resolved;
+    return { byPublishedServiceId, byWorkflowId };
   }, [members.data]);
   const rows = React.useMemo(() => {
     const merged = new Map<string, WorkflowRow>();
-    for (const item of committed.data ?? [])
-      merged.set(
-        item.workflowId,
-        toCommittedRow(
-          item,
-          membersByWorkflowId.get(item.workflowId) ?? undefined,
-        ),
-      );
+    for (const item of committed.data ?? []) {
+      const publishedServiceId = item.publishedServiceId?.trim() ?? '';
+      const member = publishedServiceId
+        ? memberIndexes.byPublishedServiceId.get(publishedServiceId)
+        : memberIndexes.byWorkflowId.get(item.workflowId);
+      merged.set(item.workflowId, toCommittedRow(item, member ?? undefined));
+    }
     for (const item of drafts.data ?? [])
       merged.set(
         item.workflowId,
@@ -269,7 +276,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     committed.data,
     draftWorkflowIds,
     drafts.data,
-    membersByWorkflowId,
+    memberIndexes,
     query,
     view,
   ]);

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts
@@ -12,6 +12,7 @@ function workflowSummary(
   return {
     scopeId: 'scope-alpha',
     workflowId,
+    publishedServiceId: `svc-${workflowId}`,
     displayName: 'Workflow',
     serviceKey: `scope-alpha:default:default:${workflowId}`,
     workflowName: 'workflow',

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
@@ -1,0 +1,44 @@
+import { scopesApi } from './scopesApi';
+
+describe('scopesApi', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('preserves the explicit published service identity on workflow summaries', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => [
+        {
+          scopeId: 'scope-alpha',
+          workflowId: 'legacy-catalogue-row-alpha',
+          publishedServiceId: 'svc-alpha',
+          displayName: 'Published workflow',
+          serviceKey: 'scope-alpha:studio:default:svc-alpha',
+          workflowName: 'published_workflow',
+          actorId: 'actor-alpha',
+          activeRevisionId: 'rev-alpha',
+          deploymentId: 'dep-alpha',
+          deploymentStatus: 'Active',
+          updatedAt: '2026-08-06T10:00:00Z',
+        },
+      ],
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(scopesApi.listWorkflows('scope-alpha')).resolves.toEqual([
+      expect.objectContaining({
+        workflowId: 'legacy-catalogue-row-alpha',
+        publishedServiceId: 'svc-alpha',
+      }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-alpha/workflows?includeSource=false',
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.ts
@@ -14,6 +14,7 @@ import {
   expectRecord,
   readBoolean,
   readOptionalRecord,
+  readOptionalString,
   readString,
   readStringArray,
   readStringRecord,
@@ -31,6 +32,12 @@ function decodeScopeWorkflowSummary(
       ['workflowId', 'WorkflowId'],
       `${label}.workflowId`,
     ),
+    publishedServiceId:
+      readOptionalString(
+        record,
+        ['publishedServiceId', 'PublishedServiceId'],
+        `${label}.publishedServiceId`,
+      ) ?? '',
     displayName: readString(
       record,
       ['displayName', 'DisplayName'],

--- a/apps/aevatar-console-web/src/shared/models/scopes.ts
+++ b/apps/aevatar-console-web/src/shared/models/scopes.ts
@@ -1,6 +1,7 @@
 export interface ScopeWorkflowSummary {
   scopeId: string;
   workflowId: string;
+  publishedServiceId: string;
   displayName: string;
   serviceKey: string;
   workflowName: string;

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
@@ -26,7 +26,7 @@ describe('ConsoleToast', () => {
     const content = <span>Request failed</span>;
     jest.spyOn(App, 'useApp').mockReturnValue({
       notification,
-    } as ReturnType<typeof App.useApp>);
+    } as unknown as ReturnType<typeof App.useApp>);
 
     const { result } = renderHook(() => useConsoleToast());
     act(() => {
@@ -65,7 +65,7 @@ describe('ConsoleToast', () => {
     const notification = createNotificationStub();
     jest.spyOn(App, 'useApp').mockReturnValue({
       notification,
-    } as ReturnType<typeof App.useApp>);
+    } as unknown as ReturnType<typeof App.useApp>);
 
     const { result } = renderHook(() => useConsoleToast());
     act(() => {


### PR DESCRIPTION
## Problem

Workflow rows merge editable draft facts, published deployment facts, and Studio member identity. Rename, Delete draft, and Archive have different owners. Published Workflow Rename was missing because the frontend decoder discarded the backend workflow summary `publishedServiceId`, so a catalogue `workflowId` that differed from the member implementation `workflowId` could not resolve its owning member.

The earlier implementation also treated a member rename as complete after only a `202 Accepted` response. `workflowId`, `memberId`, and `publishedServiceId` must remain distinct.

## Backend contract verified

Rechecked against the latest `origin/feature/integrate@b8a9d6908`:

- `ScopeWorkflowSummary` exposes `PublishedServiceId`, populated from `ServiceIdentity.ServiceId`.
- `StudioMemberSummaryResponse` exposes distinct `MemberId`, `PublishedServiceId`, and typed `ImplementationRef.WorkflowId`.
- `PATCH /api/scopes/{scopeId}/members/{memberId}` accepts `displayName` and dispatches the authoritative member rename.
- The PATCH response is `202 Accepted`; completion is observed from `GET /api/scopes/{scopeId}/members/{memberId}`.
- The relevant backend contract and endpoint files did not change between `4389ecd31` and `b8a9d6908`.

## Solution

- Preserve workflow summary `publishedServiceId` in the frontend model and decoder.
- Resolve a published row owner by one unique, explicit `publishedServiceId` match.
- When `publishedServiceId` is present but unresolved or ambiguous, do not fall back to `workflowId` and do not expose Rename.
- Retain the typed `implementationRef.workflowId` path only for older responses that omit `publishedServiceId`; never infer identity from prefixes, string shape, service keys, or route position.
- Show Rename when a row has an editable draft or one resolved member owner.
- Draft-only Rename updates YAML and observes draft materialization.
- Published-only Rename patches the resolved `memberId` and observes the member current-state read model.
- Published + editable draft Rename updates and observes both authorities before reporting success.
- Keep Delete draft restricted to editable draft ownership, Archive restricted to published deployment ownership, and Copy workflow reference available for every row.

Resulting menus:

- Published + editable draft: Rename, Copy workflow reference, Archive
- Published-only Workflow with a resolved member: Rename, Copy workflow reference, Archive
- Draft-only in Active or Drafts: Rename, Copy workflow reference, Delete draft
- Published row without a unique resolved member: Copy workflow reference, Archive

## Identity coverage

Fixtures deliberately keep the identities different:

- `memberId = m-alpha`
- `workflowId = wf-alpha`
- catalogue `workflowId = legacy-catalogue-row-alpha`
- `publishedServiceId = svc-alpha`

Tests verify that member PATCH and GET use `m-alpha`, while draft operations use `wf-alpha`. A conflict test verifies that a matching `workflowId` cannot override a disagreeing `publishedServiceId`.

## Impact

- Workflow Activity vNext catalogue actions
- Scope workflow summary decoding
- Draft and published member rename coordination
- Member current-state observation after accepted commands
- No backend, locale, dependency, or migration change in this PR

## Local verification

- Scope analyzer: 6 changed frontend files, Jest runner, 3 source files and 3 test files.
- `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand --testNamePattern="renames a published-only member|does not infer a published member"` - 2 passed.
- `pnpm exec jest src/shared/api/scopesApi.test.ts src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts --runInBand` - 6 passed.
- Earlier full changed page test before the final identity-only regression: 99 passed; it was not repeated after the focused scenario passed.
- `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts src/shared/api/scopesApi.test.ts src/shared/api/scopesApi.ts src/shared/models/scopes.ts` - passed.
- `bash tools/ci/test_stability_guards.sh` - passed.
- `git diff --check` - passed.
- No repository-native affected typecheck target is available, so local typecheck was skipped.
- Full frontend suite, typecheck, and production build are delegated to GitHub CI by personal local workflow policy.
- Authenticated Chrome smoke at `http://localhost:5175/scopes/ccb108c4-dcb3-473a-a0f7-e9859bb2f2a0/workflow-activity-vnext/workflows` against the remote backend - `周报 Workflow` menu rendered exactly Rename, Copy workflow reference, Archive; Delete draft was absent; no browser warning/error logs.

## Conflict resolution

GitHub reported the PR as mergeable; the blocking `UNSTABLE` state came from the `console-web` typecheck rather than a textual Git merge conflict.

- Added explicit, distinct `publishedServiceId` values to legacy workflow test fixtures affected by the strengthened `ScopeWorkflowSummary` contract.
- Corrected the latest base branch `ConsoleToast.test.tsx` intentionally-partial `App.useApp()` mock; base commit `48be765b7` failed CI with the same TS2352 diagnostics.
- Related tests: `pnpm exec jest src/pages/teams/workflowOperationalUnits.test.ts src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts src/shared/ui/ConsoleToast.test.tsx --runInBand` - 19 passed.
- Static checks: scoped Biome lint/check across all 9 PR files - passed.
- `bash tools/ci/test_stability_guards.sh` - passed.
- `git diff --check` - passed.
- Full frontend typecheck, suite, and build remain delegated to the newly triggered GitHub `console-web` job by personal local workflow policy.