### PR TITLE
Honor MCP connector initialization timeout

### DIFF
--- a/src/Aevatar.Bootstrap.Extensions.AI/Connectors/MCPConnectorBuilder.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/Connectors/MCPConnectorBuilder.cs
@@ -70,6 +70,8 @@ public sealed class MCPConnectorBuilder : IConnectorBuilder
             Arguments = entry.MCP.Arguments,
             Environment = entry.MCP.Environment,
             AdditionalHeaders = entry.MCP.AdditionalHeaders,
+            InitializationTimeout = TimeSpan.FromMilliseconds(
+                Math.Clamp(entry.TimeoutMs <= 0 ? 30_000 : entry.TimeoutMs, 100, 300_000)),
             HttpClient = transportHttpClient,
             OwnsHttpClient = transportHttpClient != null,
         };

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -682,8 +682,44 @@ public class AIFeatureBootstrapCoverageTests
         serverConfigField.Should().NotBeNull();
         var serverConfig = serverConfigField!.GetValue(connector).Should().BeOfType<MCPServerConfig>().Subject;
         serverConfig.Url.Should().Be("https://nyxid.example.com/mcp");
+        serverConfig.InitializationTimeout.Should().Be(TimeSpan.FromMilliseconds(15000));
         serverConfig.HttpClient.Should().NotBeNull();
         serverConfig.HttpClient!.Timeout.Should().Be(Timeout.InfiniteTimeSpan);
+    }
+
+    [Theory]
+    [InlineData(false, -1, 30000)]
+    [InlineData(false, 50, 100)]
+    [InlineData(false, 500001, 300000)]
+    [InlineData(true, -1, 30000)]
+    [InlineData(true, 50, 100)]
+    [InlineData(true, 500001, 300000)]
+    public void MCPConnectorBuilder_ShouldNormalizeInitializationTimeout(
+        bool useRemoteUrl,
+        int timeoutMs,
+        int expectedTimeoutMs)
+    {
+        var builder = new MCPConnectorBuilder(
+            new VoicePresenceBootstrapTests.TestHttpClientFactory(),
+            new VoicePresenceBootstrapTests.UnusedAgentToolExecutionPort());
+        var entry = new ConnectorConfigEntry
+        {
+            Name = "bounded-mcp",
+            Type = "mcp",
+            TimeoutMs = timeoutMs,
+            MCP = new MCPConnectorConfig
+            {
+                Command = useRemoteUrl ? string.Empty : "echo",
+                Url = useRemoteUrl ? "https://mcp.example.com/mcp" : string.Empty,
+            },
+        };
+
+        builder.TryBuild(entry, NullLogger.Instance, out var connector).Should().BeTrue();
+
+        var serverConfigField = connector!.GetType()
+            .GetField("_serverConfig", BindingFlags.Instance | BindingFlags.NonPublic);
+        var serverConfig = serverConfigField!.GetValue(connector).Should().BeOfType<MCPServerConfig>().Subject;
+        serverConfig.InitializationTimeout.Should().Be(TimeSpan.FromMilliseconds(expectedTimeoutMs));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Catalog-backed MCP connectors normalize and persist `timeoutMs`, but the shared connector builder did not pass it to `MCPServerConfig.InitializationTimeout`. Negotiation therefore always used the SDK's 30-second default.

Closes #3205.

## Solution

- map the catalog timeout into MCP initialization
- preserve the existing 30s default and 100ms..300s bounds
- cover both STDIO and Streamable HTTP configurations at default, lower, upper, and configured values

## Impact

Only MCP negotiation timeout construction changes. The existing HTTP transport lifetime, connector policy, and tool execution paths are unchanged.

## Verification

- regression RED: configured 15s expected, previous builder produced 30s
- focused MCP/bootstrap/integration/studio tests: 55/55 passed
- `dotnet build aevatar.slnx --nologo`: 0 errors
- `bash tools/ci/test_stability_guards.sh`: passed
- `bash tools/ci/architecture_guards.sh`: passed
- full `dotnet test aevatar.slnx --no-restore --no-build --nologo` with Redis 7.2.3: exit 0
- `git diff --check`: passed
