### PR TITLE
Use backend workflow catalogue in Workflow Activity

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/workflowOperationalUnits.test.ts
+++ b/apps/aevatar-console-web/src/pages/teams/workflowOperationalUnits.test.ts
@@ -2,152 +2,156 @@ import {
   buildWorkflowOperationalUnits,
   collectWorkflowOperationalServiceIds,
   resolveWorkflowOperationalUnit,
-} from "./workflowOperationalUnits";
+} from './workflowOperationalUnits';
 
-describe("workflowOperationalUnits", () => {
+describe('workflowOperationalUnits', () => {
   const workflows = [
     {
-      scopeId: "scope-a",
-      workflowId: "wf-alpha",
-      publishedServiceId: "svc-alpha",
-      displayName: "Customer Support Triage",
-      serviceKey: "scope-a:alpha",
-      workflowName: "customer-support-triage",
-      actorId: "actor://alpha",
-      activeRevisionId: "rev-alpha",
-      deploymentId: "dep-alpha",
-      deploymentStatus: "Active",
-      updatedAt: "2026-04-13T09:00:00Z",
+      scopeId: 'scope-a',
+      workflowId: 'wf-alpha',
+      publishedServiceId: 'svc-alpha',
+      serviceAppId: 'default',
+      serviceNamespace: 'default',
+      displayName: 'Customer Support Triage',
+      serviceKey: 'scope-a:alpha',
+      workflowName: 'customer-support-triage',
+      actorId: 'actor://alpha',
+      activeRevisionId: 'rev-alpha',
+      deploymentId: 'dep-alpha',
+      deploymentStatus: 'Active',
+      updatedAt: '2026-04-13T09:00:00Z',
     },
     {
-      scopeId: "scope-a",
-      workflowId: "wf-draft",
-      publishedServiceId: "svc-draft",
-      displayName: "Draft Team",
-      serviceKey: "",
-      workflowName: "draft-team",
-      actorId: "actor://draft",
-      activeRevisionId: "rev-draft",
-      deploymentId: "",
-      deploymentStatus: "Draft",
-      updatedAt: "2026-04-13T08:00:00Z",
+      scopeId: 'scope-a',
+      workflowId: 'wf-draft',
+      publishedServiceId: 'svc-draft',
+      serviceAppId: 'default',
+      serviceNamespace: 'default',
+      displayName: 'Draft Team',
+      serviceKey: '',
+      workflowName: 'draft-team',
+      actorId: 'actor://draft',
+      activeRevisionId: 'rev-draft',
+      deploymentId: '',
+      deploymentStatus: 'Draft',
+      updatedAt: '2026-04-13T08:00:00Z',
     },
   ] as const;
 
   const services = [
     {
-      serviceKey: "scope-a:alpha",
-      tenantId: "scope-a",
-      appId: "default",
-      namespace: "default",
-      serviceId: "service-alpha",
-      displayName: "Support Runtime",
-      defaultServingRevisionId: "rev-alpha",
-      activeServingRevisionId: "rev-alpha",
-      deploymentId: "dep-alpha",
-      primaryActorId: "actor://alpha",
-      deploymentStatus: "Active",
+      serviceKey: 'scope-a:alpha',
+      tenantId: 'scope-a',
+      appId: 'default',
+      namespace: 'default',
+      serviceId: 'service-alpha',
+      displayName: 'Support Runtime',
+      defaultServingRevisionId: 'rev-alpha',
+      activeServingRevisionId: 'rev-alpha',
+      deploymentId: 'dep-alpha',
+      primaryActorId: 'actor://alpha',
+      deploymentStatus: 'Active',
       endpoints: [],
       policyIds: [],
-      updatedAt: "2026-04-13T09:01:00Z",
+      updatedAt: '2026-04-13T09:01:00Z',
     },
     {
-      serviceKey: "scope-a:stale",
-      tenantId: "scope-a",
-      appId: "default",
-      namespace: "default",
-      serviceId: "service-stale",
-      displayName: "Old Runtime",
-      defaultServingRevisionId: "rev-stale",
-      activeServingRevisionId: "rev-stale",
-      deploymentId: "dep-stale",
-      primaryActorId: "actor://stale",
-      deploymentStatus: "Active",
+      serviceKey: 'scope-a:stale',
+      tenantId: 'scope-a',
+      appId: 'default',
+      namespace: 'default',
+      serviceId: 'service-stale',
+      displayName: 'Old Runtime',
+      defaultServingRevisionId: 'rev-stale',
+      activeServingRevisionId: 'rev-stale',
+      deploymentId: 'dep-stale',
+      primaryActorId: 'actor://stale',
+      deploymentStatus: 'Active',
       endpoints: [],
       policyIds: [],
-      updatedAt: "2026-04-12T09:01:00Z",
+      updatedAt: '2026-04-12T09:01:00Z',
     },
   ];
 
   const runs = [
     {
-      scopeId: "scope-a",
-      serviceId: "service-alpha",
-      runId: "run-latest",
-      actorId: "actor://alpha",
-      definitionActorId: "definition://customer-support-triage",
-      revisionId: "rev-alpha",
-      deploymentId: "dep-alpha",
-      workflowName: "customer-support-triage",
-      completionStatus: "waiting_approval",
+      scopeId: 'scope-a',
+      serviceId: 'service-alpha',
+      runId: 'run-latest',
+      actorId: 'actor://alpha',
+      definitionActorId: 'definition://customer-support-triage',
+      revisionId: 'rev-alpha',
+      deploymentId: 'dep-alpha',
+      workflowName: 'customer-support-triage',
+      completionStatus: 'waiting_approval',
       stateVersion: 2,
-      lastEventId: "evt-2",
-      lastUpdatedAt: "2026-04-13T09:05:00Z",
-      boundAt: "2026-04-13T09:00:00Z",
-      bindingUpdatedAt: "2026-04-13T09:00:00Z",
+      lastEventId: 'evt-2',
+      lastUpdatedAt: '2026-04-13T09:05:00Z',
+      boundAt: '2026-04-13T09:00:00Z',
+      bindingUpdatedAt: '2026-04-13T09:00:00Z',
       lastSuccess: false,
       totalSteps: 4,
       completedSteps: 2,
       roleReplyCount: 1,
-      lastOutput: "",
-      lastError: "Waiting on approval",
+      lastOutput: '',
+      lastError: 'Waiting on approval',
     },
     {
-      scopeId: "scope-a",
-      serviceId: "service-alpha",
-      runId: "run-good",
-      actorId: "actor://alpha",
-      definitionActorId: "definition://customer-support-triage",
-      revisionId: "rev-alpha",
-      deploymentId: "dep-alpha",
-      workflowName: "customer-support-triage",
-      completionStatus: "completed",
+      scopeId: 'scope-a',
+      serviceId: 'service-alpha',
+      runId: 'run-good',
+      actorId: 'actor://alpha',
+      definitionActorId: 'definition://customer-support-triage',
+      revisionId: 'rev-alpha',
+      deploymentId: 'dep-alpha',
+      workflowName: 'customer-support-triage',
+      completionStatus: 'completed',
       stateVersion: 1,
-      lastEventId: "evt-1",
-      lastUpdatedAt: "2026-04-13T08:55:00Z",
-      boundAt: "2026-04-13T08:50:00Z",
-      bindingUpdatedAt: "2026-04-13T08:50:00Z",
+      lastEventId: 'evt-1',
+      lastUpdatedAt: '2026-04-13T08:55:00Z',
+      boundAt: '2026-04-13T08:50:00Z',
+      bindingUpdatedAt: '2026-04-13T08:50:00Z',
       lastSuccess: true,
       totalSteps: 3,
       completedSteps: 3,
       roleReplyCount: 1,
-      lastOutput: "Resolved",
-      lastError: "",
+      lastOutput: 'Resolved',
+      lastError: '',
     },
   ] as const;
 
-  it("collects the deduped matched service ids for the roster queries", () => {
+  it('collects the deduped matched service ids for the roster queries', () => {
     expect(
       collectWorkflowOperationalServiceIds({
         services,
         workflows,
       }),
-    ).toEqual(["service-alpha"]);
+    ).toEqual(['service-alpha']);
   });
 
-  it("ignores stale service and run hints when a workflow-backed match exists", () => {
+  it('ignores stale service and run hints when a workflow-backed match exists', () => {
     const unit = resolveWorkflowOperationalUnit({
-      preferredRunId: "run-does-not-exist",
-      preferredServiceId: "service-stale",
+      preferredRunId: 'run-does-not-exist',
+      preferredServiceId: 'service-stale',
       runs,
       services,
       signals: {
-        runtimeAvailableByServiceId: new Set(["service-alpha"]),
+        runtimeAvailableByServiceId: new Set(['service-alpha']),
         servicesAvailable: true,
       },
       workflow: workflows[0],
     });
 
-    expect(unit.matchedService?.serviceId).toBe("service-alpha");
-    expect(unit.latestRun?.runId).toBe("run-latest");
-    expect(unit.attention).toBe("waiting");
+    expect(unit.matchedService?.serviceId).toBe('service-alpha');
+    expect(unit.latestRun?.runId).toBe('run-latest');
+    expect(unit.attention).toBe('waiting');
     expect(unit.staleHints).toEqual({
       runId: false,
       serviceId: true,
     });
   });
 
-  it("marks a workflow with no bound service and no service key as draft only", () => {
+  it('marks a workflow with no bound service and no service key as draft only', () => {
     const unit = resolveWorkflowOperationalUnit({
       services,
       signals: {
@@ -156,88 +160,90 @@ describe("workflowOperationalUnits", () => {
       workflow: workflows[1],
     });
 
-    expect(unit.attention).toBe("draft");
+    expect(unit.attention).toBe('draft');
     expect(unit.isDraftOnly).toBe(true);
     expect(unit.matchedService).toBeNull();
   });
 
-  it("sorts attention-first roster cards before healthy or draft cards", () => {
+  it('sorts attention-first roster cards before healthy or draft cards', () => {
     const units = buildWorkflowOperationalUnits({
       workflows: [
         ...workflows,
         {
-          scopeId: "scope-a",
-          workflowId: "wf-healthy",
-          publishedServiceId: "svc-healthy",
-          displayName: "Healthy Team",
-          serviceKey: "scope-a:healthy",
-          workflowName: "healthy-team",
-          actorId: "actor://healthy",
-          activeRevisionId: "rev-healthy",
-          deploymentId: "dep-healthy",
-          deploymentStatus: "Active",
-          updatedAt: "2026-04-13T07:00:00Z",
+          scopeId: 'scope-a',
+          workflowId: 'wf-healthy',
+          publishedServiceId: 'svc-healthy',
+          serviceAppId: 'default',
+          serviceNamespace: 'default',
+          displayName: 'Healthy Team',
+          serviceKey: 'scope-a:healthy',
+          workflowName: 'healthy-team',
+          actorId: 'actor://healthy',
+          activeRevisionId: 'rev-healthy',
+          deploymentId: 'dep-healthy',
+          deploymentStatus: 'Active',
+          updatedAt: '2026-04-13T07:00:00Z',
         },
       ],
       services: [
         ...services,
         {
-          serviceKey: "scope-a:healthy",
-          tenantId: "scope-a",
-          appId: "default",
-          namespace: "default",
-          serviceId: "service-healthy",
-          displayName: "Healthy Runtime",
-          defaultServingRevisionId: "rev-healthy",
-          activeServingRevisionId: "rev-healthy",
-          deploymentId: "dep-healthy",
-          primaryActorId: "actor://healthy",
-          deploymentStatus: "Active",
+          serviceKey: 'scope-a:healthy',
+          tenantId: 'scope-a',
+          appId: 'default',
+          namespace: 'default',
+          serviceId: 'service-healthy',
+          displayName: 'Healthy Runtime',
+          defaultServingRevisionId: 'rev-healthy',
+          activeServingRevisionId: 'rev-healthy',
+          deploymentId: 'dep-healthy',
+          primaryActorId: 'actor://healthy',
+          deploymentStatus: 'Active',
           endpoints: [],
           policyIds: [],
-          updatedAt: "2026-04-13T07:01:00Z",
+          updatedAt: '2026-04-13T07:01:00Z',
         },
       ],
       runsByServiceId: {
-        "service-alpha": runs,
-        "service-healthy": [
+        'service-alpha': runs,
+        'service-healthy': [
           {
-            scopeId: "scope-a",
-            serviceId: "service-healthy",
-            runId: "run-healthy",
-            actorId: "actor://healthy",
-            definitionActorId: "definition://healthy",
-            revisionId: "rev-healthy",
-            deploymentId: "dep-healthy",
-            workflowName: "healthy-team",
-            completionStatus: "completed",
+            scopeId: 'scope-a',
+            serviceId: 'service-healthy',
+            runId: 'run-healthy',
+            actorId: 'actor://healthy',
+            definitionActorId: 'definition://healthy',
+            revisionId: 'rev-healthy',
+            deploymentId: 'dep-healthy',
+            workflowName: 'healthy-team',
+            completionStatus: 'completed',
             stateVersion: 1,
-            lastEventId: "evt-healthy",
-            lastUpdatedAt: "2026-04-13T07:05:00Z",
-            boundAt: "2026-04-13T07:00:00Z",
-            bindingUpdatedAt: "2026-04-13T07:00:00Z",
+            lastEventId: 'evt-healthy',
+            lastUpdatedAt: '2026-04-13T07:05:00Z',
+            boundAt: '2026-04-13T07:00:00Z',
+            bindingUpdatedAt: '2026-04-13T07:00:00Z',
             lastSuccess: true,
             totalSteps: 2,
             completedSteps: 2,
             roleReplyCount: 1,
-            lastOutput: "Done",
-            lastError: "",
+            lastOutput: 'Done',
+            lastError: '',
           },
         ],
       },
       signals: {
         runtimeAvailableByServiceId: new Set([
-          "service-alpha",
-          "service-healthy",
+          'service-alpha',
+          'service-healthy',
         ]),
         servicesAvailable: true,
       },
     });
 
     expect(units.map((unit) => unit.workflow.workflowId)).toEqual([
-      "wf-alpha",
-      "wf-healthy",
-      "wf-draft",
+      'wf-alpha',
+      'wf-healthy',
+      'wf-draft',
     ]);
   });
 });

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts
@@ -28,6 +28,8 @@ function workflowDetail(
       scopeId,
       workflowId,
       publishedServiceId: receipt.publishedServiceId,
+      serviceAppId: 'workflow-app',
+      serviceNamespace: 'workflow-namespace',
       displayName: 'Publication workflow',
       serviceKey: 'workflow-publication',
       workflowName: 'Publication workflow',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -25,6 +25,88 @@ const mockConsoleToast = {
 
 const readMockUrl = () => new URL(mockLocation, 'http://console.local');
 
+type CatalogueRowFixture = {
+  readonly capabilities?: {
+    readonly open: {
+      readonly available: boolean;
+      readonly unavailableReason: string | null;
+    };
+    readonly activity: {
+      readonly available: boolean;
+      readonly unavailableReason: string | null;
+    };
+    readonly rename: {
+      readonly available: boolean;
+      readonly unavailableReason: string | null;
+    };
+    readonly delete: {
+      readonly available: boolean;
+      readonly unavailableReason: string | null;
+    };
+  };
+  readonly name: string;
+  readonly workflowId: string;
+  readonly committed?: {
+    readonly serviceKey: string;
+    readonly workflowName: string;
+    readonly actorId: string;
+    readonly activeRevisionId: string;
+    readonly deploymentId: string;
+    readonly deploymentStatus: string;
+  } | null;
+  readonly description?: string;
+  readonly hasCommittedSource?: boolean;
+  readonly hasDraftSource?: boolean;
+  readonly updatedAtSource?: string;
+  readonly updatedAtUtc?: string;
+};
+
+function createCatalogueRow(overrides: CatalogueRowFixture) {
+  const committed = overrides.committed ?? null;
+  return {
+    scopeId: 'scope-alpha',
+    description: '',
+    hasDraftSource: true,
+    hasCommittedSource: Boolean(committed),
+    updatedAtUtc: '2026-08-04T10:00:00Z',
+    updatedAtSource: committed ? 'committed' : 'draft',
+    capabilities: {
+      open: { available: true, unavailableReason: null },
+      activity: {
+        available: Boolean(committed),
+        unavailableReason: committed ? null : 'committed_source_missing',
+      },
+      rename: { available: true, unavailableReason: null },
+      delete: { available: true, unavailableReason: null },
+    },
+    sourceWatermarkUtc: '2026-08-04T10:00:00Z',
+    committed,
+    ...overrides,
+  };
+}
+
+function createCatalogueResponse(
+  items: ReturnType<typeof createCatalogueRow>[],
+  nextPageToken: string | null = null,
+) {
+  return {
+    items,
+    nextPageToken,
+    freshness: {
+      refreshWatermarkUtc: '2026-08-04T10:00:00Z',
+      sourceVersionSemantics: 'max source timestamp',
+    },
+    search: {
+      searchableFields: ['name', 'description', 'workflowId'],
+      caseSemantics: 'ordinal ignore case',
+      unicodeNormalization: 'FormKC',
+      maximumQueryLength: 128,
+      emptyQuerySemantics: 'no filter',
+      workflowIdSemantics: 'exact or prefix',
+    },
+  };
+}
+
 function createSseResponse(frames: readonly unknown[]): Response {
   const encoder = new TextEncoder();
   const body = frames
@@ -169,13 +251,11 @@ jest.mock('@/shared/studio/api', () => ({
     deleteWorkflowDraft: jest.fn(),
     getWorkspaceSettings: jest.fn(),
     getAuthSession: jest.fn(),
-    getMember: jest.fn(),
     getUserConfigRuntime: jest.fn(),
     getUserLlmSettings: jest.fn(),
     getWorkflow: jest.fn(),
     getWorkflowDraft: jest.fn(),
     getWorkflowDraftFile: jest.fn(),
-    listMembers: jest.fn(),
     listWorkflowDrafts: jest.fn(),
     parseYaml: jest.fn(),
     previewExplicitRequests: jest.fn(),
@@ -183,7 +263,6 @@ jest.mock('@/shared/studio/api', () => ({
     saveAndBindWorkflow: jest.fn(),
     saveUserLlmSettings: jest.fn(),
     serializeYaml: jest.fn(),
-    updateMemberDisplayName: jest.fn(),
     updateWorkflowDraft: jest.fn(),
   },
 }));
@@ -196,6 +275,7 @@ jest.mock('@/shared/api/scopesApi', () => ({
   scopesApi: {
     getWorkflowDetail: jest.fn(),
     listWorkflows: jest.fn(),
+    queryWorkflowCatalogue: jest.fn(),
   },
 }));
 
@@ -302,13 +382,11 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   deleteWorkflowDraft: jest.Mock;
   getWorkspaceSettings: jest.Mock;
   getAuthSession: jest.Mock;
-  getMember: jest.Mock;
   getUserConfigRuntime: jest.Mock;
   getUserLlmSettings: jest.Mock;
   getWorkflow: jest.Mock;
   getWorkflowDraft: jest.Mock;
   getWorkflowDraftFile: jest.Mock;
-  listMembers: jest.Mock;
   listWorkflowDrafts: jest.Mock;
   parseYaml: jest.Mock;
   previewExplicitRequests: jest.Mock;
@@ -316,7 +394,6 @@ const mockStudioApi = jest.requireMock('@/shared/studio/api').studioApi as {
   saveAndBindWorkflow: jest.Mock;
   saveUserLlmSettings: jest.Mock;
   serializeYaml: jest.Mock;
-  updateMemberDisplayName: jest.Mock;
   updateWorkflowDraft: jest.Mock;
 };
 const mockCreateWorkflowRevisionIdentityCandidate = jest.requireMock(
@@ -325,6 +402,7 @@ const mockCreateWorkflowRevisionIdentityCandidate = jest.requireMock(
 const mockScopesApi = jest.requireMock('@/shared/api/scopesApi').scopesApi as {
   getWorkflowDetail: jest.Mock;
   listWorkflows: jest.Mock;
+  queryWorkflowCatalogue: jest.Mock;
 };
 const mockServicesApi = jest.requireMock('@/shared/api/servicesApi')
   .servicesApi as {
@@ -356,29 +434,477 @@ describe('Workflow Activity vNext catalogue', () => {
   beforeEach(() => {
     mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/workflows';
     jest.clearAllMocks();
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([]),
+    );
     mockServicesApi.deactivateDeployment.mockResolvedValue({
       targetActorId: 'deployment-manager-alpha',
       commandId: 'cmd-archive-alpha',
       correlationId: 'corr-archive-alpha',
     });
-    mockStudioApi.listMembers.mockResolvedValue({
-      scopeId: 'scope-alpha',
-      members: [],
-      nextPageToken: null,
-    });
-    mockStudioApi.updateMemberDisplayName.mockResolvedValue({
-      status: 'accepted',
-      scopeId: 'scope-alpha',
-      memberId: 'm-alpha',
-    });
   });
 
   afterEach(() => cleanupTestQueryClients());
 
-  it('keeps language and account actions available inside the mobile navigation drawer', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
+  it('uses backend catalogue views and preserves backend row order', async () => {
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-older-first',
+          name: 'Older first',
+          updatedAtUtc: '2026-08-01T10:00:00Z',
+        }),
+        createCatalogueRow({
+          workflowId: 'wf-newer-second',
+          name: 'Newer second',
+          updatedAtUtc: '2026-08-05T10:00:00Z',
+        }),
+      ]),
+    );
 
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('Older first')).toBeInTheDocument();
+    const workflowNames = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[0]?.textContent);
+    expect(workflowNames).toEqual(['Older first', 'Newer second']);
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+      {
+        scopeId: 'scope-alpha',
+        view: 'all',
+        query: undefined,
+        cursor: undefined,
+        take: 50,
+      },
+      expect.any(AbortSignal),
+    );
+    expect(mockStudioApi.listWorkflowDrafts).not.toHaveBeenCalled();
+    expect(mockScopesApi.listWorkflows).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(
+      screen.getByRole('combobox', { name: 'Workflow view' }),
+    );
+    expect(
+      await screen.findByRole('option', { name: 'All workflows' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Drafts' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'Active workflows' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'Archived' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('maps unsupported legacy views to the backend all view', async () => {
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=archived';
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-archived',
+          name: 'Archived workflow',
+          committed: {
+            serviceKey: 'svc-archived',
+            workflowName: 'archived_workflow',
+            actorId: 'actor-archived',
+            activeRevisionId: 'rev-archived',
+            deploymentId: 'dep-archived',
+            deploymentStatus: 'Deactivated',
+          },
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('Archived workflow')).toBeInTheDocument();
+    expect(screen.getByText('All workflows')).toBeInTheDocument();
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+      expect.objectContaining({ view: 'all' }),
+      expect.any(AbortSignal),
+    );
+    expect(history.replace).toHaveBeenCalledWith(
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows',
+    );
+  });
+
+  it('sends the drafts view and restored search to the backend', async () => {
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows?q=support&view=drafts';
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-support',
+          name: 'Support triage',
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('Support triage')).toBeInTheDocument();
+    expect(
+      screen.getByRole('searchbox', { name: 'Search workflows' }),
+    ).toHaveValue('support');
+    expect(screen.getByText('Drafts')).toBeInTheDocument();
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+      {
+        scopeId: 'scope-alpha',
+        view: 'drafts',
+        query: 'support',
+        cursor: undefined,
+        take: 50,
+      },
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('debounces search and aborts an obsolete catalogue request', async () => {
+    let supportSignal: AbortSignal | undefined;
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(
+      (input: { query?: string }, signal?: AbortSignal) => {
+        if (input.query === 'support') {
+          supportSignal = signal;
+          return new Promise(() => undefined);
+        }
+        return Promise.resolve(createCatalogueResponse([]));
+      },
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
+
+    const search = screen.getByRole('searchbox', { name: 'Search workflows' });
+    fireEvent.change(search, { target: { value: ' support ' } });
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(1);
+
+    await waitFor(
+      () =>
+        expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+          expect.objectContaining({ query: 'support' }),
+          expect.any(AbortSignal),
+        ),
+      { timeout: 1000 },
+    );
+    expect(supportSignal?.aborted).toBe(false);
+
+    fireEvent.change(search, { target: { value: 'billing' } });
+    await waitFor(
+      () =>
+        expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+          expect.objectContaining({ query: 'billing' }),
+          expect.any(AbortSignal),
+        ),
+      { timeout: 1000 },
+    );
+    expect(supportSignal?.aborted).toBe(true);
+  });
+
+  it('loads the next backend page and appends it without reordering', async () => {
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(
+      (input: { cursor?: string }) =>
+        Promise.resolve(
+          input.cursor === 'page-2'
+            ? createCatalogueResponse([
+                createCatalogueRow({
+                  workflowId: 'wf-second',
+                  name: 'Second page row',
+                }),
+              ])
+            : createCatalogueResponse(
+                [
+                  createCatalogueRow({
+                    workflowId: 'wf-first',
+                    name: 'First page row',
+                  }),
+                ],
+                'page-2',
+              ),
+        ),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('First page row')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(await screen.findByText('Second page row')).toBeInTheDocument();
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: 'page-2', take: 50 }),
+      expect.any(AbortSignal),
+    );
+    const workflowNames = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[0]?.textContent);
+    expect(workflowNames).toEqual(['First page row', 'Second page row']);
+  });
+
+  it('uses backend capabilities and the workflow id for row actions', async () => {
+    const identities = {
+      memberId: 'm-alpha',
+      workflowId: 'wf-alpha',
+      publishedServiceId: 'svc-alpha',
+    };
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: identities.workflowId,
+          name: 'Invoice review',
+          capabilities: {
+            open: {
+              available: false,
+              unavailableReason: 'draft_source_missing',
+            },
+            activity: {
+              available: false,
+              unavailableReason: 'committed_source_missing',
+            },
+            rename: {
+              available: false,
+              unavailableReason: 'draft_source_missing',
+            },
+            delete: {
+              available: false,
+              unavailableReason: 'draft_source_missing',
+            },
+          },
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Invoice review')).closest('tr');
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'Open Invoice review in Workspace',
+      }),
+    ).toBeDisabled();
+    expect(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'View activity for Invoice review in Workspace',
+      }),
+    ).toBeDisabled();
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Invoice review in Workspace',
+      }),
+    );
+    expect(
+      await screen.findByRole('menuitem', {
+        name: 'Copy workflow reference',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Rename' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'Delete draft' })).toBeNull();
+    expect(document.body.textContent).not.toContain(identities.memberId);
+    expect(document.body.textContent).not.toContain(
+      identities.publishedServiceId,
+    );
+  });
+
+  it('refreshes the catalogue after a successful rename', async () => {
+    const originalYaml = 'name: support_triage\nroles: []\nsteps: []\n';
+    const renamedYaml = 'name: APAC support triage\nroles: []\nsteps: []\n';
+    let renamed = false;
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(() =>
+      Promise.resolve(
+        createCatalogueResponse([
+          createCatalogueRow({
+            workflowId: 'wf-support',
+            name: renamed ? 'APAC support triage' : 'Support triage',
+          }),
+        ]),
+      ),
+    );
+    mockStudioApi.getWorkflowDraft.mockImplementation(async () => ({
+      workflowId: 'wf-support',
+      name: renamed ? 'APAC support triage' : 'Support triage',
+      fileName: 'support.yaml',
+      filePath: '/support.yaml',
+      directoryId: 'directory-alpha',
+      directoryLabel: 'Workflows',
+      yaml: renamed ? renamedYaml : originalYaml,
+      layout: { nodes: [] },
+      updatedAtUtc: '2026-08-05T11:30:00Z',
+    }));
+    mockStudioApi.parseYaml.mockResolvedValue({
+      document: { name: 'support_triage', roles: [], steps: [] },
+      findings: [],
+    });
+    mockStudioApi.serializeYaml.mockResolvedValue({
+      document: { name: 'APAC support triage', roles: [], steps: [] },
+      findings: [],
+      yaml: renamedYaml,
+    });
+    mockStudioApi.updateWorkflowDraft.mockImplementation(async () => {
+      renamed = true;
+      return {};
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Support triage')).closest('tr');
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Support triage in Workspace',
+      }),
+    );
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
+      target: { value: 'APAC support triage' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
+
+    expect(await screen.findByText('APAC support triage')).toBeInTheDocument();
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
+    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
+  });
+
+  it('refreshes the catalogue after a successful delete', async () => {
+    let deleted = false;
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(() =>
+      Promise.resolve(
+        createCatalogueResponse(
+          deleted
+            ? []
+            : [
+                createCatalogueRow({
+                  workflowId: 'wf-support',
+                  name: 'Support triage',
+                }),
+              ],
+        ),
+      ),
+    );
+    mockStudioApi.deleteWorkflowDraft.mockImplementation(async () => {
+      deleted = true;
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Support triage')).closest('tr');
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Support triage in Workspace',
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: 'Delete draft' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete draft' }));
+
+    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
+    expect(mockStudioApi.deleteWorkflowDraft).toHaveBeenCalledWith(
+      'wf-support',
+      'scope-alpha',
+    );
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
+  });
+
+  it('observes archive through the backend catalogue and refreshes all rows', async () => {
+    const activeCommitted = {
+      serviceKey: 'svc-alpha',
+      workflowName: 'workflow_alpha',
+      actorId: 'actor-alpha',
+      activeRevisionId: 'rev-alpha',
+      deploymentId: 'dep-alpha',
+      deploymentStatus: 'Active',
+    };
+    const archivedCommitted = {
+      ...activeCommitted,
+      deploymentStatus: 'Deactivated',
+    };
+    let archived = false;
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(
+      (input: { query?: string }) =>
+        Promise.resolve(
+          createCatalogueResponse([
+            createCatalogueRow({
+              workflowId: 'wf-alpha',
+              name: 'Workflow Alpha',
+              committed:
+                archived || input.query === 'wf-alpha'
+                  ? archivedCommitted
+                  : activeCommitted,
+            }),
+          ]),
+        ),
+    );
+    mockObserveWorkflowArchival.mockImplementation(
+      async (input: { readWorkflows: () => Promise<unknown[]> }) => {
+        archived = true;
+        return {
+          kind: 'observed',
+          workflows: await input.readWorkflows(),
+        };
+      },
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Workflow Alpha')).closest('tr');
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Workflow Alpha in Workspace',
+      }),
+    );
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Archive workflow' }));
+
+    await waitFor(() =>
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith({
+        scopeId: 'scope-alpha',
+        view: 'all',
+        query: 'wf-alpha',
+        take: 100,
+      }),
+    );
+    expect(mockScopesApi.listWorkflows).not.toHaveBeenCalled();
+    expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledWith(
+      'wf-alpha',
+      'dep-alpha',
+      {
+        tenantId: 'scope-alpha',
+        appId: 'default',
+        namespace: 'default',
+      },
+    );
+    expect(await screen.findByText('Archived')).toBeInTheDocument();
+    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow archived');
+  });
+
+  it('renders one catalogue failure state and retries the same query', async () => {
+    mockScopesApi.queryWorkflowCatalogue
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(createCatalogueResponse([]));
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(
+      await screen.findByText('Workflows unavailable'),
+    ).toBeInTheDocument();
+    expect(mockConsoleToast.error).toHaveBeenCalledWith(
+      'Workflows unavailable',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry workflows' }));
+    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders the backend empty result without consulting legacy sources', async () => {
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
+    expect(mockStudioApi.listWorkflowDrafts).not.toHaveBeenCalled();
+    expect(mockScopesApi.listWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('keeps language and account actions available inside the mobile navigation drawer', async () => {
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     fireEvent.click(screen.getByLabelText('Open navigation'));
@@ -393,9 +919,6 @@ describe('Workflow Activity vNext catalogue', () => {
   });
 
   it('keeps modified brand clicks as native link navigation', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
-
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     const brand = screen.getByRole('link', { name: 'Aevatar' });
@@ -412,1588 +935,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(preventedByComponent).toBe(false);
     expect(history.push).not.toHaveBeenCalled();
   });
-
-  it('opens row Activity with only the catalogue workflow id', async () => {
-    const rowIdentities = {
-      memberId: 'm-alpha',
-      publishedServiceId: 'svc-alpha',
-      workflowId: 'wf-alpha',
-    };
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Support triage',
-        description: 'Route support requests',
-        fileName: 'support.yaml',
-        filePath: '/support.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: rowIdentities.workflowId,
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'summary-actor-alpha',
-        activeRevisionId: 'revision-alpha',
-        deploymentId: 'deployment-alpha',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const workflowSkeleton = screen.getByRole('status');
-    expect(workflowSkeleton).toHaveAttribute('data-variant', 'table');
-    expect(screen.getAllByTestId('aevatar-content-skeleton-cell')).toHaveLength(
-      16,
-    );
-    expect(screen.getByText('Loading workflows')).toHaveClass(
-      'aevatar-loading-visually-hidden',
-    );
-    expect(await screen.findByText('Support triage')).toBeInTheDocument();
-    expect(screen.getByText('Invoice review')).toBeInTheDocument();
-
-    const workflowRegion = screen.getByRole('region', { name: 'Workflows' });
-    expect(workflowRegion).toHaveAttribute('tabindex', '0');
-    expect(
-      within(workflowRegion).getByText('Support triage').closest('td'),
-    ).toHaveAttribute('data-label', 'Workflow');
-
-    fireEvent.change(
-      screen.getByRole('searchbox', { name: 'Search workflows' }),
-      {
-        target: { value: 'invoice' },
-      },
-    );
-    expect(screen.queryByText('Support triage')).not.toBeInTheDocument();
-
-    const activityLink = screen.getByRole('link', {
-      name: 'View activity for Invoice review in Workspace',
-    });
-    expect(activityLink).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-alpha',
-    );
-    fireEvent.click(activityLink);
-    expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
-    expect(history.push).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-alpha',
-    );
-    expect(history.push).not.toHaveBeenCalledWith(
-      expect.stringContaining(rowIdentities.memberId),
-    );
-    expect(history.push).not.toHaveBeenCalledWith(
-      expect.stringContaining(rowIdentities.publishedServiceId),
-    );
-
-    const openLink = screen.getByRole('link', {
-      name: 'Open Invoice review in Workspace',
-    });
-    expect(openLink).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-alpha',
-    );
-    const pushCallsBeforeModifiedClick = (history.push as jest.Mock).mock.calls
-      .length;
-    let modifiedClickPrevented = true;
-    const observeModifiedClick = (event: MouseEvent) => {
-      if (event.target !== openLink) return;
-      modifiedClickPrevented = event.defaultPrevented;
-      event.preventDefault();
-    };
-    document.addEventListener('click', observeModifiedClick);
-    fireEvent.click(openLink, { metaKey: true });
-    document.removeEventListener('click', observeModifiedClick);
-    expect(modifiedClickPrevented).toBe(false);
-    expect(history.push).toHaveBeenCalledTimes(pushCallsBeforeModifiedClick);
-
-    fireEvent.click(openLink);
-    expect(history.push).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-alpha',
-    );
-  });
-
-  it('separates workflow status and last update while disclosing descriptions on demand', async () => {
-    const writeText = jest.fn().mockResolvedValue(undefined);
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    });
-    const emeaDescription = 'Route urgent EMEA requests to the on-call queue';
-    const apacDescription = 'Escalate APAC billing requests to finance';
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-support-emea',
-        name: 'Support triage',
-        description: emeaDescription,
-        fileName: 'support-emea.yaml',
-        filePath: '/emea/support-emea.yaml',
-        directoryId: 'directory-emea',
-        directoryLabel: 'EMEA operations',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-      {
-        activeRevisionId: 'rev-support-apac-7',
-        serviceKey: 'svc-support-apac',
-        workflowId: 'wf-support-apac',
-        name: 'Support triage',
-        description: apacDescription,
-        fileName: 'support-apac.yaml',
-        filePath: '/apac/support-apac.yaml',
-        directoryId: 'directory-apac',
-        directoryLabel: 'APAC operations',
-        stepCount: 5,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-05T11:30:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-support-apac',
-        displayName: 'Support triage',
-        serviceKey: 'svc-support-apac',
-        workflowName: 'support_triage_apac',
-        actorId: 'definition-support-apac',
-        activeRevisionId: 'rev-support-apac-7',
-        deploymentId: 'deployment-support-apac',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-05T11:30:00Z',
-      },
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-nightly-reconciliation',
-        displayName: 'Nightly reconciliation',
-        serviceKey: 'svc-nightly-reconciliation',
-        workflowName: 'nightly_reconciliation',
-        actorId: 'definition-nightly-reconciliation',
-        activeRevisionId: 'rev-nightly-reconciliation-2',
-        deploymentId: 'deployment-nightly-reconciliation',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T09:15:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const duplicateNames = await screen.findAllByText('Support triage');
-    expect(duplicateNames).toHaveLength(2);
-    const apacRow = duplicateNames[0].closest('tr');
-    const emeaRow = duplicateNames[1].closest('tr');
-    const noDescriptionRow = screen
-      .getByText('Nightly reconciliation')
-      .closest('tr');
-    expect(emeaRow).not.toBeNull();
-    expect(apacRow).not.toBeNull();
-    expect(noDescriptionRow).not.toBeNull();
-
-    const workflowTable = screen.getByRole('table');
-    expect(within(workflowTable).getAllByRole('columnheader')).toHaveLength(4);
-    expect(
-      within(workflowTable).getByRole('columnheader', { name: 'Status' }),
-    ).toBeVisible();
-    expect(
-      within(workflowTable).getByRole('columnheader', {
-        name: 'Last updated',
-      }),
-    ).toBeVisible();
-    expect(
-      within(workflowTable).queryByRole('columnheader', { name: 'Created' }),
-    ).not.toBeInTheDocument();
-
-    expect(within(emeaRow as HTMLElement).getByText('Draft')).toBeVisible();
-    expect(within(apacRow as HTMLElement).getByText('Published')).toBeVisible();
-    expect(
-      within(apacRow as HTMLElement).queryByText('rev-support-apac-7'),
-    ).not.toBeInTheDocument();
-    expect(
-      within(workflowTable).queryByText('scope-alpha'),
-    ).not.toBeInTheDocument();
-    expect(
-      within(apacRow as HTMLElement).queryByText('wf-support-apac'),
-    ).not.toBeInTheDocument();
-    expect(
-      within(apacRow as HTMLElement).queryByText('svc-support-apac'),
-    ).not.toBeInTheDocument();
-    expect(
-      within(emeaRow as HTMLElement).getByRole('link', {
-        name: 'Open Support triage in EMEA operations',
-      }),
-    ).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-support-emea',
-    );
-    expect(
-      within(apacRow as HTMLElement).getByRole('link', {
-        name: 'Open Support triage in APAC operations',
-      }),
-    ).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-support-apac',
-    );
-    expect(
-      within(emeaRow as HTMLElement).getByRole('link', {
-        name: 'View activity for Support triage in EMEA operations',
-      }),
-    ).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-support-emea',
-    );
-    expect(
-      within(apacRow as HTMLElement).getByRole('link', {
-        name: 'View activity for Support triage in APAC operations',
-      }),
-    ).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-support-apac',
-    );
-    expect(
-      within(emeaRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Support triage in EMEA operations',
-      }),
-    ).toBeEnabled();
-
-    const apacUpdatedAt = new Intl.DateTimeFormat(undefined, {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    }).format(new Date('2026-08-05T11:30:00Z'));
-    expect(
-      within(apacRow as HTMLElement).getByText(apacUpdatedAt),
-    ).toBeVisible();
-    expect(
-      within(apacRow as HTMLElement)
-        .getByText(apacUpdatedAt)
-        .closest('td'),
-    ).toHaveAttribute('data-label', 'Last updated');
-
-    expect(screen.queryByText(emeaDescription)).not.toBeInTheDocument();
-    expect(screen.queryByText(apacDescription)).not.toBeInTheDocument();
-    const descriptionTriggers = within(workflowTable).getAllByRole('button', {
-      name: 'Description for Support triage',
-    });
-    expect(descriptionTriggers).toHaveLength(2);
-    expect(
-      within(noDescriptionRow as HTMLElement).queryByRole('button', {
-        name: 'Description for Nightly reconciliation',
-      }),
-    ).not.toBeInTheDocument();
-
-    fireEvent.mouseEnter(descriptionTriggers[1]);
-    const disclosedDescription = await screen.findByText(emeaDescription);
-    await waitFor(() => expect(disclosedDescription).toBeVisible());
-    expect(disclosedDescription).toHaveClass('wa-vnext__workflow-description');
-    expect(disclosedDescription.closest('.ant-popover')).toHaveClass(
-      'ant-popover-placement-bottomLeft',
-    );
-
-    fireEvent.mouseLeave(descriptionTriggers[1]);
-    await waitFor(() => expect(disclosedDescription).not.toBeVisible());
-    fireEvent.focus(descriptionTriggers[1]);
-    await waitFor(() => expect(disclosedDescription).toBeVisible());
-
-    fireEvent.click(
-      within(apacRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Support triage in APAC operations',
-      }),
-    );
-    expect(
-      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Rename', 'Copy workflow reference', 'Archive']);
-    fireEvent.click(
-      screen.getByRole('menuitem', { name: 'Copy workflow reference' }),
-    );
-    await waitFor(() =>
-      expect(writeText).toHaveBeenCalledWith('wf-support-apac'),
-    );
-    expect(writeText).not.toHaveBeenCalledWith('svc-support-apac');
-  });
-
-  it('renames a duplicate workflow without changing its definition identity', async () => {
-    const originalYaml = 'name: support_triage\nroles: []\nsteps: []\n';
-    const renamedYaml = 'name: APAC support triage\nroles: []\nsteps: []\n';
-    let authoritativeName = 'Support triage';
-    let authoritativeYaml = originalYaml;
-    let pendingName = '';
-    let pendingYaml = '';
-    let postUpdateReads = 0;
-    const drafts = [
-      {
-        workflowId: 'wf-support-emea',
-        name: 'Support triage',
-        description: 'Route urgent EMEA requests',
-        fileName: 'support-emea.yaml',
-        filePath: '/emea/support-emea.yaml',
-        directoryId: 'directory-emea',
-        directoryLabel: 'EMEA operations',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-      {
-        workflowId: 'wf-support-apac',
-        name: 'Support triage',
-        description: 'Escalate APAC billing requests',
-        fileName: 'support-apac.yaml',
-        filePath: '/apac/support-apac.yaml',
-        directoryId: 'directory-apac',
-        directoryLabel: 'APAC operations',
-        stepCount: 5,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-05T11:30:00Z',
-      },
-    ];
-    mockStudioApi.listWorkflowDrafts.mockImplementation(async () =>
-      drafts.map((draft) =>
-        draft.workflowId === 'wf-support-apac'
-          ? { ...draft, name: authoritativeName }
-          : draft,
-      ),
-    );
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-support-apac',
-        displayName: 'Support triage',
-        serviceKey: 'scope-alpha:default:default:svc-support-apac',
-        workflowName: 'support_triage',
-        actorId: 'actor-support-apac',
-        activeRevisionId: 'rev-support-apac',
-        deploymentId: 'dep-support-apac',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-05T11:29:00Z',
-      },
-    ]);
-    mockStudioApi.getWorkflowDraft.mockImplementation(async () => {
-      if (pendingName && postUpdateReads++ > 0) {
-        authoritativeName = pendingName;
-        authoritativeYaml = pendingYaml;
-      }
-      return {
-        workflowId: 'wf-support-apac',
-        name: authoritativeName,
-        fileName: 'support-apac.yaml',
-        filePath: '/apac/support-apac.yaml',
-        directoryId: 'directory-apac',
-        directoryLabel: 'APAC operations',
-        yaml: authoritativeYaml,
-        layout: { nodes: [] },
-        updatedAtUtc: '2026-08-05T11:30:00Z',
-      };
-    });
-    mockStudioApi.parseYaml.mockResolvedValue({
-      document: { name: 'support_triage', roles: [], steps: [] },
-      findings: [],
-    });
-    mockStudioApi.serializeYaml.mockResolvedValue({
-      document: { name: 'APAC support triage', roles: [], steps: [] },
-      findings: [],
-      yaml: renamedYaml,
-    });
-    mockStudioApi.updateWorkflowDraft.mockImplementation(async (input) => {
-      pendingYaml = input.yaml;
-      pendingName =
-        input.yaml === renamedYaml ? 'APAC support triage' : 'Support triage';
-      return {
-        workflowId: 'wf-support-apac',
-        name: pendingName,
-        fileName: 'support-apac.yaml',
-        filePath: '/apac/support-apac.yaml',
-        directoryId: 'directory-apac',
-        directoryLabel: 'APAC operations',
-        yaml: pendingYaml,
-        layout: { nodes: [] },
-        updatedAtUtc: '2026-08-05T11:31:00Z',
-      };
-    });
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const [apacDescriptionTrigger] = await screen.findAllByRole('button', {
-      name: 'Description for Support triage',
-    });
-    const apacRow = apacDescriptionTrigger.closest('tr');
-    fireEvent.click(
-      within(apacRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Support triage in APAC operations',
-      }),
-    );
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
-    expect(
-      await screen.findByText(
-        'Another workflow already uses this name. Duplicate names are allowed.',
-      ),
-    ).toBeInTheDocument();
-    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
-      target: { value: 'APAC support triage' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
-
-    await waitFor(() =>
-      expect(mockStudioApi.parseYaml).toHaveBeenCalledWith({
-        yaml: originalYaml,
-      }),
-    );
-    expect(mockStudioApi.serializeYaml).toHaveBeenCalledWith({
-      document: {
-        name: 'APAC support triage',
-        roles: [],
-        steps: [],
-      },
-    });
-    await waitFor(() =>
-      expect(mockStudioApi.updateWorkflowDraft).toHaveBeenCalledWith({
-        directoryId: 'directory-apac',
-        fileName: 'support-apac.yaml',
-        layout: { nodes: [] },
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-support-apac',
-        workflowName: 'APAC support triage',
-        yaml: renamedYaml,
-      }),
-    );
-    expect(await screen.findByText('APAC support triage')).toBeVisible();
-    expect(mockStudioApi.getWorkflowDraft).toHaveBeenCalledTimes(3);
-    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
-  });
-
-  it('renames a published-only member through its explicit published service identity', async () => {
-    const memberSummary = {
-      memberId: 'm-alpha',
-      scopeId: 'scope-alpha',
-      displayName: 'Published workflow',
-      description: '',
-      implementationKind: 'workflow',
-      implementationRef: {
-        implementationKind: 'workflow',
-        workflowId: 'wf-alpha',
-      },
-      lifecycleStage: 'bind_ready',
-      publishedServiceId: 'svc-alpha',
-      lastBoundRevisionId: 'rev-alpha',
-      teamId: 't-alpha',
-      createdAt: '2026-08-06T09:00:00Z',
-      updatedAt: '2026-08-06T10:00:00Z',
-    };
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockStudioApi.listMembers.mockResolvedValue({
-      scopeId: 'scope-alpha',
-      members: [memberSummary],
-      nextPageToken: null,
-    });
-    mockStudioApi.getMember
-      .mockResolvedValueOnce({ summary: memberSummary })
-      .mockResolvedValueOnce({
-        summary: {
-          ...memberSummary,
-          displayName: 'Published workflow renamed',
-        },
-      });
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'legacy-catalogue-row-alpha',
-        publishedServiceId: 'svc-alpha',
-        displayName: 'Published workflow',
-        serviceKey: 'scope-alpha:default:default:svc-alpha',
-        workflowName: 'published_workflow',
-        actorId: 'actor-alpha',
-        activeRevisionId: 'rev-alpha',
-        deploymentId: 'dep-alpha',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-06T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const publishedRow = (
-      await screen.findByText('Published workflow')
-    ).closest('tr');
-    fireEvent.click(
-      within(publishedRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Published workflow in Workspace',
-      }),
-    );
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
-    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
-      target: { value: 'Published workflow renamed' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
-
-    await waitFor(() =>
-      expect(mockStudioApi.updateMemberDisplayName).toHaveBeenCalledWith({
-        scopeId: 'scope-alpha',
-        memberId: 'm-alpha',
-        displayName: 'Published workflow renamed',
-      }),
-    );
-    await waitFor(() =>
-      expect(mockStudioApi.getMember).toHaveBeenCalledTimes(2),
-    );
-    expect(mockStudioApi.getWorkflowDraft).not.toHaveBeenCalled();
-    expect(await screen.findByText('Published workflow renamed')).toBeVisible();
-    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
-  });
-
-  it('does not infer a published member from workflow identity when service identity disagrees', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockStudioApi.listMembers.mockResolvedValue({
-      scopeId: 'scope-alpha',
-      members: [
-        {
-          memberId: 'm-alpha',
-          scopeId: 'scope-alpha',
-          displayName: 'Different published member',
-          description: '',
-          implementationKind: 'workflow',
-          implementationRef: {
-            implementationKind: 'workflow',
-            workflowId: 'wf-alpha',
-          },
-          lifecycleStage: 'bind_ready',
-          publishedServiceId: 'svc-other',
-          lastBoundRevisionId: 'rev-alpha',
-          teamId: 't-alpha',
-          createdAt: '2026-08-06T09:00:00Z',
-          updatedAt: '2026-08-06T10:00:00Z',
-        },
-      ],
-      nextPageToken: null,
-    });
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-alpha',
-        publishedServiceId: 'svc-alpha',
-        displayName: 'Published workflow without resolved owner',
-        serviceKey: 'scope-alpha:default:default:svc-alpha',
-        workflowName: 'published_workflow',
-        actorId: 'actor-alpha',
-        activeRevisionId: 'rev-alpha',
-        deploymentId: 'dep-alpha',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-06T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const publishedRow = (
-      await screen.findByText('Published workflow without resolved owner')
-    ).closest('tr');
-    fireEvent.click(
-      within(publishedRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Published workflow without resolved owner in Workspace',
-      }),
-    );
-
-    expect(
-      screen.queryByRole('menuitem', { name: 'Rename' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('menuitem', { name: 'Copy workflow reference' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('menuitem', { name: 'Archive' }),
-    ).toBeInTheDocument();
-  });
-
-  it('renames both authorities when a published member still has an editable draft', async () => {
-    const memberSummary = {
-      memberId: 'm-alpha',
-      scopeId: 'scope-alpha',
-      displayName: 'Published workflow',
-      description: '',
-      implementationKind: 'workflow',
-      implementationRef: {
-        implementationKind: 'workflow',
-        workflowId: 'wf-alpha',
-      },
-      lifecycleStage: 'bind_ready',
-      publishedServiceId: 'svc-alpha',
-      lastBoundRevisionId: 'rev-alpha',
-      teamId: 't-alpha',
-      createdAt: '2026-08-06T09:00:00Z',
-      updatedAt: '2026-08-06T10:00:00Z',
-    };
-    const draft = {
-      workflowId: 'wf-alpha',
-      name: 'Published workflow',
-      description: '',
-      fileName: 'published.yaml',
-      filePath: '/published.yaml',
-      directoryId: 'directory-alpha',
-      directoryLabel: 'Workflows',
-      stepCount: 1,
-      hasLayout: true,
-      updatedAtUtc: '2026-08-06T10:00:00Z',
-      yaml: 'name: Published workflow\nsteps: []\n',
-      layout: { nodes: [] },
-    };
-    const renamedDraft = {
-      ...draft,
-      name: 'Published workflow renamed',
-      yaml: 'name: Published workflow renamed\nsteps: []\n',
-    };
-    mockStudioApi.listWorkflowDrafts
-      .mockResolvedValueOnce([draft])
-      .mockResolvedValue([renamedDraft]);
-    mockStudioApi.listMembers.mockResolvedValue({
-      scopeId: 'scope-alpha',
-      members: [memberSummary],
-      nextPageToken: null,
-    });
-    mockStudioApi.getWorkflowDraft
-      .mockResolvedValueOnce(draft)
-      .mockResolvedValue(renamedDraft);
-    mockStudioApi.parseYaml.mockResolvedValue({
-      document: { name: 'Published workflow', steps: [] },
-    });
-    mockStudioApi.serializeYaml.mockResolvedValue({
-      document: { name: 'Published workflow renamed', steps: [] },
-      yaml: renamedDraft.yaml,
-    });
-    mockStudioApi.updateWorkflowDraft.mockResolvedValue(renamedDraft);
-    mockStudioApi.getMember
-      .mockResolvedValueOnce({ summary: memberSummary })
-      .mockResolvedValueOnce({
-        summary: {
-          ...memberSummary,
-          displayName: 'Published workflow renamed',
-        },
-      });
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-alpha',
-        publishedServiceId: 'svc-alpha',
-        displayName: 'Published workflow',
-        serviceKey: 'scope-alpha:studio:default:svc-alpha',
-        workflowName: 'published_workflow',
-        actorId: 'actor-alpha',
-        activeRevisionId: 'rev-alpha',
-        deploymentId: 'dep-alpha',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-06T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const publishedRow = (
-      await screen.findByText('Published workflow')
-    ).closest('tr');
-    fireEvent.click(
-      within(publishedRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Published workflow in Workflows',
-      }),
-    );
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Rename' }));
-    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name' }), {
-      target: { value: 'Published workflow renamed' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Save name' }));
-
-    await waitFor(() =>
-      expect(mockStudioApi.updateWorkflowDraft).toHaveBeenCalledWith(
-        expect.objectContaining({
-          scopeId: 'scope-alpha',
-          workflowId: 'wf-alpha',
-          workflowName: 'Published workflow renamed',
-        }),
-      ),
-    );
-    await waitFor(() =>
-      expect(mockStudioApi.updateMemberDisplayName).toHaveBeenCalledWith({
-        scopeId: 'scope-alpha',
-        memberId: 'm-alpha',
-        displayName: 'Published workflow renamed',
-      }),
-    );
-    await waitFor(() =>
-      expect(mockStudioApi.getMember).toHaveBeenCalledTimes(2),
-    );
-    expect(await screen.findByText('Published workflow renamed')).toBeVisible();
-    expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow renamed');
-  });
-
-  it('keeps archived workflows out of Active and keeps rename on published rows with editable drafts', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Draft workflow',
-        description: 'Editable only',
-        fileName: 'draft.yaml',
-        filePath: '/draft.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 1,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-06T09:00:00Z',
-      },
-      {
-        workflowId: 'wf-active-alpha',
-        name: 'Active workflow',
-        description: 'Editable source for the published workflow',
-        fileName: 'active.yaml',
-        filePath: '/active.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 2,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-06T11:00:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-active-alpha',
-        displayName: 'Active workflow',
-        serviceKey: 'scope-alpha:default:default:wf-active-alpha',
-        workflowName: 'active_workflow',
-        actorId: 'actor-active-alpha',
-        activeRevisionId: 'rev-active-alpha',
-        deploymentId: 'dep-active-alpha',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-06T10:00:00Z',
-      },
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-archived-alpha',
-        displayName: 'Archived workflow',
-        serviceKey: 'scope-alpha:default:default:wf-archived-alpha',
-        workflowName: 'archived_workflow',
-        actorId: 'actor-archived-alpha',
-        activeRevisionId: 'rev-archived-alpha',
-        deploymentId: 'dep-archived-alpha',
-        deploymentStatus: 'Deactivated',
-        updatedAt: '2026-08-05T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const activeName = await screen.findByText('Active workflow');
-    expect(screen.getByText('Draft workflow')).toBeInTheDocument();
-    expect(screen.queryByText('Archived workflow')).not.toBeInTheDocument();
-    expect(screen.getByText('Active workflows')).toBeInTheDocument();
-
-    const activeActions = within(
-      activeName.closest('tr') as HTMLElement,
-    ).getByRole('button', {
-      name: 'More actions for Active workflow in Workflows',
-    });
-    fireEvent.click(activeActions);
-    expect(
-      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Rename', 'Copy workflow reference', 'Archive']);
-  });
-
-  it('restores the Archived view without offering Archive again', async () => {
-    mockLocation =
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=archived';
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-active-alpha',
-        displayName: 'Active workflow',
-        serviceKey: 'scope-alpha:default:default:wf-active-alpha',
-        workflowName: 'active_workflow',
-        actorId: 'actor-active-alpha',
-        activeRevisionId: 'rev-active-alpha',
-        deploymentId: 'dep-active-alpha',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-06T10:00:00Z',
-      },
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-archived-alpha',
-        displayName: 'Archived workflow',
-        serviceKey: 'scope-alpha:default:default:wf-archived-alpha',
-        workflowName: 'archived_workflow',
-        actorId: 'actor-archived-alpha',
-        activeRevisionId: 'rev-archived-alpha',
-        deploymentId: 'dep-archived-alpha',
-        deploymentStatus: 'Deactivated',
-        updatedAt: '2026-08-05T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const archivedName = await screen.findByText('Archived workflow');
-    expect(screen.queryByText('Active workflow')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Archived')).toHaveLength(2);
-    expect(
-      within(archivedName.closest('tr') as HTMLElement).getByText('Archived'),
-    ).toBeVisible();
-
-    fireEvent.click(
-      within(archivedName.closest('tr') as HTMLElement).getByRole('button', {
-        name: 'More actions for Archived workflow in Workspace',
-      }),
-    );
-    expect(
-      screen.queryByRole('menuitem', { name: 'Archive' }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('reports Archive only after the accepted deployment deactivation is observed', async () => {
-    const activeWorkflow = {
-      scopeId: 'scope-alpha',
-      workflowId: 'wf-alpha',
-      displayName: 'Workflow Alpha',
-      serviceKey: 'scope-alpha:default:default:wf-alpha',
-      workflowName: 'workflow_alpha',
-      actorId: 'actor-alpha',
-      activeRevisionId: 'rev-alpha',
-      deploymentId: 'dep-alpha',
-      deploymentStatus: 'Active',
-      updatedAt: '2026-08-06T10:00:00Z',
-    };
-    const archivedWorkflow = {
-      ...activeWorkflow,
-      deploymentStatus: 'Deactivated',
-      updatedAt: '2026-08-06T10:01:00Z',
-    };
-    let committedRows = [activeWorkflow];
-    let resolveObservation!: (value: {
-      kind: 'observed';
-      workflows: (typeof archivedWorkflow)[];
-    }) => void;
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockImplementation(async () => committedRows);
-    mockObserveWorkflowArchival.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveObservation = resolve;
-        }),
-    );
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const workflowName = await screen.findByText('Workflow Alpha');
-    fireEvent.click(
-      within(workflowName.closest('tr') as HTMLElement).getByRole('button', {
-        name: 'More actions for Workflow Alpha in Workspace',
-      }),
-    );
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive' }));
-
-    expect(screen.getByText('Archive this workflow?')).toBeInTheDocument();
-    expect(mockServicesApi.deactivateDeployment).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole('button', { name: 'Archive workflow' }));
-
-    await waitFor(() =>
-      expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledWith(
-        'wf-alpha',
-        'dep-alpha',
-        {
-          tenantId: 'scope-alpha',
-          appId: 'default',
-          namespace: 'default',
-        },
-      ),
-    );
-    expect(mockConsoleToast.success).not.toHaveBeenCalledWith(
-      'Workflow archived',
-    );
-    expect(screen.getByText('Archive this workflow?')).toBeInTheDocument();
-
-    committedRows = [archivedWorkflow];
-    act(() => {
-      resolveObservation({
-        kind: 'observed',
-        workflows: [archivedWorkflow],
-      });
-    });
-
-    await waitFor(() =>
-      expect(mockConsoleToast.success).toHaveBeenCalledWith(
-        'Workflow archived',
-      ),
-    );
-    expect(
-      screen.queryByText('Archive this workflow?'),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText('Workflow Alpha')).not.toBeInTheDocument();
-  });
-
-  it('checks an accepted Archive again without resubmitting deactivation', async () => {
-    const activeWorkflow = {
-      scopeId: 'scope-alpha',
-      workflowId: 'wf-alpha',
-      displayName: 'Workflow Alpha',
-      serviceKey: 'scope-alpha:default:default:wf-alpha',
-      workflowName: 'workflow_alpha',
-      actorId: 'actor-alpha',
-      activeRevisionId: 'rev-alpha',
-      deploymentId: 'dep-alpha',
-      deploymentStatus: 'Active',
-      updatedAt: '2026-08-06T10:00:00Z',
-    };
-    const archivedWorkflow = {
-      ...activeWorkflow,
-      deploymentStatus: 'Deactivated',
-      updatedAt: '2026-08-06T10:01:00Z',
-    };
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([activeWorkflow]);
-    mockObserveWorkflowArchival
-      .mockResolvedValueOnce({ kind: 'delayed' })
-      .mockResolvedValueOnce({
-        kind: 'observed',
-        workflows: [archivedWorkflow],
-      });
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const workflowName = await screen.findByText('Workflow Alpha');
-    fireEvent.click(
-      within(workflowName.closest('tr') as HTMLElement).getByRole('button', {
-        name: 'More actions for Workflow Alpha in Workspace',
-      }),
-    );
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Archive workflow' }));
-
-    expect(
-      await screen.findByText(
-        "Archive was accepted, but it hasn't been confirmed yet",
-      ),
-    ).toBeInTheDocument();
-    expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledTimes(1);
-    expect(mockObserveWorkflowArchival).toHaveBeenCalledTimes(1);
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Check again' }));
-
-    await waitFor(() =>
-      expect(mockObserveWorkflowArchival).toHaveBeenCalledTimes(2),
-    );
-    expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledTimes(1);
-  });
-
-  it('resubmits Archive when the deactivation request was not accepted', async () => {
-    const activeWorkflow = {
-      scopeId: 'scope-alpha',
-      workflowId: 'wf-alpha',
-      displayName: 'Workflow Alpha',
-      serviceKey: 'scope-alpha:default:default:wf-alpha',
-      workflowName: 'workflow_alpha',
-      actorId: 'actor-alpha',
-      activeRevisionId: 'rev-alpha',
-      deploymentId: 'dep-alpha',
-      deploymentStatus: 'Active',
-      updatedAt: '2026-08-06T10:00:00Z',
-    };
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([activeWorkflow]);
-    mockServicesApi.deactivateDeployment
-      .mockRejectedValueOnce(new Error('request failed'))
-      .mockResolvedValueOnce({
-        targetActorId: 'deployment-manager-alpha',
-        commandId: 'cmd-archive-alpha',
-        correlationId: 'corr-archive-alpha',
-      });
-    mockObserveWorkflowArchival.mockResolvedValue({ kind: 'delayed' });
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const workflowName = await screen.findByText('Workflow Alpha');
-    fireEvent.click(
-      within(workflowName.closest('tr') as HTMLElement).getByRole('button', {
-        name: 'More actions for Workflow Alpha in Workspace',
-      }),
-    );
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Archive' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Archive workflow' }));
-
-    expect(
-      await screen.findByText("Workflow couldn't be archived"),
-    ).toBeInTheDocument();
-    expect(mockObserveWorkflowArchival).not.toHaveBeenCalled();
-    expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledTimes(1);
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Try again' }));
-
-    await waitFor(() =>
-      expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledTimes(2),
-    );
-    expect(mockObserveWorkflowArchival).toHaveBeenCalledTimes(1);
-  });
-
-  it('deep-links draft-only row Activity with its workflow id', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Support triage',
-        description: 'Route support requests',
-        fileName: 'support.yaml',
-        filePath: '/support.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    expect(await screen.findByText('Support triage')).toBeInTheDocument();
-    const activityLink = screen.getByRole('link', {
-      name: 'View activity for Support triage in Workflows',
-    });
-    expect(activityLink).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-draft-alpha',
-    );
-    fireEvent.click(activityLink);
-    expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
-    expect(history.push).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-draft-alpha',
-    );
-  });
-
-  it('uses one editor entry point and exposes draft-only deletion with row actions', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Support triage',
-        description: 'Route support requests',
-        fileName: 'support.yaml',
-        filePath: '/support.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'summary-actor-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const draftRow = (await screen.findByText('Support triage')).closest('tr');
-    const committedRow = screen.getByText('Invoice review').closest('tr');
-    expect(draftRow).not.toBeNull();
-    expect(committedRow).not.toBeNull();
-    const openDraft = within(draftRow as HTMLElement).getByRole('link', {
-      name: 'Open Support triage in Workflows',
-    });
-    expect(openDraft).toHaveAttribute(
-      'href',
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-draft-alpha',
-    );
-    expect(openDraft).toHaveClass(
-      'aevatar-interactive-button',
-      'ant-btn-primary',
-    );
-    const viewActivity = within(draftRow as HTMLElement).getByRole('link', {
-      name: 'View activity for Support triage in Workflows',
-    });
-    expect(viewActivity).toHaveClass('aevatar-interactive-button');
-    expect(viewActivity).not.toHaveClass('ant-btn-primary');
-    expect(
-      within(draftRow as HTMLElement).queryByRole('button', {
-        name: 'Run Support triage',
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(draftRow as HTMLElement).queryByRole('button', {
-        name: 'Delete Support triage',
-      }),
-    ).not.toBeInTheDocument();
-    const moreActions = within(draftRow as HTMLElement).getByRole('button', {
-      name: 'More actions for Support triage in Workflows',
-    });
-    expect(moreActions).toBeEnabled();
-    expect(moreActions).toHaveClass('aevatar-interactive-button');
-    expect(moreActions).not.toHaveClass('ant-btn-primary');
-    expect(
-      within(committedRow as HTMLElement).queryByRole('button', {
-        name: 'Delete Invoice review',
-      }),
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(openDraft);
-    expect(history.push).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-draft-alpha',
-    );
-
-    fireEvent.click(moreActions);
-    expect(
-      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Rename', 'Copy workflow reference', 'Delete draft']);
-    expect(screen.getByRole('separator')).toBeInTheDocument();
-    const deleteMenuItem = screen.getByRole('menuitem', {
-      name: 'Delete draft',
-    });
-    expect(deleteMenuItem).toHaveClass('ant-dropdown-menu-item-danger');
-    fireEvent.click(deleteMenuItem);
-    expect(screen.getByText('Delete editable draft?')).toBeInTheDocument();
-    expect(mockStudioApi.deleteWorkflowDraft).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-
-    fireEvent.click(
-      within(committedRow as HTMLElement).getByRole('button', {
-        name: 'More actions for Invoice review in Workspace',
-      }),
-    );
-    expect(
-      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Copy workflow reference', 'Archive']);
-    expect(screen.getByRole('menuitem', { name: 'Archive' })).toHaveClass(
-      'ant-dropdown-menu-item-danger',
-    );
-  });
-
-  it('deletes only the editable draft and refreshes authoritative draft membership', async () => {
-    mockLocation =
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=drafts';
-    let draftRows = [
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Support triage',
-        description: 'Route support requests',
-        fileName: 'support.yaml',
-        filePath: '/support.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-    ];
-    mockStudioApi.listWorkflowDrafts.mockImplementation(async () => draftRows);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-draft-alpha',
-        displayName: 'Committed support source',
-        serviceKey: 'svc-alpha',
-        workflowName: 'committed_support_source',
-        actorId: 'definition-alpha',
-        activeRevisionId: 'revision-alpha',
-        deploymentId: 'deployment-alpha',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-    mockStudioApi.deleteWorkflowDraft.mockImplementation(async () => {
-      draftRows = [];
-    });
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const draftName = await screen.findByText('Support triage');
-    const row = draftName.closest('tr');
-    expect(row).not.toBeNull();
-    fireEvent.click(
-      within(row as HTMLElement).getByRole('button', {
-        name: 'More actions for Support triage in Workflows',
-      }),
-    );
-    fireEvent.click(
-      await screen.findByRole('menuitem', { name: 'Delete draft' }),
-    );
-    expect(screen.getByText('Delete editable draft?')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Delete draft' }));
-
-    await waitFor(() =>
-      expect(mockStudioApi.deleteWorkflowDraft).toHaveBeenCalledWith(
-        'wf-draft-alpha',
-        'scope-alpha',
-      ),
-    );
-    await waitFor(() =>
-      expect(mockStudioApi.listWorkflowDrafts).toHaveBeenCalledTimes(2),
-    );
-    expect(screen.queryByText('Support triage')).not.toBeInTheDocument();
-    expect(mockServicesApi.deactivateDeployment).not.toHaveBeenCalled();
-  });
-
-  it('keeps the draft and offers retry when deletion fails', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Support triage',
-        description: 'Route support requests',
-        fileName: 'support.yaml',
-        filePath: '/support.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
-    mockStudioApi.deleteWorkflowDraft.mockRejectedValue(
-      new Error('DELETE returned 503'),
-    );
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const draftName = await screen.findByText('Support triage');
-    const row = draftName.closest('tr');
-    fireEvent.click(
-      within(row as HTMLElement).getByRole('button', {
-        name: 'More actions for Support triage in Workflows',
-      }),
-    );
-    fireEvent.click(
-      await screen.findByRole('menuitem', { name: 'Delete draft' }),
-    );
-    fireEvent.click(screen.getByRole('button', { name: 'Delete draft' }));
-
-    await waitFor(() =>
-      expect(mockConsoleToast.error).toHaveBeenCalledWith(
-        "Draft couldn't be deleted",
-      ),
-    );
-    expect(
-      screen.queryByText("Draft couldn't be deleted"),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText('DELETE returned 503')).not.toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: 'Try again' })).toBeEnabled(),
-    );
-    expect(screen.getByText('Support triage')).toBeInTheDocument();
-    expect(mockStudioApi.listWorkflowDrafts).toHaveBeenCalledTimes(1);
-  });
-
-  it('reports only the specific delete refresh failure after the draft was removed', async () => {
-    mockStudioApi.listWorkflowDrafts
-      .mockResolvedValueOnce([
-        {
-          workflowId: 'wf-draft-alpha',
-          name: 'Support triage',
-          description: 'Route support requests',
-          fileName: 'support.yaml',
-          filePath: '/support.yaml',
-          directoryId: 'directory-alpha',
-          directoryLabel: 'Workflows',
-          stepCount: 3,
-          hasLayout: true,
-          updatedAtUtc: '2026-08-04T10:00:00Z',
-        },
-      ])
-      .mockRejectedValueOnce(new Error('refresh returned 503'));
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
-    mockStudioApi.deleteWorkflowDraft.mockResolvedValue(undefined);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    const draftName = await screen.findByText('Support triage');
-    fireEvent.click(
-      within(draftName.closest('tr') as HTMLElement).getByRole('button', {
-        name: 'More actions for Support triage in Workflows',
-      }),
-    );
-    fireEvent.click(
-      await screen.findByRole('menuitem', { name: 'Delete draft' }),
-    );
-    fireEvent.click(screen.getByRole('button', { name: 'Delete draft' }));
-
-    await waitFor(() =>
-      expect(mockConsoleToast.error).toHaveBeenCalledWith(
-        "Draft was deleted, but workflows couldn't refresh",
-      ),
-    );
-    expect(mockConsoleToast.error).toHaveBeenCalledTimes(1);
-    expect(mockStudioApi.deleteWorkflowDraft).toHaveBeenCalledTimes(1);
-    expect(mockStudioApi.listWorkflowDrafts).toHaveBeenCalledTimes(2);
-  });
-
-  it('waits for both workflow sources before reporting a list failure', async () => {
-    let resolveCommitted!: (rows: unknown[]) => void;
-    mockStudioApi.listWorkflowDrafts.mockRejectedValue(
-      new Error('draft source down'),
-    );
-    mockScopesApi.listWorkflows.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveCommitted = resolve;
-        }),
-    );
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    await waitFor(() =>
-      expect(mockStudioApi.listWorkflowDrafts).toHaveBeenCalledTimes(1),
-    );
-    expect(screen.getByRole('status')).toHaveAttribute('data-variant', 'table');
-    expect(screen.getByText('Loading workflows')).toHaveClass(
-      'aevatar-loading-visually-hidden',
-    );
-    expect(
-      screen.queryByText("Some workflows couldn't be loaded"),
-    ).not.toBeInTheDocument();
-    expect(mockConsoleToast.error).not.toHaveBeenCalled();
-
-    act(() => {
-      resolveCommitted([
-        {
-          scopeId: 'scope-alpha',
-          workflowId: 'wf-committed-beta',
-          displayName: 'Invoice review',
-          serviceKey: '',
-          workflowName: 'invoice_review',
-          actorId: 'definition-beta',
-          activeRevisionId: 'revision-beta',
-          deploymentId: 'deployment-beta',
-          deploymentStatus: 'active',
-          updatedAt: '2026-08-03T10:00:00Z',
-        },
-      ]);
-    });
-
-    expect(await screen.findByText('Invoice review')).toBeInTheDocument();
-    await waitFor(() =>
-      expect(mockConsoleToast.error).toHaveBeenCalledWith(
-        "Some workflows couldn't be loaded",
-      ),
-    );
-  });
-
-  it('keeps successful rows and reports the failed source with a toast', async () => {
-    mockStudioApi.listWorkflowDrafts.mockRejectedValue(
-      new Error('draft source down'),
-    );
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'definition-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    expect(await screen.findByText('Invoice review')).toBeInTheDocument();
-    expect(
-      screen.queryByText("Some workflows couldn't be loaded"),
-    ).not.toBeInTheDocument();
-    expect(mockConsoleToast.error).toHaveBeenCalledWith(
-      "Some workflows couldn't be loaded",
-    );
-    expect(screen.queryByText(/catalogue/i)).not.toBeInTheDocument();
-    expect(screen.queryByText('No workflows yet')).not.toBeInTheDocument();
-  });
-
-  it('renders a successful empty result', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
-  });
-
-  it('restores URL search and filters Drafts by exact draft API membership', async () => {
-    mockLocation =
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows?q=support&view=drafts';
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([
-      {
-        workflowId: 'wf-draft-alpha',
-        name: 'Support triage',
-        description: 'Route support requests',
-        fileName: 'support.yaml',
-        filePath: '/support.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        stepCount: 3,
-        hasLayout: true,
-        updatedAtUtc: '2026-08-04T10:00:00Z',
-      },
-    ]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-draft-alpha',
-        displayName: 'Committed support source',
-        serviceKey: '',
-        workflowName: 'committed_support_source',
-        actorId: 'summary-actor-alpha',
-        activeRevisionId: 'revision-alpha',
-        deploymentId: 'deployment-alpha',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'summary-actor-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    expect(await screen.findByText('Support triage')).toBeInTheDocument();
-    expect(screen.queryByText('Invoice review')).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('searchbox', { name: 'Search workflows' }),
-    ).toHaveValue('support');
-    expect(screen.getByText('Drafts')).toBeInTheDocument();
-
-    const draftActions = within(
-      screen.getByText('Support triage').closest('tr') as HTMLElement,
-    ).getByRole('button', {
-      name: 'More actions for Support triage in Workflows',
-    });
-    fireEvent.click(draftActions);
-    expect(
-      (await screen.findAllByRole('menuitem')).map((item) => item.textContent),
-    ).toEqual(['Rename', 'Copy workflow reference', 'Delete draft']);
-
-    fireEvent.mouseDown(
-      screen.getByRole('combobox', { name: 'Workflow view' }),
-    );
-    expect(
-      await screen.findByRole('option', { name: 'Active workflows' }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Drafts' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: 'Archived' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('option', { name: 'Committed' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('option', { name: 'Published' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('option', { name: 'Failing' }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('writes Workflow filters to the URL and clears a filtered empty result', async () => {
-    mockStudioApi.listWorkflowDrafts.mockResolvedValue([]);
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'summary-actor-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-    expect(await screen.findByText('Invoice review')).toBeInTheDocument();
-
-    fireEvent.change(
-      screen.getByRole('searchbox', { name: 'Search workflows' }),
-      { target: { value: 'missing' } },
-    );
-
-    expect(
-      await screen.findByText('No matching workflows'),
-    ).toBeInTheDocument();
-    await waitFor(() =>
-      expect(history.replace).toHaveBeenLastCalledWith(
-        '/scopes/scope-alpha/workflow-activity-vnext/workflows?q=missing',
-      ),
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
-    expect(await screen.findByText('Invoice review')).toBeInTheDocument();
-    await waitFor(() =>
-      expect(history.replace).toHaveBeenLastCalledWith(
-        '/scopes/scope-alpha/workflow-activity-vnext/workflows',
-      ),
-    );
-  });
-
-  it('shows Drafts as unavailable instead of empty when the draft API fails', async () => {
-    mockLocation =
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=drafts';
-    mockStudioApi.listWorkflowDrafts.mockRejectedValue(
-      new Error('draft source down'),
-    );
-    mockScopesApi.listWorkflows.mockResolvedValue([
-      {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-committed-beta',
-        displayName: 'Invoice review',
-        serviceKey: '',
-        workflowName: 'invoice_review',
-        actorId: 'summary-actor-beta',
-        activeRevisionId: 'revision-beta',
-        deploymentId: 'deployment-beta',
-        deploymentStatus: 'active',
-        updatedAt: '2026-08-03T10:00:00Z',
-      },
-    ]);
-
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    expect(
-      await screen.findByText('Draft workflows unavailable'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Retry workflows' }),
-    ).toBeEnabled();
-    expect(screen.queryByText('No workflows yet')).not.toBeInTheDocument();
-  });
-
-  it('renders total source failure and supports retry', async () => {
-    mockStudioApi.listWorkflowDrafts.mockRejectedValue(new Error('offline'));
-    mockScopesApi.listWorkflows.mockRejectedValue(new Error('offline'));
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    expect(
-      await screen.findByText('Workflows unavailable'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Retry workflows' }),
-    ).toBeEnabled();
-  });
 });
-
 describe('Workflow Activity vNext settings', () => {
   beforeEach(() => {
     mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/settings';

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -15,6 +15,7 @@ import {
 import WorkflowActivityVNextPage from './index';
 
 let mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/workflows';
+let mockHistoryMutatesLocation = false;
 const mockLocationSubscribers = new Set<() => void>();
 const mockConsoleToast = {
   error: jest.fn(),
@@ -320,7 +321,14 @@ jest.mock('@/pages/settings/userLlmSaveObservation', () => ({
 jest.mock('@/shared/navigation/history', () => ({
   getLocationSnapshot: () =>
     `${readMockUrl().pathname}${readMockUrl().search}${readMockUrl().hash}`,
-  history: { push: jest.fn(), replace: jest.fn() },
+  history: {
+    push: jest.fn(),
+    replace: jest.fn((target: string) => {
+      if (!mockHistoryMutatesLocation) return;
+      mockLocation = target;
+      for (const listener of mockLocationSubscribers) listener();
+    }),
+  },
   subscribeToLocationChanges: (listener: () => void) => {
     mockLocationSubscribers.add(listener);
     return () => mockLocationSubscribers.delete(listener);
@@ -433,6 +441,7 @@ const mockObserveUserLlmSave = jest.requireMock(
 describe('Workflow Activity vNext catalogue', () => {
   beforeEach(() => {
     mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/workflows';
+    mockHistoryMutatesLocation = false;
     jest.clearAllMocks();
     mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
       createCatalogueResponse([]),
@@ -444,7 +453,10 @@ describe('Workflow Activity vNext catalogue', () => {
     });
   });
 
-  afterEach(() => cleanupTestQueryClients());
+  afterEach(() => {
+    jest.useRealTimers();
+    cleanupTestQueryClients();
+  });
 
   it('uses backend catalogue views and preserves backend row order', async () => {
     mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
@@ -562,7 +574,7 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
-  it('debounces search and aborts an obsolete catalogue request', async () => {
+  it('debounces search despite URL synchronization and aborts an obsolete request', async () => {
     let supportSignal: AbortSignal | undefined;
     mockScopesApi.queryWorkflowCatalogue.mockImplementation(
       (input: { query?: string }, signal?: AbortSignal) => {
@@ -574,33 +586,44 @@ describe('Workflow Activity vNext catalogue', () => {
       },
     );
 
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
+    jest.useFakeTimers();
+    const rendered = renderWithQueryClient(<WorkflowActivityVNextPage />);
+    try {
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(1);
 
-    const search = screen.getByRole('searchbox', { name: 'Search workflows' });
-    fireEvent.change(search, { target: { value: ' support ' } });
-    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(1);
+      mockHistoryMutatesLocation = true;
+      const search = screen.getByRole('searchbox', {
+        name: 'Search workflows',
+      });
+      fireEvent.change(search, { target: { value: ' support ' } });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(299);
+      });
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(1);
+      expect(search).toHaveValue(' support ');
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1);
+      });
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'support' }),
+        expect.any(AbortSignal),
+      );
+      expect(supportSignal?.aborted).toBe(false);
 
-    await waitFor(
-      () =>
-        expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
-          expect.objectContaining({ query: 'support' }),
-          expect.any(AbortSignal),
-        ),
-      { timeout: 1000 },
-    );
-    expect(supportSignal?.aborted).toBe(false);
-
-    fireEvent.change(search, { target: { value: 'billing' } });
-    await waitFor(
-      () =>
-        expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
-          expect.objectContaining({ query: 'billing' }),
-          expect.any(AbortSignal),
-        ),
-      { timeout: 1000 },
-    );
-    expect(supportSignal?.aborted).toBe(true);
+      fireEvent.change(search, { target: { value: 'billing' } });
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(300);
+      });
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'billing' }),
+        expect.any(AbortSignal),
+      );
+      expect(supportSignal?.aborted).toBe(true);
+    } finally {
+      rendered.unmount();
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('loads the next backend page and appends it without reordering', async () => {
@@ -642,6 +665,51 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(workflowNames).toEqual(['First page row', 'Second page row']);
   });
 
+  it('keeps loaded rows visible and retries after a next-page failure', async () => {
+    let nextPageAttempts = 0;
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(
+      (input: { cursor?: string }) => {
+        if (input.cursor !== 'page-2') {
+          return Promise.resolve(
+            createCatalogueResponse(
+              [
+                createCatalogueRow({
+                  workflowId: 'wf-first',
+                  name: 'First page row',
+                }),
+              ],
+              'page-2',
+            ),
+          );
+        }
+        nextPageAttempts += 1;
+        return nextPageAttempts === 1
+          ? Promise.reject(new Error('page unavailable'))
+          : Promise.resolve(
+              createCatalogueResponse([
+                createCatalogueRow({
+                  workflowId: 'wf-second',
+                  name: 'Second page row',
+                }),
+              ]),
+            );
+      },
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('First page row')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(
+      await screen.findByText("More workflows couldn't be loaded"),
+    ).toBeInTheDocument();
+    expect(screen.getByText('First page row')).toBeInTheDocument();
+    expect(screen.queryByText('Workflows unavailable')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(await screen.findByText('Second page row')).toBeInTheDocument();
+    expect(nextPageAttempts).toBe(2);
+  });
+
   it('uses backend capabilities and the workflow id for row actions', async () => {
     const identities = {
       memberId: 'm-alpha',
@@ -651,8 +719,8 @@ describe('Workflow Activity vNext catalogue', () => {
     mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
       createCatalogueResponse([
         createCatalogueRow({
-          workflowId: identities.workflowId,
-          name: 'Invoice review',
+          workflowId: 'wf-unavailable',
+          name: 'Unavailable workflow',
           capabilities: {
             open: {
               available: false,
@@ -672,26 +740,40 @@ describe('Workflow Activity vNext catalogue', () => {
             },
           },
         }),
+        createCatalogueRow({
+          workflowId: identities.workflowId,
+          name: 'Invoice review',
+          committed: {
+            serviceKey: 'opaque-service-key',
+            workflowName: 'invoice_review',
+            actorId: identities.memberId,
+            activeRevisionId: 'rev-alpha',
+            deploymentId: identities.publishedServiceId,
+            deploymentStatus: 'Deactivated',
+          },
+        }),
       ]),
     );
 
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
-    const row = (await screen.findByText('Invoice review')).closest('tr');
-    expect(row).not.toBeNull();
+    const unavailableRow = (
+      await screen.findByText('Unavailable workflow')
+    ).closest('tr');
+    expect(unavailableRow).not.toBeNull();
     expect(
-      within(row as HTMLElement).getByRole('button', {
-        name: 'Open Invoice review in Workspace',
+      within(unavailableRow as HTMLElement).getByRole('button', {
+        name: 'Open Unavailable workflow in Workspace',
       }),
     ).toBeDisabled();
     expect(
-      within(row as HTMLElement).getByRole('button', {
-        name: 'View activity for Invoice review in Workspace',
+      within(unavailableRow as HTMLElement).getByRole('button', {
+        name: 'View activity for Unavailable workflow in Workspace',
       }),
     ).toBeDisabled();
     fireEvent.click(
-      within(row as HTMLElement).getByRole('button', {
-        name: 'More actions for Invoice review in Workspace',
+      within(unavailableRow as HTMLElement).getByRole('button', {
+        name: 'More actions for Unavailable workflow in Workspace',
       }),
     );
     expect(
@@ -701,6 +783,24 @@ describe('Workflow Activity vNext catalogue', () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'Rename' })).toBeNull();
     expect(screen.queryByRole('menuitem', { name: 'Delete draft' })).toBeNull();
+
+    const actionableRow = screen.getByText('Invoice review').closest('tr');
+    expect(
+      within(actionableRow as HTMLElement).getByRole('link', {
+        name: 'Open Invoice review in Workspace',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-alpha',
+    );
+    expect(
+      within(actionableRow as HTMLElement).getByRole('link', {
+        name: 'View activity for Invoice review in Workspace',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/scopes/scope-alpha/workflow-activity-vnext/activity?workflowId=wf-alpha',
+    );
     expect(document.body.textContent).not.toContain(identities.memberId);
     expect(document.body.textContent).not.toContain(
       identities.publishedServiceId,
@@ -806,7 +906,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
   });
 
-  it('observes archive through the backend catalogue and refreshes all rows', async () => {
+  it('resolves archive identity and observes the exact row across catalogue pages', async () => {
     const activeCommitted = {
       serviceKey: 'svc-alpha',
       workflowName: 'workflow_alpha',
@@ -820,20 +920,52 @@ describe('Workflow Activity vNext catalogue', () => {
       deploymentStatus: 'Deactivated',
     };
     let archived = false;
+    mockScopesApi.getWorkflowDetail.mockResolvedValue({
+      available: true,
+      scopeId: 'scope-alpha',
+      workflow: {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-alpha',
+        displayName: 'Workflow Alpha',
+        serviceKey: 'opaque-service-key',
+        workflowName: 'workflow_alpha',
+        actorId: 'actor-alpha',
+        activeRevisionId: 'rev-alpha',
+        deploymentId: 'dep-authoritative',
+        deploymentStatus: 'Active',
+        updatedAt: '2026-08-04T10:00:00Z',
+        publishedServiceId: 'svc-alpha',
+        serviceAppId: 'workflow-app',
+        serviceNamespace: 'workflow-namespace',
+      },
+      source: null,
+    });
     mockScopesApi.queryWorkflowCatalogue.mockImplementation(
-      (input: { query?: string }) =>
-        Promise.resolve(
+      (input: { cursor?: string; query?: string }) => {
+        if (input.query === 'wf-alpha' && input.cursor !== 'archive-page-2') {
+          return Promise.resolve(
+            createCatalogueResponse(
+              [
+                createCatalogueRow({
+                  workflowId: 'wf-alpha-related',
+                  name: 'Prefix match',
+                  committed: archivedCommitted,
+                }),
+              ],
+              'archive-page-2',
+            ),
+          );
+        }
+        return Promise.resolve(
           createCatalogueResponse([
             createCatalogueRow({
               workflowId: 'wf-alpha',
               name: 'Workflow Alpha',
-              committed:
-                archived || input.query === 'wf-alpha'
-                  ? archivedCommitted
-                  : activeCommitted,
+              committed: archived ? archivedCommitted : activeCommitted,
             }),
           ]),
-        ),
+        );
+      },
     );
     mockObserveWorkflowArchival.mockImplementation(
       async (input: { readWorkflows: () => Promise<unknown[]> }) => {
@@ -861,17 +993,25 @@ describe('Workflow Activity vNext catalogue', () => {
         scopeId: 'scope-alpha',
         view: 'all',
         query: 'wf-alpha',
+        cursor: undefined,
         take: 100,
       }),
     );
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith({
+      scopeId: 'scope-alpha',
+      view: 'all',
+      query: 'wf-alpha',
+      cursor: 'archive-page-2',
+      take: 100,
+    });
     expect(mockScopesApi.listWorkflows).not.toHaveBeenCalled();
     expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledWith(
-      'wf-alpha',
-      'dep-alpha',
+      'svc-alpha',
+      'dep-authoritative',
       {
         tenantId: 'scope-alpha',
-        appId: 'default',
-        namespace: 'default',
+        appId: 'workflow-app',
+        namespace: 'workflow-namespace',
       },
     );
     expect(await screen.findByText('Archived')).toBeInTheDocument();

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -112,6 +112,7 @@ export const workflowActivityVNextCss = `
 .wa-vnext__toolbar-search { flex: 0 1 320px; max-width: 100%; width: 320px; }
 .wa-vnext__toolbar-filters { justify-content: flex-end; }
 .wa-vnext__toolbar-filters .ant-select { min-width: 150px; }
+.wa-vnext__pagination-actions { display: flex; justify-content: center; min-height: 32px; padding-top: 16px; }
 .wa-vnext__table-wrap {
   border: 1px solid var(--wa-line);
   border-radius: var(--wa-radius);

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -112,7 +112,8 @@ export const workflowActivityVNextCss = `
 .wa-vnext__toolbar-search { flex: 0 1 320px; max-width: 100%; width: 320px; }
 .wa-vnext__toolbar-filters { justify-content: flex-end; }
 .wa-vnext__toolbar-filters .ant-select { min-width: 150px; }
-.wa-vnext__pagination-actions { display: flex; justify-content: center; min-height: 32px; padding-top: 16px; }
+.wa-vnext__pagination-actions { align-items: center; display: flex; gap: 12px; justify-content: flex-end; min-height: 32px; padding-top: 16px; }
+.wa-vnext__pagination-actions p { color: var(--wa-danger); font-size: 12px; line-height: 17px; margin: 0; }
 .wa-vnext__table-wrap {
   border: 1px solid var(--wa-line);
   border-radius: var(--wa-radius);
@@ -365,6 +366,8 @@ export const workflowActivityVNextCss = `
   .wa-vnext__toolbar-search { flex-basis: auto; width: 100%; }
   .wa-vnext__toolbar-filters { display: grid; grid-template-columns: 1fr; width: 100%; }
   .wa-vnext__toolbar-filters .ant-space-item, .wa-vnext__toolbar-filters .ant-select, .wa-vnext__toolbar-filters .ant-btn { width: 100%; }
+  .wa-vnext__pagination-actions { align-items: stretch; flex-direction: column; }
+  .wa-vnext__pagination-actions .ant-btn { width: 100%; }
   .wa-vnext__creation-options { grid-template-columns: 1fr; }
   .wa-vnext__creation-option { min-height: 118px; }
   .wa-vnext__creation-form { gap: 18px; }

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -9,24 +9,23 @@ import {
   ReloadOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Button, Dropdown, Input, Modal, Popover, Select, Space } from 'antd';
 import React from 'react';
 import { scopesApi } from '@/shared/api/scopesApi';
 import { servicesApi } from '@/shared/api/servicesApi';
 import { t } from '@/shared/i18n/messages';
-import type { ScopeWorkflowSummary } from '@/shared/models/scopes';
+import type {
+  ScopeWorkflowCatalogueRow,
+  ScopeWorkflowCatalogueRowCapabilities,
+  ScopeWorkflowCatalogueView,
+} from '@/shared/models/scopes';
 import { history } from '@/shared/navigation/history';
 import {
   scopeServiceAppId,
   scopeServiceNamespace,
 } from '@/shared/runs/scopeConsole';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
-import type {
-  StudioMemberRoster,
-  StudioMemberSummary,
-  StudioWorkflowDraftSummary,
-} from '@/shared/studio/models';
 import AevatarContentSkeleton from '@/shared/ui/AevatarContentSkeleton';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from '@/shared/ui/interactionStandards';
@@ -50,67 +49,35 @@ type WorkflowRow = {
   readonly deploymentId: string;
   readonly deploymentStatus: string;
   readonly description: string;
+  readonly capabilities: ScopeWorkflowCatalogueRowCapabilities;
   readonly hasCommittedSource: boolean;
-  readonly hasDraftSource: boolean;
-  readonly memberId: string;
   readonly name: string;
   readonly ownershipLabel: string;
-  readonly stepCount?: number;
   readonly updatedAtUtc: string | null;
   readonly workflowId: string;
 };
 
-function toDraftRow(
-  item: StudioWorkflowDraftSummary,
-  committed?: WorkflowRow,
-): WorkflowRow {
+function toWorkflowRow(item: ScopeWorkflowCatalogueRow): WorkflowRow {
   return {
-    activeRevisionId:
-      item.activeRevisionId?.trim() || committed?.activeRevisionId || '',
+    activeRevisionId: item.committed?.activeRevisionId.trim() ?? '',
+    capabilities: item.capabilities,
     description: item.description,
-    deploymentId: committed?.deploymentId ?? '',
-    deploymentStatus: committed?.deploymentStatus ?? '',
-    hasCommittedSource: Boolean(committed),
-    hasDraftSource: true,
-    memberId: committed?.memberId ?? '',
+    deploymentId: item.committed?.deploymentId.trim() ?? '',
+    deploymentStatus: item.committed?.deploymentStatus.trim() ?? '',
+    hasCommittedSource: item.hasCommittedSource,
     name: item.name,
-    ownershipLabel:
-      item.directoryLabel.trim() ||
-      t('workflowActivityVNext.workflows.workspaceOwner', 'Workspace'),
-    stepCount: item.stepCount,
+    ownershipLabel: t(
+      'workflowActivityVNext.workflows.workspaceOwner',
+      'Workspace',
+    ),
     updatedAtUtc: item.updatedAtUtc,
     workflowId: item.workflowId,
   };
 }
 
-function toCommittedRow(
-  item: ScopeWorkflowSummary,
-  member?: StudioMemberSummary,
-): WorkflowRow {
-  return {
-    activeRevisionId: item.activeRevisionId.trim(),
-    description: '',
-    deploymentId: item.deploymentId.trim(),
-    deploymentStatus: item.deploymentStatus.trim(),
-    hasCommittedSource: true,
-    hasDraftSource: false,
-    memberId: member?.memberId.trim() ?? '',
-    name: member?.displayName.trim() || item.displayName || item.workflowName,
-    ownershipLabel: t(
-      'workflowActivityVNext.workflows.workspaceOwner',
-      'Workspace',
-    ),
-    updatedAtUtc: item.updatedAt,
-    workflowId: item.workflowId,
-  };
-}
-
-type WorkflowView = 'active' | 'archived' | 'drafts';
-
-function readWorkflowView(params: URLSearchParams): WorkflowView {
+function readWorkflowView(params: URLSearchParams): ScopeWorkflowCatalogueView {
   const view = params.get('view');
-  if (view === 'archived' || view === 'drafts') return view;
-  return 'active';
+  return view === 'drafts' ? 'drafts' : 'all';
 }
 
 function formatDate(value: string | null): string {
@@ -148,16 +115,15 @@ function handleClientLinkClick(
 
 const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const location = useConsoleLocation();
-  const queryClient = useQueryClient();
   const toast = useConsoleToast();
   const lastListErrorSignature = React.useRef('');
-  const suppressNextDraftListError = React.useRef(false);
   const initialParams = React.useMemo(
     () => new URLSearchParams(location.search),
     [location.search],
   );
   const [query, setQuery] = React.useState(initialParams.get('q') ?? '');
-  const [view, setView] = React.useState<WorkflowView>(
+  const [debouncedQuery, setDebouncedQuery] = React.useState(query.trim());
+  const [view, setView] = React.useState<ScopeWorkflowCatalogueView>(
     readWorkflowView(initialParams),
   );
   const [archiveTarget, setArchiveTarget] = React.useState<WorkflowRow | null>(
@@ -179,109 +145,58 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const [deleteFailed, setDeleteFailed] = React.useState(false);
   const [deleteSucceeded, setDeleteSucceeded] = React.useState(false);
   const [deleting, setDeleting] = React.useState(false);
-  const drafts = useQuery({
-    queryKey: ['workflow-activity-vnext', 'drafts', scopeId],
-    queryFn: () => studioApi.listWorkflowDrafts(scopeId),
-    retry: false,
-  });
-  const committed = useQuery({
-    queryKey: ['workflow-activity-vnext', 'committed', scopeId],
-    queryFn: () => scopesApi.listWorkflows(scopeId),
-    retry: false,
-  });
-  const members = useQuery({
-    queryKey: ['workflow-activity-vnext', 'members', scopeId],
-    queryFn: () => studioApi.listMembers(scopeId),
+  const catalogue = useInfiniteQuery({
+    queryKey: [
+      'workflow-activity-vnext',
+      'workflow-catalogue',
+      scopeId,
+      view,
+      debouncedQuery,
+    ],
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam, signal }) =>
+      scopesApi.queryWorkflowCatalogue(
+        {
+          scopeId,
+          view,
+          query: debouncedQuery || undefined,
+          cursor: pageParam,
+          take: 50,
+        },
+        signal,
+      ),
+    getNextPageParam: (lastPage) => lastPage.nextPageToken ?? undefined,
     retry: false,
   });
 
   React.useEffect(() => {
     const params = new URLSearchParams(location.search);
-    setQuery(params.get('q') ?? '');
+    const routeQuery = params.get('q') ?? '';
+    setQuery(routeQuery);
+    setDebouncedQuery(routeQuery.trim());
     setView(readWorkflowView(params));
   }, [location.search]);
 
   React.useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedQuery(query.trim()), 300);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+
+  React.useEffect(() => {
     const params = new URLSearchParams();
     if (query.trim()) params.set('q', query.trim());
-    if (view !== 'active') params.set('view', view);
+    if (view !== 'all') params.set('view', view);
     const suffix = params.toString();
     history.replace(`${location.pathname}${suffix ? `?${suffix}` : ''}`);
   }, [location.pathname, query, view]);
 
-  const loading = drafts.isPending || committed.isPending;
-  const draftWorkflowIds = React.useMemo(
-    () => new Set((drafts.data ?? []).map((item) => item.workflowId)),
-    [drafts.data],
-  );
-  const memberIndexes = React.useMemo(() => {
-    const byPublishedServiceId = new Map<string, StudioMemberSummary | null>();
-    const byWorkflowId = new Map<string, StudioMemberSummary | null>();
-    for (const member of members.data?.members ?? []) {
-      if (
-        member.implementationKind !== 'workflow' ||
-        member.implementationRef?.implementationKind !== 'workflow'
-      )
-        continue;
-      const publishedServiceId = member.publishedServiceId.trim();
-      if (publishedServiceId) {
-        byPublishedServiceId.set(
-          publishedServiceId,
-          byPublishedServiceId.has(publishedServiceId) ? null : member,
-        );
-      }
-      const boundWorkflowId = member.implementationRef.workflowId?.trim() ?? '';
-      if (!boundWorkflowId) continue;
-      byWorkflowId.set(
-        boundWorkflowId,
-        byWorkflowId.has(boundWorkflowId) ? null : member,
-      );
-    }
-    return { byPublishedServiceId, byWorkflowId };
-  }, [members.data]);
+  const loading = catalogue.isPending;
   const rows = React.useMemo(() => {
-    const merged = new Map<string, WorkflowRow>();
-    for (const item of committed.data ?? []) {
-      const publishedServiceId = item.publishedServiceId?.trim() ?? '';
-      const member = publishedServiceId
-        ? memberIndexes.byPublishedServiceId.get(publishedServiceId)
-        : memberIndexes.byWorkflowId.get(item.workflowId);
-      merged.set(item.workflowId, toCommittedRow(item, member ?? undefined));
-    }
-    for (const item of drafts.data ?? [])
-      merged.set(
-        item.workflowId,
-        toDraftRow(item, merged.get(item.workflowId)),
-      );
-    const normalized = query.trim().toLowerCase();
-    return [...merged.values()]
-      .filter((item) => {
-        if (view === 'drafts') return draftWorkflowIds.has(item.workflowId);
-        if (view === 'archived') return isWorkflowArchived(item);
-        return !isWorkflowArchived(item);
-      })
-      .filter(
-        (item) =>
-          !normalized ||
-          [item.name, item.description, item.workflowId].some((value) =>
-            value.toLowerCase().includes(normalized),
-          ),
-      )
-      .sort(
-        (left, right) =>
-          Date.parse(right.updatedAtUtc ?? '') -
-          Date.parse(left.updatedAtUtc ?? ''),
-      );
-  }, [
-    committed.data,
-    draftWorkflowIds,
-    drafts.data,
-    memberIndexes,
-    query,
-    view,
-  ]);
-  const totalFailure = drafts.isError && committed.isError;
-  const filtersActive = Boolean(query.trim()) || view !== 'active';
+    return (catalogue.data?.pages ?? []).flatMap((page) =>
+      page.items.map(toWorkflowRow),
+    );
+  }, [catalogue.data?.pages]);
+  const filtersActive = Boolean(query.trim()) || view !== 'all';
   const renameDuplicates = React.useMemo(() => {
     if (!renameTarget) return false;
     const normalizedName = normalizeWorkflowName(renameName);
@@ -296,41 +211,19 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   }, [renameName, renameTarget, rows]);
 
   React.useEffect(() => {
-    if (loading || (!drafts.isError && !committed.isError)) return;
+    if (loading || !catalogue.isError) return;
 
-    const errorSignature = [
-      scopeId,
-      drafts.isError ? drafts.errorUpdatedAt : 0,
-      committed.isError ? committed.errorUpdatedAt : 0,
-    ].join(':');
+    const errorSignature = [scopeId, catalogue.errorUpdatedAt].join(':');
     if (lastListErrorSignature.current === errorSignature) return;
 
     lastListErrorSignature.current = errorSignature;
-    if (suppressNextDraftListError.current && drafts.isError) {
-      suppressNextDraftListError.current = false;
-      return;
-    }
-
     toast.error(
-      t(
-        'workflowActivityVNext.workflows.partialUnavailable',
-        "Some workflows couldn't be loaded",
-      ),
+      t('workflowActivityVNext.workflows.unavailable', 'Workflows unavailable'),
     );
-  }, [
-    committed.errorUpdatedAt,
-    committed.isError,
-    drafts.errorUpdatedAt,
-    drafts.isError,
-    loading,
-    scopeId,
-    toast,
-  ]);
+  }, [catalogue.errorUpdatedAt, catalogue.isError, loading, scopeId, toast]);
 
   const retry = () => {
-    void drafts.refetch();
-    void committed.refetch();
-    void members.refetch();
+    void catalogue.refetch();
   };
 
   const copyWorkflowReference = async (row: WorkflowRow) => {
@@ -370,77 +263,39 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     if (!renameTarget || !workflowName || renaming) return;
     setRenaming(true);
     try {
-      if (!renameTarget.hasDraftSource && !renameTarget.memberId) {
-        throw new Error('Workflow has no rename authority');
+      const draft = await studioApi.getWorkflowDraft(
+        renameTarget.workflowId,
+        scopeId,
+      );
+      const parsed = await studioApi.parseYaml({ yaml: draft.yaml });
+      if (!parsed.document)
+        throw new Error('Workflow YAML could not be parsed');
+      const serialized = await studioApi.serializeYaml({
+        document: {
+          ...parsed.document,
+          name: workflowName,
+        },
+      });
+      await studioApi.updateWorkflowDraft({
+        directoryId: draft.directoryId,
+        fileName: draft.fileName,
+        layout: draft.layout,
+        scopeId,
+        workflowId: renameTarget.workflowId,
+        workflowName,
+        yaml: serialized.yaml,
+      });
+      const observation = await observeDraftMaterialization({
+        workflowId: renameTarget.workflowId,
+        read: (workflowId) => studioApi.getWorkflowDraft(workflowId, scopeId),
+        isNotFound: (candidate) => isStudioApiStatus(candidate, 404),
+        isObserved: (candidate) => candidate.name.trim() === workflowName,
+      });
+      if (observation.kind === 'delayed') {
+        throw new Error('Workflow rename was not observed');
       }
-
-      if (renameTarget.hasDraftSource) {
-        const draft = await studioApi.getWorkflowDraft(
-          renameTarget.workflowId,
-          scopeId,
-        );
-        const parsed = await studioApi.parseYaml({ yaml: draft.yaml });
-        if (!parsed.document)
-          throw new Error('Workflow YAML could not be parsed');
-        const serialized = await studioApi.serializeYaml({
-          document: {
-            ...parsed.document,
-            name: workflowName,
-          },
-        });
-        await studioApi.updateWorkflowDraft({
-          directoryId: draft.directoryId,
-          fileName: draft.fileName,
-          layout: draft.layout,
-          scopeId,
-          workflowId: renameTarget.workflowId,
-          workflowName,
-          yaml: serialized.yaml,
-        });
-        const observation = await observeDraftMaterialization({
-          workflowId: renameTarget.workflowId,
-          read: (workflowId) => studioApi.getWorkflowDraft(workflowId, scopeId),
-          isNotFound: (candidate) => isStudioApiStatus(candidate, 404),
-          isObserved: (candidate) => candidate.name.trim() === workflowName,
-        });
-        if (observation.kind === 'delayed') {
-          throw new Error('Workflow rename was not observed');
-        }
-        const refreshed = await drafts.refetch();
-        if (refreshed.isError) throw refreshed.error;
-      }
-
-      if (renameTarget.memberId) {
-        await studioApi.updateMemberDisplayName({
-          scopeId,
-          memberId: renameTarget.memberId,
-          displayName: workflowName,
-        });
-        const observation = await observeDraftMaterialization({
-          workflowId: renameTarget.memberId,
-          read: (memberId) => studioApi.getMember(scopeId, memberId),
-          isNotFound: (candidate) => isStudioApiStatus(candidate, 404),
-          isObserved: (candidate) =>
-            candidate.summary.displayName.trim() === workflowName,
-        });
-        if (observation.kind === 'delayed') {
-          throw new Error('Member rename was not observed');
-        }
-        queryClient.setQueryData<StudioMemberRoster | undefined>(
-          ['workflow-activity-vnext', 'members', scopeId],
-          (current) =>
-            current
-              ? {
-                  ...current,
-                  members: current.members.map((member) =>
-                    member.memberId === renameTarget.memberId
-                      ? observation.workflow.summary
-                      : member,
-                  ),
-                }
-              : current,
-        );
-      }
+      const refreshed = await catalogue.refetch();
+      if (refreshed.isError) throw refreshed.error;
       setRenameTarget(null);
       setRenameName('');
       toast.success(
@@ -494,7 +349,17 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       }
 
       const observation = await observeWorkflowArchival({
-        readWorkflows: () => scopesApi.listWorkflows(scopeId),
+        readWorkflows: async () => {
+          const response = await scopesApi.queryWorkflowCatalogue({
+            scopeId,
+            view: 'all',
+            query: target.workflowId,
+            take: 100,
+          });
+          return response.items
+            .filter((item) => item.workflowId === target.workflowId)
+            .map(toWorkflowRow);
+        },
         workflowId: target.workflowId,
       });
       if (observation.kind === 'delayed') {
@@ -502,11 +367,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         return;
       }
 
-      queryClient.setQueryData(
-        ['workflow-activity-vnext', 'committed', scopeId],
-        observation.workflows,
-      );
-      void committed.refetch();
+      await catalogue.refetch();
       setArchiveTarget(null);
       setArchiveSubmitted(false);
       setArchivePhase('idle');
@@ -558,9 +419,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         }
       }
 
-      suppressNextDraftListError.current = true;
-      const refreshed = await drafts.refetch();
-      if (!refreshed.isError) suppressNextDraftListError.current = false;
+      const refreshed = await catalogue.refetch();
       if (refreshed.isError) throw refreshed.error;
       setDeleteTarget(null);
       setDeleteSucceeded(false);
@@ -641,25 +500,17 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
             options={[
               {
                 label: t(
-                  'workflowActivityVNext.workflows.activeView',
-                  'Active workflows',
+                  'workflowActivityVNext.workflows.allView',
+                  'All workflows',
                 ),
-                value: 'active',
+                value: 'all',
               },
               {
-                disabled: drafts.isError,
                 label: t(
                   'workflowActivityVNext.workflows.draftsView',
                   'Drafts',
                 ),
                 value: 'drafts',
-              },
-              {
-                label: t(
-                  'workflowActivityVNext.workflows.archivedView',
-                  'Archived',
-                ),
-                value: 'archived',
               },
             ]}
             value={view}
@@ -678,34 +529,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           tableMinWidth={900}
           variant="table"
         />
-      ) : view === 'drafts' && drafts.isError ? (
-        <div className="wa-vnext__state" role="alert">
-          <div>
-            <h2>
-              {t(
-                'workflowActivityVNext.workflows.draftsUnavailable',
-                'Draft workflows unavailable',
-              )}
-            </h2>
-            <p>
-              {t(
-                'workflowActivityVNext.workflows.draftsUnavailableDescription',
-                'Try again to load draft workflows.',
-              )}
-            </p>
-            <Button
-              aria-label={t(
-                'workflowActivityVNext.workflows.retryAria',
-                'Retry workflows',
-              )}
-              icon={<ReloadOutlined />}
-              onClick={() => void drafts.refetch()}
-            >
-              {t('workflowActivityVNext.common.retry', 'Retry')}
-            </Button>
-          </div>
-        </div>
-      ) : totalFailure ? (
+      ) : catalogue.isError ? (
         <div className="wa-vnext__state" role="alert">
           <div>
             <h2>
@@ -761,7 +585,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
               <Button
                 onClick={() => {
                   setQuery('');
-                  setView('active');
+                  setView('all');
                 }}
               >
                 {t(
@@ -825,12 +649,6 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 const description = row.description.trim();
                 const isArchived = isWorkflowArchived(row);
                 const isPublished = Boolean(row.activeRevisionId);
-                const showRenameAction =
-                  row.hasDraftSource || Boolean(row.memberId);
-                const showDeleteDraftAction =
-                  row.hasDraftSource && (view === 'drafts' || !isPublished);
-                const showArchiveAction =
-                  view !== 'drafts' && canArchiveWorkflow(row);
                 const workflowName = (
                   <span className="wa-vnext__title">{row.name}</span>
                 );
@@ -927,10 +745,18 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                             { name: row.name, owner: row.ownershipLabel },
                           )}
                           className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-                          href={editorHref}
+                          disabled={!row.capabilities.open.available}
+                          href={
+                            row.capabilities.open.available
+                              ? editorHref
+                              : undefined
+                          }
                           icon={<EditOutlined />}
-                          onClick={(event) =>
-                            handleClientLinkClick(event, editorHref)
+                          onClick={
+                            row.capabilities.open.available
+                              ? (event) =>
+                                  handleClientLinkClick(event, editorHref)
+                              : undefined
                           }
                           type="primary"
                         >
@@ -943,10 +769,18 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                             { name: row.name, owner: row.ownershipLabel },
                           )}
                           className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
-                          href={activityHref}
+                          disabled={!row.capabilities.activity.available}
+                          href={
+                            row.capabilities.activity.available
+                              ? activityHref
+                              : undefined
+                          }
                           icon={<HistoryOutlined />}
-                          onClick={(event) =>
-                            handleClientLinkClick(event, activityHref)
+                          onClick={
+                            row.capabilities.activity.available
+                              ? (event) =>
+                                  handleClientLinkClick(event, activityHref)
+                              : undefined
                           }
                         >
                           {t(
@@ -957,7 +791,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                         <Dropdown
                           menu={{
                             items: [
-                              ...(showRenameAction
+                              ...(row.capabilities.rename.available
                                 ? [
                                     {
                                       icon: <EditOutlined />,
@@ -977,10 +811,11 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                                   'Copy workflow reference',
                                 ),
                               },
-                              ...(showDeleteDraftAction || showArchiveAction
+                              ...(row.capabilities.delete.available ||
+                              canArchiveWorkflow(row)
                                 ? [{ type: 'divider' as const }]
                                 : []),
-                              ...(showDeleteDraftAction
+                              ...(row.capabilities.delete.available
                                 ? [
                                     {
                                       danger: true,
@@ -993,7 +828,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                                     },
                                   ]
                                 : []),
-                              ...(showArchiveAction
+                              ...(canArchiveWorkflow(row)
                                 ? [
                                     {
                                       danger: true,
@@ -1041,6 +876,16 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           </table>
         </TableScrollRegion>
       )}
+      {rows.length > 0 && catalogue.hasNextPage ? (
+        <div className="wa-vnext__pagination-actions">
+          <Button
+            loading={catalogue.isFetchingNextPage}
+            onClick={() => void catalogue.fetchNextPage()}
+          >
+            {t('workflowActivityVNext.workflows.loadMore', 'Load more')}
+          </Button>
+        </div>
+      ) : null}
       <Modal
         cancelButtonProps={{ disabled: archiving }}
         cancelText={t('workflowActivityVNext.common.cancel', 'Cancel')}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -21,10 +21,6 @@ import type {
   ScopeWorkflowCatalogueView,
 } from '@/shared/models/scopes';
 import { history } from '@/shared/navigation/history';
-import {
-  scopeServiceAppId,
-  scopeServiceNamespace,
-} from '@/shared/runs/scopeConsole';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
 import AevatarContentSkeleton from '@/shared/ui/AevatarContentSkeleton';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
@@ -75,6 +71,35 @@ function toWorkflowRow(item: ScopeWorkflowCatalogueRow): WorkflowRow {
   };
 }
 
+async function readWorkflowCatalogueMatch(
+  scopeId: string,
+  workflowId: string,
+): Promise<readonly WorkflowRow[]> {
+  let cursor: string | undefined;
+  const visitedCursors = new Set<string>();
+
+  do {
+    const response = await scopesApi.queryWorkflowCatalogue({
+      scopeId,
+      view: 'all',
+      query: workflowId,
+      cursor,
+      take: 100,
+    });
+    const target = response.items.find(
+      (item) => item.workflowId === workflowId,
+    );
+    if (target) return [toWorkflowRow(target)];
+
+    const nextCursor = response.nextPageToken ?? undefined;
+    if (!nextCursor || visitedCursors.has(nextCursor)) return [];
+    visitedCursors.add(nextCursor);
+    cursor = nextCursor;
+  } while (cursor);
+
+  return [];
+}
+
 function readWorkflowView(params: URLSearchParams): ScopeWorkflowCatalogueView {
   const view = params.get('view');
   return view === 'drafts' ? 'drafts' : 'all';
@@ -117,6 +142,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   const location = useConsoleLocation();
   const toast = useConsoleToast();
   const lastListErrorSignature = React.useRef('');
+  const selfAuthoredSearch = React.useRef<string | null>(null);
   const initialParams = React.useMemo(
     () => new URLSearchParams(location.search),
     [location.search],
@@ -170,6 +196,11 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   });
 
   React.useEffect(() => {
+    if (selfAuthoredSearch.current === location.search) {
+      selfAuthoredSearch.current = null;
+      return;
+    }
+    selfAuthoredSearch.current = null;
     const params = new URLSearchParams(location.search);
     const routeQuery = params.get('q') ?? '';
     setQuery(routeQuery);
@@ -187,8 +218,11 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     if (query.trim()) params.set('q', query.trim());
     if (view !== 'all') params.set('view', view);
     const suffix = params.toString();
-    history.replace(`${location.pathname}${suffix ? `?${suffix}` : ''}`);
-  }, [location.pathname, query, view]);
+    const nextSearch = suffix ? `?${suffix}` : '';
+    if (nextSearch === location.search) return;
+    selfAuthoredSearch.current = nextSearch;
+    history.replace(`${location.pathname}${nextSearch}`);
+  }, [location.pathname, location.search, query, view]);
 
   const loading = catalogue.isPending;
   const rows = React.useMemo(() => {
@@ -211,7 +245,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   }, [renameName, renameTarget, rows]);
 
   React.useEffect(() => {
-    if (loading || !catalogue.isError) return;
+    if (loading || !catalogue.isLoadingError) return;
 
     const errorSignature = [scopeId, catalogue.errorUpdatedAt].join(':');
     if (lastListErrorSignature.current === errorSignature) return;
@@ -220,7 +254,13 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     toast.error(
       t('workflowActivityVNext.workflows.unavailable', 'Workflows unavailable'),
     );
-  }, [catalogue.errorUpdatedAt, catalogue.isError, loading, scopeId, toast]);
+  }, [
+    catalogue.errorUpdatedAt,
+    catalogue.isLoadingError,
+    loading,
+    scopeId,
+    toast,
+  ]);
 
   const retry = () => {
     void catalogue.refetch();
@@ -335,13 +375,29 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
 
     try {
       if (!accepted) {
-        await servicesApi.deactivateDeployment(
+        const detail = await scopesApi.getWorkflowDetail(
+          scopeId,
           target.workflowId,
-          target.deploymentId,
+        );
+        const published = detail.workflow;
+        if (
+          !detail.available ||
+          !published ||
+          published.workflowId !== target.workflowId ||
+          !published.publishedServiceId.trim() ||
+          !published.serviceAppId.trim() ||
+          !published.serviceNamespace.trim() ||
+          !published.deploymentId.trim()
+        ) {
+          throw new Error('Published workflow identity is unavailable');
+        }
+        await servicesApi.deactivateDeployment(
+          published.publishedServiceId,
+          published.deploymentId,
           {
             tenantId: scopeId,
-            appId: scopeServiceAppId,
-            namespace: scopeServiceNamespace,
+            appId: published.serviceAppId,
+            namespace: published.serviceNamespace,
           },
         );
         accepted = true;
@@ -349,17 +405,8 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       }
 
       const observation = await observeWorkflowArchival({
-        readWorkflows: async () => {
-          const response = await scopesApi.queryWorkflowCatalogue({
-            scopeId,
-            view: 'all',
-            query: target.workflowId,
-            take: 100,
-          });
-          return response.items
-            .filter((item) => item.workflowId === target.workflowId)
-            .map(toWorkflowRow);
-        },
+        readWorkflows: () =>
+          readWorkflowCatalogueMatch(scopeId, target.workflowId),
         workflowId: target.workflowId,
       });
       if (observation.kind === 'delayed') {
@@ -481,6 +528,9 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
             'Search workflows',
           )}
           className="wa-vnext__toolbar-search"
+          maxLength={
+            catalogue.data?.pages[0]?.search.maximumQueryLength ?? undefined
+          }
           onChange={(event) => setQuery(event.target.value)}
           placeholder={t(
             'workflowActivityVNext.workflows.search',
@@ -529,7 +579,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           tableMinWidth={900}
           variant="table"
         />
-      ) : catalogue.isError ? (
+      ) : catalogue.isLoadingError ? (
         <div className="wa-vnext__state" role="alert">
           <div>
             <h2>
@@ -878,6 +928,14 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       )}
       {rows.length > 0 && catalogue.hasNextPage ? (
         <div className="wa-vnext__pagination-actions">
+          {catalogue.isFetchNextPageError ? (
+            <p role="alert">
+              {t(
+                'workflowActivityVNext.workflows.loadMoreFailed',
+                "More workflows couldn't be loaded",
+              )}
+            </p>
+          ) : null}
           <Button
             loading={catalogue.isFetchingNextPage}
             onClick={() => void catalogue.fetchNextPage()}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts
@@ -1,26 +1,20 @@
-import type { ScopeWorkflowSummary } from '@/shared/models/scopes';
 import {
   canArchiveWorkflow,
   isWorkflowArchived,
   observeWorkflowArchival,
+  type WorkflowArchivalObservationItem,
 } from './workflowArchival';
 
 function workflowSummary(
   workflowId: string,
   deploymentStatus: string,
-): ScopeWorkflowSummary {
+): WorkflowArchivalObservationItem {
   return {
-    scopeId: 'scope-alpha',
     workflowId,
-    publishedServiceId: `svc-${workflowId}`,
-    displayName: 'Workflow',
-    serviceKey: `scope-alpha:default:default:${workflowId}`,
-    workflowName: 'workflow',
-    actorId: `actor-${workflowId}`,
     activeRevisionId: `rev-${workflowId}`,
     deploymentId: `dep-${workflowId}`,
     deploymentStatus,
-    updatedAt: '2026-08-06T10:00:00Z',
+    hasCommittedSource: true,
   };
 }
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.ts
@@ -1,10 +1,12 @@
-import type { ScopeWorkflowSummary } from '@/shared/models/scopes';
-
 export type WorkflowArchivalFacts = {
   readonly activeRevisionId: string;
   readonly deploymentId: string;
   readonly deploymentStatus: string;
   readonly hasCommittedSource: boolean;
+};
+
+export type WorkflowArchivalObservationItem = WorkflowArchivalFacts & {
+  readonly workflowId: string;
 };
 
 export const WORKFLOW_ARCHIVAL_OBSERVATION_DELAYS_MS = [
@@ -14,7 +16,7 @@ export const WORKFLOW_ARCHIVAL_OBSERVATION_DELAYS_MS = [
 export type WorkflowArchivalObservationResult =
   | {
       readonly kind: 'observed';
-      readonly workflows: readonly ScopeWorkflowSummary[];
+      readonly workflows: readonly WorkflowArchivalObservationItem[];
     }
   | { readonly kind: 'delayed' };
 
@@ -46,7 +48,9 @@ function defaultWait(delayMs: number): Promise<void> {
 
 export async function observeWorkflowArchival(input: {
   readonly delaysMs?: readonly number[];
-  readonly readWorkflows: () => Promise<readonly ScopeWorkflowSummary[]>;
+  readonly readWorkflows: () => Promise<
+    readonly WorkflowArchivalObservationItem[]
+  >;
   readonly wait?: (delayMs: number) => Promise<void>;
   readonly workflowId: string;
 }): Promise<WorkflowArchivalObservationResult> {

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
@@ -170,4 +170,43 @@ describe('scopesApi workflow catalogue', () => {
     expect(response.freshness.refreshWatermarkUtc).toBe('2026-08-04T10:00:00Z');
     expect(response.search.maximumQueryLength).toBe(128);
   });
+
+  it('preserves distinct published service identity from workflow detail', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        available: true,
+        scopeId: 'scope-alpha',
+        workflow: {
+          scopeId: 'scope-alpha',
+          workflowId: 'wf-alpha',
+          displayName: 'Workflow Alpha',
+          serviceKey: 'opaque-service-key',
+          workflowName: 'workflow_alpha',
+          actorId: 'actor-alpha',
+          activeRevisionId: 'rev-alpha',
+          deploymentId: 'dep-alpha',
+          deploymentStatus: 'Active',
+          updatedAt: '2026-08-04T10:00:00Z',
+          publishedServiceId: 'svc-alpha',
+          serviceAppId: 'workflow-app',
+          serviceNamespace: 'workflow-namespace',
+        },
+        source: null,
+      }),
+    } as Response) as typeof global.fetch;
+
+    const response = await scopesApi.getWorkflowDetail(
+      'scope-alpha',
+      'wf-alpha',
+    );
+
+    expect(response.workflow).toMatchObject({
+      workflowId: 'wf-alpha',
+      publishedServiceId: 'svc-alpha',
+      serviceAppId: 'workflow-app',
+      serviceNamespace: 'workflow-namespace',
+    });
+  });
 });

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
@@ -167,9 +167,7 @@ describe('scopesApi workflow catalogue', () => {
       },
     });
     expect(response.items[1]?.committed).toBeNull();
-    expect(response.freshness.refreshWatermarkUtc).toBe(
-      '2026-08-04T10:00:00Z',
-    );
+    expect(response.freshness.refreshWatermarkUtc).toBe('2026-08-04T10:00:00Z');
     expect(response.search.maximumQueryLength).toBe(128);
   });
 });

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
@@ -1,11 +1,27 @@
+import { persistAuthSession } from '@/shared/auth/session';
 import { scopesApi } from './scopesApi';
 
-describe('scopesApi', () => {
+describe('scopesApi workflow catalogue', () => {
   const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: { sub: 'user-1' },
+    });
+  });
 
   afterEach(() => {
     global.fetch = originalFetch;
     jest.restoreAllMocks();
+    window.localStorage.clear();
   });
 
   it('preserves the explicit published service identity on workflow summaries', async () => {
@@ -15,6 +31,8 @@ describe('scopesApi', () => {
           scopeId: 'scope-alpha',
           workflowId: 'legacy-catalogue-row-alpha',
           publishedServiceId: 'svc-alpha',
+          serviceAppId: 'workflow-app',
+          serviceNamespace: 'workflow-namespace',
           displayName: 'Published workflow',
           serviceKey: 'scope-alpha:studio:default:svc-alpha',
           workflowName: 'published_workflow',
@@ -39,6 +57,119 @@ describe('scopesApi', () => {
     ]);
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/scopes/scope-alpha/workflows?includeSource=false',
+      expect.objectContaining({ headers: expect.any(Headers) }),
     );
+  });
+
+  it('queries and decodes the backend-owned workflow catalogue contract', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [
+          {
+            scopeId: 'scope alpha',
+            workflowId: 'wf-alpha',
+            name: '审批 workflow',
+            description: 'Handles approvals',
+            hasDraftSource: true,
+            hasCommittedSource: true,
+            updatedAtUtc: '2026-08-04T10:00:00Z',
+            updatedAtSource: 'committed',
+            capabilities: {
+              open: { available: true, unavailableReason: null },
+              activity: { available: true, unavailableReason: null },
+              rename: { available: true, unavailableReason: null },
+              delete: { available: false, unavailableReason: 'policy_denied' },
+            },
+            sourceWatermarkUtc: '2026-08-04T10:00:00Z',
+            committed: {
+              serviceKey: 'scope-alpha:workflow:default:svc-alpha',
+              workflowName: 'approval_flow',
+              actorId: 'actor-alpha',
+              activeRevisionId: 'rev-alpha',
+              deploymentId: 'dep-alpha',
+              deploymentStatus: 'Active',
+            },
+          },
+          {
+            scopeId: 'scope alpha',
+            workflowId: 'wf-draft',
+            name: 'Draft only',
+            description: '',
+            hasDraftSource: true,
+            hasCommittedSource: false,
+            updatedAtUtc: '2026-08-03T10:00:00Z',
+            updatedAtSource: 'draft',
+            capabilities: {
+              open: { available: true, unavailableReason: null },
+              activity: {
+                available: false,
+                unavailableReason: 'committed_source_missing',
+              },
+              rename: { available: true, unavailableReason: null },
+              delete: { available: true, unavailableReason: null },
+            },
+            sourceWatermarkUtc: '2026-08-03T10:00:00Z',
+            committed: null,
+          },
+        ],
+        nextPageToken: 'next token',
+        freshness: {
+          refreshWatermarkUtc: '2026-08-04T10:00:00Z',
+          sourceVersionSemantics: 'max source timestamp',
+        },
+        search: {
+          searchableFields: ['name', 'description', 'workflowId'],
+          caseSemantics: 'ordinal ignore case',
+          unicodeNormalization: 'FormKC',
+          maximumQueryLength: 128,
+          emptyQuerySemantics: 'no filter',
+          workflowIdSemantics: 'exact or prefix',
+        },
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+    const controller = new AbortController();
+
+    const response = await scopesApi.queryWorkflowCatalogue(
+      {
+        scopeId: 'scope alpha',
+        view: 'drafts',
+        query: '审批 flow',
+        cursor: 'next token',
+        take: 25,
+      },
+      controller.signal,
+    );
+
+    const [input, init] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit | undefined,
+    ];
+    expect(input).toBe(
+      '/api/scopes/scope%20alpha/workflow-catalogue?view=drafts&query=%E5%AE%A1%E6%89%B9+flow&cursor=next+token&take=25',
+    );
+    expect(init?.signal).toBe(controller.signal);
+    expect(response.nextPageToken).toBe('next token');
+    expect(response.items[0]).toMatchObject({
+      workflowId: 'wf-alpha',
+      capabilities: {
+        open: { available: true, unavailableReason: null },
+        activity: { available: true, unavailableReason: null },
+        rename: { available: true, unavailableReason: null },
+        delete: { available: false, unavailableReason: 'policy_denied' },
+      },
+      committed: {
+        serviceKey: 'scope-alpha:workflow:default:svc-alpha',
+        actorId: 'actor-alpha',
+        deploymentId: 'dep-alpha',
+      },
+    });
+    expect(response.items[1]?.committed).toBeNull();
+    expect(response.freshness.refreshWatermarkUtc).toBe(
+      '2026-08-04T10:00:00Z',
+    );
+    expect(response.search.maximumQueryLength).toBe(128);
   });
 });

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.ts
@@ -22,7 +22,6 @@ import {
   readNullableString,
   readNumber,
   readOptionalRecord,
-  readOptionalString,
   readString,
   readStringArray,
   readStringRecord,
@@ -246,12 +245,6 @@ function decodeScopeWorkflowSummary(
       ['workflowId', 'WorkflowId'],
       `${label}.workflowId`,
     ),
-    publishedServiceId:
-      readOptionalString(
-        record,
-        ['publishedServiceId', 'PublishedServiceId'],
-        `${label}.publishedServiceId`,
-      ) ?? '',
     displayName: readString(
       record,
       ['displayName', 'DisplayName'],
@@ -287,6 +280,21 @@ function decodeScopeWorkflowSummary(
       record,
       ['updatedAt', 'UpdatedAt'],
       `${label}.updatedAt`,
+    ),
+    publishedServiceId: readString(
+      record,
+      ['publishedServiceId', 'PublishedServiceId'],
+      `${label}.publishedServiceId`,
+    ),
+    serviceAppId: readString(
+      record,
+      ['serviceAppId', 'ServiceAppId'],
+      `${label}.serviceAppId`,
+    ),
+    serviceNamespace: readString(
+      record,
+      ['serviceNamespace', 'ServiceNamespace'],
+      `${label}.serviceNamespace`,
     ),
   };
 }

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.ts
@@ -3,22 +3,236 @@ import type {
   ScopeScriptDetail,
   ScopeScriptSource,
   ScopeScriptSummary,
+  ScopeWorkflowCatalogueActionCapability,
+  ScopeWorkflowCatalogueCommittedFacts,
+  ScopeWorkflowCatalogueQuery,
+  ScopeWorkflowCatalogueResponse,
+  ScopeWorkflowCatalogueRow,
+  ScopeWorkflowCatalogueRowCapabilities,
   ScopeWorkflowDetail,
   ScopeWorkflowSource,
   ScopeWorkflowSummary,
 } from '@/shared/models/scopes';
-import { requestJson } from './http/client';
+import { requestJson, withQuery } from './http/client';
 import {
   type Decoder,
   expectArray,
   expectRecord,
   readBoolean,
+  readNullableString,
+  readNumber,
   readOptionalRecord,
   readOptionalString,
   readString,
   readStringArray,
   readStringRecord,
 } from './http/decoders';
+
+function decodeScopeWorkflowCatalogueActionCapability(
+  value: unknown,
+  label: string,
+): ScopeWorkflowCatalogueActionCapability {
+  const record = expectRecord(value, label);
+  return {
+    available: readBoolean(
+      record,
+      ['available', 'Available'],
+      `${label}.available`,
+    ),
+    unavailableReason: readNullableString(
+      record,
+      ['unavailableReason', 'UnavailableReason'],
+      `${label}.unavailableReason`,
+    ),
+  };
+}
+
+function decodeScopeWorkflowCatalogueCapabilities(
+  value: unknown,
+  label: string,
+): ScopeWorkflowCatalogueRowCapabilities {
+  const record = expectRecord(value, label);
+  return {
+    open: decodeScopeWorkflowCatalogueActionCapability(
+      record.open ?? record.Open,
+      `${label}.open`,
+    ),
+    activity: decodeScopeWorkflowCatalogueActionCapability(
+      record.activity ?? record.Activity,
+      `${label}.activity`,
+    ),
+    rename: decodeScopeWorkflowCatalogueActionCapability(
+      record.rename ?? record.Rename,
+      `${label}.rename`,
+    ),
+    delete: decodeScopeWorkflowCatalogueActionCapability(
+      record.delete ?? record.Delete,
+      `${label}.delete`,
+    ),
+  };
+}
+
+function decodeScopeWorkflowCatalogueCommittedFacts(
+  value: unknown,
+  label: string,
+): ScopeWorkflowCatalogueCommittedFacts | null {
+  if (value === null || value === undefined) return null;
+
+  const record = expectRecord(value, label);
+  return {
+    serviceKey: readString(
+      record,
+      ['serviceKey', 'ServiceKey'],
+      `${label}.serviceKey`,
+    ),
+    workflowName: readString(
+      record,
+      ['workflowName', 'WorkflowName'],
+      `${label}.workflowName`,
+    ),
+    actorId: readString(record, ['actorId', 'ActorId'], `${label}.actorId`),
+    activeRevisionId: readString(
+      record,
+      ['activeRevisionId', 'ActiveRevisionId'],
+      `${label}.activeRevisionId`,
+    ),
+    deploymentId: readString(
+      record,
+      ['deploymentId', 'DeploymentId'],
+      `${label}.deploymentId`,
+    ),
+    deploymentStatus: readString(
+      record,
+      ['deploymentStatus', 'DeploymentStatus'],
+      `${label}.deploymentStatus`,
+    ),
+  };
+}
+
+function decodeScopeWorkflowCatalogueRow(
+  value: unknown,
+  label = 'ScopeWorkflowCatalogueRow',
+): ScopeWorkflowCatalogueRow {
+  const record = expectRecord(value, label);
+  return {
+    scopeId: readString(record, ['scopeId', 'ScopeId'], `${label}.scopeId`),
+    workflowId: readString(
+      record,
+      ['workflowId', 'WorkflowId'],
+      `${label}.workflowId`,
+    ),
+    name: readString(record, ['name', 'Name'], `${label}.name`),
+    description: readString(
+      record,
+      ['description', 'Description'],
+      `${label}.description`,
+    ),
+    hasDraftSource: readBoolean(
+      record,
+      ['hasDraftSource', 'HasDraftSource'],
+      `${label}.hasDraftSource`,
+    ),
+    hasCommittedSource: readBoolean(
+      record,
+      ['hasCommittedSource', 'HasCommittedSource'],
+      `${label}.hasCommittedSource`,
+    ),
+    updatedAtUtc: readString(
+      record,
+      ['updatedAtUtc', 'UpdatedAtUtc'],
+      `${label}.updatedAtUtc`,
+    ),
+    updatedAtSource: readString(
+      record,
+      ['updatedAtSource', 'UpdatedAtSource'],
+      `${label}.updatedAtSource`,
+    ),
+    capabilities: decodeScopeWorkflowCatalogueCapabilities(
+      record.capabilities ?? record.Capabilities,
+      `${label}.capabilities`,
+    ),
+    sourceWatermarkUtc: readString(
+      record,
+      ['sourceWatermarkUtc', 'SourceWatermarkUtc'],
+      `${label}.sourceWatermarkUtc`,
+    ),
+    committed: decodeScopeWorkflowCatalogueCommittedFacts(
+      record.committed ?? record.Committed,
+      `${label}.committed`,
+    ),
+  };
+}
+
+const decodeScopeWorkflowCatalogueResponse: Decoder<
+  ScopeWorkflowCatalogueResponse
+> = (value, label = 'ScopeWorkflowCatalogueResponse') => {
+  const record = expectRecord(value, label);
+  const freshness = expectRecord(
+    record.freshness ?? record.Freshness,
+    `${label}.freshness`,
+  );
+  const search = expectRecord(
+    record.search ?? record.Search,
+    `${label}.search`,
+  );
+
+  return {
+    items: expectArray(
+      record.items ?? record.Items,
+      `${label}.items`,
+      decodeScopeWorkflowCatalogueRow,
+    ),
+    nextPageToken: readNullableString(
+      record,
+      ['nextPageToken', 'NextPageToken'],
+      `${label}.nextPageToken`,
+    ),
+    freshness: {
+      refreshWatermarkUtc: readNullableString(
+        freshness,
+        ['refreshWatermarkUtc', 'RefreshWatermarkUtc'],
+        `${label}.freshness.refreshWatermarkUtc`,
+      ),
+      sourceVersionSemantics: readString(
+        freshness,
+        ['sourceVersionSemantics', 'SourceVersionSemantics'],
+        `${label}.freshness.sourceVersionSemantics`,
+      ),
+    },
+    search: {
+      searchableFields: readStringArray(
+        search,
+        ['searchableFields', 'SearchableFields'],
+        `${label}.search.searchableFields`,
+      ),
+      caseSemantics: readString(
+        search,
+        ['caseSemantics', 'CaseSemantics'],
+        `${label}.search.caseSemantics`,
+      ),
+      unicodeNormalization: readString(
+        search,
+        ['unicodeNormalization', 'UnicodeNormalization'],
+        `${label}.search.unicodeNormalization`,
+      ),
+      maximumQueryLength: readNumber(
+        search,
+        ['maximumQueryLength', 'MaximumQueryLength'],
+        `${label}.search.maximumQueryLength`,
+      ),
+      emptyQuerySemantics: readString(
+        search,
+        ['emptyQuerySemantics', 'EmptyQuerySemantics'],
+        `${label}.search.emptyQuerySemantics`,
+      ),
+      workflowIdSemantics: readString(
+        search,
+        ['workflowIdSemantics', 'WorkflowIdSemantics'],
+        `${label}.search.workflowIdSemantics`,
+      ),
+    },
+  };
+};
 
 function decodeScopeWorkflowSummary(
   value: unknown,
@@ -283,6 +497,25 @@ const decodeScopeScriptSummaries: Decoder<ScopeScriptSummary[]> = (value) =>
   expectArray(value, 'ScopeScriptSummary[]', decodeScopeScriptSummary);
 
 export const scopesApi = {
+  queryWorkflowCatalogue(
+    input: ScopeWorkflowCatalogueQuery,
+    signal?: AbortSignal,
+  ): Promise<ScopeWorkflowCatalogueResponse> {
+    return requestJson(
+      withQuery(
+        `/api/scopes/${encodeURIComponent(input.scopeId)}/workflow-catalogue`,
+        {
+          view: input.view,
+          query: input.query?.trim() || undefined,
+          cursor: input.cursor,
+          take: input.take,
+        },
+      ),
+      decodeScopeWorkflowCatalogueResponse,
+      { signal },
+    );
+  },
+
   listWorkflows(scopeId: string): Promise<ScopeWorkflowSummary[]> {
     return requestJson(
       `/api/scopes/${encodeURIComponent(scopeId)}/workflows?includeSource=false`,

--- a/apps/aevatar-console-web/src/shared/models/scopes.ts
+++ b/apps/aevatar-console-web/src/shared/models/scopes.ts
@@ -63,7 +63,6 @@ export interface ScopeWorkflowCatalogueQuery {
 export interface ScopeWorkflowSummary {
   scopeId: string;
   workflowId: string;
-  publishedServiceId: string;
   displayName: string;
   serviceKey: string;
   workflowName: string;
@@ -72,6 +71,9 @@ export interface ScopeWorkflowSummary {
   deploymentId: string;
   deploymentStatus: string;
   updatedAt: string;
+  publishedServiceId: string;
+  serviceAppId: string;
+  serviceNamespace: string;
 }
 
 export interface ScopeWorkflowSource {

--- a/apps/aevatar-console-web/src/shared/models/scopes.ts
+++ b/apps/aevatar-console-web/src/shared/models/scopes.ts
@@ -1,3 +1,65 @@
+export type ScopeWorkflowCatalogueView = 'all' | 'drafts';
+
+export interface ScopeWorkflowCatalogueActionCapability {
+  available: boolean;
+  unavailableReason: string | null;
+}
+
+export interface ScopeWorkflowCatalogueRowCapabilities {
+  open: ScopeWorkflowCatalogueActionCapability;
+  activity: ScopeWorkflowCatalogueActionCapability;
+  rename: ScopeWorkflowCatalogueActionCapability;
+  delete: ScopeWorkflowCatalogueActionCapability;
+}
+
+export interface ScopeWorkflowCatalogueCommittedFacts {
+  serviceKey: string;
+  workflowName: string;
+  actorId: string;
+  activeRevisionId: string;
+  deploymentId: string;
+  deploymentStatus: string;
+}
+
+export interface ScopeWorkflowCatalogueRow {
+  scopeId: string;
+  workflowId: string;
+  name: string;
+  description: string;
+  hasDraftSource: boolean;
+  hasCommittedSource: boolean;
+  updatedAtUtc: string;
+  updatedAtSource: string;
+  capabilities: ScopeWorkflowCatalogueRowCapabilities;
+  sourceWatermarkUtc: string;
+  committed: ScopeWorkflowCatalogueCommittedFacts | null;
+}
+
+export interface ScopeWorkflowCatalogueResponse {
+  items: ScopeWorkflowCatalogueRow[];
+  nextPageToken: string | null;
+  freshness: {
+    refreshWatermarkUtc: string | null;
+    sourceVersionSemantics: string;
+  };
+  search: {
+    searchableFields: string[];
+    caseSemantics: string;
+    unicodeNormalization: string;
+    maximumQueryLength: number;
+    emptyQuerySemantics: string;
+    workflowIdSemantics: string;
+  };
+}
+
+export interface ScopeWorkflowCatalogueQuery {
+  scopeId: string;
+  view: ScopeWorkflowCatalogueView;
+  query?: string;
+  cursor?: string;
+  take?: number;
+}
+
 export interface ScopeWorkflowSummary {
   scopeId: string;
   workflowId: string;

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -590,6 +590,9 @@ describe('studioApi host-session requests', () => {
               deploymentId: 'dep-draft',
               deploymentStatus: 'Running',
               updatedAt: '2026-04-15T00:00:00Z',
+              publishedServiceId: 'published-draft',
+              serviceAppId: 'workflow-app',
+              serviceNamespace: 'workflow-namespace',
             },
             {
               scopeId: 'scope-1',
@@ -602,6 +605,9 @@ describe('studioApi host-session requests', () => {
               deploymentId: 'dep-published',
               deploymentStatus: 'Running',
               updatedAt: '2026-04-14T00:00:00Z',
+              publishedServiceId: 'published-workflow',
+              serviceAppId: 'workflow-app',
+              serviceNamespace: 'workflow-namespace',
             },
           ],
         } as Response;
@@ -687,6 +693,9 @@ describe('studioApi host-session requests', () => {
                 deploymentId: 'dep-1',
                 deploymentStatus: 'Pending',
                 updatedAt: '2026-04-16T00:00:00Z',
+                publishedServiceId: 'published-workflow-1',
+                serviceAppId: 'workflow-app',
+                serviceNamespace: 'workflow-namespace',
               },
               source: {
                 workflowYaml: 'name: published-demo\nsteps: []\n',
@@ -753,6 +762,9 @@ describe('studioApi host-session requests', () => {
           deploymentId: 'dep-1',
           deploymentStatus: 'Running',
           updatedAt: '2026-04-17T00:00:00Z',
+          publishedServiceId: 'published-workflow-1',
+          serviceAppId: 'workflow-app',
+          serviceNamespace: 'workflow-namespace',
         },
         source: {
           workflowYaml: 'name: published-demo-v2\nsteps: []\n',

--- a/docs/superpowers/plans/2026-08-07-workflow-catalogue-frontend.md
+++ b/docs/superpowers/plans/2026-08-07-workflow-catalogue-frontend.md
@@ -1,0 +1,452 @@
+# Workflow Catalogue Frontend Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Workflow Activity vNext browser-owned draft/committed catalogue join with the backend scope workflow catalogue query.
+
+**Architecture:** Add the backend response and query types to the scope models, decode the contract at `scopesApi`, and consume it with one cancellable cursor query in `WorkflowsPage`. The page renders backend ordering and capabilities directly; existing write operations remain unchanged and invalidate the new catalogue after their observations complete.
+
+**Tech Stack:** React 19, TypeScript 5.6, TanStack React Query 5, Ant Design 6, Jest 29, Testing Library.
+
+---
+
+## File Map
+
+- Modify `apps/aevatar-console-web/src/shared/models/scopes.ts`: own the strong frontend representation of the backend scope workflow catalogue contract.
+- Modify `apps/aevatar-console-web/src/shared/api/scopesApi.ts`: decode the catalogue response and build the typed query URL with cancellation.
+- Create `apps/aevatar-console-web/src/shared/api/scopesApi.test.ts`: verify URL, signal, and boundary decoding behavior.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`: replace two list queries and browser semantics with the backend cursor query.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`: verify catalogue views, search, pagination, capabilities, identity isolation, and mutation refresh behavior.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts`: add stable layout for the pagination command below the table.
+
+### Task 1: Add The Typed Scope Catalogue API
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/shared/models/scopes.ts`
+- Modify: `apps/aevatar-console-web/src/shared/api/scopesApi.ts`
+- Create: `apps/aevatar-console-web/src/shared/api/scopesApi.test.ts`
+
+- [ ] **Step 1: Write the failing API contract test**
+
+Create `scopesApi.test.ts` with an authenticated fetch fixture. Return one camel-case catalogue response containing an overlapping row and assert that this call:
+
+```ts
+const controller = new AbortController();
+const response = await scopesApi.queryWorkflowCatalogue(
+  {
+    scopeId: 'scope alpha',
+    view: 'drafts',
+    query: '审批 flow',
+    cursor: 'next token',
+    take: 25,
+  },
+  controller.signal,
+);
+```
+
+requests:
+
+```text
+/api/scopes/scope%20alpha/workflow-catalogue?view=drafts&query=%E5%AE%A1%E6%89%B9+flow&cursor=next+token&take=25
+```
+
+Assert `init.signal === controller.signal`, the decoded `workflowId` is `wf-alpha`, all four capability values are retained, committed facts remain distinct, `nextPageToken` is retained, and a `null` committed object decodes as `null` in a second row.
+
+- [ ] **Step 2: Run the API test to verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web jest src/shared/api/scopesApi.test.ts --runInBand
+```
+
+Expected: FAIL because `queryWorkflowCatalogue` and the catalogue model types do not exist.
+
+- [ ] **Step 3: Add exact catalogue model types**
+
+Add these public shapes to `scopes.ts`:
+
+```ts
+export type ScopeWorkflowCatalogueView = 'all' | 'drafts';
+
+export interface ScopeWorkflowCatalogueActionCapability {
+  available: boolean;
+  unavailableReason: string | null;
+}
+
+export interface ScopeWorkflowCatalogueRowCapabilities {
+  open: ScopeWorkflowCatalogueActionCapability;
+  activity: ScopeWorkflowCatalogueActionCapability;
+  rename: ScopeWorkflowCatalogueActionCapability;
+  delete: ScopeWorkflowCatalogueActionCapability;
+}
+
+export interface ScopeWorkflowCatalogueCommittedFacts {
+  serviceKey: string;
+  workflowName: string;
+  actorId: string;
+  activeRevisionId: string;
+  deploymentId: string;
+  deploymentStatus: string;
+}
+
+export interface ScopeWorkflowCatalogueRow {
+  scopeId: string;
+  workflowId: string;
+  name: string;
+  description: string;
+  hasDraftSource: boolean;
+  hasCommittedSource: boolean;
+  updatedAtUtc: string;
+  updatedAtSource: string;
+  capabilities: ScopeWorkflowCatalogueRowCapabilities;
+  sourceWatermarkUtc: string;
+  committed: ScopeWorkflowCatalogueCommittedFacts | null;
+}
+
+export interface ScopeWorkflowCatalogueResponse {
+  items: ScopeWorkflowCatalogueRow[];
+  nextPageToken: string | null;
+  freshness: {
+    refreshWatermarkUtc: string | null;
+    sourceVersionSemantics: string;
+  };
+  search: {
+    searchableFields: string[];
+    caseSemantics: string;
+    unicodeNormalization: string;
+    maximumQueryLength: number;
+    emptyQuerySemantics: string;
+    workflowIdSemantics: string;
+  };
+}
+
+export interface ScopeWorkflowCatalogueQuery {
+  scopeId: string;
+  view: ScopeWorkflowCatalogueView;
+  query?: string;
+  cursor?: string;
+  take?: number;
+}
+```
+
+- [ ] **Step 4: Implement strict boundary decoders and the API method**
+
+In `scopesApi.ts`, add focused decoders using the existing `expectRecord`, `expectArray`, `readBoolean`, `readNumber`, `readNullableString`, `readString`, and `readStringArray` helpers. Decode both camel-case and Pascal-case keys, matching the existing API boundary style.
+
+Add:
+
+```ts
+queryWorkflowCatalogue(
+  input: ScopeWorkflowCatalogueQuery,
+  signal?: AbortSignal,
+): Promise<ScopeWorkflowCatalogueResponse> {
+  return requestJson(
+    withQuery(
+      `/api/scopes/${encodeURIComponent(input.scopeId)}/workflow-catalogue`,
+      {
+        view: input.view,
+        query: input.query?.trim() || undefined,
+        cursor: input.cursor,
+        take: input.take,
+      },
+    ),
+    decodeScopeWorkflowCatalogueResponse,
+    { signal },
+  );
+}
+```
+
+Import `withQuery` from the HTTP client. Do not reuse `ScopeWorkflowSummary`; the catalogue has a different semantic contract.
+
+- [ ] **Step 5: Run the API test to verify GREEN**
+
+Run the same focused Jest command. Expected: PASS with no warnings.
+
+- [ ] **Step 6: Commit the API increment**
+
+```bash
+git add apps/aevatar-console-web/src/shared/models/scopes.ts \
+  apps/aevatar-console-web/src/shared/api/scopesApi.ts \
+  apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+git commit -m "Add scope workflow catalogue client"
+```
+
+### Task 2: Replace Client Catalogue Semantics With The Backend Query
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts`
+
+- [ ] **Step 1: Replace catalogue mocks and write failing page tests**
+
+Extend the `scopesApi` mock with `queryWorkflowCatalogue`. Replace the catalogue setup in the directly affected tests with responses shaped as:
+
+```ts
+{
+  items: [catalogueRow],
+  nextPageToken: null,
+  freshness: {
+    refreshWatermarkUtc: '2026-08-04T10:00:00Z',
+    sourceVersionSemantics: 'max source timestamp',
+  },
+  search: {
+    searchableFields: ['name', 'description', 'workflowId'],
+    caseSemantics: 'ordinal ignore case',
+    unicodeNormalization: 'FormKC',
+    maximumQueryLength: 128,
+    emptyQuerySemantics: 'no filter',
+    workflowIdSemantics: 'exact or prefix',
+  },
+}
+```
+
+Add focused tests proving:
+
+```ts
+expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
+  expect.objectContaining({ scopeId: 'scope-alpha', view: 'all', take: 50 }),
+  expect.any(AbortSignal),
+);
+expect(mockStudioApi.listWorkflowDrafts).not.toHaveBeenCalled();
+expect(mockScopesApi.listWorkflows).not.toHaveBeenCalled();
+```
+
+Also assert the selector offers `All workflows` and `Drafts`, does not offer Active or Archived, and a legacy `?view=archived` URL queries `view=all`.
+
+Add a server-order assertion using two rows whose timestamps would have caused the old browser sort to reverse them.
+
+- [ ] **Step 2: Run only the new catalogue page tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web jest \
+  src/pages/workflow-activity-vnext/index.test.tsx \
+  --runInBand \
+  --testNamePattern='backend catalogue|All workflows|legacy catalogue|backend row order'
+```
+
+Expected: FAIL because the page still calls and merges the two old sources.
+
+- [ ] **Step 3: Implement backend view state, debounce, and infinite query**
+
+In `WorkflowsPage.tsx`:
+
+- Replace `WorkflowView` with `ScopeWorkflowCatalogueView`.
+- Make `readWorkflowView` return only `all` or `drafts`, defaulting all other values to `all`.
+- Remove `toDraftRow`, `toCommittedRow`, both old list queries, `draftWorkflowIds`, and the merge/filter/sort memo.
+- Keep raw input state and derive a debounced query with a local effect and 300 ms timer cleanup.
+- Use `useInfiniteQuery` with a query key containing scope, view, and debounced query.
+
+Use this query shape:
+
+```ts
+const catalogue = useInfiniteQuery({
+  queryKey: [
+    'workflow-activity-vnext',
+    'workflow-catalogue',
+    scopeId,
+    view,
+    debouncedQuery,
+  ],
+  initialPageParam: undefined as string | undefined,
+  queryFn: ({ pageParam, signal }) =>
+    scopesApi.queryWorkflowCatalogue(
+      {
+        scopeId,
+        view,
+        query: debouncedQuery || undefined,
+        cursor: pageParam,
+        take: 50,
+      },
+      signal,
+    ),
+  getNextPageParam: (lastPage) => lastPage.nextPageToken ?? undefined,
+  retry: false,
+});
+```
+
+Map loaded items to presentation rows without changing order. Use `committed?.activeRevisionId`, `deploymentId`, and `deploymentStatus`, defaulting presentation-only missing strings to empty strings. Keep every identity in its named field.
+
+Write only `view=drafts` to the URL; omit `view=all` as the default. Keep trimmed `q` in the URL.
+
+- [ ] **Step 4: Render cursor pagination without disturbing existing rows**
+
+Below `TableScrollRegion`, render a stable pagination action only when `catalogue.hasNextPage` is true:
+
+```tsx
+<div className="wa-vnext__pagination-actions">
+  <Button
+    loading={catalogue.isFetchingNextPage}
+    onClick={() => void catalogue.fetchNextPage()}
+  >
+    {t('workflowActivityVNext.workflows.loadMore', 'Load more')}
+  </Button>
+</div>
+```
+
+Add a compact flex rule in `styles.ts` that reserves stable spacing and right-aligns the command on desktop while stretching it on small screens.
+
+- [ ] **Step 5: Run the focused page tests to verify GREEN**
+
+Run the exact command from Step 2. Expected: PASS.
+
+- [ ] **Step 6: Write and verify RED tests for search cancellation and pagination**
+
+Use fake timers to type `审批`, assert no second query before 300 ms, advance timers, and assert the new request receives `query: '审批'` plus an AbortSignal.
+
+Return a first page with `nextPageToken: '1'`, click Load more, and assert the next request carries `cursor: '1'`; then resolve the second page and assert both pages render in backend order.
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web jest \
+  src/pages/workflow-activity-vnext/index.test.tsx \
+  --runInBand \
+  --testNamePattern='debounces backend catalogue search|loads the next catalogue page'
+```
+
+Expected before final implementation adjustments: FAIL on the new assertions. After implementing timer cleanup and next-page rendering: PASS.
+
+- [ ] **Step 7: Commit the query migration increment**
+
+```bash
+git add apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+git commit -m "Use backend workflow catalogue query"
+```
+
+### Task 3: Honor Backend Capabilities And Refresh The Catalogue
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
+
+- [ ] **Step 1: Write failing capability and refresh tests**
+
+Add one row with `activity.available=false`, `rename.available=false`, and `delete.available=false`; assert Activity is disabled and Rename/Delete menu entries are absent even when source flags might otherwise imply availability.
+
+Add mutation assertions that successful rename, delete, and observed archive each call:
+
+```ts
+expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
+```
+
+Do not assert a refresh through `listWorkflowDrafts` or cache writes to the removed committed query key.
+
+- [ ] **Step 2: Run the capability tests to verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web jest \
+  src/pages/workflow-activity-vnext/index.test.tsx \
+  --runInBand \
+  --testNamePattern='backend catalogue capabilities|refreshes the catalogue after rename|refreshes the catalogue after delete|refreshes the catalogue after archive'
+```
+
+Expected: FAIL because actions and mutation refreshes still use old source facts and query instances.
+
+- [ ] **Step 3: Bind actions to capabilities and catalogue refresh**
+
+- Disable Open and Activity when their backend capability is unavailable. Do not construct client navigation for a disabled action.
+- Include Rename and Delete menu entries only when their backend capability is available.
+- Continue deriving Archive only through `canArchiveWorkflow` because the backend catalogue capability set does not define Archive.
+- Replace successful `drafts.refetch()` and `committed.refetch()` calls with `catalogue.refetch()`.
+- Remove the old committed query cache write after archive observation.
+- Make archive observation read `view=all` from `queryWorkflowCatalogue`, use the exact workflow ID as `query`, and select the exact `workflowId` from the returned rows. Do not call `listWorkflows` as a fallback.
+- Simplify error reporting to one catalogue error signature and one retry handler.
+
+- [ ] **Step 4: Run the focused capability tests to verify GREEN**
+
+Run the exact command from Step 2. Expected: PASS.
+
+- [ ] **Step 5: Run the complete directly affected test files**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web jest \
+  src/shared/api/scopesApi.test.ts \
+  src/pages/workflow-activity-vnext/index.test.tsx \
+  --runInBand
+```
+
+Expected: both suites pass. Fix only failures caused by the catalogue migration; preserve unrelated assertions and behavior.
+
+- [ ] **Step 6: Commit the capability increment**
+
+```bash
+git add apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx \
+  apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+git commit -m "Honor workflow catalogue capabilities"
+```
+
+### Task 4: Focused Validation And Pull Request Delivery
+
+**Files:**
+- Review all task files and the two planning documents.
+
+- [ ] **Step 1: Run the frontend scope analyzer**
+
+```bash
+python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py \
+  --repo . \
+  --base origin/feat/2026-08-04_workflow-activity-vnext
+```
+
+Read the reported affected tests and `staticCheckFiles`. Do not expand to a full frontend command.
+
+- [ ] **Step 2: Run the required test stability guard**
+
+```bash
+bash tools/ci/test_stability_guards.sh
+```
+
+Expected: PASS because the timer-based debounce test uses Jest fake timers rather than repository polling helpers.
+
+- [ ] **Step 3: Run changed-file static checks only**
+
+Use Biome against exactly the analyzer's TypeScript/TSX `staticCheckFiles`, for example:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec biome lint \
+  src/shared/models/scopes.ts \
+  src/shared/api/scopesApi.ts \
+  src/shared/api/scopesApi.test.ts \
+  src/pages/workflow-activity-vnext/index.test.tsx \
+  src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx \
+  src/pages/workflow-activity-vnext/styles.ts
+```
+
+Do not run local `tsc`, full lint, full test, or production build. No reliable affected-only typecheck target exists, so GitHub CI owns full type verification.
+
+- [ ] **Step 4: Review and commit any validation-only fixes**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff origin/feat/2026-08-04_workflow-activity-vnext...HEAD -- \
+  apps/aevatar-console-web \
+  docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md \
+  docs/superpowers/plans/2026-08-07-workflow-catalogue-frontend.md
+```
+
+Stage only task files and use `Fix workflow catalogue frontend validation` if a final validation commit is necessary.
+
+- [ ] **Step 5: Push and create the pull request**
+
+Push `feat/2026-08-07_workflow-catalogue-frontend` and create a PR targeting `feat/2026-08-04_workflow-activity-vnext`.
+
+The PR body must contain Problem and solution, Impacted paths, and Local verification. Record every exact focused command and result, plus:
+
+```text
+Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
+```
+
+Stop after returning the PR URL. Do not babysit CI.

--- a/docs/superpowers/plans/2026-08-07-workflow-catalogue-frontend.md
+++ b/docs/superpowers/plans/2026-08-07-workflow-catalogue-frontend.md
@@ -297,7 +297,7 @@ Run the exact command from Step 2. Expected: PASS.
 
 Use fake timers to type `审批`, assert no second query before 300 ms, advance timers, and assert the new request receives `query: '审批'` plus an AbortSignal.
 
-Return a first page with `nextPageToken: '1'`, click Load more, and assert the next request carries `cursor: '1'`; then resolve the second page and assert both pages render in backend order.
+Return a first page with `nextPageToken: '1'`, click Load more, and assert the next request carries `cursor: '1'`; then resolve the second page and assert both pages render in backend order. Also reject a next-page request, assert the first page remains visible with a local pagination error, then retry the same cursor successfully.
 
 Run:
 
@@ -355,9 +355,10 @@ Expected: FAIL because actions and mutation refreshes still use old source facts
 - Disable Open and Activity when their backend capability is unavailable. Do not construct client navigation for a disabled action.
 - Include Rename and Delete menu entries only when their backend capability is available.
 - Continue deriving Archive only through `canArchiveWorkflow` because the backend catalogue capability set does not define Archive.
+- Resolve the archive command identity from `getWorkflowDetail`: require the exact `workflowId`, then pass the backend-provided `publishedServiceId`, `serviceAppId`, `serviceNamespace`, and `deploymentId`. Never parse `serviceKey` or substitute `workflowId` for `publishedServiceId`.
 - Replace successful `drafts.refetch()` and `committed.refetch()` calls with `catalogue.refetch()`.
 - Remove the old committed query cache write after archive observation.
-- Make archive observation read `view=all` from `queryWorkflowCatalogue`, use the exact workflow ID as `query`, and select the exact `workflowId` from the returned rows. Do not call `listWorkflows` as a fallback.
+- Make archive observation read `view=all` from `queryWorkflowCatalogue`, use the exact workflow ID as `query`, follow `nextPageToken` until exhausted, and select only the exact `workflowId` from the returned rows. Do not call `listWorkflows` as a fallback.
 - Simplify error reporting to one catalogue error signature and one retry handler.
 
 - [ ] **Step 4: Run the focused capability tests to verify GREEN**

--- a/docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md
+++ b/docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md
@@ -1,0 +1,98 @@
+# Workflow Catalogue Frontend Integration Design
+
+## Goal
+
+Migrate the Workflow Activity vNext catalogue from two client-owned source queries to the backend-owned scope workflow catalogue contract.
+
+The page must stop joining draft and committed rows, stop filtering or sorting the complete catalogue in browser memory, and stop treating workflow, member, published service, deployment, or actor identities as interchangeable.
+
+## Backend Contract
+
+The frontend will call:
+
+```http
+GET /api/scopes/{scopeId}/workflow-catalogue?view=all|drafts&query={query}&cursor={cursor}&take=50
+```
+
+The API client will model and decode the complete response:
+
+- `items`
+- `nextPageToken`
+- `freshness`
+- `search`
+- row source facts
+- row capabilities
+- committed workflow facts
+
+The API belongs in `scopesApi` because its route, authorization boundary, and returned runtime facts are scope-owned. The query accepts an `AbortSignal` so React Query can cancel superseded searches and view changes.
+
+## Page Semantics
+
+The catalogue selector will contain only the backend-supported views:
+
+- `All workflows` maps to `view=all`.
+- `Drafts` maps to `view=drafts`.
+
+The old `Active workflows` and `Archived` catalogue filters will be removed. Existing URL values outside `all|drafts`, including `active` and `archived`, will resolve to `all`. Archived workflows remain visible in `All workflows` and retain their row-level Archived status.
+
+Search text remains visible immediately and is written to the URL. A short debounce controls the server query. The query key contains `scopeId`, backend view, and debounced search text. React Query cancels the obsolete request when any of those values changes.
+
+The page will use cursor-based infinite querying with `take=50`. It will render returned pages in backend order and expose a Load more command while `nextPageToken` is present. The client may flatten loaded pages for rendering, but it must not join, filter, or sort catalogue rows.
+
+## Row Mapping And Actions
+
+The page will map each backend row directly to its presentation model:
+
+- `workflowId` remains the only workflow route and Activity query identity.
+- `name`, `description`, and `updatedAtUtc` come directly from the catalogue row.
+- runtime fields come only from the optional `committed` object.
+- the ownership label remains the scope workspace label because the catalogue response does not expose a directory owner.
+
+`Open`, `Activity`, `Rename`, and `Delete` availability will come from the corresponding backend capability fields. Unavailable primary actions will be disabled rather than inferred from source flags. Rename and Delete menu entries will be present only when their capabilities are available.
+
+Archive is not part of the new catalogue capability contract. The existing archive eligibility policy remains based on committed deployment facts and deployment status. After archive observation succeeds, the catalogue query is invalidated and refreshed.
+
+Rename and Delete continue to use their existing command paths. After successful materialization or deletion, they refresh the catalogue query instead of refreshing the removed draft list query.
+
+## Loading And Failure States
+
+The two-source partial-failure model will be deleted. The first catalogue page has one loading state, one failure state, and one retry action.
+
+Loading another page keeps existing rows visible and disables the Load more command while the request is pending. A next-page failure keeps existing rows visible and allows the same command to retry.
+
+An empty `items` result is authoritative for the selected backend view and search query.
+
+## Testing
+
+Implementation will follow test-first development.
+
+Focused API tests will verify:
+
+- exact route and query parameter encoding
+- `all` and `drafts` view values
+- cursor and `take` propagation
+- AbortSignal propagation
+- response decoding, including nullable committed facts and capabilities
+
+Focused Workflow Activity tests will verify:
+
+- one catalogue request replaces the draft and committed list requests
+- only All workflows and Drafts are offered
+- URL restoration maps unsupported legacy values to All workflows
+- search is debounced and superseded requests are cancelable
+- Drafts is sent to the server instead of applied in browser memory
+- backend row order is preserved
+- Load more uses `nextPageToken` and appends the next page
+- row actions honor backend capabilities
+- archive, rename, and delete refresh the catalogue query
+- workflow routes never use member, service, deployment, or actor identities
+
+Local validation will run only directly related Jest files and changed-file static checks. Full frontend tests, typecheck, and production build remain delegated to GitHub CI.
+
+## Non-Goals
+
+- Adding frontend-only Active or Archived catalogue filters
+- Downloading every page to recreate those filters
+- Changing backend catalogue semantics
+- Changing archive, rename, delete, or workflow publication command contracts
+- Refactoring unrelated Workflow Activity pages

--- a/docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md
+++ b/docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md
@@ -50,7 +50,7 @@ The page will map each backend row directly to its presentation model:
 
 `Open`, `Activity`, `Rename`, and `Delete` availability will come from the corresponding backend capability fields. Unavailable primary actions will be disabled rather than inferred from source flags. Rename and Delete menu entries will be present only when their capabilities are available.
 
-Archive is not part of the new catalogue capability contract. The existing archive eligibility policy remains based on committed deployment facts and deployment status. After archive observation succeeds, the catalogue query is invalidated and refreshed.
+Archive is not part of the new catalogue capability contract. The existing archive eligibility policy remains based on committed deployment facts and deployment status. The catalogue does not expose the published service identity needed by the archive command, so confirmation resolves `publishedServiceId`, `serviceAppId`, `serviceNamespace`, and the authoritative `deploymentId` from the workflow detail read model. The frontend must not parse `serviceKey` or substitute `workflowId` for a service identity. Archive observation searches the catalogue in `view=all` and follows every returned cursor until the exact `workflowId` is found or the result is exhausted. After archive observation succeeds, the catalogue query is refreshed.
 
 Rename and Delete continue to use their existing command paths. After successful materialization or deletion, they refresh the catalogue query instead of refreshing the removed draft list query.
 
@@ -58,7 +58,7 @@ Rename and Delete continue to use their existing command paths. After successful
 
 The two-source partial-failure model will be deleted. The first catalogue page has one loading state, one failure state, and one retry action.
 
-Loading another page keeps existing rows visible and disables the Load more command while the request is pending. A next-page failure keeps existing rows visible and allows the same command to retry.
+Loading another page keeps existing rows visible and disables the Load more command while the request is pending. A next-page failure keeps existing rows visible, reports the failure beside the pagination action, and allows the same command to retry.
 
 An empty `items` result is authoritative for the selected backend view and search query.
 
@@ -73,6 +73,7 @@ Focused API tests will verify:
 - cursor and `take` propagation
 - AbortSignal propagation
 - response decoding, including nullable committed facts and capabilities
+- distinct published service identity from the workflow detail contract
 
 Focused Workflow Activity tests will verify:
 
@@ -83,8 +84,9 @@ Focused Workflow Activity tests will verify:
 - Drafts is sent to the server instead of applied in browser memory
 - backend row order is preserved
 - Load more uses `nextPageToken` and appends the next page
+- a failed next page preserves loaded rows and retries the same cursor
 - row actions honor backend capabilities
-- archive, rename, and delete refresh the catalogue query
+- archive resolves its distinct service identity, observes across catalogue pages, and refreshes the catalogue query
 - workflow routes never use member, service, deployment, or actor identities
 
 Local validation will run only directly related Jest files and changed-file static checks. Full frontend tests, typecheck, and production build remain delegated to GitHub CI.


### PR DESCRIPTION
## Problem and solution

Workflow Activity assembled its catalogue in the browser by joining draft, committed workflow, and member APIs. That duplicated backend ownership of row identity, ordering, filtering, capabilities, and pagination.

This change adopts the backend-owned `GET /api/scopes/{scopeId}/workflow-catalogue` contract directly. The page now uses backend `all` and `drafts` views, preserves server order, debounces search, forwards cancellation, paginates by cursor, and renders actions from backend capabilities. Rename, delete, and archive refresh the catalogue. Archive resolution reads the backend workflow detail for `publishedServiceId`, `serviceAppId`, and `serviceNamespace`, and archive observation follows catalogue page tokens until the exact workflow ID is found.

## Impacted paths

- `apps/aevatar-console-web/src/shared/models/scopes.ts`
- `apps/aevatar-console-web/src/shared/api/scopesApi.ts`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowArchival.ts`
- Related focused Jest tests and Workflow Activity styles
- `docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md`
- `docs/superpowers/plans/2026-08-07-workflow-catalogue-frontend.md`

## Base

- `feat/2026-08-04_workflow-activity-vnext`

## Local verification

- Related tests, batch 1: `pnpm exec jest src/pages/team-member-workflow-studio/index.test.tsx src/pages/teams/detail.test.tsx src/pages/studio/index.test.tsx src/pages/chat/index.test.tsx src/pages/studio/components/StudioFilesPage.test.tsx src/pages/settings/index.test.tsx src/pages/studio/components/StudioMemberInvokePanel.test.tsx src/pages/Deployments/index.test.tsx src/pages/gagents/index.test.tsx src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx --runInBand` - 10 suites passed, 411 tests passed
- Related tests, batch 2: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx src/pages/scopes/invoke.test.tsx src/pages/teams/home.test.tsx src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx src/pages/governance/index.test.tsx src/pages/scopes/assets.test.tsx src/pages/services/index.test.tsx src/pages/workflow-activity-vnext/activity/RunDetailPage.test.tsx src/pages/runtime-published-runs/index.test.tsx src/pages/MissionWall/index.test.tsx --runInBand` - 10 suites passed, 191 tests passed
- Related tests, batch 3: `pnpm exec jest src/pages/teams/new.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx src/pages/team-member-invoke/index.test.tsx src/shared/studio/api.test.ts src/pages/scopes/files.test.tsx src/pages/workflow-activity-vnext/hooks/useWorkflowPublication.test.ts src/shared/studio/memberDeletion.test.ts src/pages/workflow-activity-vnext/hooks/useDraftMaterialization.test.ts src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts src/shared/api/scopesApi.test.ts --runInBand` - 10 suites passed, 116 tests passed
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx src/pages/workflow-activity-vnext/workflows/workflowArchival.test.ts src/pages/workflow-activity-vnext/workflows/workflowArchival.ts src/shared/api/scopesApi.test.ts src/shared/api/scopesApi.ts src/shared/models/scopes.ts src/shared/studio/api.test.ts` - 9 files passed
- Test stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Diff whitespace check: `git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD` - passed
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy