### PR TITLE
Fix workflow draft filtering and refresh loading

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -554,6 +554,7 @@ const workflowActivityVNextMessages = {
     "The page you requested isn't available.",
   'workflowActivityVNext.unavailable.title': 'Unavailable',
   'workflowActivityVNext.workflows.activeView': 'Active workflows',
+  'workflowActivityVNext.workflows.allView': 'All workflows',
   'workflowActivityVNext.workflows.archive': 'Archive',
   'workflowActivityVNext.workflows.archiveCheckAgain': 'Check again',
   'workflowActivityVNext.workflows.archiveConfirm': 'Archive workflow',
@@ -596,6 +597,9 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.empty': 'No workflows yet',
   'workflowActivityVNext.workflows.emptyDescription':
     'Create a workflow to get started.',
+  'workflowActivityVNext.workflows.loadMore': 'Load more',
+  'workflowActivityVNext.workflows.loadMoreFailed':
+    "More workflows couldn't be loaded",
   'workflowActivityVNext.workflows.loading': 'Loading workflows…',
   'workflowActivityVNext.workflows.moreActionsAria':
     'More actions for {name} in {owner}',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -515,6 +515,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.unavailable.description': '你请求的页面不可用。',
     'workflowActivityVNext.unavailable.title': '不可用',
     'workflowActivityVNext.workflows.activeView': '活跃工作流',
+    'workflowActivityVNext.workflows.allView': '全部工作流',
     'workflowActivityVNext.workflows.archive': '归档',
     'workflowActivityVNext.workflows.archiveCheckAgain': '再次检查',
     'workflowActivityVNext.workflows.archiveConfirm': '归档工作流',
@@ -555,6 +556,8 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.empty': '暂无工作流',
     'workflowActivityVNext.workflows.emptyDescription':
       '创建一个工作流即可开始。',
+    'workflowActivityVNext.workflows.loadMore': '加载更多',
+    'workflowActivityVNext.workflows.loadMoreFailed': '无法加载更多工作流',
     'workflowActivityVNext.workflows.loading': '正在加载工作流…',
     'workflowActivityVNext.workflows.moreActionsAria':
       '{owner}中{name}的更多操作',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -574,6 +574,122 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
+  it('excludes published workflows from the Drafts product view', async () => {
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=drafts';
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-draft-alpha',
+          name: 'Support triage draft',
+        }),
+        createCatalogueRow({
+          workflowId: 'wf-published-alpha',
+          name: 'Published support workflow',
+          committed: {
+            serviceKey: 'service-key-alpha',
+            workflowName: 'published_support_workflow',
+            actorId: 'actor-alpha',
+            activeRevisionId: 'rev-alpha',
+            deploymentId: 'dep-alpha',
+            deploymentStatus: 'Active',
+          },
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('Support triage draft')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Published support workflow'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps Drafts pagination available when a page contains only published workflows', async () => {
+    mockLocation =
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=drafts';
+    mockScopesApi.queryWorkflowCatalogue.mockImplementation(
+      (input: { cursor?: string }) =>
+        Promise.resolve(
+          input.cursor === 'page-2'
+            ? createCatalogueResponse([
+                createCatalogueRow({
+                  workflowId: 'wf-draft-beta',
+                  name: 'Billing draft',
+                }),
+              ])
+            : createCatalogueResponse(
+                [
+                  createCatalogueRow({
+                    workflowId: 'wf-published-alpha',
+                    name: 'Published support workflow',
+                    committed: {
+                      serviceKey: 'service-key-alpha',
+                      workflowName: 'published_support_workflow',
+                      actorId: 'actor-alpha',
+                      activeRevisionId: 'rev-alpha',
+                      deploymentId: 'dep-alpha',
+                      deploymentStatus: 'Active',
+                    },
+                  }),
+                ],
+                'page-2',
+              ),
+        ),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(
+      await screen.findByText('No matching workflows'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Published support workflow'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(await screen.findByText('Billing draft')).toBeInTheDocument();
+  });
+
+  it('shows table loading while manually refreshing the catalogue', async () => {
+    let resolveRefresh!: (
+      response: ReturnType<typeof createCatalogueResponse>,
+    ) => void;
+    mockScopesApi.queryWorkflowCatalogue
+      .mockResolvedValueOnce(
+        createCatalogueResponse([
+          createCatalogueRow({
+            workflowId: 'wf-draft-alpha',
+            name: 'Support triage',
+          }),
+        ]),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByText('Support triage')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh workflows' }));
+
+    await waitFor(() =>
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.getByText('Loading workflows')).toHaveClass(
+      'aevatar-loading-visually-hidden',
+    );
+
+    act(() => resolveRefresh(createCatalogueResponse([])));
+    expect(await screen.findByText('No workflows yet')).toBeInTheDocument();
+  });
+
   it('debounces search despite URL synchronization and aborts an obsolete request', async () => {
     let supportSignal: AbortSignal | undefined;
     mockScopesApi.queryWorkflowCatalogue.mockImplementation(
@@ -627,17 +743,17 @@ describe('Workflow Activity vNext catalogue', () => {
   });
 
   it('loads the next backend page and appends it without reordering', async () => {
+    let resolveNextPage!: (
+      response: ReturnType<typeof createCatalogueResponse>,
+    ) => void;
     mockScopesApi.queryWorkflowCatalogue.mockImplementation(
       (input: { cursor?: string }) =>
-        Promise.resolve(
-          input.cursor === 'page-2'
-            ? createCatalogueResponse([
-                createCatalogueRow({
-                  workflowId: 'wf-second',
-                  name: 'Second page row',
-                }),
-              ])
-            : createCatalogueResponse(
+        input.cursor === 'page-2'
+          ? new Promise((resolve) => {
+              resolveNextPage = resolve;
+            })
+          : Promise.resolve(
+              createCatalogueResponse(
                 [
                   createCatalogueRow({
                     workflowId: 'wf-first',
@@ -646,13 +762,35 @@ describe('Workflow Activity vNext catalogue', () => {
                 ],
                 'page-2',
               ),
-        ),
+            ),
     );
 
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     expect(await screen.findByText('First page row')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() =>
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Load more').closest('button')).toHaveClass(
+        'ant-btn-loading',
+      ),
+    );
+    expect(screen.getByText('First page row')).toBeInTheDocument();
+    expect(screen.queryByText('Loading workflows')).not.toBeInTheDocument();
+
+    act(() =>
+      resolveNextPage(
+        createCatalogueResponse([
+          createCatalogueRow({
+            workflowId: 'wf-second',
+            name: 'Second page row',
+          }),
+        ]),
+      ),
+    );
     expect(await screen.findByText('Second page row')).toBeInTheDocument();
     expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
       expect.objectContaining({ cursor: 'page-2', take: 50 }),

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -224,12 +224,20 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     history.replace(`${location.pathname}${nextSearch}`);
   }, [location.pathname, location.search, query, view]);
 
-  const loading = catalogue.isPending;
+  const loading =
+    catalogue.isPending ||
+    (catalogue.isFetching && !catalogue.isFetchingNextPage);
   const rows = React.useMemo(() => {
     return (catalogue.data?.pages ?? []).flatMap((page) =>
-      page.items.map(toWorkflowRow),
+      page.items
+        .filter(
+          (item) =>
+            view !== 'drafts' ||
+            (item.hasDraftSource && !item.committed?.activeRevisionId.trim()),
+        )
+        .map(toWorkflowRow),
     );
-  }, [catalogue.data?.pages]);
+  }, [catalogue.data?.pages, view]);
   const filtersActive = Boolean(query.trim()) || view !== 'all';
   const renameDuplicates = React.useMemo(() => {
     if (!renameTarget) return false;
@@ -926,7 +934,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           </table>
         </TableScrollRegion>
       )}
-      {rows.length > 0 && catalogue.hasNextPage ? (
+      {catalogue.hasNextPage ? (
         <div className="wa-vnext__pagination-actions">
           {catalogue.isFetchNextPageError ? (
             <p role="alert">

--- a/docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md
+++ b/docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md
@@ -33,11 +33,19 @@ The catalogue selector will contain only the backend-supported views:
 - `All workflows` maps to `view=all`.
 - `Drafts` maps to `view=drafts`.
 
+The product meaning of `Drafts` is unpublished workflow drafts. The current
+backend `view=drafts` transport is broader: it returns every row with a draft
+source, including published workflows that retain an editable draft. Until the
+backend contract exposes the narrower product view, the page excludes rows
+with an active committed revision from the Drafts presentation. This adapter
+must preserve the backend cursor even when every row on a loaded page is
+excluded, so later unpublished drafts remain reachable through pagination.
+
 The old `Active workflows` and `Archived` catalogue filters will be removed. Existing URL values outside `all|drafts`, including `active` and `archived`, will resolve to `all`. Archived workflows remain visible in `All workflows` and retain their row-level Archived status.
 
 Search text remains visible immediately and is written to the URL. A short debounce controls the server query. The query key contains `scopeId`, backend view, and debounced search text. React Query cancels the obsolete request when any of those values changes.
 
-The page will use cursor-based infinite querying with `take=50`. It will render returned pages in backend order and expose a Load more command while `nextPageToken` is present. The client may flatten loaded pages for rendering, but it must not join, filter, or sort catalogue rows.
+The page will use cursor-based infinite querying with `take=50`. It will render returned pages in backend order and expose a Load more command while `nextPageToken` is present. The client may flatten loaded pages for rendering. It must not join or sort catalogue rows, and the only permitted row filter is the Drafts semantic adapter described above.
 
 ## Row Mapping And Actions
 
@@ -56,9 +64,9 @@ Rename and Delete continue to use their existing command paths. After successful
 
 ## Loading And Failure States
 
-The two-source partial-failure model will be deleted. The first catalogue page has one loading state, one failure state, and one retry action.
+The two-source partial-failure model will be deleted. The first catalogue page has one loading state, one failure state, and one retry action. A manual catalogue refresh reuses the table loading state while the authoritative page is refetched.
 
-Loading another page keeps existing rows visible and disables the Load more command while the request is pending. A next-page failure keeps existing rows visible, reports the failure beside the pagination action, and allows the same command to retry.
+Loading another page keeps existing rows visible and disables the Load more command while the request is pending; it must not switch the table back to its loading skeleton. A next-page failure keeps existing rows visible, reports the failure beside the pagination action, and allows the same command to retry.
 
 An empty `items` result is authoritative for the selected backend view and search query.
 


### PR DESCRIPTION
## Problem and solution

- The backend catalogue currently defines `view=drafts` as workflows that have a draft source. Published workflows retain an editable draft source, so published rows were intentionally returned by that transport view even though the product label `Drafts` means unpublished workflows.
- Add a narrow typed presentation adapter for the Drafts product view: keep rows with a draft source only when they do not have an active committed revision. Preserve backend cursor pagination even when every row in the current page is excluded, so later genuine drafts remain reachable.
- Treat a manual catalogue refetch as table loading while excluding `isFetchingNextPage`, so Refresh displays the table skeleton and Load more keeps existing rows visible with its own loading state.
- Document the temporary frontend adapter and the backend contract debt. The preferred follow-up is for the backend to expose a catalogue view whose contract directly matches unpublished drafts.

## Impacted paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
- `docs/superpowers/specs/2026-08-07-workflow-catalogue-frontend-design.md`

## Local verification

- Focused regressions: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand --detectOpenHandles -t 'excludes published workflows|keeps Drafts pagination|shows table loading|loads the next backend page'` - 4 passed, 0 failed.
- Changed test file: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand --detectOpenHandles` - 92 passed, 0 failed.
- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx --runInBand` - 92 passed, 0 failed.
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx` - checked 2 files, no fixes required.
- Test stability guard: `bash tools/ci/test_stability_guards.sh` - passed.
- Documentation lint: `bash tools/docs/lint.sh` - 87 files checked, 0 errors.
- Diff validation: `git diff --check` - passed.
- A reliable affected TypeScript target is unavailable, so local typecheck was skipped.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
