### PR TITLE
Remove save location loading notice

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -380,9 +380,6 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.new.templateName.incidentTriage': 'Incident triage',
   'workflowActivityVNext.new.title': 'New workflow',
   'workflowActivityVNext.new.validateCreate': 'Import and open',
-  'workflowActivityVNext.new.workspaceLoading': 'Loading save locations…',
-  'workflowActivityVNext.new.workspaceLoadingDescription':
-    'Choose a creation method now. Your input stays on this page while the current workspace save location loads.',
   'workflowActivityVNext.new.workspaceUnavailable':
     'Save locations unavailable',
   'workflowActivityVNext.new.workspaceUnavailableDescription':

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -356,9 +356,6 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.new.templateName.incidentTriage': '事件分流',
     'workflowActivityVNext.new.title': '新建工作流',
     'workflowActivityVNext.new.validateCreate': '导入并打开',
-    'workflowActivityVNext.new.workspaceLoading': '正在加载保存位置…',
-    'workflowActivityVNext.new.workspaceLoadingDescription':
-      '现在可以先选择创建方式；当前工作区的保存位置加载期间，你的输入会保留在此页面。',
     'workflowActivityVNext.new.workspaceUnavailable': '保存位置不可用',
     'workflowActivityVNext.new.workspaceUnavailableDescription':
       '现在可以先选择创建方式；恢复访问权限期间，你的输入会保留在此页面。',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
@@ -122,12 +122,12 @@ describe('New workflow save-target recovery', () => {
 
   afterEach(() => cleanupTestQueryClients());
 
-  it('allows method selection and input while save locations are loading', () => {
+  it('keeps the creation chooser quiet and usable while save locations load', () => {
     mockStudioApi.getWorkspaceSettings.mockReturnValue(new Promise(() => {}));
 
     renderWithQueryClient(<NewWorkflowPage scopeId="scope-alpha" />);
 
-    expect(screen.getByText('Loading save locations…')).toBeVisible();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     const importYaml = screen.getByRole('button', { name: 'Import YAML' });
     expect(importYaml).toBeEnabled();
     fireEvent.click(importYaml);

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
@@ -12,11 +12,11 @@ import { scopesApi } from '@/shared/api/scopesApi';
 import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
-import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import type {
   StudioValidationFinding,
   StudioWorkflowSaveResult,
 } from '@/shared/studio/models';
+import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { useDraftMaterialization } from '../hooks/useDraftMaterialization';
 import {
   buildWorkflowActivityEditorHref,
@@ -306,20 +306,6 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
       scopeId={scopeId}
       title={t('workflowActivityVNext.new.title', 'New workflow')}
     >
-      {workspace.isPending ? (
-        <Alert
-          description={t(
-            'workflowActivityVNext.new.workspaceLoadingDescription',
-            'Choose a creation method now. Your input stays on this page while the current workspace save location loads.',
-          )}
-          message={t(
-            'workflowActivityVNext.new.workspaceLoading',
-            'Loading save locations…',
-          )}
-          showIcon
-          type="info"
-        />
-      ) : null}
       {workspace.isError ? (
         <Alert
           action={


### PR DESCRIPTION
## Problem and solution

The New workflow chooser rendered a large informational alert while workspace save locations were loading. The chooser is already usable during that request, so the alert added visual noise without providing an action.

Remove only the pending save-location alert and its unused English and Chinese messages. Keep save-location loading in the background, keep all creation methods usable, and preserve the actionable error and no-directory recovery alerts.

## CI baseline sync

The previous `console-web` check failed in `hardcodedCopyAudit.test.ts` because the PR still used target commit `2889e6588`, where three new Workflows fallback messages were missing from the English catalog:

- `workflowActivityVNext.workflows.allView`
- `workflowActivityVNext.workflows.loadMore`
- `workflowActivityVNext.workflows.loadMoreFailed`

The latest `feat/2026-08-04_workflow-activity-vnext` commit `b8e0eae37` includes the merged #3291 catalog fix. This branch now includes that target-branch commit. The final PR diff against the current target branch remains limited to removing the save-location loading notice.

## Impacted paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx`
- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`
- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`

No backend contracts, routes, persistence, or documentation changed.

## Local verification

- CI failure and directly corresponding tests: `pnpm exec jest src/locales/hardcodedCopyAudit.test.ts src/locales/catalog.test.ts src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx --runInBand`
  - PASS: 3 suites, 26 tests
- Fresh completion check: `pnpm exec jest src/locales/hardcodedCopyAudit.test.ts src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx --runInBand`
  - PASS: 2 suites, 19 tests
- Changed-file static checks: `pnpm exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx`
  - PASS: 4 files
- Test stability guard: `bash tools/ci/test_stability_guards.sh`
  - PASS
- Baseline integrity: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py`
  - PASS: 17/17 frames and byte-identical generator output
- Diff validation: `git diff --check`
  - PASS

Jest dependency discovery for the global locale catalogs expands to more than 100 suites, effectively the full frontend suite, so that expanded command was not executed locally. The full frontend suite, typecheck, and production build are delegated to GitHub CI under the incremental frontend policy.

## Design baseline

```text
Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py
```
