### PR TITLE
Merge latest feature/integrate into dev

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatAguiSseEventWriter.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatAguiSseEventWriter.cs
@@ -166,7 +166,8 @@ internal static class NyxIdChatAguiSseEventWriter
                 StringComparison.Ordinal) &&
             customEvent.Payload.Is(NyxIdChatTaskState.Descriptor))
         {
-            payload = customEvent.Payload.Unpack<NyxIdChatTaskState>();
+            payload = NyxIdChatTaskPlanWireMapper.FromState(
+                customEvent.Payload.Unpack<NyxIdChatTaskState>());
             return true;
         }
 
@@ -176,7 +177,8 @@ internal static class NyxIdChatAguiSseEventWriter
                 StringComparison.Ordinal) &&
             customEvent.Payload.Is(NyxIdChatTaskStepChanged.Descriptor))
         {
-            payload = customEvent.Payload.Unpack<NyxIdChatTaskStepChanged>();
+            payload = NyxIdChatTaskPlanWireMapper.FromState(
+                customEvent.Payload.Unpack<NyxIdChatTaskStepChanged>());
             return true;
         }
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationAguiFrameBuilder.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationAguiFrameBuilder.cs
@@ -5,8 +5,8 @@ namespace Aevatar.GAgents.NyxidChat;
 
 /// <summary>
 /// Presentation-only mapping from committed controller facts to AGUI frames.
-/// It never derives task state: snapshots and step changes are the exact
-/// protobuf values already committed by the conversation authority.
+/// It preserves the established projection transport types; the HTTP boundary
+/// maps task observations to the public TaskPlan contract.
 /// </summary>
 internal static class NyxIdChatConversationAguiFrameBuilder
 {

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.State.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.State.cs
@@ -57,12 +57,13 @@ public static partial class NyxIdChatEndpoints
 
         return result.Status switch
         {
-            NyxIdChatConversationStateQueryStatus.Current => Results.Ok(
+            NyxIdChatConversationStateQueryStatus.Current => Results.Json(
                 new NyxIdChatConversationStateResponse(
                     "current",
                     result.StateVersion,
                     result.TurnId,
-                    Snapshot: result.Snapshot)),
+                    Snapshot: result.Snapshot),
+                NyxIdChatStateJson.Options),
             NyxIdChatConversationStateQueryStatus.NotModified => Results.Ok(
                 new NyxIdChatConversationStateResponse(
                     "not_modified",

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatSseWriter.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatSseWriter.cs
@@ -226,9 +226,9 @@ internal sealed class NyxIdChatSseWriter
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(payload);
-        var node = JsonNode.Parse(JsonFormatter.Default.Format(payload))
-                   ?? throw new InvalidOperationException("Typed custom payload must serialize to JSON.");
-        NormalizeNyxIdEnumValues(node);
+        var node = payload is NyxIdChatTaskPlan or NyxIdChatTaskPlanStepChanged
+            ? NyxIdChatTaskPlanJsonFormatter.FormatTaskPlan(payload)
+            : NyxIdChatTaskPlanJsonFormatter.FormatProtobuf(payload);
         return WriteFrameAsync(new
         {
             type = "CUSTOM",
@@ -254,85 +254,6 @@ internal sealed class NyxIdChatSseWriter
                 timeoutSeconds,
             }
         }, sequence, ct);
-
-    private static void NormalizeNyxIdEnumValues(JsonNode node)
-    {
-        switch (node)
-        {
-            case JsonObject obj:
-                foreach (var property in obj.ToArray())
-                {
-                    if (property.Value is JsonValue value &&
-                        value.TryGetValue<string>(out var text) &&
-                        TryNormalizeNyxIdEnumValue(text, out var normalized))
-                    {
-                        obj[property.Key] = normalized;
-                    }
-                    else if (property.Value is not null)
-                    {
-                        NormalizeNyxIdEnumValues(property.Value);
-                    }
-                }
-                break;
-            case JsonArray array:
-                for (var index = 0; index < array.Count; index++)
-                {
-                    if (array[index] is JsonValue value &&
-                        value.TryGetValue<string>(out var text) &&
-                        TryNormalizeNyxIdEnumValue(text, out var normalized))
-                    {
-                        array[index] = normalized;
-                    }
-                    else if (array[index] is not null)
-                    {
-                        NormalizeNyxIdEnumValues(array[index]!);
-                    }
-                }
-                break;
-        }
-    }
-
-    private static bool TryNormalizeNyxIdEnumValue(string value, out string normalized)
-    {
-        string[] prefixes =
-        [
-            "NYX_ID_CHAT_CONTINUATION_ADMISSION_STATUS_",
-            "NYX_ID_CHAT_STEP_CONTROL_KIND_",
-            "NYX_ID_CHAT_ACTION_DISPOSITION_",
-            "NYX_ID_CHAT_OPERATION_PHASE_",
-            "NYX_ID_CHAT_EFFECT_EVIDENCE_",
-            "NYX_ID_CHAT_TRANSITION_OUTCOME_",
-            "NYX_ID_CHAT_CONTINUATION_KIND_",
-            "NYX_ID_CHAT_CONTROL_OUTCOME_",
-            "NYX_ID_ASSISTANT_ACTION_RISK_",
-            "NYX_ID_ASSISTANT_ACTION_TIER_",
-            "NYX_ID_ASSISTANT_ACTION_KIND_",
-            "NYX_ID_CHAT_CONTROL_KIND_",
-            "NYX_ID_CHAT_TURN_STATUS_",
-            "NYX_ID_CHAT_TASK_STATUS_",
-            "NYX_ID_CHAT_STEP_STATUS_",
-            "NYX_ID_CHAT_STEP_KIND_",
-            "NYX_ID_CHAT_PLAN_GATE_MODE_",
-            "NYX_ID_CHAT_STEP_ADDED_BY_",
-            "NYX_ID_CHAT_STEP_ESTIMATE_KIND_",
-            "NYX_ID_CHAT_SUBSTEP_STATUS_",
-            "NYX_ID_CHAT_STEP_CHANGE_KIND_",
-            "NYX_ID_CHAT_ATTENTION_KIND_",
-            "NYX_ID_CHAT_APPROVAL_REVERSIBILITY_",
-            "NYX_ID_CHAT_NEEDS_YOU_RESOLUTION_OUTCOME_",
-        ];
-        foreach (var prefix in prefixes)
-        {
-            if (!value.StartsWith(prefix, StringComparison.Ordinal))
-                continue;
-
-            normalized = value[prefix.Length..].ToLowerInvariant();
-            return true;
-        }
-
-        normalized = value;
-        return false;
-    }
 
     private static object BuildPresentationPayload(
         ToolPresentationDescriptor? presentation,

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanJsonFormatter.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanJsonFormatter.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Google.Protobuf;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+internal static class NyxIdChatTaskPlanJsonFormatter
+{
+    private const long MaxBrowserSafeInteger = 9_007_199_254_740_991;
+
+    public static JsonNode FormatTaskPlan(IMessage payload)
+    {
+        var node = FormatProtobuf(payload);
+        NormalizeBrowserSafeIntegers(node);
+        return node;
+    }
+
+    public static JsonNode FormatProtobuf(IMessage payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        var node = JsonNode.Parse(JsonFormatter.Default.Format(payload))
+                   ?? throw new InvalidOperationException(
+                       "Typed custom payload must serialize to JSON.");
+        NormalizeNyxIdEnumValues(node);
+        return node;
+    }
+
+    private static void NormalizeBrowserSafeIntegers(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var property in obj.ToArray())
+                {
+                    if (property.Value is JsonValue value &&
+                        IsBrowserNumberField(property.Key) &&
+                        value.TryGetValue<string>(out var text) &&
+                        long.TryParse(
+                            text,
+                            NumberStyles.Integer,
+                            CultureInfo.InvariantCulture,
+                            out var parsed))
+                    {
+                        if (parsed is < -MaxBrowserSafeInteger or > MaxBrowserSafeInteger)
+                        {
+                            throw new InvalidOperationException(
+                                $"TaskPlan field '{property.Key}' exceeds the browser-safe integer range.");
+                        }
+                        obj[property.Key] = parsed;
+                    }
+                    else if (property.Value is not null)
+                    {
+                        NormalizeBrowserSafeIntegers(property.Value);
+                    }
+                }
+                break;
+            case JsonArray array:
+                foreach (var item in array)
+                {
+                    if (item is not null)
+                        NormalizeBrowserSafeIntegers(item);
+                }
+                break;
+        }
+    }
+
+    private static bool IsBrowserNumberField(string propertyName) =>
+        propertyName is "operationGeneration" or "latestProgressSequence";
+
+    private static void NormalizeNyxIdEnumValues(JsonNode node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                foreach (var property in obj.ToArray())
+                {
+                    if (property.Value is JsonValue value &&
+                        value.TryGetValue<string>(out var text) &&
+                        TryNormalizeNyxIdEnumValue(text, out var normalized))
+                    {
+                        obj[property.Key] = normalized;
+                    }
+                    else if (property.Value is not null)
+                    {
+                        NormalizeNyxIdEnumValues(property.Value);
+                    }
+                }
+                break;
+            case JsonArray array:
+                for (var index = 0; index < array.Count; index++)
+                {
+                    if (array[index] is JsonValue value &&
+                        value.TryGetValue<string>(out var text) &&
+                        TryNormalizeNyxIdEnumValue(text, out var normalized))
+                    {
+                        array[index] = normalized;
+                    }
+                    else if (array[index] is not null)
+                    {
+                        NormalizeNyxIdEnumValues(array[index]!);
+                    }
+                }
+                break;
+        }
+    }
+
+    private static bool TryNormalizeNyxIdEnumValue(string value, out string normalized)
+    {
+        string[] prefixes =
+        [
+            "NYX_ID_CHAT_CONTINUATION_ADMISSION_STATUS_",
+            "NYX_ID_CHAT_STEP_CONTROL_KIND_",
+            "NYX_ID_CHAT_ACTION_DISPOSITION_",
+            "NYX_ID_CHAT_OPERATION_PHASE_",
+            "NYX_ID_CHAT_EFFECT_EVIDENCE_",
+            "NYX_ID_CHAT_TRANSITION_OUTCOME_",
+            "NYX_ID_CHAT_CONTINUATION_KIND_",
+            "NYX_ID_CHAT_CONTROL_OUTCOME_",
+            "NYX_ID_ASSISTANT_ACTION_RISK_",
+            "NYX_ID_ASSISTANT_ACTION_TIER_",
+            "NYX_ID_ASSISTANT_ACTION_KIND_",
+            "NYX_ID_CHAT_CONTROL_KIND_",
+            "NYX_ID_CHAT_TURN_STATUS_",
+            "NYX_ID_CHAT_TASK_STATUS_",
+            "NYX_ID_CHAT_STEP_STATUS_",
+            "NYX_ID_CHAT_STEP_KIND_",
+            "NYX_ID_CHAT_PLAN_GATE_MODE_",
+            "NYX_ID_CHAT_STEP_ADDED_BY_",
+            "NYX_ID_CHAT_STEP_ESTIMATE_KIND_",
+            "NYX_ID_CHAT_SUBSTEP_STATUS_",
+            "NYX_ID_CHAT_STEP_CHANGE_KIND_",
+            "NYX_ID_CHAT_ATTENTION_KIND_",
+            "NYX_ID_CHAT_APPROVAL_REVERSIBILITY_",
+            "NYX_ID_CHAT_NEEDS_YOU_RESOLUTION_OUTCOME_",
+        ];
+        foreach (var prefix in prefixes)
+        {
+            if (!value.StartsWith(prefix, StringComparison.Ordinal))
+                continue;
+
+            normalized = value[prefix.Length..].ToLowerInvariant();
+            return true;
+        }
+
+        normalized = value;
+        return false;
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanSnapshotJsonConverter.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanSnapshotJsonConverter.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.Studio.Application.Studio.Abstractions;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+internal static class NyxIdChatStateJson
+{
+    public static JsonSerializerOptions Options { get; } = CreateOptions();
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.Converters.Add(new NyxIdChatTaskPlanSnapshotJsonConverter());
+        return options;
+    }
+}
+
+internal sealed class NyxIdChatTaskPlanSnapshotJsonConverter
+    : JsonConverter<NyxIdChatConversationTaskSnapshot>
+{
+    public override NyxIdChatConversationTaskSnapshot Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) =>
+        throw new NotSupportedException("TaskPlan current-state JSON is write-only.");
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        NyxIdChatConversationTaskSnapshot value,
+        JsonSerializerOptions options)
+    {
+        var taskPlan = NyxIdChatTaskPlanWireMapper.FromSnapshot(value);
+        NyxIdChatTaskPlanJsonFormatter.FormatTaskPlan(taskPlan).WriteTo(writer, options);
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanWireMapper.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanWireMapper.cs
@@ -1,0 +1,415 @@
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+internal static class NyxIdChatTaskPlanWireMapper
+{
+    public static NyxIdChatTaskPlan FromState(NyxIdChatTaskState task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        var plan = new NyxIdChatTaskPlan
+        {
+            TaskId = task.TaskId,
+            TurnId = task.TurnId,
+            Status = task.Status,
+            ActiveStepId = task.ActiveStepId,
+            ActiveOperationId = task.ActiveOperationId,
+            FailureCode = task.FailureCode,
+            SafeMessage = task.SafeMessage,
+            CreatedAt = task.CreatedAt?.Clone(),
+            UpdatedAt = task.UpdatedAt?.Clone(),
+            SchemaVersion = task.SchemaVersion,
+            ActorId = task.ActorId,
+            PlanId = task.PlanId,
+            PlanRevision = task.PlanRevision,
+            Title = task.Title,
+            Gate = task.Gate?.Clone(),
+        };
+        plan.Steps.AddRange(task.Steps
+            .OrderBy(static step => step.Order)
+            .ThenBy(static step => step.StepId, StringComparer.Ordinal)
+            .Select(FromState));
+        return plan;
+    }
+
+    public static NyxIdChatTaskPlan FromSnapshot(NyxIdChatConversationTaskSnapshot task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        var plan = new NyxIdChatTaskPlan
+        {
+            TaskId = task.TaskId,
+            TurnId = task.TurnId,
+            Status = ParseTaskStatus(task.Status),
+            ActiveStepId = task.ActiveStepId ?? string.Empty,
+            ActiveOperationId = task.ActiveOperationId ?? string.Empty,
+            FailureCode = task.FailureCode ?? string.Empty,
+            SafeMessage = task.SafeMessage ?? string.Empty,
+            CreatedAt = ToTimestamp(task.CreatedAt),
+            UpdatedAt = ToTimestamp(task.UpdatedAt),
+            SchemaVersion = task.SchemaVersion,
+            ActorId = task.ActorId ?? string.Empty,
+            PlanId = task.PlanId ?? string.Empty,
+            PlanRevision = task.PlanRevision,
+            Title = task.Title ?? string.Empty,
+            Gate = FromSnapshot(task.Gate),
+        };
+        plan.Steps.AddRange(task.Steps
+            .OrderBy(static step => step.Order)
+            .ThenBy(static step => step.StepId, StringComparer.Ordinal)
+            .Select(FromSnapshot));
+        return plan;
+    }
+
+    public static NyxIdChatTaskPlanStep FromState(NyxIdChatTaskStepState step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+
+        var result = new NyxIdChatTaskPlanStep
+        {
+            StepId = step.StepId,
+            Order = step.Order,
+            Kind = step.Kind,
+            Status = step.Status,
+            Required = step.Required,
+            Description = step.Description,
+            Source = step.Source?.Clone(),
+            MayChangeExternalState = step.MayChangeExternalState,
+            ExternalEffect = step.ExternalEffect,
+            Operation = FromState(step.Operation),
+            ApprovalRequestId = step.ApprovalRequestId,
+            ActionRequestId = step.ActionRequestId,
+            FailureCode = step.FailureCode,
+            SafeMessage = step.SafeMessage,
+            SafeToSkip = step.SafeToSkip,
+            AvailableActions = step.AvailableActions?.Clone(),
+            UpdatedAt = step.UpdatedAt?.Clone(),
+            AddedBy = step.AddedBy,
+            Estimate = step.Estimate?.Clone(),
+        };
+        result.DependsOn.AddRange(step.DependsOn);
+        result.Substeps.AddRange(step.Substeps.Select(static substep => substep.Clone()));
+        return result;
+    }
+
+    public static NyxIdChatTaskPlanStepChanged FromState(NyxIdChatTaskStepChanged changed)
+    {
+        ArgumentNullException.ThrowIfNull(changed);
+
+        var result = new NyxIdChatTaskPlanStepChanged
+        {
+            TaskId = changed.TaskId,
+            PlanRevision = changed.PlanRevision,
+            ChangeKind = changed.ChangeKind,
+        };
+        if (changed.Step is not null)
+            result.Step = FromState(changed.Step);
+        return result;
+    }
+
+    private static NyxIdChatTaskPlanStep FromSnapshot(NyxIdChatConversationStepSnapshot step)
+    {
+        var result = new NyxIdChatTaskPlanStep
+        {
+            StepId = step.StepId,
+            Order = step.Order,
+            Kind = ParseStepKind(step.Kind),
+            Status = ParseStepStatus(step.Status),
+            Required = step.Required,
+            Description = step.Description ?? string.Empty,
+            Source = FromSnapshot(step.Source),
+            MayChangeExternalState = step.MayChangeExternalState,
+            ExternalEffect = ParseEffectEvidence(step.ExternalEffect),
+            Operation = FromSnapshot(step.Operation),
+            ApprovalRequestId = step.ApprovalRequestId ?? string.Empty,
+            ActionRequestId = step.ActionRequestId ?? string.Empty,
+            FailureCode = step.FailureCode ?? string.Empty,
+            SafeMessage = step.SafeMessage ?? string.Empty,
+            SafeToSkip = step.SafeToSkip,
+            AvailableActions = FromSnapshot(step.AvailableActions),
+            UpdatedAt = ToTimestamp(step.UpdatedAt),
+            AddedBy = ParseStepAddedBy(step.AddedBy),
+            Estimate = FromSnapshot(step.Estimate),
+        };
+        if (step.DependsOn is not null)
+            result.DependsOn.AddRange(step.DependsOn);
+        if (step.Substeps is not null)
+        {
+            result.Substeps.AddRange(step.Substeps.Select(static substep =>
+                new NyxIdChatSubstepState
+                {
+                    SubstepId = substep.SubstepId,
+                    Title = substep.Title,
+                    Status = ParseSubstepStatus(substep.Status),
+                }));
+        }
+        return result;
+    }
+
+    private static NyxIdChatTaskPlanOperation? FromState(NyxIdChatOperationState? operation)
+    {
+        if (operation is null)
+            return null;
+
+        var key = operation.Key;
+        return new NyxIdChatTaskPlanOperation
+        {
+            ConversationActorId = key?.ConversationActorId ?? string.Empty,
+            TurnId = key?.TurnId ?? string.Empty,
+            TaskId = key?.TaskId ?? string.Empty,
+            StepId = key?.StepId ?? string.Empty,
+            OperationId = key?.OperationId ?? string.Empty,
+            OperationGeneration = key?.OperationGeneration ?? 0,
+            Kind = operation.Kind,
+            Phase = operation.Phase,
+            MayChangeExternalState = operation.MayChangeExternalState,
+            Idempotent = operation.Idempotent,
+            LatestProgressSequence = operation.LatestProgressSequence,
+            TerminalCode = operation.TerminalCode,
+            SafeMessage = operation.SafeMessage,
+            RequestedAt = operation.RequestedAt?.Clone(),
+            DispatchedAt = operation.DispatchedAt?.Clone(),
+            CompletedAt = operation.CompletedAt?.Clone(),
+        };
+    }
+
+    private static NyxIdChatTaskPlanOperation? FromSnapshot(
+        NyxIdChatConversationOperationSnapshot? operation) =>
+        operation is null
+            ? null
+            : new NyxIdChatTaskPlanOperation
+            {
+                ConversationActorId = operation.ConversationActorId,
+                TurnId = operation.TurnId,
+                TaskId = operation.TaskId,
+                StepId = operation.StepId,
+                OperationId = operation.OperationId,
+                OperationGeneration = operation.OperationGeneration,
+                Kind = ParseStepKind(operation.Kind),
+                Phase = ParseOperationPhase(operation.Phase),
+                MayChangeExternalState = operation.MayChangeExternalState,
+                Idempotent = operation.Idempotent,
+                LatestProgressSequence = operation.LatestProgressSequence,
+                TerminalCode = operation.TerminalCode ?? string.Empty,
+                SafeMessage = operation.SafeMessage ?? string.Empty,
+                RequestedAt = ToTimestamp(operation.RequestedAt),
+                DispatchedAt = ToTimestamp(operation.DispatchedAt),
+                CompletedAt = ToTimestamp(operation.CompletedAt),
+            };
+
+    private static NyxIdChatStepSource? FromSnapshot(
+        NyxIdChatConversationStepSourceSnapshot? source)
+    {
+        if (source?.Llm is not null)
+        {
+            return new NyxIdChatStepSource
+            {
+                Llm = new NyxIdChatLLMStepSource { Model = source.Llm.Model },
+            };
+        }
+
+        if (source?.Tool is not null)
+        {
+            var tool = new NyxIdChatToolStepSource
+            {
+                ToolName = source.Tool.ToolName,
+                ServiceSlug = source.Tool.ServiceSlug ?? string.Empty,
+                ServiceId = source.Tool.ServiceId ?? string.Empty,
+            };
+            if (source.Tool.ReadinessCapabilityId is not null)
+                tool.ReadinessCapabilityId = source.Tool.ReadinessCapabilityId;
+            return new NyxIdChatStepSource { Tool = tool };
+        }
+
+        if (source?.BrowserAction is not null)
+        {
+            return new NyxIdChatStepSource
+            {
+                BrowserAction = new NyxIdChatBrowserActionStepSource
+                {
+                    Action = ParseAssistantAction(source.BrowserAction.Action),
+                    ActionRequestId = source.BrowserAction.ActionRequestId ?? string.Empty,
+                },
+            };
+        }
+
+        if (source?.Postcondition is not null)
+        {
+            return new NyxIdChatStepSource
+            {
+                Postcondition = new NyxIdChatPostconditionStepSource
+                {
+                    ActionRequestId = source.Postcondition.ActionRequestId ?? string.Empty,
+                    Check = source.Postcondition.Check ?? string.Empty,
+                },
+            };
+        }
+
+        if (source?.Input is not null)
+        {
+            return new NyxIdChatStepSource
+            {
+                Input = new NyxIdChatInputStepSource
+                {
+                    RequestId = source.Input.RequestId ?? string.Empty,
+                },
+            };
+        }
+
+        if (source?.Approval is not null)
+        {
+            return new NyxIdChatStepSource
+            {
+                Approval = new NyxIdChatApprovalStepSource
+                {
+                    ApprovalRequestId = source.Approval.ApprovalRequestId ?? string.Empty,
+                },
+            };
+        }
+
+        return source?.Web is null
+            ? null
+            : new NyxIdChatStepSource { Web = new NyxIdChatWebStepSource() };
+    }
+
+    private static NyxIdChatAvailableActions? FromSnapshot(
+        NyxIdChatAvailableActionsSnapshot? actions) =>
+        actions is null
+            ? null
+            : new NyxIdChatAvailableActions
+            {
+                Retry = actions.Retry,
+                Skip = actions.Skip,
+                Stop = actions.Stop,
+            };
+
+    private static NyxIdChatPlanGate? FromSnapshot(
+        NyxIdChatConversationPlanGateSnapshot? gate) =>
+        gate is null
+            ? null
+            : new NyxIdChatPlanGate
+            {
+                Mode = ParsePlanGateMode(gate.Mode),
+                Reason = gate.Reason ?? string.Empty,
+            };
+
+    private static NyxIdChatStepEstimate? FromSnapshot(
+        NyxIdChatConversationStepEstimateSnapshot? estimate) =>
+        estimate is null
+            ? null
+            : new NyxIdChatStepEstimate
+            {
+                Kind = ParseStepEstimateKind(estimate.Kind),
+                Seconds = estimate.Seconds,
+            };
+
+    private static Timestamp? ToTimestamp(DateTimeOffset? value) =>
+        value.HasValue ? Timestamp.FromDateTimeOffset(value.Value) : null;
+
+    private static NyxIdChatTaskStatus ParseTaskStatus(string value) => value switch
+    {
+        "active" => NyxIdChatTaskStatus.Active,
+        "succeeded" => NyxIdChatTaskStatus.Succeeded,
+        "failed" => NyxIdChatTaskStatus.Failed,
+        "stopped" => NyxIdChatTaskStatus.Stopped,
+        "blocked" => NyxIdChatTaskStatus.Blocked,
+        _ => NyxIdChatTaskStatus.Unspecified,
+    };
+
+    private static NyxIdChatStepStatus ParseStepStatus(string value) => value switch
+    {
+        "planned" => NyxIdChatStepStatus.Planned,
+        "waiting" => NyxIdChatStepStatus.Waiting,
+        "running" => NyxIdChatStepStatus.Running,
+        "done" => NyxIdChatStepStatus.Done,
+        "failed" => NyxIdChatStepStatus.Failed,
+        "skipped" => NyxIdChatStepStatus.Skipped,
+        "cancelled" => NyxIdChatStepStatus.Cancelled,
+        "uncertain" => NyxIdChatStepStatus.Uncertain,
+        _ => NyxIdChatStepStatus.Unspecified,
+    };
+
+    private static NyxIdChatEffectEvidence ParseEffectEvidence(string value) => value switch
+    {
+        "not_started" => NyxIdChatEffectEvidence.NotStarted,
+        "not_applied" => NyxIdChatEffectEvidence.NotApplied,
+        "confirmed" => NyxIdChatEffectEvidence.Confirmed,
+        "may_have_changed" => NyxIdChatEffectEvidence.MayHaveChanged,
+        _ => NyxIdChatEffectEvidence.Unspecified,
+    };
+
+    private static NyxIdChatStepKind ParseStepKind(string value) => value switch
+    {
+        "llm" => NyxIdChatStepKind.Llm,
+        "tool" => NyxIdChatStepKind.Tool,
+        "browser_action" => NyxIdChatStepKind.BrowserAction,
+        "postcondition" => NyxIdChatStepKind.Postcondition,
+        "input" => NyxIdChatStepKind.Input,
+        "approval" => NyxIdChatStepKind.Approval,
+        "web" => NyxIdChatStepKind.Web,
+        _ => NyxIdChatStepKind.Unspecified,
+    };
+
+    private static NyxIdChatPlanGateMode ParsePlanGateMode(string value) => value switch
+    {
+        "auto" => NyxIdChatPlanGateMode.Auto,
+        "confirm" => NyxIdChatPlanGateMode.Confirm,
+        _ => NyxIdChatPlanGateMode.Unspecified,
+    };
+
+    private static NyxIdChatStepAddedBy ParseStepAddedBy(string? value) => value switch
+    {
+        "initial" => NyxIdChatStepAddedBy.Initial,
+        "replan" => NyxIdChatStepAddedBy.Replan,
+        "steering" => NyxIdChatStepAddedBy.Steering,
+        _ => NyxIdChatStepAddedBy.Unspecified,
+    };
+
+    private static NyxIdChatStepEstimateKind ParseStepEstimateKind(string value) => value switch
+    {
+        "duration" => NyxIdChatStepEstimateKind.Duration,
+        _ => NyxIdChatStepEstimateKind.Unspecified,
+    };
+
+    private static NyxIdChatSubstepStatus ParseSubstepStatus(string value) => value switch
+    {
+        "running" => NyxIdChatSubstepStatus.Running,
+        "done" => NyxIdChatSubstepStatus.Done,
+        "failed" => NyxIdChatSubstepStatus.Failed,
+        _ => NyxIdChatSubstepStatus.Unspecified,
+    };
+
+    private static NyxIdChatOperationPhase ParseOperationPhase(string value) => value switch
+    {
+        "requested" => NyxIdChatOperationPhase.Requested,
+        "dispatched" => NyxIdChatOperationPhase.Dispatched,
+        "running" => NyxIdChatOperationPhase.Running,
+        "succeeded" => NyxIdChatOperationPhase.Succeeded,
+        "failed" => NyxIdChatOperationPhase.Failed,
+        "cancelled" => NyxIdChatOperationPhase.Cancelled,
+        "uncertain" => NyxIdChatOperationPhase.Uncertain,
+        _ => NyxIdChatOperationPhase.Unspecified,
+    };
+
+    private static NyxIdAssistantActionKind ParseAssistantAction(string value) =>
+        value.Replace('.', '_') switch
+        {
+            "service_connect" => NyxIdAssistantActionKind.ServiceConnect,
+            "service_reauthorize" => NyxIdAssistantActionKind.ServiceReauthorize,
+            "provider_set_app_credentials" => NyxIdAssistantActionKind.ProviderSetAppCredentials,
+            "key_create" => NyxIdAssistantActionKind.KeyCreate,
+            "key_rotate" => NyxIdAssistantActionKind.KeyRotate,
+            "node_register_token" => NyxIdAssistantActionKind.NodeRegisterToken,
+            "node_rotate_token" => NyxIdAssistantActionKind.NodeRotateToken,
+            "node_inject_credential" => NyxIdAssistantActionKind.NodeInjectCredential,
+            "service_account_create" => NyxIdAssistantActionKind.ServiceAccountCreate,
+            "service_account_rotate_secret" => NyxIdAssistantActionKind.ServiceAccountRotateSecret,
+            "developer_app_create" => NyxIdAssistantActionKind.DeveloperAppCreate,
+            "developer_app_rotate_secret" => NyxIdAssistantActionKind.DeveloperAppRotateSecret,
+            "account_mfa_setup" => NyxIdAssistantActionKind.AccountMfaSetup,
+            "device_onboard" => NyxIdAssistantActionKind.DeviceOnboard,
+            _ => NyxIdAssistantActionKind.Unspecified,
+        };
+}

--- a/agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto
@@ -362,10 +362,82 @@ message NyxIdChatTaskState {
   NyxIdChatPlanGate gate = 16;
 }
 
+// Public TaskPlan projection shared by live AGUI frames and current-state
+// responses. Execution-only retry inputs and idempotency keys remain in the
+// authoritative actor state and are deliberately absent here.
+message NyxIdChatTaskPlanOperation {
+  string conversation_actor_id = 1;
+  string turn_id = 2;
+  string task_id = 3;
+  string step_id = 4;
+  string operation_id = 5;
+  int64 operation_generation = 6;
+  NyxIdChatStepKind kind = 7;
+  NyxIdChatOperationPhase phase = 8;
+  bool may_change_external_state = 9;
+  bool idempotent = 10;
+  int64 latest_progress_sequence = 11;
+  string terminal_code = 12;
+  string safe_message = 13;
+  google.protobuf.Timestamp requested_at = 14;
+  google.protobuf.Timestamp dispatched_at = 15;
+  google.protobuf.Timestamp completed_at = 16;
+}
+
+message NyxIdChatTaskPlanStep {
+  string step_id = 1;
+  int32 order = 2;
+  NyxIdChatStepKind kind = 3;
+  NyxIdChatStepStatus status = 4;
+  bool required = 5;
+  string description = 6;
+  NyxIdChatStepSource source = 7;
+  bool may_change_external_state = 8;
+  NyxIdChatEffectEvidence external_effect = 9;
+  NyxIdChatTaskPlanOperation operation = 10;
+  string approval_request_id = 11;
+  string action_request_id = 12;
+  string failure_code = 13;
+  string safe_message = 14;
+  bool safe_to_skip = 15;
+  NyxIdChatAvailableActions available_actions = 16;
+  google.protobuf.Timestamp updated_at = 17;
+  NyxIdChatStepAddedBy added_by = 18;
+  repeated string depends_on = 19;
+  NyxIdChatStepEstimate estimate = 20;
+  repeated NyxIdChatSubstepState substeps = 21;
+}
+
+message NyxIdChatTaskPlan {
+  string task_id = 1;
+  string turn_id = 2;
+  NyxIdChatTaskStatus status = 3;
+  repeated NyxIdChatTaskPlanStep steps = 4;
+  string active_step_id = 5;
+  string active_operation_id = 6;
+  string failure_code = 7;
+  string safe_message = 8;
+  google.protobuf.Timestamp created_at = 9;
+  google.protobuf.Timestamp updated_at = 10;
+  int32 schema_version = 11;
+  string actor_id = 12;
+  string plan_id = 13;
+  int32 plan_revision = 14;
+  string title = 15;
+  NyxIdChatPlanGate gate = 16;
+}
+
 message NyxIdChatTaskStepChanged {
   string task_id = 1;
   int32 plan_revision = 2;
   NyxIdChatTaskStepState step = 3;
+  NyxIdChatStepChangeKind change_kind = 4;
+}
+
+message NyxIdChatTaskPlanStepChanged {
+  string task_id = 1;
+  int32 plan_revision = 2;
+  NyxIdChatTaskPlanStep step = 3;
   NyxIdChatStepChangeKind change_kind = 4;
 }
 

--- a/apps/aevatar-console-web/src/pages/chat/chatActorState.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatActorState.test.ts
@@ -7,99 +7,99 @@ import {
   reduceActorFrame,
   validateActionRequest,
   writeCachedActionRequest,
-} from "./chatActorState";
+} from './chatActorState';
 
 const actionRequest = {
   schemaVersion: 4,
-  actorId: "conversation-alpha",
-  originTurnId: "turn-alpha",
-  taskId: "task-alpha",
-  stepId: "step-connect",
-  actionRequestId: "action-alpha",
-  action: "service.connect",
+  actorId: 'conversation-alpha',
+  originTurnId: 'turn-alpha',
+  taskId: 'task-alpha',
+  stepId: 'step-connect',
+  actionRequestId: 'action-alpha',
+  action: 'service.connect',
   params: {
     catalogService: {
-      serviceSlug: "api-github",
-      requestedScopes: ["repo"],
+      serviceSlug: 'api-github',
+      requestedScopes: ['repo'],
     },
   },
 } as const;
 
 const currentEnvelope = {
-  status: "current",
+  status: 'current',
   stateVersion: 7,
-  turnId: "turn-alpha",
+  turnId: 'turn-alpha',
   snapshot: {
-    actorId: "conversation-alpha",
-    scopeId: "scope-alpha",
+    actorId: 'conversation-alpha',
+    scopeId: 'scope-alpha',
     stateVersion: 7,
     progressSequence: 11,
     activeTurn: {
-      turnId: "turn-alpha",
-      taskId: "task-alpha",
-      status: "active",
+      turnId: 'turn-alpha',
+      taskId: 'task-alpha',
+      status: 'active',
     },
     latestTurn: null,
     recentTerminalTurns: [],
     activeTask: {
-      taskId: "task-alpha",
-      turnId: "turn-alpha",
-      status: "active",
+      taskId: 'task-alpha',
+      turnId: 'turn-alpha',
+      status: 'active',
       steps: [
         {
-          stepId: "step-alpha",
+          stepId: 'step-alpha',
           order: 1,
-          kind: "tool",
-          status: "failed",
+          kind: 'tool',
+          status: 'failed',
           availableActions: { retry: true, skip: false, stop: true },
           operation: { operationGeneration: 2 },
         },
       ],
     },
     pendingInput: {
-      requestId: "input-alpha",
-      turnId: "turn-alpha",
-      taskId: "task-alpha",
-      stepId: "step-input",
-      prompt: "Select a region",
-      options: [{ optionId: "option-sg", label: "Singapore" }],
-      askedAt: "2026-08-04T08:00:00Z",
+      requestId: 'input-alpha',
+      turnId: 'turn-alpha',
+      taskId: 'task-alpha',
+      stepId: 'step-input',
+      prompt: 'Select a region',
+      options: [{ optionId: 'option-sg', label: 'Singapore' }],
+      askedAt: '2026-08-04T08:00:00Z',
       allowFreeText: false,
       multiSelect: false,
     },
     pendingApproval: {
-      approvalRequestId: "approval-alpha",
-      turnId: "turn-alpha",
-      taskId: "task-alpha",
-      stepId: "step-approval",
-      toolName: "deploy",
-      action: "Deploy",
-      target: "production",
+      approvalRequestId: 'approval-alpha',
+      turnId: 'turn-alpha',
+      taskId: 'task-alpha',
+      stepId: 'step-approval',
+      toolName: 'deploy',
+      action: 'Deploy',
+      target: 'production',
     },
     pendingActions: [],
   },
 };
 
-describe("chatActorState", () => {
+describe('chatActorState', () => {
   beforeEach(() => globalThis.sessionStorage.clear());
   afterEach(() => jest.restoreAllMocks());
 
-  it("applies only monotonic typed current-state results and actor actions", () => {
-    const initial = createChatActorProjection("conversation-alpha");
+  it('applies only monotonic typed current-state results and actor actions', () => {
+    const initial = createChatActorProjection('conversation-alpha');
     const current = applyCurrentStateResult(initial, currentEnvelope);
 
     expect(current.reloadWithoutCursor).toBe(false);
     expect(current.projection).toMatchObject({
-      actorId: "conversation-alpha",
-      scopeId: "scope-alpha",
+      actorId: 'conversation-alpha',
+      scopeId: 'scope-alpha',
       stateVersion: 7,
       progressSequence: 11,
-      pendingInput: { requestId: "input-alpha" },
-      pendingApproval: { approvalRequestId: "approval-alpha" },
+      pendingInput: { requestId: 'input-alpha' },
+      pendingApproval: { approvalRequestId: 'approval-alpha' },
     });
-    expect(actorCan(current.projection, "retry", "step-alpha")).toBe(true);
-    expect(actorCan(current.projection, "skip", "step-alpha")).toBe(false);
-    expect(actorCan(current.projection, "stop")).toBe(true);
+    expect(actorCan(current.projection, 'retry', 'step-alpha')).toBe(true);
+    expect(actorCan(current.projection, 'skip', 'step-alpha')).toBe(false);
+    expect(actorCan(current.projection, 'stop')).toBe(true);
 
     const older = applyCurrentStateResult(current.projection, {
       ...currentEnvelope,
@@ -114,37 +114,37 @@ describe("chatActorState", () => {
 
     expect(
       applyCurrentStateResult(current.projection, {
-        status: "not_modified",
+        status: 'not_modified',
         stateVersion: 7,
-        turnId: "turn-alpha",
-      }).projection
+        turnId: 'turn-alpha',
+      }).projection,
     ).toBe(current.projection);
     expect(
       applyCurrentStateResult(current.projection, {
-        status: "reload_required",
+        status: 'reload_required',
         stateVersion: 7,
-        reasonCode: "turn_mismatch",
-      }).reloadWithoutCursor
+        reasonCode: 'turn_mismatch',
+      }).reloadWithoutCursor,
     ).toBe(true);
     expect(
-      applyCurrentStateResult(current.projection, { status: "not_found" })
-        .projection.stateVersion
+      applyCurrentStateResult(current.projection, { status: 'not_found' })
+        .projection.stateVersion,
     ).toBe(0);
   });
 
-  it("reduces canonical actor frames by monotonic progress sequence", () => {
+  it('reduces canonical actor frames by monotonic progress sequence', () => {
     const snapshotFrame = decodeActorFrame({
-      type: "CUSTOM",
+      type: 'CUSTOM',
       sequence: 5,
       custom: {
-        name: "nyxid.task.snapshot",
+        name: 'nyxid.task.snapshot',
         payload: {
-          taskId: "task-alpha",
-          turnId: "turn-alpha",
-          status: "active",
+          taskId: 'task-alpha',
+          turnId: 'turn-alpha',
+          status: 'active',
           steps: [
             {
-              stepId: "step-alpha",
+              stepId: 'step-alpha',
               order: 1,
               availableActions: { retry: false, skip: true, stop: false },
             },
@@ -153,182 +153,184 @@ describe("chatActorState", () => {
       },
     });
     const first = reduceActorFrame(
-      createChatActorProjection("conversation-alpha"),
-      snapshotFrame
+      createChatActorProjection('conversation-alpha'),
+      snapshotFrame,
     );
     const changed = reduceActorFrame(
       first,
       decodeActorFrame({
-        type: "CUSTOM",
+        type: 'CUSTOM',
         sequence: 6,
         custom: {
-          name: "nyxid.task.step.changed",
+          name: 'nyxid.task.step.changed',
           payload: {
-            taskId: "task-alpha",
+            taskId: 'task-alpha',
             planRevision: 2,
-            changeKind: "status",
+            changeKind: 'status',
             step: {
-              stepId: "step-alpha",
+              stepId: 'step-alpha',
               order: 1,
               availableActions: { retry: true, skip: false, stop: true },
             },
           },
         },
-      })
+      }),
     );
     const stale = reduceActorFrame(
       changed,
       decodeActorFrame({
-        type: "CUSTOM",
+        type: 'CUSTOM',
         sequence: 4,
         custom: {
-          name: "nyxid.task.step.changed",
+          name: 'nyxid.task.step.changed',
           payload: {
-            taskId: "task-alpha",
+            taskId: 'task-alpha',
             planRevision: 1,
-            changeKind: "status",
+            changeKind: 'status',
             step: {
-              stepId: "step-alpha",
+              stepId: 'step-alpha',
               availableActions: { retry: false, skip: true, stop: false },
             },
           },
         },
-      })
+      }),
     );
 
     expect(first.progressSequence).toBe(5);
-    expect(actorCan(first, "skip", "step-alpha")).toBe(true);
+    expect(actorCan(first, 'skip', 'step-alpha')).toBe(true);
     expect(changed.progressSequence).toBe(6);
-    expect(actorCan(changed, "retry", "step-alpha")).toBe(true);
-    expect(actorCan(changed, "skip", "step-alpha")).toBe(false);
+    expect(actorCan(changed, 'retry', 'step-alpha')).toBe(true);
+    expect(actorCan(changed, 'skip', 'step-alpha')).toBe(false);
     expect(stale).toBe(changed);
   });
 
-  it("accepts only secret-free schema-v4 service.connect requests", () => {
+  it('accepts only secret-free schema-v4 service.connect requests', () => {
     expect(validateActionRequest(actionRequest)).toEqual(actionRequest);
     expect(
       validateActionRequest({
         ...actionRequest,
         params: {
           customService: {
-            name: "Private API",
-            endpointUrl: "https://example.com/api",
-            authMethod: "header",
-            authKeyName: "X-Service-Key",
+            name: 'Private API',
+            endpointUrl: 'https://example.com/api',
+            authMethod: 'header',
+            authKeyName: 'X-Service-Key',
           },
         },
-      }).params
+      }).params,
     ).toEqual({
       customService: {
-        name: "Private API",
-        endpointUrl: "https://example.com/api",
-        authMethod: "header",
-        authKeyName: "X-Service-Key",
+        name: 'Private API',
+        endpointUrl: 'https://example.com/api',
+        authMethod: 'header',
+        authKeyName: 'X-Service-Key',
       },
     });
     expect(() =>
-      validateActionRequest({ ...actionRequest, schemaVersion: 3 })
-    ).toThrow(expect.objectContaining({ code: "NYXID_ACTION_UNSUPPORTED" }));
+      validateActionRequest({ ...actionRequest, schemaVersion: 3 }),
+    ).toThrow(expect.objectContaining({ code: 'NYXID_ACTION_UNSUPPORTED' }));
     expect(() =>
-      validateActionRequest({ ...actionRequest, apiKey: "secret" })
-    ).toThrow(expect.objectContaining({ code: "NYXID_FIELD_UNDECLARED" }));
-    expect(() =>
-      validateActionRequest({
-        ...actionRequest,
-        params: {
-          customService: {
-            name: "Private API",
-            endpointUrl: "https://user:pass@example.com/api",
-            authMethod: "bearer",
-          },
-        },
-      })
-    ).toThrow(expect.objectContaining({ code: "NYXID_URL_UNSAFE" }));
+      validateActionRequest({ ...actionRequest, apiKey: 'secret' }),
+    ).toThrow(expect.objectContaining({ code: 'NYXID_FIELD_UNDECLARED' }));
     expect(() =>
       validateActionRequest({
         ...actionRequest,
         params: {
           customService: {
-            name: "Private API",
-            endpointUrl: "https://example.com/api",
-            authMethod: "header",
-            authKeyName: "X Service Key",
+            name: 'Private API',
+            endpointUrl: 'https://user:pass@example.com/api',
+            authMethod: 'bearer',
           },
         },
-      })
-    ).toThrow(expect.objectContaining({ code: "NYXID_ACTION_VARIANT_INVALID" }));
-    expect(() =>
-      validateActionRequest({
-        ...actionRequest,
-        params: { catalogService: { serviceSlug: "nyxid_live_secret123" } },
-      })
-    ).toThrow(expect.objectContaining({ code: "NYXID_SECRET_FORBIDDEN" }));
+      }),
+    ).toThrow(expect.objectContaining({ code: 'NYXID_URL_UNSAFE' }));
     expect(() =>
       validateActionRequest({
         ...actionRequest,
         params: {
           customService: {
-            name: "Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature",
-            endpointUrl: "https://example.com/api",
-            authMethod: "bearer",
+            name: 'Private API',
+            endpointUrl: 'https://example.com/api',
+            authMethod: 'header',
+            authKeyName: 'X Service Key',
           },
         },
-      })
-    ).toThrow(expect.objectContaining({ code: "NYXID_SECRET_FORBIDDEN" }));
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: 'NYXID_ACTION_VARIANT_INVALID' }),
+    );
+    expect(() =>
+      validateActionRequest({
+        ...actionRequest,
+        params: { catalogService: { serviceSlug: 'nyxid_live_secret123' } },
+      }),
+    ).toThrow(expect.objectContaining({ code: 'NYXID_SECRET_FORBIDDEN' }));
+    expect(() =>
+      validateActionRequest({
+        ...actionRequest,
+        params: {
+          customService: {
+            name: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature',
+            endpointUrl: 'https://example.com/api',
+            authMethod: 'bearer',
+          },
+        },
+      }),
+    ).toThrow(expect.objectContaining({ code: 'NYXID_SECRET_FORBIDDEN' }));
   });
 
-  it("rejects an action request owned by a different conversation actor", () => {
-    const projection = createChatActorProjection("conversation-alpha");
+  it('rejects an action request owned by a different conversation actor', () => {
+    const projection = createChatActorProjection('conversation-alpha');
     const next = reduceActorFrame(
       projection,
       decodeActorFrame({
-        type: "CUSTOM",
+        type: 'CUSTOM',
         sequence: 1,
         custom: {
-          name: "nyxid.action.request",
-          payload: { ...actionRequest, actorId: "conversation-beta" },
+          name: 'nyxid.action.request',
+          payload: { ...actionRequest, actorId: 'conversation-beta' },
         },
-      })
+      }),
     );
 
     expect(next.actions.size).toBe(0);
     expect(next.conflicts).toContainEqual({
-      code: "NYXID_STATE_IDENTITY_CONFLICT",
+      code: 'NYXID_STATE_IDENTITY_CONFLICT',
     });
   });
 
-  it("conflicts instead of replacing action params under the same identity", () => {
+  it('conflicts instead of replacing action params under the same identity', () => {
     const first = reduceActorFrame(
-      createChatActorProjection("conversation-alpha"),
+      createChatActorProjection('conversation-alpha'),
       decodeActorFrame({
         sequence: 1,
-        custom: { name: "nyxid.action.request", payload: actionRequest },
-      })
+        custom: { name: 'nyxid.action.request', payload: actionRequest },
+      }),
     );
     const next = reduceActorFrame(
       first,
       decodeActorFrame({
         sequence: 2,
         custom: {
-          name: "nyxid.action.request",
+          name: 'nyxid.action.request',
           payload: {
             ...actionRequest,
-            params: { catalogService: { serviceSlug: "api-gitlab" } },
+            params: { catalogService: { serviceSlug: 'api-gitlab' } },
           },
         },
-      })
+      }),
     );
 
-    expect(next.actions.get("action-alpha")).toMatchObject({
+    expect(next.actions.get('action-alpha')).toMatchObject({
       conflicted: true,
       request: actionRequest,
     });
   });
 
-  it("disables duplicate current-state action identities", () => {
+  it('disables duplicate current-state action identities', () => {
     writeCachedActionRequest(actionRequest);
     const result = applyCurrentStateResult(
-      createChatActorProjection("conversation-alpha"),
+      createChatActorProjection('conversation-alpha'),
       {
         ...currentEnvelope,
         snapshot: {
@@ -341,63 +343,63 @@ describe("chatActorState", () => {
             },
             {
               ...actionRequest,
-              originTurnId: "turn-beta",
+              originTurnId: 'turn-beta',
               reports: [],
               postconditionResult: null,
             },
           ],
         },
-      }
+      },
     );
 
-    expect(result.projection.actions.get("action-alpha")).toMatchObject({
+    expect(result.projection.actions.get('action-alpha')).toMatchObject({
       conflicted: true,
       request: null,
     });
   });
 
-  it("keeps live actions usable when session storage is unavailable", () => {
+  it('keeps live actions usable when session storage is unavailable', () => {
     const setItem = jest
-      .spyOn(Storage.prototype, "setItem")
+      .spyOn(Storage.prototype, 'setItem')
       .mockImplementation(() => {
-        throw new DOMException("Unavailable", "SecurityError");
+        throw new DOMException('Unavailable', 'SecurityError');
       });
 
     expect(() =>
       reduceActorFrame(
-        createChatActorProjection("conversation-alpha"),
+        createChatActorProjection('conversation-alpha'),
         decodeActorFrame({
           sequence: 1,
-          custom: { name: "nyxid.action.request", payload: actionRequest },
-        })
-      )
+          custom: { name: 'nyxid.action.request', payload: actionRequest },
+        }),
+      ),
     ).not.toThrow();
     setItem.mockRestore();
   });
 
-  it("restores cached action params only for the exact pending identity", () => {
+  it('restores cached action params only for the exact pending identity', () => {
     writeCachedActionRequest(actionRequest);
     expect(
       readCachedActionRequest({
         schemaVersion: 4,
-        actorId: "conversation-alpha",
-        originTurnId: "turn-alpha",
-        taskId: "task-alpha",
-        stepId: "step-connect",
-        actionRequestId: "action-alpha",
-        action: "service.connect",
-      })
+        actorId: 'conversation-alpha',
+        originTurnId: 'turn-alpha',
+        taskId: 'task-alpha',
+        stepId: 'step-connect',
+        actionRequestId: 'action-alpha',
+        action: 'service.connect',
+      }),
     ).toEqual(actionRequest);
 
     const colonActor = {
       ...actionRequest,
-      actorId: "conversation:alpha",
-      actionRequestId: "action",
+      actorId: 'conversation:alpha',
+      actionRequestId: 'action',
     } as const;
     const colonAction = {
       ...actionRequest,
-      actorId: "conversation",
-      actionRequestId: "alpha:action",
+      actorId: 'conversation',
+      actionRequestId: 'alpha:action',
     } as const;
     writeCachedActionRequest(colonActor);
     writeCachedActionRequest(colonAction);
@@ -410,7 +412,7 @@ describe("chatActorState", () => {
         stepId: colonActor.stepId,
         actionRequestId: colonActor.actionRequestId,
         action: colonActor.action,
-      })
+      }),
     ).toEqual(colonActor);
     expect(
       readCachedActionRequest({
@@ -421,35 +423,35 @@ describe("chatActorState", () => {
         stepId: colonAction.stepId,
         actionRequestId: colonAction.actionRequestId,
         action: colonAction.action,
-      })
+      }),
     ).toEqual(colonAction);
     expect(
       readCachedActionRequest({
         schemaVersion: 4,
-        actorId: "conversation-alpha",
-        originTurnId: "turn-alpha",
-        taskId: "task-alpha",
-        stepId: "step-other",
-        actionRequestId: "action-alpha",
-        action: "service.connect",
-      })
+        actorId: 'conversation-alpha',
+        originTurnId: 'turn-alpha',
+        taskId: 'task-alpha',
+        stepId: 'step-other',
+        actionRequestId: 'action-alpha',
+        action: 'service.connect',
+      }),
     ).toBeNull();
 
     writeCachedActionRequest({
       ...actionRequest,
-      actorId: "conversation-beta",
-      params: { catalogService: { serviceSlug: "api-gitlab" } },
+      actorId: 'conversation-beta',
+      params: { catalogService: { serviceSlug: 'api-gitlab' } },
     });
     expect(
       readCachedActionRequest({
         schemaVersion: 4,
-        actorId: "conversation-alpha",
-        originTurnId: "turn-alpha",
-        taskId: "task-alpha",
-        stepId: "step-connect",
-        actionRequestId: "action-alpha",
-        action: "service.connect",
-      })
+        actorId: 'conversation-alpha',
+        originTurnId: 'turn-alpha',
+        taskId: 'task-alpha',
+        stepId: 'step-connect',
+        actionRequestId: 'action-alpha',
+        action: 'service.connect',
+      }),
     ).toEqual(actionRequest);
   });
 });

--- a/apps/aevatar-console-web/src/pages/chat/chatActorState.test.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatActorState.test.ts
@@ -156,16 +156,41 @@ describe("chatActorState", () => {
       createChatActorProjection("conversation-alpha"),
       snapshotFrame
     );
-    const stale = reduceActorFrame(
+    const changed = reduceActorFrame(
       first,
+      decodeActorFrame({
+        type: "CUSTOM",
+        sequence: 6,
+        custom: {
+          name: "nyxid.task.step.changed",
+          payload: {
+            taskId: "task-alpha",
+            planRevision: 2,
+            changeKind: "status",
+            step: {
+              stepId: "step-alpha",
+              order: 1,
+              availableActions: { retry: true, skip: false, stop: true },
+            },
+          },
+        },
+      })
+    );
+    const stale = reduceActorFrame(
+      changed,
       decodeActorFrame({
         type: "CUSTOM",
         sequence: 4,
         custom: {
           name: "nyxid.task.step.changed",
           payload: {
-            stepId: "step-alpha",
-            availableActions: { retry: true, skip: false, stop: true },
+            taskId: "task-alpha",
+            planRevision: 1,
+            changeKind: "status",
+            step: {
+              stepId: "step-alpha",
+              availableActions: { retry: false, skip: true, stop: false },
+            },
           },
         },
       })
@@ -173,7 +198,10 @@ describe("chatActorState", () => {
 
     expect(first.progressSequence).toBe(5);
     expect(actorCan(first, "skip", "step-alpha")).toBe(true);
-    expect(stale).toBe(first);
+    expect(changed.progressSequence).toBe(6);
+    expect(actorCan(changed, "retry", "step-alpha")).toBe(true);
+    expect(actorCan(changed, "skip", "step-alpha")).toBe(false);
+    expect(stale).toBe(changed);
   });
 
   it("accepts only secret-free schema-v4 service.connect requests", () => {

--- a/apps/aevatar-console-web/src/pages/chat/chatActorState.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatActorState.ts
@@ -227,7 +227,7 @@ export function reduceActorFrame(
       applyTask(next, frame.payload);
       break;
     case "task_step_changed":
-      applyStep(next, frame.payload);
+      applyStep(next, optionalRecord(frame.payload.step));
       break;
     case "control_changed":
       next.latestControlResult = cloneRecord(frame.payload);
@@ -566,7 +566,11 @@ function applyTask(projection: ChatActorProjection, task: JsonRecord): void {
   projection.steps = new Map(steps.map((step) => [step.stepId, cloneStep(step)]));
 }
 
-function applyStep(projection: ChatActorProjection, input: JsonRecord): void {
+function applyStep(
+  projection: ChatActorProjection,
+  input: JsonRecord | null
+): void {
+  if (!input) return;
   const stepId = readIdentity(input.stepId);
   if (!stepId) return;
   const step = { ...projection.steps.get(stepId), ...cloneRecord(input), stepId };

--- a/apps/aevatar-console-web/src/pages/chat/chatActorState.ts
+++ b/apps/aevatar-console-web/src/pages/chat/chatActorState.ts
@@ -1,54 +1,53 @@
 type JsonRecord = Record<string, unknown>;
 
 const ACTOR_EVENT_NAMES = {
-  "nyxid.task.snapshot": "task_snapshot",
-  "nyxid.task.step.changed": "task_step_changed",
-  "nyxid.control.changed": "control_changed",
-  "nyxid.continuation.changed": "continuation_changed",
-  "nyxid.step.control.changed": "step_control_changed",
-  "nyxid.input.request": "input_request",
-  "nyxid.input.changed": "input_changed",
-  "nyxid.approval.request": "approval_request",
-  "nyxid.approval.changed": "approval_changed",
-  "nyxid.action.request": "action_request",
+  'nyxid.task.snapshot': 'task_snapshot',
+  'nyxid.task.step.changed': 'task_step_changed',
+  'nyxid.control.changed': 'control_changed',
+  'nyxid.continuation.changed': 'continuation_changed',
+  'nyxid.step.control.changed': 'step_control_changed',
+  'nyxid.input.request': 'input_request',
+  'nyxid.input.changed': 'input_changed',
+  'nyxid.approval.request': 'approval_request',
+  'nyxid.approval.changed': 'approval_changed',
+  'nyxid.action.request': 'action_request',
 } as const;
 
 const ACTION_IDENTITY_KEYS = [
-  "actorId",
-  "originTurnId",
-  "taskId",
-  "stepId",
-  "actionRequestId",
+  'actorId',
+  'originTurnId',
+  'taskId',
+  'stepId',
+  'actionRequestId',
 ] as const;
 const ACTION_KEYS = [
-  "schemaVersion",
+  'schemaVersion',
   ...ACTION_IDENTITY_KEYS,
-  "action",
-  "params",
+  'action',
+  'params',
 ];
 const FORBIDDEN_ACTION_KEY =
   /(?:^|[_-])(authorization|api[-_]?key|token|secret|password|credential|cookie|user[-_]?code|device[-_]?code)(?:$|[_-])/i;
 const SECRET_VALUE =
   /(Bearer\s+)[A-Za-z0-9._~+/-]+|nyx(?:id)?_[A-Za-z0-9_-]{8,}/gi;
-const ACTION_CACHE_PREFIX = "aevatar-console:chat-action:v4:";
+const ACTION_CACHE_PREFIX = 'aevatar-console:chat-action:v4:';
 const CUSTOM_SERVICE_AUTH_METHODS = [
-  "bearer",
-  "header",
-  "query",
-  "path",
-  "basic",
-  "body",
-  "none",
+  'bearer',
+  'header',
+  'query',
+  'path',
+  'basic',
+  'body',
+  'none',
 ] as const;
-type ChatCustomServiceAuthMethod =
-  (typeof CUSTOM_SERVICE_AUTH_METHODS)[number];
+type ChatCustomServiceAuthMethod = (typeof CUSTOM_SERVICE_AUTH_METHODS)[number];
 
 export class ChatActorProtocolError extends Error {
   readonly code: string;
 
   constructor(message: string, code: string) {
     super(message);
-    this.name = "ChatActorProtocolError";
+    this.name = 'ChatActorProtocolError';
     this.code = code;
   }
 }
@@ -88,7 +87,7 @@ export type ChatServiceConnectActionRequest = {
   readonly taskId: string;
   readonly stepId: string;
   readonly actionRequestId: string;
-  readonly action: "service.connect";
+  readonly action: 'service.connect';
   readonly params:
     | {
         readonly catalogService: {
@@ -147,29 +146,29 @@ export type ChatActorProjection = {
 };
 
 export type ChatActorFrame =
-  | { type: "ignored" }
+  | { type: 'ignored' }
   | {
       type:
-        | "task_snapshot"
-        | "task_step_changed"
-        | "control_changed"
-        | "continuation_changed"
-        | "step_control_changed"
-        | "input_request"
-        | "input_changed"
-        | "approval_request"
-        | "approval_changed";
+        | 'task_snapshot'
+        | 'task_step_changed'
+        | 'control_changed'
+        | 'continuation_changed'
+        | 'step_control_changed'
+        | 'input_request'
+        | 'input_changed'
+        | 'approval_request'
+        | 'approval_changed';
       sequence: number;
       payload: JsonRecord;
     }
   | {
-      type: "action_request";
+      type: 'action_request';
       sequence: number;
       request: ChatServiceConnectActionRequest;
     };
 
 export function createChatActorProjection(
-  actorId: string | null = null
+  actorId: string | null = null,
 ): ChatActorProjection {
   return {
     actorId,
@@ -197,60 +196,63 @@ export function createChatActorProjection(
 export function decodeActorFrame(raw: unknown): ChatActorFrame {
   const frame = optionalRecord(raw);
   const custom = optionalRecord(frame?.custom);
-  const name = typeof custom?.name === "string" ? custom.name : "";
+  const name = typeof custom?.name === 'string' ? custom.name : '';
   const type = ACTOR_EVENT_NAMES[name as keyof typeof ACTOR_EVENT_NAMES];
-  if (!type) return { type: "ignored" };
+  if (!type) return { type: 'ignored' };
   const sequence = frame?.sequence;
   if (!validVersion(sequence)) {
     throw new ChatActorProtocolError(
-      "Actor progress sequence is invalid.",
-      "NYXID_SEQUENCE_INVALID"
+      'Actor progress sequence is invalid.',
+      'NYXID_SEQUENCE_INVALID',
     );
   }
   const payload = unpackAny(custom?.payload);
-  return type === "action_request"
+  return type === 'action_request'
     ? { type, sequence, request: validateActionRequest(payload) }
     : { type, sequence, payload };
 }
 
 export function reduceActorFrame(
   projection: ChatActorProjection,
-  frame: ChatActorFrame
+  frame: ChatActorFrame,
 ): ChatActorProjection {
-  if (frame.type === "ignored" || frame.sequence < projection.progressSequence) {
+  if (
+    frame.type === 'ignored' ||
+    frame.sequence < projection.progressSequence
+  ) {
     return projection;
   }
   const next = cloneProjection(projection);
   next.progressSequence = frame.sequence;
   switch (frame.type) {
-    case "task_snapshot":
+    case 'task_snapshot':
       applyTask(next, frame.payload);
       break;
-    case "task_step_changed":
+    case 'task_step_changed':
       applyStep(next, optionalRecord(frame.payload.step));
       break;
-    case "control_changed":
+    case 'control_changed':
       next.latestControlResult = cloneRecord(frame.payload);
       break;
-    case "continuation_changed":
+    case 'continuation_changed':
       next.continuation = cloneRecord(frame.payload);
       break;
-    case "step_control_changed":
+    case 'step_control_changed':
       next.latestStepControlResult = cloneRecord(frame.payload);
       break;
-    case "input_request":
+    case 'input_request':
       next.pendingInput = frame.payload as ChatPendingInput;
       break;
-    case "input_changed":
+    case 'input_changed':
       next.latestInputResolution = cloneRecord(frame.payload);
       if (next.pendingInput?.requestId === frame.payload.requestId) {
         next.pendingInput = null;
       }
       break;
-    case "approval_request":
+    case 'approval_request':
       next.pendingApproval = normalizePendingApproval(frame.payload);
       break;
-    case "approval_changed":
+    case 'approval_changed':
       next.latestApprovalResolution = cloneRecord(frame.payload);
       if (
         next.pendingApproval?.approvalRequestId ===
@@ -259,7 +261,7 @@ export function reduceActorFrame(
         next.pendingApproval = null;
       }
       break;
-    case "action_request":
+    case 'action_request':
       applyActionRequest(next, frame.request);
       break;
   }
@@ -268,37 +270,37 @@ export function reduceActorFrame(
 
 export function applyCurrentStateResult(
   projection: ChatActorProjection,
-  input: unknown
+  input: unknown,
 ): { projection: ChatActorProjection; reloadWithoutCursor: boolean } {
   const envelope = optionalRecord(input);
   if (!envelope) {
     return {
-      projection: withConflict(projection, "NYXID_STATE_STATUS_INVALID"),
+      projection: withConflict(projection, 'NYXID_STATE_STATUS_INVALID'),
       reloadWithoutCursor: false,
     };
   }
   const status = envelope.status;
-  if (status === "reload_required") {
+  if (status === 'reload_required') {
     return { projection, reloadWithoutCursor: true };
   }
-  if (status === "not_found") {
+  if (status === 'not_found') {
     return {
       projection: createChatActorProjection(projection.actorId),
       reloadWithoutCursor: false,
     };
   }
-  if (status === "not_modified") {
+  if (status === 'not_modified') {
     return validVersion(envelope.stateVersion) &&
       envelope.stateVersion === projection.stateVersion
       ? { projection, reloadWithoutCursor: false }
       : {
-          projection: withConflict(projection, "NYXID_STATE_VERSION_CONFLICT"),
+          projection: withConflict(projection, 'NYXID_STATE_VERSION_CONFLICT'),
           reloadWithoutCursor: false,
         };
   }
-  if (status !== "current") {
+  if (status !== 'current') {
     return {
-      projection: withConflict(projection, "NYXID_STATE_STATUS_INVALID"),
+      projection: withConflict(projection, 'NYXID_STATE_STATUS_INVALID'),
       reloadWithoutCursor: false,
     };
   }
@@ -311,7 +313,7 @@ export function applyCurrentStateResult(
     !validVersion(snapshot.progressSequence)
   ) {
     return {
-      projection: withConflict(projection, "NYXID_STATE_SNAPSHOT_INVALID"),
+      projection: withConflict(projection, 'NYXID_STATE_SNAPSHOT_INVALID'),
       reloadWithoutCursor: false,
     };
   }
@@ -330,7 +332,7 @@ export function applyCurrentStateResult(
     (projection.scopeId && projection.scopeId !== scopeId)
   ) {
     return {
-      projection: withConflict(projection, "NYXID_STATE_IDENTITY_CONFLICT"),
+      projection: withConflict(projection, 'NYXID_STATE_IDENTITY_CONFLICT'),
       reloadWithoutCursor: false,
     };
   }
@@ -347,16 +349,18 @@ export function applyCurrentStateResult(
         .filter((value): value is JsonRecord => Boolean(value))
         .map(cloneRecord)
     : [];
-  next.pendingInput = optionalRecord(snapshot.pendingInput) as ChatPendingInput | null;
+  next.pendingInput = optionalRecord(
+    snapshot.pendingInput,
+  ) as ChatPendingInput | null;
   next.pendingApproval = normalizePendingApproval(snapshot.pendingApproval);
   next.controlFence = cloneNullableRecord(snapshot.controlFence);
   next.latestControlResult = cloneNullableRecord(snapshot.latestControlResult);
   next.continuation = cloneNullableRecord(snapshot.continuationAdmission);
   next.latestInputResolution = cloneNullableRecord(
-    snapshot.latestInputResolution
+    snapshot.latestInputResolution,
   );
   next.latestApprovalResolution = cloneNullableRecord(
-    snapshot.latestApprovalResolution
+    snapshot.latestApprovalResolution,
   );
   next.conflicts = [...projection.conflicts];
   const activeTask = optionalRecord(snapshot.activeTask);
@@ -367,13 +371,13 @@ export function applyCurrentStateResult(
 
 export function actorCan(
   projection: ChatActorProjection | null | undefined,
-  action: "retry" | "skip" | "stop",
-  stepId?: string
+  action: 'retry' | 'skip' | 'stop',
+  stepId?: string,
 ): boolean {
   if (!projection) return false;
-  if (action === "stop" && !stepId) {
+  if (action === 'stop' && !stepId) {
     return [...projection.steps.values()].some(
-      (step) => step.availableActions?.stop === true
+      (step) => step.availableActions?.stop === true,
     );
   }
   if (!stepId) return false;
@@ -381,37 +385,37 @@ export function actorCan(
 }
 
 export function validateActionRequest(
-  input: unknown
+  input: unknown,
 ): ChatServiceConnectActionRequest {
   const value = unpackAny(input);
   assertAllowedKeys(value, ACTION_KEYS);
-  if (value.schemaVersion !== 4 || value.action !== "service.connect") {
+  if (value.schemaVersion !== 4 || value.action !== 'service.connect') {
     throw new ChatActorProtocolError(
-      "Unsupported NyxID action request.",
-      "NYXID_ACTION_UNSUPPORTED"
+      'Unsupported NyxID action request.',
+      'NYXID_ACTION_UNSUPPORTED',
     );
   }
   const identity = Object.fromEntries(
-    ACTION_IDENTITY_KEYS.map((key) => [key, requireIdentity(value[key])])
+    ACTION_IDENTITY_KEYS.map((key) => [key, requireIdentity(value[key])]),
   ) as Record<(typeof ACTION_IDENTITY_KEYS)[number], string>;
   const params = validateServiceConnectParams(value.params);
   rejectSecretBearingInput({ ...identity, params });
   return {
     schemaVersion: 4,
     ...identity,
-    action: "service.connect",
+    action: 'service.connect',
     params,
   };
 }
 
 export function writeCachedActionRequest(
-  request: ChatServiceConnectActionRequest
+  request: ChatServiceConnectActionRequest,
 ): void {
   const validated = validateActionRequest(request);
   try {
     globalThis.sessionStorage?.setItem(
       actionCacheKey(validated.actorId, validated.actionRequestId),
-      JSON.stringify(validated)
+      JSON.stringify(validated),
     );
   } catch {
     // Session cache is optional; live actor facts remain authoritative.
@@ -419,11 +423,11 @@ export function writeCachedActionRequest(
 }
 
 export function readCachedActionRequest(
-  summary: Omit<ChatActionSummary, "request">
+  summary: Omit<ChatActionSummary, 'request'>,
 ): ChatServiceConnectActionRequest | null {
   try {
     const raw = globalThis.sessionStorage?.getItem(
-      actionCacheKey(summary.actorId, summary.actionRequestId)
+      actionCacheKey(summary.actorId, summary.actionRequestId),
     );
     if (!raw || summary.conflicted) return null;
     const request = validateActionRequest(JSON.parse(raw));
@@ -439,29 +443,29 @@ export function readCachedActionRequest(
 
 export function chatActionIdentityKey(
   actorId: string,
-  actionRequestId: string
+  actionRequestId: string,
 ): string {
   return JSON.stringify([actorId, actionRequestId]);
 }
 
 function validateServiceConnectParams(
-  input: unknown
-): ChatServiceConnectActionRequest["params"] {
-  const value = requireRecord(input, "NYXID_ACTION_VARIANT_INVALID");
-  assertAllowedKeys(value, ["catalogService", "customService"]);
-  const hasCatalog = "catalogService" in value;
-  const hasCustom = "customService" in value;
+  input: unknown,
+): ChatServiceConnectActionRequest['params'] {
+  const value = requireRecord(input, 'NYXID_ACTION_VARIANT_INVALID');
+  assertAllowedKeys(value, ['catalogService', 'customService']);
+  const hasCatalog = 'catalogService' in value;
+  const hasCustom = 'customService' in value;
   if (hasCatalog === hasCustom) throw invalidVariant();
   if (hasCatalog) {
     const catalog = requireRecord(
       value.catalogService,
-      "NYXID_ACTION_VARIANT_INVALID"
+      'NYXID_ACTION_VARIANT_INVALID',
     );
     assertAllowedKeys(catalog, [
-      "serviceSlug",
-      "requestedScopes",
-      "viaNodeId",
-      "targetOrgId",
+      'serviceSlug',
+      'requestedScopes',
+      'viaNodeId',
+      'targetOrgId',
     ]);
     const serviceSlug = requireBoundedString(catalog.serviceSlug, 128);
     if (!/^[A-Za-z0-9._-]+$/.test(serviceSlug)) throw invalidVariant();
@@ -478,7 +482,7 @@ function validateServiceConnectParams(
         ...(requestedScopes !== undefined
           ? {
               requestedScopes: requestedScopes.map((scope) =>
-                requireBoundedString(scope, 256)
+                requireBoundedString(scope, 256),
               ),
             }
           : {}),
@@ -494,19 +498,19 @@ function validateServiceConnectParams(
 
   const custom = requireRecord(
     value.customService,
-    "NYXID_ACTION_VARIANT_INVALID"
+    'NYXID_ACTION_VARIANT_INVALID',
   );
   assertAllowedKeys(custom, [
-    "name",
-    "endpointUrl",
-    "authMethod",
-    "authKeyName",
-    "viaNodeId",
-    "targetOrgId",
+    'name',
+    'endpointUrl',
+    'authMethod',
+    'authKeyName',
+    'viaNodeId',
+    'targetOrgId',
   ]);
   const requestedAuthMethod = requireBoundedString(custom.authMethod, 32);
   const authMethod = CUSTOM_SERVICE_AUTH_METHODS.find(
-    (method) => method === requestedAuthMethod
+    (method) => method === requestedAuthMethod,
   );
   if (!authMethod) throw invalidVariant();
   const endpointUrl = requireBoundedString(custom.endpointUrl, 2048);
@@ -514,7 +518,10 @@ function validateServiceConnectParams(
     custom.authKeyName === undefined
       ? undefined
       : requireBoundedString(custom.authKeyName, 256);
-  if (authKeyName !== undefined && !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(authKeyName)) {
+  if (
+    authKeyName !== undefined &&
+    !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(authKeyName)
+  ) {
     throw invalidVariant();
   }
   let url: URL;
@@ -524,7 +531,7 @@ function validateServiceConnectParams(
     throw unsafeUrl();
   }
   if (
-    url.protocol !== "https:" ||
+    url.protocol !== 'https:' ||
     !url.hostname ||
     url.username ||
     url.password ||
@@ -557,34 +564,41 @@ function applyTask(projection: ChatActorProjection, task: JsonRecord): void {
         .filter((value): value is JsonRecord => Boolean(value))
         .map((value) => value as ChatActorStep)
         .filter((step) => Boolean(readIdentity(step.stepId)))
-        .sort((left, right) =>
-          Number(left.order ?? Number.MAX_SAFE_INTEGER) -
-            Number(right.order ?? Number.MAX_SAFE_INTEGER) ||
-          left.stepId.localeCompare(right.stepId)
+        .sort(
+          (left, right) =>
+            Number(left.order ?? Number.MAX_SAFE_INTEGER) -
+              Number(right.order ?? Number.MAX_SAFE_INTEGER) ||
+            left.stepId.localeCompare(right.stepId),
         )
     : [];
-  projection.steps = new Map(steps.map((step) => [step.stepId, cloneStep(step)]));
+  projection.steps = new Map(
+    steps.map((step) => [step.stepId, cloneStep(step)]),
+  );
 }
 
 function applyStep(
   projection: ChatActorProjection,
-  input: JsonRecord | null
+  input: JsonRecord | null,
 ): void {
   if (!input) return;
   const stepId = readIdentity(input.stepId);
   if (!stepId) return;
-  const step = { ...projection.steps.get(stepId), ...cloneRecord(input), stepId };
+  const step = {
+    ...projection.steps.get(stepId),
+    ...cloneRecord(input),
+    stepId,
+  };
   projection.steps.set(stepId, step as ChatActorStep);
 }
 
 function applyActionRequest(
   projection: ChatActorProjection,
-  request: ChatServiceConnectActionRequest
+  request: ChatServiceConnectActionRequest,
 ): void {
   if (projection.actorId && projection.actorId !== request.actorId) {
     projection.conflicts = [
       ...projection.conflicts,
-      { code: "NYXID_STATE_IDENTITY_CONFLICT" },
+      { code: 'NYXID_STATE_IDENTITY_CONFLICT' },
     ];
     return;
   }
@@ -605,7 +619,7 @@ function applyActionRequest(
   projection.actions.set(request.actionRequestId, {
     schemaVersion: request.schemaVersion,
     ...Object.fromEntries(
-      ACTION_IDENTITY_KEYS.map((key) => [key, request[key]])
+      ACTION_IDENTITY_KEYS.map((key) => [key, request[key]]),
     ),
     action: request.action,
     reports: existing?.reports ?? [],
@@ -621,7 +635,7 @@ function actionCacheKey(actorId: string, actionRequestId: string): string {
 
 function applyActionSummaries(
   projection: ChatActorProjection,
-  input: unknown
+  input: unknown,
 ): void {
   projection.actions = new Map();
   if (!Array.isArray(input)) return;
@@ -642,19 +656,19 @@ function applyActionSummaries(
       });
       projection.conflicts = [
         ...projection.conflicts,
-        { code: "NYXID_ACTION_ID_CONFLICT" },
+        { code: 'NYXID_ACTION_ID_CONFLICT' },
       ];
       continue;
     }
     const item: ChatActionSummary = {
       schemaVersion:
-        typeof summary.schemaVersion === "number" ? summary.schemaVersion : 0,
-      actorId: projection.actorId ?? "",
+        typeof summary.schemaVersion === 'number' ? summary.schemaVersion : 0,
+      actorId: projection.actorId ?? '',
       originTurnId,
       taskId,
       stepId,
       actionRequestId,
-      action: typeof summary.action === "string" ? summary.action : "",
+      action: typeof summary.action === 'string' ? summary.action : '',
       reports: Array.isArray(summary.reports)
         ? (summary.reports.filter(optionalRecord) as JsonRecord[])
         : [],
@@ -671,19 +685,20 @@ function normalizePendingApproval(input: unknown): ChatPendingApproval | null {
   const presentation = optionalRecord(value.presentation);
   const normalized = { ...cloneRecord(value), ...(presentation ?? {}) };
   const approvalRequestId = readIdentity(
-    value.approvalRequestId ?? value.requestId
+    value.approvalRequestId ?? value.requestId,
   );
   if (!approvalRequestId) return null;
   return {
     ...normalized,
     approvalRequestId,
-    toolName: typeof normalized.toolName === "string" ? normalized.toolName : "",
+    toolName:
+      typeof normalized.toolName === 'string' ? normalized.toolName : '',
   };
 }
 
 function actionIdentityMatches(
   summary: ChatActionSummary,
-  request: ChatServiceConnectActionRequest
+  request: ChatServiceConnectActionRequest,
 ): boolean {
   return (
     summary.schemaVersion === request.schemaVersion &&
@@ -693,20 +708,23 @@ function actionIdentityMatches(
 }
 
 function unpackAny(input: unknown): JsonRecord {
-  const value = requireRecord(input, "NYXID_ACTION_VARIANT_INVALID");
+  const value = requireRecord(input, 'NYXID_ACTION_VARIANT_INVALID');
   const nested = optionalRecord(value.value);
   if (nested) return nested;
   const result = { ...value };
-  delete result["@type"];
+  delete result['@type'];
   return result;
 }
 
-function assertAllowedKeys(value: JsonRecord, allowed: readonly string[]): void {
+function assertAllowedKeys(
+  value: JsonRecord,
+  allowed: readonly string[],
+): void {
   const set = new Set(allowed);
   if (Object.keys(value).some((key) => !set.has(key))) {
     throw new ChatActorProtocolError(
-      "NyxID action contains an undeclared field.",
-      "NYXID_FIELD_UNDECLARED"
+      'NyxID action contains an undeclared field.',
+      'NYXID_FIELD_UNDECLARED',
     );
   }
 }
@@ -714,12 +732,12 @@ function assertAllowedKeys(value: JsonRecord, allowed: readonly string[]): void 
 function rejectSecretBearingInput(value: unknown): void {
   if (Array.isArray(value)) {
     value.forEach(rejectSecretBearingInput);
-  } else if (value && typeof value === "object") {
+  } else if (value && typeof value === 'object') {
     for (const [key, child] of Object.entries(value)) {
       if (FORBIDDEN_ACTION_KEY.test(key)) throw secretForbidden();
       rejectSecretBearingInput(child);
     }
-  } else if (typeof value === "string") {
+  } else if (typeof value === 'string') {
     SECRET_VALUE.lastIndex = 0;
     if (SECRET_VALUE.test(value)) throw secretForbidden();
   }
@@ -727,22 +745,22 @@ function rejectSecretBearingInput(value: unknown): void {
 
 function requireRecord(input: unknown, code: string): JsonRecord {
   const value = optionalRecord(input);
-  if (!value) throw new ChatActorProtocolError("Invalid object.", code);
+  if (!value) throw new ChatActorProtocolError('Invalid object.', code);
   return value;
 }
 
 function optionalRecord(input: unknown): JsonRecord | null {
-  return input && typeof input === "object" && !Array.isArray(input)
+  return input && typeof input === 'object' && !Array.isArray(input)
     ? (input as JsonRecord)
     : null;
 }
 
 function validVersion(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
 function readIdentity(value: unknown): string | null {
-  if (typeof value !== "string" || value.length < 1 || value.length > 256) {
+  if (typeof value !== 'string' || value.length < 1 || value.length > 256) {
     return null;
   }
   const invalid = [...value].some((character) => {
@@ -756,8 +774,8 @@ function requireIdentity(value: unknown): string {
   const identity = readIdentity(value);
   if (!identity) {
     throw new ChatActorProtocolError(
-      "NyxID action identity is invalid.",
-      "NYXID_IDENTITY_INVALID"
+      'NyxID action identity is invalid.',
+      'NYXID_IDENTITY_INVALID',
     );
   }
   return identity;
@@ -765,7 +783,7 @@ function requireIdentity(value: unknown): string {
 
 function requireBoundedString(value: unknown, maximum: number): string {
   if (
-    typeof value !== "string" ||
+    typeof value !== 'string' ||
     value.length < 1 ||
     value.length > maximum ||
     value.trim() !== value
@@ -777,22 +795,22 @@ function requireBoundedString(value: unknown, maximum: number): string {
 
 function invalidVariant(): ChatActorProtocolError {
   return new ChatActorProtocolError(
-    "NyxID action params are invalid.",
-    "NYXID_ACTION_VARIANT_INVALID"
+    'NyxID action params are invalid.',
+    'NYXID_ACTION_VARIANT_INVALID',
   );
 }
 
 function unsafeUrl(): ChatActorProtocolError {
   return new ChatActorProtocolError(
-    "NyxID action URL is unsafe.",
-    "NYXID_URL_UNSAFE"
+    'NyxID action URL is unsafe.',
+    'NYXID_URL_UNSAFE',
   );
 }
 
 function secretForbidden(): ChatActorProtocolError {
   return new ChatActorProtocolError(
-    "NyxID action input must not contain secrets.",
-    "NYXID_SECRET_FORBIDDEN"
+    'NyxID action input must not contain secrets.',
+    'NYXID_SECRET_FORBIDDEN',
   );
 }
 
@@ -802,7 +820,7 @@ function cloneProjection(projection: ChatActorProjection): ChatActorProjection {
     recentTerminalTurns: projection.recentTerminalTurns.map(cloneRecord),
     task: cloneNullableRecord(projection.task),
     steps: new Map(
-      [...projection.steps].map(([key, value]) => [key, cloneStep(value)])
+      [...projection.steps].map(([key, value]) => [key, cloneStep(value)]),
     ),
     pendingInput: projection.pendingInput
       ? ({ ...projection.pendingInput } as ChatPendingInput)
@@ -811,7 +829,7 @@ function cloneProjection(projection: ChatActorProjection): ChatActorProjection {
       ? ({ ...projection.pendingApproval } as ChatPendingApproval)
       : null,
     actions: new Map(
-      [...projection.actions].map(([key, value]) => [key, { ...value }])
+      [...projection.actions].map(([key, value]) => [key, { ...value }]),
     ),
     conflicts: [...projection.conflicts],
   };
@@ -838,7 +856,7 @@ function cloneNullableRecord(value: unknown): JsonRecord | null {
 
 function withConflict(
   projection: ChatActorProjection,
-  code: string
+  code: string,
 ): ChatActorProjection {
   const next = cloneProjection(projection);
   if (!next.conflicts.some((conflict) => conflict.code === code)) {

--- a/docs/canon/nyxid-chat-api.md
+++ b/docs/canon/nyxid-chat-api.md
@@ -157,8 +157,11 @@ Actor-authored task observation is committed before publication. The controller 
 
 ### TaskPlan observation contract
 
-`nyxid.task.snapshot.custom.payload` is the complete actor-owned TaskPlan. Its
-stable v1 fields are:
+`nyxid.task.snapshot.custom.payload` is the complete public `NyxIdChatTaskPlan`
+projection of the actor-owned task. The live adapter and current-state adapter
+both map their typed input to this protobuf contract and use the same JSON
+formatter; they never serialize the actor state or a read-model DTO directly.
+Its stable v1 fields are:
 
 | Field | Meaning |
 |---|---|
@@ -179,6 +182,20 @@ reserved `web` source. Tool source keeps `toolName`, exact `serviceSlug`, exact
 `serviceId`, and optional producer-authored `readinessCapabilityId` separate.
 Postcondition source carries `actionRequestId` plus the stable `check`; approval
 source carries the exact `approvalRequestId`.
+
+The public operation is flattened as
+`conversationActorId / turnId / taskId / stepId / operationId /
+operationGeneration` plus kind, phase, effect evidence, progress, safe terminal
+fields, and timestamps. `operationGeneration` and `latestProgressSequence` are
+serialized as JSON numbers only while they are within the browser-safe integer
+range; values outside that range fail closed. This is an explicit browser wire
+rule layered on the strong `int64` protobuf fields, not `JsonFormatter.Default`
+behavior. Timestamps use canonical protobuf JSON UTC formatting, and absent or
+default protobuf fields are omitted while present empty messages remain `{}`.
+
+`retryInputRebuildable` and operation `idempotencyKey` are execution-control
+facts. They remain in actor-owned state and are deliberately excluded from the
+public TaskPlan, current-state read model, SSE frames, and browser decoder.
 
 `nyxid.task.step.changed.custom.payload` is always the complete typed envelope
 `taskId / planRevision / step / changeKind`. It never publishes a bare step.

--- a/src/Aevatar.Studio.Application.Abstractions/Studio/Abstractions/INyxIdChatConversationStateQueryPort.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Studio/Abstractions/INyxIdChatConversationStateQueryPort.cs
@@ -165,7 +165,7 @@ public sealed record NyxIdChatConversationStepSnapshot(
     string? FailureCode,
     string? SafeMessage,
     bool SafeToSkip,
-    NyxIdChatAvailableActionsSnapshot AvailableActions,
+    NyxIdChatAvailableActionsSnapshot? AvailableActions,
     DateTimeOffset? UpdatedAt,
     NyxIdChatConversationOperationSnapshot? Operation,
     NyxIdChatConversationStepSourceSnapshot? Source = null,

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ProjectionNyxIdChatConversationStateQueryPort.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ProjectionNyxIdChatConversationStateQueryPort.cs
@@ -247,10 +247,12 @@ internal sealed class ProjectionNyxIdChatConversationStateQueryPort
             NullIfEmpty(step.FailureCode),
             NullIfEmpty(step.SafeMessage),
             step.SafeToSkip,
-            new NyxIdChatAvailableActionsSnapshot(
-                step.AvailableActions?.Retry ?? false,
-                step.AvailableActions?.Skip ?? false,
-                step.AvailableActions?.Stop ?? false),
+            step.AvailableActions == null
+                ? null
+                : new NyxIdChatAvailableActionsSnapshot(
+                    step.AvailableActions.Retry,
+                    step.AvailableActions.Skip,
+                    step.AvailableActions.Stop),
             ToDateTimeOffset(step.UpdatedAt),
             ToOperation(step.Operation),
             ToSource(step.Source),

--- a/src/Aevatar.Studio.Projection/Projectors/NyxIdChatConversationCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/NyxIdChatConversationCurrentStateProjector.cs
@@ -286,17 +286,18 @@ public sealed class NyxIdChatConversationCurrentStateProjector
     private static NyxIdChatConversationOperationDocument? ToOperation(
         NyxIdChatOperationState? operation)
     {
-        if (operation?.Key == null)
+        if (operation == null)
             return null;
 
+        var key = operation.Key;
         return new NyxIdChatConversationOperationDocument
         {
-            ConversationActorId = operation.Key.ConversationActorId,
-            TurnId = operation.Key.TurnId,
-            TaskId = operation.Key.TaskId,
-            StepId = operation.Key.StepId,
-            OperationId = operation.Key.OperationId,
-            OperationGeneration = operation.Key.OperationGeneration,
+            ConversationActorId = key?.ConversationActorId ?? string.Empty,
+            TurnId = key?.TurnId ?? string.Empty,
+            TaskId = key?.TaskId ?? string.Empty,
+            StepId = key?.StepId ?? string.Empty,
+            OperationId = key?.OperationId ?? string.Empty,
+            OperationGeneration = key?.OperationGeneration ?? 0,
             Kind = ToWireName(operation.Kind),
             Phase = ToWireName(operation.Phase),
             MayChangeExternalState = operation.MayChangeExternalState,

--- a/test/Aevatar.AI.Tests/NyxIdChatStateEndpointTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatStateEndpointTests.cs
@@ -1,9 +1,21 @@
 using System.Security.Claims;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using Aevatar.AGUI.Contracts;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Infrastructure.ActorBacked;
+using Aevatar.Studio.Projection.Orchestration;
+using Aevatar.Studio.Projection.Projectors;
+using Aevatar.Studio.Projection.ReadModels;
 using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -18,6 +30,92 @@ public sealed class NyxIdChatStateEndpointTests
 {
     private const string StateRoute =
         "/api/scopes/{scopeId}/nyxid-chat/conversations/{actorId}/state";
+
+    [Fact]
+    public async Task GetState_ActiveTask_ShouldExactlyMatchLiveTaskPlanAndStepChanged()
+    {
+        var task = BuildConvergenceTask();
+        var state = new NyxIdChatConversationGAgentState
+        {
+            ConversationActorId = "conversation-alpha",
+            ScopeId = "scope-alpha",
+            ProgressSequence = 67,
+            ActiveTurn = new NyxIdChatTurnState
+            {
+                TurnId = task.TurnId,
+                TaskId = task.TaskId,
+                Status = NyxIdChatTurnStatus.Active,
+            },
+            LatestTurn = new NyxIdChatTurnState
+            {
+                TurnId = task.TurnId,
+                TaskId = task.TaskId,
+                Status = NyxIdChatTurnStatus.Active,
+            },
+            ActiveTask = task,
+        };
+
+        var frames = NyxIdChatConversationAguiFrameBuilder.BuildStarted(
+            state.ConversationActorId,
+            state.ActiveTurn.TurnId,
+            state);
+        var liveFrames = await WriteLiveFramesAsync(frames, state.ActiveTurn.TurnId);
+        var liveTask = JsonNode.Parse(liveFrames.Single(frame =>
+                frame["custom"]?["name"]?.GetValue<string>() ==
+                NyxIdChatConversationAguiFrameBuilder.TaskSnapshotEventName)
+            ["custom"]!["payload"]!.ToJsonString())!;
+        var changedStep = JsonNode.Parse(liveFrames.Single(frame =>
+                frame["custom"]?["name"]?.GetValue<string>() ==
+                NyxIdChatConversationAguiFrameBuilder.TaskStepChangedEventName)
+            ["custom"]!["payload"]!["step"]!.ToJsonString())!;
+
+        var dispatcher = new RecordingTaskStateWriteDispatcher();
+        var projector = new NyxIdChatConversationCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-08-07T12:26:00Z")));
+        await projector.ProjectAsync(
+            new StudioMaterializationContext
+            {
+                RootActorId = state.ConversationActorId,
+                ProjectionKind = "nyxid-chat-conversation",
+            },
+            WrapCommittedState(state));
+
+        dispatcher.Document.Should().NotBeNull();
+        var document = dispatcher.Document!;
+        var queryPort = new ProjectionNyxIdChatConversationStateQueryPort(
+            new SingleTaskStateDocumentReader(document));
+        var response = await ExecuteAsync(queryPort, string.Empty);
+
+        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        var responseNode = JsonNode.Parse(response.Body)!.AsObject();
+        var snapshot = responseNode["snapshot"]!.AsObject();
+        var currentTask = snapshot["activeTask"]!;
+        JsonNode.DeepEquals(liveTask, currentTask).Should().BeTrue(
+            "live and reconnect paths serialize one public TaskPlan contract");
+        JsonNode.DeepEquals(liveTask["steps"]![0], changedStep).Should().BeTrue(
+            "task.step.changed uses the same public step contract as task.snapshot");
+
+        snapshot.ContainsKey("activeTurn").Should().BeTrue();
+        snapshot["activeTurn"]!.AsObject().ContainsKey("failureCode").Should().BeTrue(
+            "the narrow TaskPlan converter must not alter other current-state JSON");
+        currentTask["createdAt"]!.GetValue<string>().Should()
+            .Be("2026-08-07T12:25:05.949835500Z");
+        currentTask["steps"]![0]!["operation"]!["operationGeneration"]!
+            .GetValue<long>().Should().Be(1);
+        currentTask["steps"]![0]!["operation"]!["latestProgressSequence"]!
+            .GetValue<long>().Should().Be(7);
+        currentTask["steps"]![0]!["availableActions"]!.AsObject().Count
+            .Should().Be(0, "a present all-false message remains a present empty object");
+        currentTask["steps"]![1]!.AsObject().ContainsKey("availableActions").Should().BeFalse(
+            "an absent message remains absent");
+        currentTask["steps"]![1]!["operation"]!.AsObject().Count.Should().Be(0,
+            "a present empty operation remains a present empty object");
+        currentTask["steps"]![0]!.AsObject().ContainsKey("retryInputRebuildable")
+            .Should().BeFalse();
+        currentTask["steps"]![0]!["operation"]!.AsObject().ContainsKey("idempotencyKey")
+            .Should().BeFalse();
+    }
 
     [Fact]
     public async Task GetState_ShouldReturnCurrentSnapshotFromTypedQueryPort()
@@ -239,6 +337,143 @@ public sealed class NyxIdChatStateEndpointTests
         source.Should().NotContain("EnsureAndAttachLeaseAsync");
     }
 
+    private static NyxIdChatTaskState BuildConvergenceTask()
+    {
+        var createdAt = new Timestamp
+        {
+            Seconds = 1_786_105_505,
+            Nanos = 949_835_500,
+        };
+        var updatedAt = new Timestamp
+        {
+            Seconds = 1_786_105_510,
+            Nanos = 919_334_800,
+        };
+        var operation = new NyxIdChatOperationState
+        {
+            Key = new NyxIdChatOperationKey
+            {
+                ConversationActorId = "conversation-alpha",
+                TurnId = "turn-alpha",
+                TaskId = "task-alpha",
+                StepId = "step-alpha",
+                OperationId = "operation-alpha",
+                OperationGeneration = 1,
+            },
+            Kind = NyxIdChatStepKind.Llm,
+            Phase = NyxIdChatOperationPhase.Succeeded,
+            IdempotencyKey = "actor-internal-idempotency-alpha",
+            LatestProgressSequence = 7,
+            RequestedAt = createdAt.Clone(),
+            DispatchedAt = new Timestamp
+            {
+                Seconds = 1_786_105_506,
+                Nanos = 191_562_800,
+            },
+            CompletedAt = updatedAt.Clone(),
+        };
+        return new NyxIdChatTaskState
+        {
+            TaskId = "task-alpha",
+            TurnId = "turn-alpha",
+            Status = NyxIdChatTaskStatus.Active,
+            ActiveStepId = "step-beta",
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            SchemaVersion = 4,
+            ActorId = "conversation-alpha",
+            PlanId = "plan-alpha",
+            PlanRevision = 2,
+            Title = "Complete the requested assistant task",
+            Gate = new NyxIdChatPlanGate { Mode = NyxIdChatPlanGateMode.Auto },
+            Steps =
+            {
+                new NyxIdChatTaskStepState
+                {
+                    StepId = "step-alpha",
+                    Order = 1,
+                    Kind = NyxIdChatStepKind.Llm,
+                    Status = NyxIdChatStepStatus.Done,
+                    Required = true,
+                    Description = "Generate the next assistant response.",
+                    Source = new NyxIdChatStepSource
+                    {
+                        Llm = new NyxIdChatLLMStepSource(),
+                    },
+                    ExternalEffect = NyxIdChatEffectEvidence.NotApplied,
+                    Operation = operation,
+                    AvailableActions = new NyxIdChatAvailableActions(),
+                    UpdatedAt = updatedAt.Clone(),
+                    RetryInputRebuildable = true,
+                    AddedBy = NyxIdChatStepAddedBy.Initial,
+                },
+                new NyxIdChatTaskStepState
+                {
+                    StepId = "step-beta",
+                    Order = 2,
+                    Kind = NyxIdChatStepKind.Input,
+                    Status = NyxIdChatStepStatus.Waiting,
+                    Required = true,
+                    Description = "Collect deployment preferences.",
+                    Source = new NyxIdChatStepSource
+                    {
+                        Input = new NyxIdChatInputStepSource
+                        {
+                            RequestId = "input-alpha",
+                        },
+                    },
+                    ExternalEffect = NyxIdChatEffectEvidence.NotStarted,
+                    Operation = new NyxIdChatOperationState(),
+                    UpdatedAt = updatedAt.Clone(),
+                    AddedBy = NyxIdChatStepAddedBy.Replan,
+                    DependsOn = { "step-alpha" },
+                    Estimate = new NyxIdChatStepEstimate(),
+                    Substeps = { new NyxIdChatSubstepState() },
+                },
+            },
+        };
+    }
+
+    private static async Task<IReadOnlyList<JsonNode>> WriteLiveFramesAsync(
+        IReadOnlyList<AGUIEvent> frames,
+        string messageId)
+    {
+        var http = new DefaultHttpContext();
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+        var writer = new NyxIdChatSseWriter(http.Response);
+        foreach (var frame in frames)
+            await NyxIdChatAguiSseEventWriter.WriteAsync(frame, messageId, writer);
+
+        body.Position = 0;
+        var text = await new StreamReader(body).ReadToEndAsync();
+        return text.Split("\n\n", StringSplitOptions.RemoveEmptyEntries)
+            .Select(static frame => frame.Trim())
+            .Where(static frame => frame.StartsWith("data: ", StringComparison.Ordinal))
+            .Select(static frame => JsonNode.Parse(frame["data: ".Length..])!)
+            .ToArray();
+    }
+
+    private static EventEnvelope WrapCommittedState(
+        NyxIdChatConversationGAgentState state) => new()
+    {
+        Id = "event-alpha-23",
+        Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-08-07T12:26:00Z")),
+        Route = EnvelopeRouteSemantics.CreateObserverPublication(state.ConversationActorId),
+        Payload = Any.Pack(new CommittedStateEventPublished
+        {
+            StateEvent = new StateEvent
+            {
+                EventId = "event-alpha-23",
+                Version = 23,
+                EventData = Any.Pack(new NyxIdChatTurnStartedEvent { State = state }),
+                Timestamp = Timestamp.FromDateTimeOffset(
+                    DateTimeOffset.Parse("2026-08-07T12:26:00Z")),
+            },
+            StateRoot = Any.Pack(state),
+        }),
+    };
+
     private static async Task<(int StatusCode, string Body)> ExecuteAsync(
         INyxIdChatConversationStateQueryPort queryPort,
         string queryString,
@@ -318,6 +553,51 @@ public sealed class NyxIdChatStateEndpointTests
 
         return directory?.FullName
             ?? throw new InvalidOperationException("Repository root could not be resolved.");
+    }
+
+    private sealed class RecordingTaskStateWriteDispatcher
+        : IProjectionWriteDispatcher<NyxIdChatConversationCurrentStateDocument>
+    {
+        public NyxIdChatConversationCurrentStateDocument? Document { get; private set; }
+
+        public Task<ProjectionWriteResult> UpsertAsync(
+            NyxIdChatConversationCurrentStateDocument readModel,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Document = readModel.Clone();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(
+            string id,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class SingleTaskStateDocumentReader(
+        NyxIdChatConversationCurrentStateDocument document)
+        : IProjectionDocumentReader<NyxIdChatConversationCurrentStateDocument, string>
+    {
+        public Task<NyxIdChatConversationCurrentStateDocument?> GetAsync(
+            string key,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<NyxIdChatConversationCurrentStateDocument?>(
+                document.Clone());
+        }
+
+        public Task<ProjectionDocumentQueryResult<NyxIdChatConversationCurrentStateDocument>>
+            QueryAsync(
+                ProjectionDocumentQuery query,
+                CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class FixedProjectionClock(DateTimeOffset utcNow) : IProjectionClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
     }
 
     private sealed class RecordingQueryPort : INyxIdChatConversationStateQueryPort

--- a/test/Aevatar.AI.Tests/NyxIdChatTaskContractTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatTaskContractTests.cs
@@ -230,8 +230,54 @@ public sealed class NyxIdChatTaskContractTests
         AssertEnumField<NyxIdChatTaskStepState>("added_by", nameof(NyxIdChatStepAddedBy));
         AssertEnumField<NyxIdChatStepEstimate>("kind", nameof(NyxIdChatStepEstimateKind));
         AssertEnumField<NyxIdChatSubstepState>("status", nameof(NyxIdChatSubstepStatus));
-        AssertEnumField<NyxIdChatTaskStepChanged>("change_kind", nameof(NyxIdChatStepChangeKind));
+        AssertEnumField<NyxIdChatTaskPlanStepChanged>(
+            "change_kind",
+            nameof(NyxIdChatStepChangeKind));
         AssertEnumField<NyxIdChatActionReport>("disposition", nameof(NyxIdChatActionDisposition));
+    }
+
+    [Fact]
+    public void PublicTaskPlan_ShouldExcludeExecutionOnlyActorState()
+    {
+        NyxIdChatTaskPlan.Descriptor.Fields.InFieldNumberOrder()
+            .Select(static field => field.Name)
+            .Should().NotContain("retry_input_rebuildable");
+        NyxIdChatTaskPlanStep.Descriptor.Fields.InFieldNumberOrder()
+            .Select(static field => field.Name)
+            .Should().NotContain("retry_input_rebuildable");
+        NyxIdChatTaskPlanOperation.Descriptor.Fields.InFieldNumberOrder()
+            .Select(static field => field.Name)
+            .Should().NotContain("idempotency_key");
+        NyxIdChatTaskPlanStepChanged.Descriptor.FindFieldByName("step").MessageType
+            .Should().BeSameAs(NyxIdChatTaskPlanStep.Descriptor);
+        NyxIdChatTaskStepChanged.Descriptor.FindFieldByName("step").MessageType
+            .Should().BeSameAs(
+                NyxIdChatTaskStepState.Descriptor,
+                "the legacy message type must retain its published wire layout");
+    }
+
+    [Theory]
+    [InlineData(9_007_199_254_740_992, 0, "operationGeneration")]
+    [InlineData(0, -9_007_199_254_740_992, "latestProgressSequence")]
+    public void PublicTaskPlan_ShouldRejectBrowserUnsafeIntegers(
+        long operationGeneration,
+        long latestProgressSequence,
+        string fieldName)
+    {
+        var plan = new NyxIdChatTaskPlan();
+        plan.Steps.Add(new NyxIdChatTaskPlanStep
+        {
+            Operation = new NyxIdChatTaskPlanOperation
+            {
+                OperationGeneration = operationGeneration,
+                LatestProgressSequence = latestProgressSequence,
+            },
+        });
+
+        var act = () => NyxIdChatTaskPlanJsonFormatter.FormatTaskPlan(plan);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*'{fieldName}'*browser-safe integer range*");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/NyxIdChatConversationCurrentStateProjectorTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdChatConversationCurrentStateProjectorTests.cs
@@ -221,6 +221,32 @@ public sealed class NyxIdChatConversationCurrentStateProjectorTests
     }
 
     [Fact]
+    public async Task ProjectAsync_ShouldPreservePresentEmptyOperationMessage()
+    {
+        var dispatcher = new RecordingWriteDispatcher();
+        var projector = new NyxIdChatConversationCurrentStateProjector(
+            dispatcher,
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-08-07T12:30:00Z")));
+        var state = BuildState();
+        state.ActiveTask.Steps.Single(step => step.StepId == "step-alpha").Operation =
+            new NyxIdChatOperationState();
+
+        await projector.ProjectAsync(
+            NewContext(),
+            WrapCommitted(
+                new NyxIdChatOperationReconciledEvent(),
+                state,
+                version: 31,
+                eventId: "event-alpha-31",
+                stateEventTimestamp: DateTimeOffset.Parse("2026-08-07T12:29:00Z")));
+
+        var operation = dispatcher.Upserts.Should().ContainSingle().Which.ActiveTask.Steps
+            .Single(step => step.StepId == "step-alpha").Operation;
+        operation.Should().NotBeNull();
+        operation.CalculateSize().Should().Be(0);
+    }
+
+    [Fact]
     public async Task ProjectAsync_ShouldIgnoreNonControllerCommittedState()
     {
         var dispatcher = new RecordingWriteDispatcher();

--- a/test/Aevatar.Studio.Tests/ProjectionNyxIdChatConversationStateQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/ProjectionNyxIdChatConversationStateQueryPortTests.cs
@@ -110,6 +110,30 @@ public sealed class ProjectionNyxIdChatConversationStateQueryPortTests
     }
 
     [Fact]
+    public async Task GetAsync_ShouldPreserveAvailableActionsMessagePresence()
+    {
+        var document = BuildDocument(stateVersion: 8);
+        var absent = document.ActiveTask.Steps.Single();
+        absent.AvailableActions = null;
+        var present = absent.Clone();
+        present.StepId = "step-present-actions";
+        present.Order = 2;
+        present.AvailableActions = new NyxIdChatConversationAvailableActionsDocument();
+        document.ActiveTask.Steps.Add(present);
+        var port = new ProjectionNyxIdChatConversationStateQueryPort(
+            new RecordingReader { Document = document });
+
+        var result = await port.GetAsync(new NyxIdChatConversationStateQuery(
+            "scope-alpha",
+            "conversation-alpha"));
+
+        var steps = result.Snapshot!.ActiveTask!.Steps;
+        steps.Single(step => step.StepId == "step-alpha").AvailableActions.Should().BeNull();
+        steps.Single(step => step.StepId == "step-present-actions").AvailableActions
+            .Should().BeEquivalentTo(new NyxIdChatAvailableActionsSnapshot(false, false, false));
+    }
+
+    [Fact]
     public async Task GetAttentionSummariesAsync_ShouldBatchReadActorScopedProjectionTruth()
     {
         var valid = BuildDocument(stateVersion: 23);


### PR DESCRIPTION
## Problem

`feature/integrate` advanced to `20702c08d8a7ad3a0f02bfe83bd178233bc42bd1` while #3336 was completing. That commit is not present in the `dev` merge commit from #3336, so the two remote branches cannot yet be aligned without losing work.

## Solution

- Merge the latest `feature/integrate` commit into the current `dev` tip with merge history preserved.
- Keep the typed NyxID TaskPlan observation contract, backend projection/query changes, API documentation, and focused tests together.
- Apply Biome formatting to the two changed chat actor-state files so the console quality gate accepts the feature commit.

## Affected Paths

- `agents/Aevatar.GAgents.NyxidChat/`
- `apps/aevatar-console-web/src/pages/chat/`
- `src/Aevatar.Studio.Application.Abstractions/`
- `src/Aevatar.Studio.Infrastructure/`
- `src/Aevatar.Studio.Projection/`
- `test/Aevatar.AI.Tests/`
- `test/Aevatar.Studio.Tests/`
- `docs/canon/nyxid-chat-api.md`

## Verification

- `bash tools/ci/test_stability_guards.sh` - passed
- `bash tools/ci/query_projection_priming_guard.sh` - passed
- `bash tools/ci/projection_state_version_guard.sh` - passed
- `bash tools/ci/projection_state_mirror_current_state_guard.sh` - passed
- `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/chat/chatActorState.test.ts` - 8/8 passed
- `pnpm --dir apps/aevatar-console-web tsc` - passed
- `pnpm --dir apps/aevatar-console-web exec biome check src/pages/chat/chatActorState.ts src/pages/chat/chatActorState.test.ts` - passed
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter 'FullyQualifiedName~NyxIdChatTaskContractTests|FullyQualifiedName~NyxIdChatStateEndpointTests'` - 15/15 passed
- `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter 'FullyQualifiedName~NyxIdChatConversationCurrentStateProjectorTests|FullyQualifiedName~ProjectionNyxIdChatConversationStateQueryPortTests'` - 21/21 passed
- `git diff --check` - passed

The complete frontend suite was not run locally under the incremental testing policy; CI provides the repository-wide console gate.

## Documentation

The feature commit updates `docs/canon/nyxid-chat-api.md` alongside the typed wire contract. No additional architecture document is required for this synchronization PR.
