### PR TITLE
Deploy NyxID assistant management reads

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentProfiles/AgentProfileTurnCatalogMaterializer.cs
@@ -696,7 +696,8 @@ public sealed class AgentProfileTurnCatalogMaterializer
         return !descriptor.Capabilities.Contains(
                    AgentToolCapabilities.RequiresHumanSession,
                    StringComparer.Ordinal) ||
-               !string.IsNullOrWhiteSpace(toolContext.Credentials.NyxIdAccessToken);
+               !string.IsNullOrWhiteSpace(
+                   AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(toolContext.Credentials));
     }
 
     private static bool DeclaresCapability(IAgentTool tool, string capability) =>

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
@@ -829,8 +829,40 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
     public Task<string> GetNodeAsync(string token, string id, CancellationToken ct) =>
         GetAsync(token, $"/api/v1/nodes/{Uri.EscapeDataString(id)}", ct);
 
+    public Task<string> ListPendingNodeCredentialsAsync(
+        string token,
+        string nodeId,
+        bool? includeHistory,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nodeId);
+        var path = $"/api/v1/nodes/{Uri.EscapeDataString(nodeId.Trim())}/credentials/pending";
+        if (includeHistory.HasValue)
+            path += $"?include_history={includeHistory.Value.ToString().ToLowerInvariant()}";
+        return GetAsync(token, path, ct);
+    }
+
     public Task<string> DeleteNodeAsync(string token, string id, CancellationToken ct) =>
         DeleteAsync(token, $"/api/v1/nodes/{Uri.EscapeDataString(id)}", ct);
+
+    // ─── Service pools ───
+
+    public Task<string> ListServicePoolsAsync(
+        string token,
+        string? organizationOwnerId,
+        CancellationToken ct)
+    {
+        var path = "/api/v1/service-pools";
+        if (!string.IsNullOrWhiteSpace(organizationOwnerId))
+            path += "?org_id=" + Uri.EscapeDataString(organizationOwnerId.Trim());
+        return GetAsync(token, path, ct);
+    }
+
+    public Task<string> GetServicePoolAsync(string token, string poolId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(poolId);
+        return GetAsync(token, $"/api/v1/service-pools/{Uri.EscapeDataString(poolId.Trim())}", ct);
+    }
 
     // ─── Approvals ───
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs
@@ -57,6 +57,8 @@ public sealed class NyxIdAssistantToolSource : IAgentToolSource
             ReadOnly(new NyxIdServicesTool(_client), ["list", "show"], "list", "id"),
             ReadOnly(new NyxIdApiKeysTool(_client), ["list", "show"], "list", "id", "org"),
             ReadOnly(new NyxIdNodesTool(_client), ["list", "show"], "list", "id"),
+            new NyxIdNodeCredentialsTool(_client),
+            new NyxIdServicePoolsTool(_client),
             ReadOnly(
                 new NyxIdApprovalsTool(_client),
                 ["list", "show", "configs", "grants"],
@@ -169,7 +171,8 @@ internal sealed class NyxIdAssistantReadOnlyActionTool :
         if (!IsAllowed(argumentsJson))
             return RejectedJson;
 
-        var token = AgentToolRequestContext.NyxIdAccessToken;
+        var token = AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(
+            AgentToolRequestContext.Current?.Credentials);
         if (string.IsNullOrWhiteSpace(token))
             return MissingTokenJson;
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAccountTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAccountTool.cs
@@ -6,6 +6,8 @@ namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 /// <summary>Tool to view current NyxID user profile and account status.</summary>
 public sealed class NyxIdAccountTool : INyxIdBuiltInTool, IAgentToolCapabilityDescriptor
 {
+    private const string InvalidArgumentsJson = "{\"error\":\"invalid_arguments\"}";
+
     public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
 
     private readonly NyxIdApiClient _client;
@@ -17,13 +19,19 @@ public sealed class NyxIdAccountTool : INyxIdBuiltInTool, IAgentToolCapabilityDe
     public string Description =>
         "Get the current NyxID user's profile information including name, email, and account status.";
 
-    public string ParametersSchema => """{"type":"object","properties":{}}""";
+    public string ParametersSchema =>
+        """{"type":"object","properties":{},"additionalProperties":false}""";
 
     public bool IsReadOnly => true;
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
-        var token = AgentToolRequestContext.NyxIdAccessToken;
+        var args = ToolArgs.Parse(argumentsJson);
+        if (args.HasParseError || !args.HasOnly())
+            return InvalidArgumentsJson;
+
+        var token = AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(
+            AgentToolRequestContext.Current?.Credentials);
         if (string.IsNullOrWhiteSpace(token))
             return """{"error":"No NyxID access token available. User must be authenticated."}""";
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAssistantReadResponseProjector.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdAssistantReadResponseProjector.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+
+namespace Aevatar.AI.ToolProviders.NyxId.Tools;
+
+internal static class NyxIdAssistantReadResponseProjector
+{
+    private const string InvalidResponseJson = "{\"error\":\"invalid_nyxid_response\"}";
+
+    private static readonly string[] PendingCredentialProperties =
+    [
+        "id",
+        "node_id",
+        "service_slug",
+        "injection_method",
+        "field_name",
+        "created_at",
+        "expires_at",
+        "consumed_at",
+        "declined_at",
+        "remote_state",
+        "is_active",
+    ];
+
+    private static readonly string[] ServicePoolProperties =
+    [
+        "id",
+        "user_id",
+        "slug",
+        "strategy",
+        "rr_counter",
+        "is_active",
+        "created_at",
+        "updated_at",
+    ];
+
+    private static readonly string[] ServicePoolMemberProperties =
+    [
+        "user_service_id",
+        "weight",
+        "enabled",
+    ];
+
+    public static string ProjectPendingNodeCredentials(string json) =>
+        ProjectCollectionResponse(json, "pending_credentials", ProjectPendingCredential);
+
+    public static string ProjectServicePools(string json, bool isList)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (TryProjectError(document.RootElement, out var error))
+                return error;
+
+            if (isList)
+            {
+                if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                    !document.RootElement.TryGetProperty("pools", out var pools) ||
+                    pools.ValueKind != JsonValueKind.Array ||
+                    pools.EnumerateArray().Any(static pool => pool.ValueKind != JsonValueKind.Object))
+                {
+                    return InvalidResponseJson;
+                }
+
+                return JsonSerializer.Serialize(new Dictionary<string, object?>
+                {
+                    ["pools"] = pools.EnumerateArray().Select(ProjectServicePool).ToArray(),
+                });
+            }
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                return InvalidResponseJson;
+
+            return JsonSerializer.Serialize(ProjectServicePool(document.RootElement));
+        }
+        catch (JsonException)
+        {
+            return InvalidResponseJson;
+        }
+    }
+
+    private static string ProjectCollectionResponse(
+        string json,
+        string collectionProperty,
+        Func<JsonElement, Dictionary<string, object?>> projectItem)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (TryProjectError(document.RootElement, out var error))
+                return error;
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                !document.RootElement.TryGetProperty(collectionProperty, out var collection) ||
+                collection.ValueKind != JsonValueKind.Array ||
+                collection.EnumerateArray().Any(static item => item.ValueKind != JsonValueKind.Object))
+            {
+                return InvalidResponseJson;
+            }
+
+            return JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                [collectionProperty] = collection.EnumerateArray().Select(projectItem).ToArray(),
+            });
+        }
+        catch (JsonException)
+        {
+            return InvalidResponseJson;
+        }
+    }
+
+    private static Dictionary<string, object?> ProjectPendingCredential(JsonElement item) =>
+        ProjectProperties(item, PendingCredentialProperties);
+
+    private static Dictionary<string, object?> ProjectServicePool(JsonElement item)
+    {
+        var projected = ProjectProperties(item, ServicePoolProperties);
+        if (item.ValueKind == JsonValueKind.Object &&
+            item.TryGetProperty("members", out var members) &&
+            members.ValueKind == JsonValueKind.Array)
+        {
+            projected["members"] = members.EnumerateArray()
+                .Select(member => ProjectProperties(member, ServicePoolMemberProperties))
+                .ToArray();
+        }
+
+        return projected;
+    }
+
+    private static Dictionary<string, object?> ProjectProperties(
+        JsonElement source,
+        IEnumerable<string> properties)
+    {
+        var projected = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (source.ValueKind != JsonValueKind.Object)
+            return projected;
+
+        foreach (var property in properties)
+        {
+            if (source.TryGetProperty(property, out var value))
+                projected[property] = value.Clone();
+        }
+
+        return projected;
+    }
+
+    private static bool TryProjectError(JsonElement root, out string errorJson)
+    {
+        errorJson = string.Empty;
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("error", out var error) ||
+            error.ValueKind != JsonValueKind.True)
+        {
+            return false;
+        }
+
+        var projected = new Dictionary<string, object?>
+        {
+            ["error"] = true,
+        };
+        if (root.TryGetProperty("status", out var status) && status.ValueKind == JsonValueKind.Number)
+            projected["status"] = status.Clone();
+        if (root.TryGetProperty("retry_after_seconds", out var retryAfter) &&
+            retryAfter.ValueKind == JsonValueKind.Number)
+        {
+            projected["retry_after_seconds"] = retryAfter.Clone();
+        }
+
+        errorJson = JsonSerializer.Serialize(projected);
+        return true;
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdNodeCredentialsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdNodeCredentialsTool.cs
@@ -1,0 +1,72 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.NyxId.Tools;
+
+/// <summary>Reads pending credential delivery metadata for a NyxID node.</summary>
+public sealed class NyxIdNodeCredentialsTool : INyxIdBuiltInTool, IAgentToolCapabilityDescriptor
+{
+    private const string MissingTokenJson =
+        "{\"error\":\"No source-readable NyxID user bearer is available.\"}";
+    private const string InvalidArgumentsJson = "{\"error\":\"invalid_arguments\"}";
+
+    private readonly NyxIdApiClient _client;
+
+    public NyxIdNodeCredentialsTool(NyxIdApiClient client) =>
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+
+    public string Name => "nyxid_node_credentials";
+
+    public string Description =>
+        "List pending credential delivery metadata for one NyxID node. Never returns key material.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "properties": {
+            "action": { "type": "string", "enum": ["list"], "default": "list" },
+            "node_id": { "type": "string" },
+            "include_history": { "type": "boolean" }
+          },
+          "required": ["node_id"],
+          "additionalProperties": false
+        }
+        """;
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.NeverRequire;
+
+    public bool IsReadOnly => true;
+
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var args = ToolArgs.Parse(argumentsJson);
+        if (args.HasParseError ||
+            !args.HasOnly("action", "node_id", "include_history") ||
+            args.Has("action") && !args.IsString("action") ||
+            !args.IsString("node_id") ||
+            args.Has("include_history") && !args.IsBoolean("include_history") ||
+            !string.Equals(args.Str("action") ?? "list", "list", StringComparison.Ordinal) ||
+            args.Has("include_history") && !args.Bool("include_history").HasValue)
+        {
+            return InvalidArgumentsJson;
+        }
+
+        var nodeId = args.Str("node_id")?.Trim();
+        if (string.IsNullOrWhiteSpace(nodeId))
+            return "{\"error\":\"'node_id' is required for list\"}";
+
+        var token = AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(
+            AgentToolRequestContext.Current?.Credentials);
+        if (string.IsNullOrWhiteSpace(token))
+            return MissingTokenJson;
+
+        var response = await _client.ListPendingNodeCredentialsAsync(
+            token,
+            nodeId,
+            args.Bool("include_history"),
+            ct).ConfigureAwait(false);
+        return NyxIdAssistantReadResponseProjector.ProjectPendingNodeCredentials(response);
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicePoolsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdServicePoolsTool.cs
@@ -1,0 +1,74 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.NyxId.Tools;
+
+/// <summary>Reads NyxID service pool metadata.</summary>
+public sealed class NyxIdServicePoolsTool : INyxIdBuiltInTool, IAgentToolCapabilityDescriptor
+{
+    private const string MissingTokenJson =
+        "{\"error\":\"No source-readable NyxID user bearer is available.\"}";
+    private const string InvalidArgumentsJson = "{\"error\":\"invalid_arguments\"}";
+
+    private readonly NyxIdApiClient _client;
+
+    public NyxIdServicePoolsTool(NyxIdApiClient client) =>
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+
+    public string Name => "nyxid_service_pools";
+
+    public string Description => "List service pools or show one service pool from NyxID.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "properties": {
+            "action": { "type": "string", "enum": ["list", "show"], "default": "list" },
+            "id": { "type": "string" },
+            "org_id": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+        """;
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.NeverRequire;
+
+    public bool IsReadOnly => true;
+
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var args = ToolArgs.Parse(argumentsJson);
+        if (args.HasParseError ||
+            !args.HasOnly("action", "id", "org_id") ||
+            args.Has("action") && !args.IsString("action") ||
+            args.Has("id") && !args.IsString("id") ||
+            args.Has("org_id") && !args.IsString("org_id"))
+        {
+            return InvalidArgumentsJson;
+        }
+
+        var action = args.Str("action")?.Trim() ?? "list";
+        if (action is not ("list" or "show") ||
+            action == "list" && args.Has("id") ||
+            action == "show" && args.Has("org_id"))
+        {
+            return InvalidArgumentsJson;
+        }
+
+        var id = args.Str("id")?.Trim();
+        if (action == "show" && string.IsNullOrWhiteSpace(id))
+            return "{\"error\":\"'id' is required for show\"}";
+
+        var token = AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(
+            AgentToolRequestContext.Current?.Credentials);
+        if (string.IsNullOrWhiteSpace(token))
+            return MissingTokenJson;
+
+        var response = action == "show"
+            ? await _client.GetServicePoolAsync(token, id!, ct).ConfigureAwait(false)
+            : await _client.ListServicePoolsAsync(token, args.Str("org_id"), ct).ConfigureAwait(false);
+        return NyxIdAssistantReadResponseProjector.ProjectServicePools(response, action == "list");
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSessionsTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSessionsTool.cs
@@ -6,6 +6,8 @@ namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 /// <summary>Tool to list NyxID active sessions.</summary>
 public sealed class NyxIdSessionsTool : INyxIdBuiltInTool, IAgentToolCapabilityDescriptor
 {
+    private const string InvalidArgumentsJson = "{\"error\":\"invalid_arguments\"}";
+
     public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
 
     private readonly NyxIdApiClient _client;
@@ -17,13 +19,19 @@ public sealed class NyxIdSessionsTool : INyxIdBuiltInTool, IAgentToolCapabilityD
     public string Description =>
         "List the user's active NyxID sessions, showing device info, IP address, and expiration.";
 
-    public string ParametersSchema => """{"type":"object","properties":{}}""";
+    public string ParametersSchema =>
+        """{"type":"object","properties":{},"additionalProperties":false}""";
 
     public bool IsReadOnly => true;
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
-        var token = AgentToolRequestContext.NyxIdAccessToken;
+        var args = ToolArgs.Parse(argumentsJson);
+        if (args.HasParseError || !args.HasOnly())
+            return InvalidArgumentsJson;
+
+        var token = AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(
+            AgentToolRequestContext.Current?.Credentials);
         if (string.IsNullOrWhiteSpace(token))
             return """{"error":"No NyxID access token available. User must be authenticated."}""";
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdStatusTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdStatusTool.cs
@@ -7,6 +7,8 @@ namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 /// <summary>Tool to show NyxID account overview (user, services, API keys, nodes).</summary>
 public sealed class NyxIdStatusTool : INyxIdBuiltInTool, IAgentToolCapabilityDescriptor
 {
+    private const string InvalidArgumentsJson = "{\"error\":\"invalid_arguments\"}";
+
     public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
 
     private readonly NyxIdApiClient _client;
@@ -18,13 +20,19 @@ public sealed class NyxIdStatusTool : INyxIdBuiltInTool, IAgentToolCapabilityDes
     public string Description =>
         "Get a comprehensive account overview combining user profile, connected services, API keys, and nodes in one call.";
 
-    public string ParametersSchema => """{"type":"object","properties":{}}""";
+    public string ParametersSchema =>
+        """{"type":"object","properties":{},"additionalProperties":false}""";
 
     public bool IsReadOnly => true;
 
     public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
     {
-        var token = AgentToolRequestContext.NyxIdAccessToken;
+        var args = ToolArgs.Parse(argumentsJson);
+        if (args.HasParseError || !args.HasOnly())
+            return InvalidArgumentsJson;
+
+        var token = AgentToolSourceReadableNyxIdCredential.ResolveBearerToken(
+            AgentToolRequestContext.Current?.Credentials);
         if (string.IsNullOrWhiteSpace(token))
             return """{"error":"No NyxID access token available. User must be authenticated."}""";
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/ToolArgs.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/ToolArgs.cs
@@ -36,6 +36,9 @@ internal sealed class ToolArgs
                 return new ToolArgs([], raw);
 
             using var doc = JsonDocument.Parse(raw);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return new ToolArgs([], raw, "Invalid JSON: tool arguments must be an object.");
+
             var dict = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
             foreach (var prop in doc.RootElement.EnumerateObject())
                 dict[prop.Name] = prop.Value.Clone();
@@ -112,4 +115,20 @@ internal sealed class ToolArgs
 
     /// <summary>Whether a property exists.</summary>
     public bool Has(string name) => _props.ContainsKey(name);
+
+    /// <summary>Whether a supplied property is a JSON string.</summary>
+    public bool IsString(string name) =>
+        _props.TryGetValue(name, out var element) && element.ValueKind == JsonValueKind.String;
+
+    /// <summary>Whether a supplied property is a JSON boolean.</summary>
+    public bool IsBoolean(string name) =>
+        _props.TryGetValue(name, out var element) &&
+        element.ValueKind is JsonValueKind.True or JsonValueKind.False;
+
+    /// <summary>Whether every supplied property belongs to the closed argument set.</summary>
+    public bool HasOnly(params string[] names)
+    {
+        var allowed = names.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return _props.Keys.All(allowed.Contains);
+    }
 }

--- a/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
+++ b/test/Aevatar.AI.Tests/AgentProfileTurnCatalogMaterializerTests.cs
@@ -1411,6 +1411,37 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
     }
 
     [Fact]
+    public async Task MaterializeAsync_HumanSessionToolWithRawProxyDelegation_ShouldBeRejected()
+    {
+        var humanSessionTool = new CapabilityTool(
+            "task",
+            [AgentToolCapabilities.RequiresHumanSession]);
+        var tools = new IAgentTool[] { humanSessionTool };
+        var fetcher = new RecordingFetcher(SuccessfulFetch());
+
+        var catalog = await NewMaterializer(
+                RegistryWithRoute(tools),
+                new RecordingClassifier(AgentProfileTurnClassificationResult.NoMatch()),
+                fetcher)
+            .MaterializeAsync(
+                SealProfile(BuildProfile(withAlias: true)),
+                "/alpha",
+                "proxy-delegation",
+                tools,
+                ToolContext(
+                    "proxy-delegation",
+                    AgentToolNyxIdCredentialKind.ProxyDelegation),
+                CancellationToken.None);
+
+        catalog.FinalAllowedToolNames.Should().BeEmpty();
+        catalog.RouteOwnedTools.Should().BeEmpty();
+        catalog.Diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Code == AgentProfileTurnDiagnosticCode.ToolCapabilityRejected &&
+            diagnostic.Detail == "task");
+        fetcher.CallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task MaterializeAsync_NyxIdChatProfile_ShouldHideRawProxyWithoutLosingTypedTools()
     {
         var options = new NyxIdToolOptions { BaseUrl = "https://nyx.example" };
@@ -1528,10 +1559,13 @@ public sealed class AgentProfileTurnCatalogMaterializerTests
             SkillSha256,
             skillMarkdown);
 
-    private static AgentToolExecutionContext ToolContext(string? accessToken = "token") =>
+    private static AgentToolExecutionContext ToolContext(
+        string? accessToken = "token",
+        AgentToolNyxIdCredentialKind credentialKind =
+            AgentToolNyxIdCredentialKind.SourceReadableUserBearer) =>
         AgentToolExecutionContext.Empty with
         {
-            Credentials = new AgentToolCredentials(accessToken, null, null),
+            Credentials = new AgentToolCredentials(accessToken, null, null, credentialKind),
         };
 
     private static IReadOnlyList<IAgentTool> NewTools(params string[] names) =>

--- a/test/Aevatar.AI.Tests/NyxIdAssistantToolSourceTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdAssistantToolSourceTests.cs
@@ -22,12 +22,21 @@ public sealed class NyxIdAssistantToolSourceTests
         "nyxid_services",
         "nyxid_api_keys",
         "nyxid_nodes",
+        "nyxid_node_credentials",
+        "nyxid_service_pools",
         "nyxid_approvals",
         "nyxid_endpoints",
         "nyxid_external_keys",
         "nyxid_notifications",
         "nyxid_providers",
         "nyxid_orgs",
+    ];
+
+    private static readonly string[] ClosedEmptyArgumentToolNames =
+    [
+        "nyxid_account",
+        "nyxid_status",
+        "nyxid_sessions",
     ];
 
     private static readonly string[] ManagementReadToolNames =
@@ -37,6 +46,8 @@ public sealed class NyxIdAssistantToolSourceTests
         "nyxid_services",
         "nyxid_api_keys",
         "nyxid_nodes",
+        "nyxid_node_credentials",
+        "nyxid_service_pools",
         "nyxid_approvals",
         "nyxid_endpoints",
         "nyxid_external_keys",
@@ -65,10 +76,19 @@ public sealed class NyxIdAssistantToolSourceTests
             tool.IsDestructive.Should().BeFalse();
             tool.Should().BeAssignableTo<IAgentToolCapabilityDescriptor>()
                 .Which.Capabilities.Should().Contain(AgentToolCapabilities.RequiresHumanSession);
+            tool.ApprovalMode.Should().Be(ToolApprovalMode.NeverRequire);
             tool.ParametersSchema.Should()
                 .NotMatchRegex("(?i)(authorization|api[-_]?key|token|secret|password|credential|cookie)");
             using var schema = JsonDocument.Parse(tool.ParametersSchema);
             schema.RootElement.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
+        }
+
+        foreach (var name in ClosedEmptyArgumentToolNames)
+        {
+            var tool = tools.Single(candidate => candidate.Name == name);
+            using var schema = JsonDocument.Parse(tool.ParametersSchema);
+            schema.RootElement.GetProperty("additionalProperties").GetBoolean().Should().BeFalse();
+            tool.ApprovalMode.Should().Be(ToolApprovalMode.NeverRequire);
         }
 
         using var servicesSchema = JsonDocument.Parse(
@@ -112,7 +132,11 @@ public sealed class NyxIdAssistantToolSourceTests
 
         using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
         {
-            Credentials = new AgentToolCredentials("request-token", null, null),
+            Credentials = new AgentToolCredentials(
+                "request-token",
+                null,
+                null,
+                AgentToolNyxIdCredentialKind.SourceReadableUserBearer),
         });
         var result = await services.ExecuteAsync(
             """{"action":"show","id":"service-alpha"}""");
@@ -124,6 +148,200 @@ public sealed class NyxIdAssistantToolSourceTests
         handler.LastBearerToken.Should().Be("request-token");
     }
 
+    [Fact]
+    public async Task NewParityReads_ShouldUseSourceBearerAndExactNyxIdRoutes()
+    {
+        var handler = new RecordingHandler(static request =>
+            request.RequestUri?.AbsolutePath.Contains("credentials/pending", StringComparison.Ordinal) == true
+                ? """{"pending_credentials":[]}"""
+                : request.RequestUri?.AbsolutePath == "/api/v1/service-pools"
+                    ? """{"pools":[]}"""
+                    : """{"id":"pool-alpha","members":[]}""");
+        using var client = CreateClient(handler);
+        var source = new NyxIdAssistantToolSource(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.test" },
+            client);
+        var tools = await source.DiscoverToolsAsync();
+
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(
+                "proxy-delegation",
+                null,
+                null,
+                AgentToolNyxIdCredentialKind.ProxyDelegation,
+                "source-readable-bearer"),
+        });
+
+        await tools.Single(static tool => tool.Name == "nyxid_node_credentials")
+            .ExecuteAsync("""{"action":"list","node_id":"node/alpha","include_history":true}""");
+        await tools.Single(static tool => tool.Name == "nyxid_node_credentials")
+            .ExecuteAsync("""{"node_id":"node-beta"}""");
+        await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"list","org_id":"org/alpha"}""");
+        await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"show","id":"pool/alpha"}""");
+
+        handler.Requests.Select(static request => request.PathAndQuery).Should().Equal(
+            "/api/v1/nodes/node%2Falpha/credentials/pending?include_history=true",
+            "/api/v1/nodes/node-beta/credentials/pending",
+            "/api/v1/service-pools?org_id=org%2Falpha",
+            "/api/v1/service-pools/pool%2Falpha");
+        handler.Requests.Should().OnlyContain(static request =>
+            request.Method == HttpMethod.Get && request.BearerToken == "source-readable-bearer");
+    }
+
+    [Fact]
+    public async Task NewParityReads_ShouldProjectOnlyPinnedMetadataFields()
+    {
+        var handler = new RecordingHandler(static request =>
+            request.RequestUri?.AbsolutePath.Contains("credentials/pending", StringComparison.Ordinal) == true
+                ? """
+                  {
+                    "pending_credentials": [{
+                      "id": "pending-alpha",
+                      "node_id": "node-alpha",
+                      "service_slug": "calendar",
+                      "is_active": true,
+                      "target_url": "https://callback.test/path?token=query-secret#fragment-secret",
+                      "label": "label-secret",
+                      "created_by_user_id": "creator-secret",
+                      "owner_user_id": "owner-secret",
+                      "node_pubkey": "must-not-pass",
+                      "ciphertext": "must-not-pass",
+                      "secret": "must-not-pass"
+                    }],
+                    "secret": "must-not-pass"
+                  }
+                  """
+                : """
+                  {
+                    "pools": [{
+                      "id": "pool-alpha",
+                      "slug": "primary",
+                      "name": "sk-pool-secret",
+                      "members": [{
+                        "user_service_id": "service-alpha",
+                        "weight": 1,
+                        "enabled": true,
+                        "secret": "must-not-pass"
+                      }],
+                      "secret": "must-not-pass"
+                    }],
+                    "secret": "must-not-pass"
+                  }
+                  """);
+        using var client = CreateClient(handler);
+        var tools = await new NyxIdAssistantToolSource(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.test" },
+            client).DiscoverToolsAsync();
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(
+                "source-readable-bearer",
+                null,
+                null,
+                AgentToolNyxIdCredentialKind.SourceReadableUserBearer),
+        });
+
+        var credentials = await tools.Single(static tool => tool.Name == "nyxid_node_credentials")
+            .ExecuteAsync("""{"node_id":"node-alpha"}""");
+        var pools = await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"list"}""");
+
+        credentials.Should().Contain("pending-alpha").And.Contain("node-alpha");
+        pools.Should().Contain("pool-alpha").And.Contain("service-alpha");
+        credentials.Should().NotMatchRegex("(?i)(pubkey|ciphertext|secret|must-not-pass)");
+        pools.Should().NotMatchRegex("(?i)(secret|must-not-pass)");
+    }
+
+    [Fact]
+    public async Task NewParityReads_ShouldStripSensitiveUpstreamErrorDetails()
+    {
+        var handler = new RecordingHandler(_ => """
+            {
+              "error": true,
+              "status": 403,
+              "retry_after_seconds": 5,
+              "body": "{\"error\":\"org_role_insufficient\",\"session_token\":\"must-not-pass\",\"approve_url\":\"https://secret.test\"}"
+            }
+            """);
+        using var client = CreateClient(handler);
+        var tools = await new NyxIdAssistantToolSource(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.test" },
+            client).DiscoverToolsAsync();
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(
+                "source-readable-bearer",
+                null,
+                null,
+                AgentToolNyxIdCredentialKind.SourceReadableUserBearer),
+        });
+
+        var result = await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"list"}""");
+
+        result.Should().Be("{\"error\":true,\"status\":403,\"retry_after_seconds\":5}");
+        result.Should().NotMatchRegex("(?i)(body|session_token|approve_url|must-not-pass|secret\\.test)");
+    }
+
+    [Fact]
+    public async Task ManagementReads_ShouldFailClosedForRawDelegationAndUndeclaredArguments()
+    {
+        var handler = new RecordingHandler();
+        using var client = CreateClient(handler);
+        var source = new NyxIdAssistantToolSource(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.test" },
+            client);
+        var tools = await source.DiscoverToolsAsync();
+
+        using var _ = AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+        {
+            Credentials = new AgentToolCredentials(
+                "proxy-delegation",
+                null,
+                null,
+                AgentToolNyxIdCredentialKind.ProxyDelegation),
+        });
+
+        var accountResult = await tools.Single(static tool => tool.Name == "nyxid_account")
+            .ExecuteAsync("{}");
+        var poolResult = await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"list"}""");
+        var secretArgumentResult = await tools.Single(static tool => tool.Name == "nyxid_node_credentials")
+            .ExecuteAsync("""{"action":"list","node_id":"node-alpha","credential":"must-not-pass"}""");
+        var nonObjectResult = await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("[]");
+        var objectNodeIdResult = await tools.Single(static tool => tool.Name == "nyxid_node_credentials")
+            .ExecuteAsync("""{"node_id":{"secret":"must-not-pass"}}""");
+        var stringHistoryResult = await tools.Single(static tool => tool.Name == "nyxid_node_credentials")
+            .ExecuteAsync("""{"node_id":"node-alpha","include_history":"true"}""");
+        var listWithIdResult = await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"list","id":"pool-alpha"}""");
+        var showWithOrgResult = await tools.Single(static tool => tool.Name == "nyxid_service_pools")
+            .ExecuteAsync("""{"action":"show","id":"pool-alpha","org_id":"org-alpha"}""");
+        var accountWithSecretResult = await tools.Single(static tool => tool.Name == "nyxid_account")
+            .ExecuteAsync("""{"secret":"must-not-pass"}""");
+        var statusWithSecretResult = await tools.Single(static tool => tool.Name == "nyxid_status")
+            .ExecuteAsync("""{"secret":"must-not-pass"}""");
+        var sessionsWithSecretResult = await tools.Single(static tool => tool.Name == "nyxid_sessions")
+            .ExecuteAsync("""{"secret":"must-not-pass"}""");
+
+        accountResult.Should().Contain("No NyxID access token available");
+        poolResult.Should().Contain("No source-readable NyxID user bearer");
+        secretArgumentResult.Should().Contain("invalid_arguments");
+        nonObjectResult.Should().Contain("invalid_arguments");
+        objectNodeIdResult.Should().Contain("invalid_arguments");
+        stringHistoryResult.Should().Contain("invalid_arguments");
+        listWithIdResult.Should().Contain("invalid_arguments");
+        showWithOrgResult.Should().Contain("invalid_arguments");
+        accountWithSecretResult.Should().Contain("invalid_arguments");
+        statusWithSecretResult.Should().Contain("invalid_arguments");
+        sessionsWithSecretResult.Should().Contain("invalid_arguments");
+        handler.RequestCount.Should().Be(0);
+    }
+
     private static NyxIdApiClient CreateClient(HttpMessageHandler handler) =>
         new(
             new NyxIdToolOptions { BaseUrl = "https://nyx.test" },
@@ -131,10 +349,18 @@ public sealed class NyxIdAssistantToolSourceTests
 
     private sealed class RecordingHandler : HttpMessageHandler
     {
+        public sealed record RecordedRequest(HttpMethod Method, string PathAndQuery, string? BearerToken);
+
+        public List<RecordedRequest> Requests { get; } = [];
         public int RequestCount { get; private set; }
         public HttpMethod? LastMethod { get; private set; }
         public string? LastPathAndQuery { get; private set; }
         public string? LastBearerToken { get; private set; }
+
+        private readonly Func<HttpRequestMessage, string> _responseFactory;
+
+        public RecordingHandler(Func<HttpRequestMessage, string>? responseFactory = null) =>
+            _responseFactory = responseFactory ?? (_ => "{}");
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -145,9 +371,13 @@ public sealed class NyxIdAssistantToolSourceTests
             LastMethod = request.Method;
             LastPathAndQuery = request.RequestUri?.PathAndQuery;
             LastBearerToken = request.Headers.Authorization?.Parameter;
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri?.PathAndQuery ?? string.Empty,
+                request.Headers.Authorization?.Parameter));
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent("{}"),
+                Content = new StringContent(_responseFactory(request)),
             });
         }
     }

--- a/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+using System.Net;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -7,6 +9,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.AI.Core.Tools;
+using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.ToolSetRegistry;
 using Aevatar.AGUI.Contracts;
 using Aevatar.Audit;
@@ -822,6 +825,175 @@ public sealed class NyxIdChatConversationGAgentTests
         var finishedFrames = frames.Where(static frame => frame.RunFinished is not null).ToArray();
         finishedFrames.Should().ContainSingle().Which.RunFinished.Status
             .Should().Be(RunCompletionStatus.Blocked);
+    }
+
+    [Fact]
+    public async Task UnprofiledHumanSessionTurn_ShouldInvokePinnedAccountStatusAndSessionsWithoutApproval()
+    {
+        const string conversationActorId = "conversation-pinned-class-r";
+        const string sourceReadableBearer = "source-readable-bearer";
+        string[] expectedToolNames = ["nyxid_account", "nyxid_status", "nyxid_sessions"];
+        var handler = new RecordingNyxIdReadHandler();
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyxid.test" };
+        using var apiClient = new NyxIdApiClient(options, new HttpClient(handler));
+        var assistantSource = new NyxIdAssistantToolSource(options, apiClient);
+        var provider = new PinnedClassRToolCallProvider(expectedToolNames);
+        var eventStore = new InMemoryEventStoreForTests();
+        var dispatch = new RecordingActorDispatchPort([], static (_, _) => Task.CompletedTask);
+        using var services = BuildEventSourcingServices(eventStore);
+        var agent = CreateController(services, conversationActorId, dispatch);
+        await agent.ActivateAsync();
+        var start = CreateStartTurnCommand();
+        start.ConversationActorId = conversationActorId;
+        start.Prompt = "Show my NyxID account, status, and active sessions.";
+        start.LlmControl.NyxIdAccessToken = sourceReadableBearer;
+        start.ToolContext.Credentials.NyxIdAccessToken = sourceReadableBearer;
+        start.ToolContext.Credentials.NyxIdCredentialKind =
+            AgentToolNyxIdCredentialKindPayload.SourceReadableUserBearer;
+        start.ToolContext.Channel = new AgentToolChannelContextPayload
+        {
+            Platform = NyxIdChatServiceDefaults.ServiceId,
+        };
+        SetOwner(start, "owner-alpha");
+
+        await agent.HandleEventAsync(CreateEnvelope(
+            conversationActorId,
+            new NyxIdChatConversationCreateCommand
+            {
+                ScopeId = start.ScopeId,
+                CreatedLocally = true,
+                RequestedActorId = conversationActorId,
+                FirstTurn = start,
+            }));
+
+        var replyGenerator = new NyxIdConversationReplyGenerator(
+            provider,
+            new BuiltInPromptFloorProvider(),
+            toolSources: [new FixedToolSource([new CanonicalProfileTool("forged_ordinary_tool")])],
+            toolExecutionPort: services.GetRequiredService<IAgentToolExecutionPort>(),
+            nyxIdChatToolSources: [assistantSource]);
+        var generationExecutor = new AgentRunReplyGenerationExecutor(
+            new RecordingActorDispatchPort([], static (_, _) => Task.CompletedTask),
+            replyGenerator,
+            interactiveReplyCollector: null,
+            relayOptions: null,
+            logger: NullLogger<AgentRunReplyGenerationExecutor>.Instance);
+        var turnExecutor = new NyxIdChatTurnOperationExecutor(generationExecutor);
+        var session = new NyxIdChatTransientExecutionSession();
+        var inputCases = new List<NyxIdChatOperationDispatchCommand.InputOneofCase>();
+
+        for (var operationIndex = 0; operationIndex < 7; operationIndex++)
+        {
+            dispatch.OperationCalls.Should().HaveCountGreaterThan(
+                operationIndex,
+                $"operation {operationIndex + 1} must be dispatched by the authoritative controller");
+            var command = dispatch.OperationCalls[operationIndex].Envelope.Payload
+                .Unpack<NyxIdChatOperationDispatchCommand>();
+            inputCases.Add(command.InputCase);
+            var execution = await turnExecutor.ExecuteAsync(
+                command,
+                session,
+                static (_, _) => Task.CompletedTask,
+                CancellationToken.None);
+            await agent.HandleEventAsync(CreateEnvelope(conversationActorId, execution.Result));
+        }
+
+        dispatch.OperationCalls.Should().HaveCount(7);
+        inputCases.Should().Equal(
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Llm,
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Tool,
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Llm,
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Tool,
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Llm,
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Tool,
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Llm);
+
+        provider.Requests.Should().HaveCount(4);
+        var firstRequest = provider.Requests[0];
+        firstRequest.Tools.Should().NotBeNull();
+        var firstTools = firstRequest.Tools!;
+        firstTools.Select(static tool => tool.Name).Should().Contain(expectedToolNames);
+        firstTools.Should().NotContain(static tool => tool.Name == "forged_ordinary_tool");
+        firstTools.Should().NotContain(static tool => tool.Name == "nyxid_proxy");
+        var requestedTools = firstTools
+            .Where(tool => expectedToolNames.Contains(tool.Name, StringComparer.Ordinal))
+            .ToArray();
+        requestedTools.Should().HaveCount(3);
+        requestedTools.Should().OnlyContain(static tool =>
+            tool.ApprovalMode == ToolApprovalMode.NeverRequire &&
+            tool.IsReadOnly &&
+            !tool.IsDestructive &&
+            tool.GetCallSafety("{}").IsReadOnly &&
+            !tool.GetCallSafety("{}").IsDestructive);
+        foreach (var tool in requestedTools)
+        {
+            tool.Should().BeAssignableTo<IAgentToolCapabilityDescriptor>();
+            ((IAgentToolCapabilityDescriptor)tool).Capabilities.Should()
+                .Contain(AgentToolCapabilities.RequiresHumanSession);
+        }
+        for (var index = 0; index < expectedToolNames.Length; index++)
+        {
+            provider.Requests[index + 1].Messages.Should().ContainSingle(message =>
+                message.Role == "tool" &&
+                message.ToolCallId == $"call-{expectedToolNames[index]}");
+        }
+
+        handler.Requests.Should().HaveCount(6);
+        handler.Requests.Select(static request => request.PathAndQuery).Should().BeEquivalentTo(
+            "/api/v1/users/me",
+            "/api/v1/users/me",
+            "/api/v1/keys",
+            "/api/v1/api-keys",
+            "/api/v1/nodes",
+            "/api/v1/sessions");
+        handler.Requests.Should().OnlyContain(request =>
+            request.Method == HttpMethod.Get && request.BearerToken == sourceReadableBearer);
+
+        var committed = await eventStore.GetEventsAsync(conversationActorId);
+        var reconciliations = committed
+            .Where(static item => item.EventData.Is(NyxIdChatOperationReconciledEvent.Descriptor))
+            .Select(static item => item.EventData.Unpack<NyxIdChatOperationReconciledEvent>())
+            .ToArray();
+        var toolReconciliations = reconciliations
+            .Where(static item =>
+                item.Result.ResultCase == NyxIdChatOperationResultSignal.ResultOneofCase.Tool)
+            .ToArray();
+        toolReconciliations.Should().HaveCount(3);
+        toolReconciliations.Select(static item => item.Result.Tool.Receipt.ToolName)
+            .Should().Equal(expectedToolNames);
+        toolReconciliations.Should().OnlyContain(static item =>
+            item.Result.Tool.Receipt.Status == AgentToolReceiptStatus.Success &&
+            item.Result.Tool.Receipt.ApprovalMode == AgentToolReceiptApprovalMode.NeverRequire &&
+            item.Result.Tool.Receipt.Effect == AgentToolReceiptEffect.ReadOnly &&
+            !item.Result.Tool.Receipt.IsDestructive &&
+            string.IsNullOrEmpty(item.Result.Tool.Receipt.ApprovalRequestId) &&
+            item.Result.Tool.Receipt.AuthorizationRequired == null);
+        var durableToolCalls = reconciliations
+            .Where(static item =>
+                item.Result.ResultCase == NyxIdChatOperationResultSignal.ResultOneofCase.Llm)
+            .SelectMany(static item => item.Result.Llm.ToolCalls)
+            .ToArray();
+        durableToolCalls.Should().HaveCount(3);
+        durableToolCalls.Should().OnlyContain(static call =>
+            call.Safety != null &&
+            call.Safety.IsReadOnly &&
+            !call.Safety.IsDestructive &&
+            !call.Safety.MayChangeExternalState);
+        committed.Should().NotContain(static item =>
+            item.EventData.Is(NyxIdChatActionRequestedEvent.Descriptor));
+
+        agent.State.ActiveTurn.Status.Should().Be(NyxIdChatTurnStatus.Succeeded);
+        agent.State.ActiveTask.Status.Should().Be(NyxIdChatTaskStatus.Succeeded);
+        agent.State.ActiveTask.Steps.Where(static step => step.Kind == NyxIdChatStepKind.Tool)
+            .Should().HaveCount(3).And.OnlyContain(static step =>
+                step.Status == NyxIdChatStepStatus.Done);
+        agent.State.PendingApproval.Should().BeNull();
+        agent.State.PendingActions.Should().BeEmpty();
+        agent.State.PendingInput.Should().BeNull();
+        committed.Should().OnlyContain(item =>
+            !Encoding.UTF8.GetString(item.EventData.ToByteArray())
+                .Contains(sourceReadableBearer, StringComparison.Ordinal));
+        agent.State.ToString().Should().NotContain(sourceReadableBearer);
     }
 
     [Fact]
@@ -4470,6 +4642,95 @@ public sealed class NyxIdChatConversationGAgentTests
             };
         }
     }
+
+    private sealed class PinnedClassRToolCallProvider(
+        IReadOnlyList<string> toolNames) : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "pinned-class-r-test";
+        public List<LLMRequest> Requests { get; } = [];
+
+        public ILLMProvider GetProvider(string name) => this;
+        public ILLMProvider GetDefault() => this;
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var round = Requests.Count;
+            Requests.Add(request);
+            if (round < toolNames.Count)
+            {
+                var toolName = toolNames[round];
+                yield return new LLMStreamChunk
+                {
+                    DeltaToolCall = new ToolCall
+                    {
+                        Id = $"call-{toolName}",
+                        Name = toolName,
+                        ArgumentsJson = "{}",
+                    },
+                };
+                await Task.CompletedTask;
+                yield return new LLMStreamChunk
+                {
+                    FinishReason = "tool_calls",
+                    IsLast = true,
+                };
+                yield break;
+            }
+
+            yield return new LLMStreamChunk
+            {
+                DeltaContent = "NyxID account reads completed.",
+            };
+            await Task.CompletedTask;
+            yield return new LLMStreamChunk
+            {
+                FinishReason = "stop",
+                IsLast = true,
+            };
+        }
+    }
+
+    private sealed class RecordingNyxIdReadHandler : HttpMessageHandler
+    {
+        private readonly ConcurrentQueue<RecordedNyxIdReadRequest> _requests = new();
+
+        public IReadOnlyCollection<RecordedNyxIdReadRequest> Requests => _requests.ToArray();
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _requests.Enqueue(new RecordedNyxIdReadRequest(
+                request.Method,
+                request.RequestUri?.PathAndQuery ?? string.Empty,
+                request.Headers.Authorization?.Parameter ?? string.Empty));
+            var responseJson = request.RequestUri?.AbsolutePath switch
+            {
+                "/api/v1/users/me" =>
+                    "{\"id\":\"user-alpha\",\"email\":\"user@example.test\",\"status\":\"active\"}",
+                "/api/v1/keys" => "{\"keys\":[]}",
+                "/api/v1/api-keys" => "{\"api_keys\":[]}",
+                "/api/v1/nodes" => "{\"nodes\":[]}",
+                "/api/v1/sessions" => "{\"sessions\":[]}",
+                _ => "{\"error\":\"unexpected_route\"}",
+            };
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson, Encoding.UTF8, "application/json"),
+                RequestMessage = request,
+            });
+        }
+    }
+
+    private sealed record RecordedNyxIdReadRequest(
+        HttpMethod Method,
+        string PathAndQuery,
+        string BearerToken);
 
     private static NyxIdAssistantActionRegistry CreateActionRegistry() =>
         NyxIdAssistantActionRegistry.Load("""


### PR DESCRIPTION
## Problem and solution

Production deploys from the protected dev branch. feature/integrate now contains the NyxID Assistant Class-R management-read batch at fae59d63788e4670d4252591df788a9ac3cf1705, while dev remains at e9206e1ba4d39fa47c298a868d3b63ec2ceeb193.

This PR merges that exact feature/integrate revision into dev without altering the feature commit. It adds source-readable bearer enforcement, strict closed schemas, response allowlist projection, node-credential reads, service-pool reads, and authoritative chat-turn coverage.

## Affected paths

- src/Aevatar.AI.ToolProviders.NyxId/
- test/Aevatar.AI.Tests/

## Verification

- Full Aevatar.AI.Tests suite: 2507/2507 passed
- Focused management-read batch: 61/61 passed
- dotnet build aevatar.slnx --nologo: passed with 0 errors
- bash tools/ci/test_stability_guards.sh: passed
- bash tools/ci/architecture_guards.sh: passed
- git diff --check: passed

After merge, the exact deployed image will be verified before the next online-testable batch starts.

## Documentation

No architecture contract changed in this incremental batch; the existing NyxID Assistant boundary documents remain authoritative.