### PR TITLE
Remove generic Ornn skill tools from Studio workflow

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -84,7 +84,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
     /// <c>RoleDefinition.AgentToolScope</c>, intersected with any step scope by the execution kernel →
     /// <c>ToolVisibility</c>). It INCLUDES Studio team/member/draft creation, web authoring research, member workflow binding,
     /// Studio managed-runtime-safe Aevatar invocation, <c>aevatar_provision_workflow_schedule</c> + the observe tools and EXCLUDES
-    /// both the Lark <c>scheduled_agent_creator</c>, unmanaged workflow starts, and the hanging loose-definition tools
+    /// direct Ornn skill discovery, the Lark <c>scheduled_agent_creator</c>, unmanaged workflow starts, and the hanging loose-definition tools
     /// (<c>workflow_create_def</c>/<c>update</c>/<c>read</c>/<c>list_defs</c>);
     /// the allowlist is the lever that keeps those out of the studio surface entirely (prompt steering alone is
     /// unreliable while a tool is visible).
@@ -443,8 +443,6 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
               - list_external_workflow_capabilities
               - inspect_external_workflow_capability_readiness
               - preview_workflow_explicit_requests
-              - ornn_search_skills
-              - use_skill
             tool_sets:
               - nyxid.connected_services
         steps:

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -423,6 +423,8 @@ public class WorkflowDefinitionCatalogTests
         allowed.Should().NotContain("ssh_exec");
         allowed.Should().NotContain("codex_exec");
         allowed.Should().NotContain("code_execute");
+        allowed.Should().NotContain("ornn_search_skills");
+        allowed.Should().NotContain("use_skill");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

#3352 reworks the blocked #3292 path as a smaller independently reviewable slice. The selected slice keeps Studio workflow authoring on the Application-owned capability path and removes generic Ornn skill discovery tools from the Studio workflow allowlist.

Fixes #3352.

## Solution

- Remove ornn_search_skills and use_skill from the built-in Studio workflow allowed_tools list.
- Update the surrounding Studio allowlist comment to state that direct Ornn skill discovery is intentionally excluded.
- Add regression assertions that the parsed Studio role does not expose these generic Ornn tools while retaining the existing NyxID/external capability authoring tools.

## Impact

Affected paths:

- src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
- test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs

This does not change generic Ornn tools outside the Studio workflow surface.

## Verification

- bash tools/ci/test_stability_guards.sh: passed
- dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~BuiltInStudioYaml_ShouldExposeNyxIdCapabilityToolsWithoutCollapsingServiceSemantics: passed, 1/1 tests

The earlier FKST broad affected-test run selected broader infrastructure and hit environment blockers unrelated to this slice, including missing redis-server.
