### PR TITLE
Fix published workflow Run readiness

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1767,6 +1767,13 @@ describe('Workflow Activity vNext settings', () => {
 });
 
 describe('Workflow Activity vNext editor', () => {
+  const unavailableWorkflowDetail = {
+    available: false,
+    scopeId: 'scope-alpha',
+    workflow: null,
+    source: null,
+  } as const;
+
   beforeEach(() => {
     mockLocation =
       '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-committed-source';
@@ -1831,6 +1838,9 @@ describe('Workflow Activity vNext editor', () => {
         findings: [],
       },
     });
+    mockScopesApi.getWorkflowDetail.mockResolvedValue(
+      unavailableWorkflowDetail,
+    );
   });
 
   afterEach(() => cleanupTestQueryClients());
@@ -1924,12 +1934,14 @@ describe('Workflow Activity vNext editor', () => {
     let resolveWorkflowObservation:
       | ((workflow: typeof observedWorkflow) => void)
       | undefined;
-    mockScopesApi.getWorkflowDetail.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveWorkflowObservation = resolve;
-        }),
-    );
+    mockScopesApi.getWorkflowDetail
+      .mockResolvedValueOnce(unavailableWorkflowDetail)
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveWorkflowObservation = resolve;
+          }),
+      );
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Publish' }));
@@ -2082,7 +2094,11 @@ describe('Workflow Activity vNext editor', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled();
     expect(mockStudioApi.publishWorkflow).toHaveBeenCalledTimes(1);
-    expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
+    expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(1);
+    expect(mockScopesApi.getWorkflowDetail).toHaveBeenLastCalledWith(
+      'scope-alpha',
+      'wf-draft-alpha',
+    );
     expect(mockScopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
   });
 
@@ -2143,7 +2159,7 @@ describe('Workflow Activity vNext editor', () => {
 
   function arrangeObservedWorkflowPublication(): void {
     arrangeSavedDraftPublication();
-    mockScopesApi.getWorkflowDetail.mockResolvedValue({
+    const observedWorkflow = {
       available: true,
       scopeId: 'scope-alpha',
       workflow: {
@@ -2160,7 +2176,10 @@ describe('Workflow Activity vNext editor', () => {
         updatedAt: '2026-08-06T10:00:00Z',
       },
       source: null,
-    });
+    };
+    mockScopesApi.getWorkflowDetail
+      .mockResolvedValueOnce(unavailableWorkflowDetail)
+      .mockResolvedValue(observedWorkflow);
   }
 
   async function publishObservedWorkflow(): Promise<void> {
@@ -2240,6 +2259,7 @@ describe('Workflow Activity vNext editor', () => {
   it('continues publication observation after a transient read failure without another action', async () => {
     arrangeSavedDraftPublication();
     mockScopesApi.getWorkflowDetail
+      .mockResolvedValueOnce(unavailableWorkflowDetail)
       .mockRejectedValueOnce(
         Object.assign(new Error('HTTP 503'), { status: 503 }),
       )
@@ -2276,7 +2296,7 @@ describe('Workflow Activity vNext editor', () => {
     expect(
       screen.queryByRole('button', { name: 'Check again' }),
     ).not.toBeInTheDocument();
-    expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(2);
+    expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(3);
     expect(mockScopesApi.getWorkflowDetail).toHaveBeenLastCalledWith(
       'scope-alpha',
       'wf-draft-alpha',
@@ -2317,7 +2337,7 @@ describe('Workflow Activity vNext editor', () => {
     expect(
       screen.queryByRole('button', { name: 'Check again' }),
     ).not.toBeInTheDocument();
-    expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(1);
+    expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(2);
     expect(mockScopesApi.getWorkflowDetail).toHaveBeenLastCalledWith(
       'scope-alpha',
       'wf-draft-alpha',
@@ -2381,7 +2401,7 @@ describe('Workflow Activity vNext editor', () => {
         acceptanceStage: 'accepted',
         propagationStage: 'readmodel_propagating',
       });
-    mockScopesApi.getWorkflowDetail.mockResolvedValue({
+    const observedWorkflow = {
       available: true,
       scopeId: 'scope-alpha',
       workflow: {
@@ -2398,7 +2418,10 @@ describe('Workflow Activity vNext editor', () => {
         updatedAt: '2026-08-06T10:00:00Z',
       },
       source: null,
-    });
+    };
+    mockScopesApi.getWorkflowDetail
+      .mockResolvedValueOnce(unavailableWorkflowDetail)
+      .mockResolvedValue(observedWorkflow);
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Publish' }));
@@ -2450,7 +2473,7 @@ describe('Workflow Activity vNext editor', () => {
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
       });
-      expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(1);
+      expect(mockScopesApi.getWorkflowDetail).toHaveBeenCalledTimes(2);
       expect(mockScopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalled();
       await act(async () => {
         await jest.advanceTimersByTimeAsync(5_000);
@@ -3546,6 +3569,68 @@ describe('Workflow Activity vNext editor', () => {
       'title',
       'Publish this workflow before running it.',
     );
+  });
+
+  it('restores an authoritative publication when opening a published workflow', async () => {
+    mockStudioApi.getWorkflow.mockResolvedValue({
+      workflowId: 'wf-committed-source',
+      name: 'Committed source',
+      fileName: 'committed-source.yaml',
+      filePath: '/workflows/committed-source.yaml',
+      directoryId: 'directory-alpha',
+      directoryLabel: 'Workflows',
+      yaml: 'name: committed_source\nroles: []\nsteps:\n  - id: step-root\n    type: llm_call\n',
+      updatedAtUtc: '2026-08-10T03:20:32Z',
+      document: {
+        name: 'committed_source',
+        roles: [],
+        steps: [{ id: 'step-root', type: 'llm_call' }],
+      },
+      draftExists: true,
+      findings: [],
+    });
+    mockScopesApi.getWorkflowDetail.mockResolvedValue({
+      available: true,
+      scopeId: 'scope-alpha',
+      workflow: {
+        scopeId: 'scope-alpha',
+        workflowId: 'wf-committed-source',
+        displayName: 'Committed source',
+        serviceKey: 'opaque-service-key',
+        workflowName: 'committed_source',
+        actorId: 'actor-existing',
+        activeRevisionId: 'rev-existing',
+        deploymentId: 'deployment-existing',
+        deploymentStatus: 'Available',
+        updatedAt: '2026-08-10T03:20:32Z',
+        publishedServiceId: 'svc-existing',
+        serviceAppId: 'workflow-app',
+        serviceNamespace: 'workflow-namespace',
+      },
+      source: {
+        workflowYaml:
+          'name: committed_source\nroles: []\nsteps:\n  - id: step-root\n    type: llm_call\n',
+        definitionActorId: 'definition-existing',
+        inlineWorkflowYamls: null,
+      },
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const run = await screen.findByRole('button', { name: 'Run' });
+    await waitFor(() => expect(run).toBeEnabled());
+    expect(run).not.toHaveAttribute('title');
+    expect(
+      screen.queryByRole('button', { name: 'Publish' }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(run);
+
+    const drawer = await screen.findByRole('dialog', {
+      name: 'Run published workflow',
+    });
+    expect(within(drawer).getByText('svc-existing')).toBeInTheDocument();
+    expect(within(drawer).getByText('rev-existing')).toBeInTheDocument();
+    expect(mockStudioApi.publishWorkflow).not.toHaveBeenCalled();
   });
 
   it('opens the published run drawer after publication is observed', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -7,10 +7,12 @@ import {
   RocketOutlined,
   SaveOutlined,
 } from '@ant-design/icons';
+import { useQuery } from '@tanstack/react-query';
 import { Alert, Button, Input, Modal, Segmented, Space, Tooltip } from 'antd';
 import React from 'react';
 import WorkflowStudioCanvasRegion from '@/pages/team-member-workflow-studio/components/WorkflowStudioCanvasRegion';
 import WorkflowStudioNodeLibrary from '@/pages/team-member-workflow-studio/components/WorkflowStudioNodeLibrary';
+import { scopesApi } from '@/shared/api/scopesApi';
 import { formatUtcDateTime } from '@/shared/datetime/dateTime';
 import { t } from '@/shared/i18n/messages';
 import { getLocationSnapshot, history } from '@/shared/navigation/history';
@@ -23,7 +25,10 @@ import {
   isRunStatusTerminal,
 } from '../activity/runPresentation';
 import { useConsoleLocation } from '../hooks/useConsoleLocation';
-import { useWorkflowEditor } from '../hooks/useWorkflowEditor';
+import {
+  useWorkflowEditor,
+  type WorkflowPublishedInvocationTarget,
+} from '../hooks/useWorkflowEditor';
 import {
   useWorkflowPublication,
   type WorkflowPublicationReceipt,
@@ -67,6 +72,31 @@ function hasNonBlankIdentifier(value: unknown): value is string {
   return typeof value === 'string' && Boolean(value.trim());
 }
 
+function restorePublishedInvocationTarget(
+  scopeId: string,
+  workflowId: string,
+  detail: Awaited<ReturnType<typeof scopesApi.getWorkflowDetail>> | undefined,
+): WorkflowPublishedInvocationTarget | null {
+  const published = detail?.workflow;
+  if (
+    detail?.available !== true ||
+    detail.scopeId !== scopeId ||
+    !published ||
+    published.scopeId !== scopeId ||
+    published.workflowId !== workflowId ||
+    !hasNonBlankIdentifier(published.activeRevisionId) ||
+    !hasNonBlankIdentifier(published.publishedServiceId)
+  ) {
+    return null;
+  }
+
+  return {
+    publishedServiceId: published.publishedServiceId,
+    revisionId: published.activeRevisionId,
+    workflowId: published.workflowId,
+  };
+}
+
 const WorkflowEditorPage: React.FC<{
   readonly scopeId: string;
   readonly workflowId: string;
@@ -83,6 +113,16 @@ const WorkflowEditorPage: React.FC<{
   const activeScopeId = activeEditorRoute.scopeId;
   const activeWorkflowId = activeEditorRoute.workflowId;
   const editor = useWorkflowEditor(activeScopeId, activeWorkflowId);
+  const restoredPublication = useQuery({
+    queryKey: [
+      'workflow-activity-vnext',
+      'workflow-publication-current',
+      activeScopeId,
+      activeWorkflowId,
+    ],
+    queryFn: () => scopesApi.getWorkflowDetail(activeScopeId, activeWorkflowId),
+    retry: false,
+  });
   const toast = useConsoleToast();
   const [mode, setMode] = React.useState<'canvas' | 'yaml'>('canvas');
   const [nodeLibraryOpen, setNodeLibraryOpen] = React.useState(false);
@@ -179,15 +219,14 @@ const WorkflowEditorPage: React.FC<{
     else toast.error(toastMessage, { key: toastKey });
   }, [publication.phase, publicationReceipt, publicationStage, toast]);
   const publicationObserved = publication.phase === 'observed';
-  const publicationStale = Boolean(
-    publicationReceipt &&
-      publishedDocumentVersion !== null &&
-      publishedDocumentVersion !== editor.documentVersion,
+  const restoredPublishedInvocationTarget = restorePublishedInvocationTarget(
+    activeScopeId,
+    activeWorkflowId,
+    restoredPublication.data,
   );
-  const publishedInvocationTarget =
+  const observedPublishedInvocationTarget =
     publicationReceipt &&
     publicationObserved &&
-    !publicationStale &&
     hasNonBlankIdentifier(publication.publishedServiceId)
       ? {
           publishedServiceId: publication.publishedServiceId,
@@ -195,6 +234,21 @@ const WorkflowEditorPage: React.FC<{
           workflowId: publicationReceipt.workflowId,
         }
       : null;
+  const publishedTargetDocumentVersion = publicationReceipt
+    ? publishedDocumentVersion
+    : restoredPublishedInvocationTarget
+      ? 0
+      : null;
+  const publicationStale = Boolean(
+    publishedTargetDocumentVersion !== null &&
+      publishedTargetDocumentVersion !== editor.documentVersion,
+  );
+  const publishedInvocationTarget =
+    !publicationStale && publicationReceipt
+      ? observedPublishedInvocationTarget
+      : !publicationStale && publicationStage !== 'submitting'
+        ? restoredPublishedInvocationTarget
+        : null;
   const canOpenPublishedRun = Boolean(
     publishedInvocationTarget &&
       editor.canRun &&
@@ -704,7 +758,7 @@ const WorkflowEditorPage: React.FC<{
       ),
     });
   }
-  const publicationCurrent = publicationObserved && !publicationStale;
+  const publicationCurrent = Boolean(publishedInvocationTarget);
   const canPublish = publishReadinessIssues.length === 0 && !publicationCurrent;
   const publishLabel = publicationActionPending
     ? t('workflowActivityVNext.publish.publishing', 'Publishing')
@@ -720,42 +774,41 @@ const WorkflowEditorPage: React.FC<{
             { count: publishReadinessIssues.length },
           )
       : t('workflowActivityVNext.editor.publish', 'Publish');
+  const publishedTargetResolving =
+    publicationReceipt !== null ||
+    publicationStage === 'submitting' ||
+    restoredPublication.isPending;
   const runDisabledReason = publicationStale
     ? t(
         'workflowActivityVNext.editor.publishLatestBeforeRun',
         'Save and publish the latest changes before running.',
       )
-    : !publicationReceipt
-      ? t(
-          'workflowActivityVNext.editor.publishBeforeRun',
-          'Publish this workflow before running it.',
-        )
-      : !publicationObserved
+    : !publishedInvocationTarget
+      ? publishedTargetResolving
         ? t(
             'workflowActivityVNext.editor.waitForPublishedRun',
             'Wait for the published revision to become available.',
           )
-        : !publishedInvocationTarget
+        : t(
+            'workflowActivityVNext.editor.publishBeforeRun',
+            'Publish this workflow before running it.',
+          )
+      : editor.dirty || hasUnappliedNodeChanges
+        ? t(
+            'workflowActivityVNext.editor.publishLatestBeforeRun',
+            'Save and publish the latest changes before running.',
+          )
+        : !editor.canRun
           ? t(
-              'workflowActivityVNext.editor.waitForPublishedRun',
-              'Wait for the published revision to become available.',
+              'workflowActivityVNext.editor.runUnavailable',
+              'Add at least one valid step before running.',
             )
-          : editor.dirty || hasUnappliedNodeChanges
+          : editorWriteLocked
             ? t(
-                'workflowActivityVNext.editor.publishLatestBeforeRun',
-                'Save and publish the latest changes before running.',
+                'workflowActivityVNext.editor.waitForEditorBeforeRun',
+                'Wait for the workflow update to finish.',
               )
-            : !editor.canRun
-              ? t(
-                  'workflowActivityVNext.editor.runUnavailable',
-                  'Add at least one valid step before running.',
-                )
-              : editorWriteLocked
-                ? t(
-                    'workflowActivityVNext.editor.waitForEditorBeforeRun',
-                    'Wait for the workflow update to finish.',
-                  )
-                : undefined;
+            : undefined;
   const saveStatus = editor.validating
     ? t('workflowActivityVNext.editor.validating', 'Validating workflow…')
     : editor.saving || editor.receiptPending

--- a/docs/superpowers/plans/2026-08-10-published-run-readiness-recovery.md
+++ b/docs/superpowers/plans/2026-08-10-published-run-readiness-recovery.md
@@ -1,0 +1,57 @@
+# Published Run Readiness Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable published Workflow Activity Run after a fresh editor mount by restoring the exact active revision and published service from the authoritative workflow detail.
+
+**Architecture:** Keep draft authoring state and published invocation state separate. `WorkflowEditorPage` reads the exact scope workflow detail, derives a typed publication receipt only from matching authoritative identities, and feeds that receipt through the existing publication observer; a receipt from a new Publish command takes precedence while it is active.
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, Jest, Testing Library, Biome.
+
+---
+
+### Task 1: Lock Fresh-Session Published Run Behavior
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] Add a test whose draft and scope workflow detail share `workflowId = "wf-committed-source"` while the detail exposes `activeRevisionId = "rev-existing"` and `publishedServiceId = "svc-existing"`.
+- [ ] Render a fresh editor, wait for Run to become enabled, open it, and assert that the drawer shows `rev-existing` and `svc-existing`.
+- [ ] Run only that test and verify it fails because the current editor requires a same-session publication receipt.
+
+Run:
+
+```bash
+pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand -t 'restores an authoritative publication when opening a published workflow'
+```
+
+### Task 2: Restore the Authoritative Publication
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx`
+
+- [ ] Query `scopesApi.getWorkflowDetail(activeScopeId, activeWorkflowId)` with a route-scoped query key and no retries.
+- [ ] Derive a restored receipt only from an available exact scope/workflow match with non-blank `activeRevisionId` and `publishedServiceId`.
+- [ ] Prefer a same-session Publish receipt; suppress the restored receipt while a replacement Publish submission is active.
+- [ ] Feed the effective receipt to the existing publication observer and derive the restored document version from the current editor version.
+- [ ] Run the focused regression test and verify it passes.
+
+### Task 3: Protect Existing Behavior
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] Give editor tests an explicit unpublished workflow detail by default so every test declares its publication state honestly.
+- [ ] Run dependency-related tests for the changed editor page and the changed test file.
+- [ ] Run the repository test stability guard because a frontend test changed.
+- [ ] Run Biome only on analyzer-reported static-check files.
+
+### Task 4: Deliver the Focused Fix
+
+**Files:**
+- Review all files changed from `origin/feat/2026-08-04_workflow-activity-vnext`.
+
+- [ ] Run `frontend_change_scope.py` with the feature branch as base and record its exact commands.
+- [ ] Review the diff for identity mixing, stale route state, and unrelated changes.
+- [ ] Stage only this task's files, commit, push, and open a ready pull request targeting `feat/2026-08-04_workflow-activity-vnext`.
+- [ ] Record focused test/static-check results and delegate the full frontend suite, typecheck, and build to GitHub CI.

--- a/docs/superpowers/plans/2026-08-10-published-run-readiness-recovery.md
+++ b/docs/superpowers/plans/2026-08-10-published-run-readiness-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Enable published Workflow Activity Run after a fresh editor mount by restoring the exact active revision and published service from the authoritative workflow detail.
 
-**Architecture:** Keep draft authoring state and published invocation state separate. `WorkflowEditorPage` reads the exact scope workflow detail, derives a typed publication receipt only from matching authoritative identities, and feeds that receipt through the existing publication observer; a receipt from a new Publish command takes precedence while it is active.
+**Architecture:** Keep draft authoring state and published invocation state separate. `WorkflowEditorPage` reads the exact scope workflow detail and restores a typed invocation target only from matching authoritative identities; the existing observer remains responsible for a receipt from a new Publish command, which takes precedence while it is active.
 
 **Tech Stack:** React 19, TypeScript, TanStack Query, Jest, Testing Library, Biome.
 
@@ -31,9 +31,9 @@ pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand -t '
 - Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx`
 
 - [ ] Query `scopesApi.getWorkflowDetail(activeScopeId, activeWorkflowId)` with a route-scoped query key and no retries.
-- [ ] Derive a restored receipt only from an available exact scope/workflow match with non-blank `activeRevisionId` and `publishedServiceId`.
-- [ ] Prefer a same-session Publish receipt; suppress the restored receipt while a replacement Publish submission is active.
-- [ ] Feed the effective receipt to the existing publication observer and derive the restored document version from the current editor version.
+- [ ] Derive a restored invocation target only from an available exact scope/workflow match with non-blank `activeRevisionId` and `publishedServiceId`.
+- [ ] Prefer a same-session Publish receipt; suppress the restored invocation target while a replacement Publish submission is active.
+- [ ] Keep the receipt observer scoped to newly accepted Publish commands and derive the restored target's document version from the initial editor revision.
 - [ ] Run the focused regression test and verify it passes.
 
 ### Task 3: Protect Existing Behavior

--- a/docs/superpowers/specs/2026-08-10-published-run-readiness-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-10-published-run-readiness-recovery-design.md
@@ -24,9 +24,10 @@ contains non-blank active revision and published service identities.
 
 1. The editor loads its editable draft through `studioApi.getWorkflow`.
 2. In parallel, it reads `/api/scopes/:scopeId/workflows/:workflowId`.
-3. An authoritative active publication seeds the publication observation path.
-4. The existing observer confirms that the active revision and callable service
-   still match before Run is enabled.
+3. An authoritative active publication directly supplies the restored published
+   invocation target; the detail read itself is the current read-model evidence.
+4. The existing receipt observer remains responsible for a newly accepted
+   Publish command until its new active revision and callable service appear.
 5. A Publish started in the current editor session temporarily supersedes the
    restored publication until the new receipt is observed.
 6. Route changes resolve publication state again for the new exact workflow ID.

--- a/docs/superpowers/specs/2026-08-10-published-run-readiness-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-10-published-run-readiness-recovery-design.md
@@ -1,0 +1,51 @@
+# Published Run Readiness Recovery Design
+
+## Context
+
+The Workflow catalogue renders `Published` from the authoritative committed
+facts returned by the scope workflow catalogue. Opening that row mounts a new
+editor session whose publication receipt starts empty, so Run is disabled until
+the user publishes again in that same session. The editor therefore treats a
+transient command receipt as durable publication state.
+
+## Semantic Decision
+
+Published Run readiness comes from the scope workflow detail read model for the
+exact route `scopeId + workflowId`. A publication receipt remains evidence for
+observing a newly accepted Publish command, but it is not the owner of an
+already active publication.
+
+`workflowId`, `activeRevisionId`, and `publishedServiceId` retain separate
+meanings. The editor may construct a published invocation target only when the
+detail is available, its scope and workflow identities match the route, and it
+contains non-blank active revision and published service identities.
+
+## Data Flow
+
+1. The editor loads its editable draft through `studioApi.getWorkflow`.
+2. In parallel, it reads `/api/scopes/:scopeId/workflows/:workflowId`.
+3. An authoritative active publication seeds the publication observation path.
+4. The existing observer confirms that the active revision and callable service
+   still match before Run is enabled.
+5. A Publish started in the current editor session temporarily supersedes the
+   restored publication until the new receipt is observed.
+6. Route changes resolve publication state again for the new exact workflow ID.
+
+The editor records the current local document version when it adopts restored
+publication state. Later local edits make that target stale, preserving the
+existing save-and-publish-again protection.
+
+## Failure Behavior
+
+An unavailable, mismatched, unpublished, or uncallable workflow detail does not
+produce a target. Existing unauthorized, forbidden, delayed, and failed
+publication observation states remain unchanged. The editor never substitutes
+`workflowId` or `activeRevisionId` for `publishedServiceId`.
+
+## Verification
+
+Focused UI coverage must prove that a published workflow opened in a fresh
+editor session enables Run with the exact authoritative service and revision.
+Existing coverage must continue to prove that an unpublished workflow remains
+disabled, local edits stale the target, and a newly published workflow is not
+runnable until observation completes.


### PR DESCRIPTION
## Problem

The Workflow catalogue reads authoritative committed facts and shows `Published`, but a fresh editor session initializes its publication receipt to `null`. The editor therefore disables Run and offers Publish again even when the exact workflow already has an active revision and callable published service.

## Solution

- Read the authoritative scope workflow detail for the exact route `scopeId + workflowId`.
- Restore a published invocation target only when the returned scope/workflow identities match and both `activeRevisionId` and `publishedServiceId` are non-blank.
- Keep a newly accepted same-session Publish receipt authoritative while its replacement revision is being observed.
- Preserve local document-version stale protection after restoring a published target.
- Show the restored `Published` state, remove the stale publish-first Run title, and hide the redundant Publish action.
- Add a regression covering a published workflow opened in a fresh editor session with distinct workflow, revision, and service identities.

## Impact paths

- Workflow Activity vNext editor publication readiness
- Published Run target selection
- Workflow publication/run regression coverage
- Published Run readiness design and implementation documentation

## Local verification

- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx --runInBand` — 96 passed
- Changed test file: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand` — 96 passed
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx` — passed
- Test stability guard: `bash tools/ci/test_stability_guards.sh` — passed
- Documentation lint: `bash tools/docs/lint.sh` — 87 files checked, 0 errors
- Full frontend suite/typecheck/build: deferred to GitHub CI by personal local workflow policy
