### PR TITLE
Add scope workflow archive command

### DIFF
--- a/docs/canon/workflow-catalog-visibility.md
+++ b/docs/canon/workflow-catalog-visibility.md
@@ -77,3 +77,19 @@ Contract:
 - Rows expose typed capabilities for `open`, `activity`, `rename`, and `delete`. Unavailable actions carry a typed unavailable reason instead of requiring the client to infer from sources.
 - Rows keep `workflowId`, committed `actorId`, deployment/service IDs, and other identities separate. `workflowId` must not be reused as `memberId` or `publishedServiceId`.
 - `freshness.refreshWatermarkUtc` is the maximum source `UpdatedAt` observed from the materialized draft workspace and committed workflow read models used by the query. It is a refresh watermark, not a synthetic local `StateVersion++`.
+
+## Scope workflow archive command
+
+Workflow Activity archives a published workflow through the scope-owned command endpoint:
+
+`POST /api/scopes/{scopeId}/workflows/{workflowId}:archive`
+
+The browser supplies only the independently typed `scopeId` and `workflowId`. After `AevatarScopeAccessGuard` validates the caller, the Application service resolves `publishedServiceId`, service app/namespace, and `deploymentId` from the authoritative scope workflow read model and dispatches deployment deactivation. The generic service-identity endpoint is not a browser fallback and its service-principal access requirements remain unchanged.
+
+Archive is accepted-only and preserves the editable draft, published revisions, committed facts, and Activity. The client reports success only after the exact `workflowId` is observed with a deactivated deployment. Permanent deletion, if introduced, requires a separate explicitly named purge contract.
+
+Workflow Activity presents one destructive list action according to the dominant row source:
+
+- draft-only rows expose `Delete draft`;
+- published rows expose `Archive`, whether or not a draft source also exists;
+- archived rows expose neither Archive nor Delete draft.

--- a/docs/superpowers/plans/2026-08-10-workflow-archive-boundary.md
+++ b/docs/superpowers/plans/2026-08-10-workflow-archive-boundary.md
@@ -1,0 +1,448 @@
+# Workflow Archive Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give authenticated scope users a correct Workflow Archive command and make Workflow Activity show exactly one destructive list action for each draft or published row.
+
+**Architecture:** A new scope-owned Application port resolves published service and deployment identities from the authoritative Workflow read model, then dispatches the existing deployment deactivation command. The frontend feature branch calls only that scope contract and applies a published-dominant menu policy while retaining catalogue-based completion observation.
+
+**Tech Stack:** .NET 10, ASP.NET Core minimal APIs, Protobuf service commands, xUnit, FluentAssertions, React, TypeScript, React Query, Jest, Testing Library, Biome.
+
+---
+
+### Task 1: Document The Archive Boundary
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-10-workflow-archive-boundary-design.md`
+- Create: `docs/superpowers/plans/2026-08-10-workflow-archive-boundary.md`
+- Modify: `docs/canon/workflow-catalog-visibility.md`
+
+- [ ] **Step 1: Record the approved product semantics**
+
+Document these exact invariants:
+
+```text
+draft-only -> Delete draft
+published with or without draft -> Archive
+archived -> no Archive action
+Archive -> deactivate deployment and preserve committed history
+```
+
+- [ ] **Step 2: Record the identity boundary**
+
+Document the endpoint and source of every identity:
+
+```http
+POST /api/scopes/{scopeId}/workflows/{workflowId}:archive
+```
+
+```text
+browser: scopeId + workflowId
+read model: publishedServiceId + serviceAppId + serviceNamespace + deploymentId
+```
+
+- [ ] **Step 3: Commit the backend design with the implementation**
+
+Stage the design, plan, canonical documentation, and backend source only after
+the backend focused tests pass.
+
+### Task 2: Add The Backend Archive Application Contract
+
+**Files:**
+- Create: `src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowArchiveCommandPort.cs`
+- Modify: `src/platform/Aevatar.GAgentService.Abstractions/ScopeWorkflows/ScopeWorkflowModels.cs`
+- Create: `src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowArchiveApplicationService.cs`
+- Test: `test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowArchiveApplicationServiceTests.cs`
+
+- [ ] **Step 1: Write the failing identity-resolution test**
+
+Add a test that supplies deliberately distinct identities:
+
+```csharp
+var workflow = new ScopeWorkflowSummary(
+    ScopeId: "scope-alpha",
+    WorkflowId: "wf-alpha",
+    DisplayName: "Alpha",
+    ServiceKey: "opaque-key",
+    WorkflowName: "alpha",
+    ActorId: "m-alpha",
+    ActiveRevisionId: "rev-alpha",
+    DeploymentId: "dep-alpha",
+    DeploymentStatus: "Active",
+    UpdatedAt: DateTimeOffset.UtcNow)
+{
+    PublishedServiceId = "svc-alpha",
+    ServiceAppId = "workflow-app",
+    ServiceNamespace = "workflow-namespace",
+};
+
+var result = await service.ArchiveAsync(
+    new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+
+commands.DeactivateCommand!.Identity.ServiceId.Should().Be("svc-alpha");
+commands.DeactivateCommand.DeploymentId.Should().Be("dep-alpha");
+result.WorkflowId.Should().Be("wf-alpha");
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter FullyQualifiedName~ScopeWorkflowArchiveApplicationServiceTests
+```
+
+Expected: compilation fails because the archive request, port, result, and
+Application service do not exist.
+
+- [ ] **Step 3: Add the narrow contract and accepted result**
+
+Create:
+
+```csharp
+public interface IScopeWorkflowArchiveCommandPort
+{
+    Task<ScopeWorkflowArchiveAcceptedResult> ArchiveAsync(
+        ScopeWorkflowArchiveRequest request,
+        CancellationToken ct = default);
+}
+```
+
+Add strongly typed models:
+
+```csharp
+public sealed record ScopeWorkflowArchiveRequest(string ScopeId, string WorkflowId);
+
+public sealed record ScopeWorkflowArchiveAcceptedResult(
+    string ScopeId,
+    string WorkflowId,
+    string DeploymentId,
+    ScopeWorkflowCommandAcceptedHandle CommandHandle,
+    string ReadModelUrl,
+    string AcceptanceStage = "accepted",
+    string PropagationStage = "readmodel_propagating");
+```
+
+- [ ] **Step 4: Implement minimal Application dispatch**
+
+The implementation must:
+
+```csharp
+var lookup = await _workflowQueryPort.LookupByWorkflowIdAsync(scopeId, workflowId, ct);
+if (!lookup.IsRunnable)
+    throw ScopeWorkflowArchiveRejectedException.FromLookup(lookup);
+
+var workflow = lookup.Workflow!;
+EnsureActive(workflow.DeploymentStatus);
+var receipt = await _serviceCommandPort.DeactivateServiceDeploymentAsync(
+    new DeactivateServiceDeploymentCommand
+    {
+        Identity = new ServiceIdentity
+        {
+            TenantId = workflow.ScopeId,
+            AppId = workflow.ServiceAppId,
+            Namespace = workflow.ServiceNamespace,
+            ServiceId = workflow.PublishedServiceId,
+        },
+        DeploymentId = workflow.DeploymentId,
+    },
+    ct);
+```
+
+Return a standard command handle with stage `deactivate_deployment` and the
+read-model URL `/api/scopes/{scopeId}/workflows/{workflowId}`.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run the same filtered test command. Expected: the identity-resolution test
+passes.
+
+- [ ] **Step 6: Write rejection tests**
+
+Add separate tests proving:
+
+```text
+NotFound lookup -> archive rejection and zero service commands
+Stale lookup -> archive rejection and zero service commands
+Deactivated status -> WORKFLOW_NOT_ACTIVE and zero service commands
+blank publishedServiceId -> WORKFLOW_ARCHIVE_IDENTITY_UNAVAILABLE and zero commands
+```
+
+- [ ] **Step 7: Run rejection tests and verify RED**
+
+Run the filtered Application test command. Expected: new rejection assertions
+fail until validation and typed rejection categories are implemented.
+
+- [ ] **Step 8: Implement rejection categories and validation**
+
+Add `ScopeWorkflowArchiveRejectedException` with stable `Code` and a failure
+kind independent of HTTP. Normalize status with case-insensitive comparison to
+`ServiceDeploymentStatus.Active.ToString()`. Validate every identity component
+and the deployment ID before dispatch.
+
+- [ ] **Step 9: Verify GREEN**
+
+Run the filtered Application test command. Expected: all archive Application
+tests pass with no command dispatched for any rejection case.
+
+### Task 3: Expose The Scope-Owned HTTP Endpoint
+
+**Files:**
+- Modify: `src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs`
+- Modify: `src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs`
+- Test: `test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs`
+
+- [ ] **Step 1: Write the failing accepted endpoint test**
+
+Add a recording `IScopeWorkflowArchiveCommandPort` and assert:
+
+```csharp
+var result = await ScopeWorkflowEndpoints.HandleArchiveWorkflowAsync(
+    http,
+    "scope-alpha",
+    "wf-alpha",
+    port,
+    CancellationToken.None);
+
+await result.ExecuteAsync(http);
+http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+port.Request.Should().Be(new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+```
+
+The test caller has `scope_id=scope-alpha` but deliberately has no service
+identity claims.
+
+- [ ] **Step 2: Run the endpoint test and verify RED**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter FullyQualifiedName~HandleArchiveWorkflowAsync
+```
+
+Expected: compilation fails because the handler does not exist.
+
+- [ ] **Step 3: Map the route and handler**
+
+Register:
+
+```csharp
+group.MapPost("/{scopeId}/workflows/{workflowId}:archive", HandleArchiveWorkflowAsync)
+    .Produces<ScopeWorkflowArchiveAcceptedResult>(StatusCodes.Status202Accepted)
+    .Produces(StatusCodes.Status400BadRequest)
+    .Produces(StatusCodes.Status403Forbidden)
+    .Produces(StatusCodes.Status404NotFound)
+    .Produces(StatusCodes.Status409Conflict);
+```
+
+The handler must call `AevatarScopeAccessGuard` first, delegate to the archive
+port, return `Results.Accepted`, and map typed Application rejection kinds.
+It must not call `ServiceIdentityEndpointAccess`.
+
+- [ ] **Step 4: Register the Application port**
+
+Add:
+
+```csharp
+services.TryAddSingleton<
+    IScopeWorkflowArchiveCommandPort,
+    ScopeWorkflowArchiveApplicationService>();
+```
+
+- [ ] **Step 5: Verify GREEN**
+
+Run the filtered endpoint test command. Expected: accepted route test passes.
+
+- [ ] **Step 6: Add endpoint failure tests**
+
+Add focused tests for scope mismatch, not found, and inactive conflict. Assert
+that scope mismatch never calls the archive port and that error bodies contain
+stable codes.
+
+- [ ] **Step 7: Run endpoint tests**
+
+Run the same filtered endpoint test command. Expected: all Archive handler
+tests pass.
+
+### Task 4: Add The Frontend Scope API
+
+**Files (frontend-only branch):**
+- Modify: `apps/aevatar-console-web/src/shared/models/scopes.ts`
+- Modify: `apps/aevatar-console-web/src/shared/api/scopesApi.ts`
+- Modify: `apps/aevatar-console-web/src/shared/api/scopesApi.test.ts`
+
+- [ ] **Step 1: Write the failing API wrapper test**
+
+Test the exact call:
+
+```ts
+const result = await scopesApi.archiveWorkflow('scope alpha', 'wf/alpha');
+
+expect(mockFetch).toHaveBeenCalledWith(
+  '/api/scopes/scope%20alpha/workflows/wf%2Falpha:archive',
+  expect.objectContaining({ method: 'POST' }),
+);
+expect(result.workflowId).toBe('wf-alpha');
+```
+
+Use distinct `workflowId`, `deploymentId`, and command identity fixture values.
+
+- [ ] **Step 2: Run the API test and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest src/shared/api/scopesApi.test.ts --runInBand
+```
+
+Expected: test fails because `archiveWorkflow` is undefined.
+
+- [ ] **Step 3: Add models, decoder, and API wrapper**
+
+Add a `ScopeWorkflowArchiveAcceptedResult` model matching the backend response.
+Decode all stable fields with structured decoder helpers. Implement a POST with
+no service identity request body:
+
+```ts
+archiveWorkflow(scopeId: string, workflowId: string) {
+  return requestJson(
+    `/api/scopes/${encodeURIComponent(scopeId)}/workflows/${encodeURIComponent(workflowId)}:archive`,
+    decodeScopeWorkflowArchiveAcceptedResult,
+    { method: 'POST' },
+  );
+}
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the focused API test. Expected: all `scopesApi.test.ts` tests pass.
+
+### Task 5: Switch Archive And Normalize Destructive Menu Actions
+
+**Files (frontend-only branch):**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] **Step 1: Write failing menu-policy tests**
+
+Create three rows with distinct identities and assert:
+
+```text
+draft-only: Delete draft present, Archive absent
+published + draft: Delete draft absent, Archive present
+published-only: Delete draft absent, Archive present
+```
+
+- [ ] **Step 2: Write the failing scope Archive call test**
+
+Confirming Archive must assert:
+
+```ts
+expect(mockScopesApi.archiveWorkflow).toHaveBeenCalledWith(
+  'scope-alpha',
+  'wf-alpha',
+);
+expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
+expect(mockServicesApi.deactivateDeployment).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 3: Run Workflow Activity tests and verify RED**
+
+Run:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand
+```
+
+Expected: published-with-draft still exposes Delete draft and Archive still
+calls the generic service API.
+
+- [ ] **Step 4: Implement the minimal frontend change**
+
+Remove the `servicesApi` import and detail lookup. Submit:
+
+```ts
+await scopesApi.archiveWorkflow(scopeId, target.workflowId);
+```
+
+Compute the list-level draft delete policy once per row:
+
+```ts
+const canDeleteDraft =
+  row.capabilities.delete.available && !row.hasCommittedSource;
+```
+
+Use `canDeleteDraft` for the divider and Delete draft menu item. Keep the
+existing `canArchiveWorkflow(row)` policy and observation-only retry behavior.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run the focused Workflow Activity test. Expected: all tests pass.
+
+### Task 6: Focused Validation And Delivery
+
+**Files:**
+- Review all files changed in each worktree independently.
+
+- [ ] **Step 1: Run backend focused checks**
+
+Run:
+
+```bash
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter FullyQualifiedName~ScopeWorkflowArchiveApplicationServiceTests
+dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter FullyQualifiedName~HandleArchiveWorkflowAsync
+bash tools/ci/test_stability_guards.sh
+bash tools/ci/architecture_guards.sh
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Run frontend scope and focused checks**
+
+Run the frontend incremental scope guard against
+`origin/feat/2026-08-04_workflow-activity-vnext`, then run only:
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest src/shared/api/scopesApi.test.ts src/pages/workflow-activity-vnext/index.test.tsx --runInBand
+bash tools/ci/test_stability_guards.sh
+```
+
+Run Biome only for changed frontend files. Do not run full frontend Jest,
+lint, `tsc`, or production build locally; GitHub CI owns full verification.
+
+- [ ] **Step 3: Review backend and frontend diffs separately**
+
+Use:
+
+```bash
+git diff --check
+git diff --stat
+git diff
+```
+
+Confirm the frontend branch contains only `apps/aevatar-console-web/**` files
+and the backend branch contains no Workflow Activity frontend source.
+
+- [ ] **Step 4: Commit and push the backend branch**
+
+Stage only backend task files and commit:
+
+```bash
+git commit -m "Add scope workflow archive command"
+git push -u origin fix/2026-08-10_workflow-archive-command
+```
+
+Create a PR targeting `feature/integrate` with focused validation results.
+
+- [ ] **Step 5: Commit and push the frontend branch**
+
+Stage only frontend task files and commit:
+
+```bash
+git commit -m "Fix workflow archive actions"
+git push -u origin fix/2026-08-10_workflow-archive-boundary
+```
+
+Create a PR targeting `feat/2026-08-04_workflow-activity-vnext`, state its
+dependency on the backend PR, list exact focused commands, and delegate the
+full frontend suite/build to GitHub CI.

--- a/docs/superpowers/specs/2026-08-10-workflow-archive-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-10-workflow-archive-boundary-design.md
@@ -1,0 +1,166 @@
+# Workflow Archive Boundary Design
+
+**Date:** 2026-08-10
+**Status:** Approved for implementation
+
+## Problem
+
+Workflow Activity currently archives a published Workflow by resolving its
+published service identity in the browser and calling the generic service
+deployment endpoint:
+
+```http
+POST /api/services/{publishedServiceId}/deployments/{deploymentId}:deactivate
+```
+
+That endpoint belongs to the service-identity administration boundary. An
+authenticated browser session carries user and scope authority, not the
+`tenant_id`, `app_id`, and `namespace` service-principal claims required by
+`ServiceIdentityEndpointAccess`. The backend therefore correctly returns
+`403 SERVICE_IDENTITY_ACCESS_DENIED`; request-body identity fields cannot be
+used as a fallback for an already authenticated caller.
+
+The Workflow catalogue also joins two independently owned resources by stable
+`workflowId`:
+
+- an optional editable workspace draft;
+- an optional committed published Workflow and active deployment.
+
+The page currently presents `Delete draft` whenever the draft exists and
+`Archive` whenever the deployment is active. A published row that still has a
+draft consequently presents two destructive actions, while a committed-only
+row presents only Archive. The distinction is technically explainable but is
+not a coherent list-level product model.
+
+## Product Semantics
+
+The Workflow list uses the row's dominant lifecycle surface:
+
+| Row facts | Destructive list action |
+|---|---|
+| Draft source only | `Delete draft` |
+| Published source, with or without a draft | `Archive` |
+| Archived published source | None |
+
+`Delete draft` removes only the editable workspace document. It is never
+presented as a lifecycle action for a published row.
+
+`Archive` is a logical, reversible product boundary:
+
+- stop new runs by deactivating the authoritative published deployment;
+- preserve the editable draft, published revisions, committed events, and
+  Activity history;
+- let normal catalogue filtering hide or de-emphasize archived material;
+- require a separate explicitly named delete/purge contract if permanent
+  physical removal is introduced in the future.
+
+The current change does not add physical deletion, cascade cleanup, or a new
+global linear Workflow lifecycle.
+
+## Backend Contract
+
+Add a user-facing scope-owned command:
+
+```http
+POST /api/scopes/{scopeId}/workflows/{workflowId}:archive
+```
+
+The request has no body. `scopeId` and `workflowId` retain their isolated
+meanings; the browser does not submit `publishedServiceId`, `deploymentId`,
+`serviceAppId`, or `serviceNamespace`.
+
+The endpoint performs only host responsibilities:
+
+1. validate caller access to `scopeId` with `AevatarScopeAccessGuard`;
+2. delegate to a narrow `IScopeWorkflowArchiveCommandPort`;
+3. map application rejection categories to HTTP status and error payloads;
+4. return `202 Accepted` for a successfully dispatched command.
+
+The Application implementation resolves the Workflow through the existing
+scope Workflow query/read-model contract. The resolved summary is the sole
+source of:
+
+- `ScopeId` -> service identity tenant;
+- `ServiceAppId` -> service identity app;
+- `ServiceNamespace` -> service identity namespace;
+- `PublishedServiceId` -> service identity service ID;
+- `DeploymentId` -> target deployment.
+
+The implementation never assumes `workflowId == publishedServiceId`, never
+parses identity prefixes, and never accepts a browser-provided service
+identity. It verifies that the deployment is currently `Active` before
+dispatching `DeactivateServiceDeploymentCommand` through
+`IServiceCommandPort`.
+
+The accepted result contains scope/workflow identity, the exact target
+deployment ID, the standard command handle, and the Workflow read-model URL.
+Acceptance means only that the command entered dispatch. It does not claim
+that the deployment is already deactivated or that projections are current.
+
+## Frontend Contract
+
+The frontend branch based on
+`feat/2026-08-04_workflow-activity-vnext` remains frontend-only. It adds
+`scopesApi.archiveWorkflow(scopeId, workflowId)` and removes the direct
+`servicesApi.deactivateDeployment` call from Workflow Activity.
+
+After `202 Accepted`, the existing bounded observer continues querying the
+scope Workflow catalogue. Success is reported only after the exact
+`workflowId` has authoritative `deploymentStatus = Deactivated`. A delayed
+observation retries only observation and never resubmits the archive command.
+
+Menu visibility becomes:
+
+```text
+canDeleteDraftFromList = capabilities.delete.available && !hasCommittedSource
+canArchiveFromList = committed deployment facts indicate Active
+```
+
+Rename may remain available when a published row retains an editable draft;
+the change removes only the conflicting destructive `Delete draft` action.
+
+## Failure Semantics
+
+- Missing Workflow: `404 SCOPE_WORKFLOW_NOT_FOUND`.
+- Ambiguous, stale, or not-ready published identity: `409` with a stable
+  Workflow archive rejection code.
+- Deployment already inactive or deactivated: `409 WORKFLOW_NOT_ACTIVE` and no
+  duplicate command dispatch.
+- Invalid route identity: `400 INVALID_USER_WORKFLOW_REQUEST`.
+- Scope access denial: the existing scope guard response, before application
+  dispatch.
+- Accepted but not yet projected: frontend keeps the dialog open and offers
+  observation-only retry.
+
+The generic `/api/services/...:deactivate` endpoint and
+`ServiceIdentityEndpointAccess` are unchanged.
+
+## Branch Boundaries
+
+- Backend contract and canonical documentation are implemented from latest
+  `feature/integrate` on `fix/2026-08-10_workflow-archive-command`.
+- Frontend API integration and menu policy are implemented from latest
+  `feat/2026-08-04_workflow-activity-vnext` on
+  `fix/2026-08-10_workflow-archive-boundary`.
+- No backend source, tests, configuration, or documentation are added to the
+  frontend feature branch.
+
+## Verification
+
+Backend focused tests prove:
+
+- the route accepts a user-scoped caller without service-principal claims;
+- the Application service resolves distinct workflow, published-service, and
+  deployment identities from the read model;
+- only an active deployment dispatches deactivation;
+- missing, stale, and inactive Workflows dispatch no command;
+- the HTTP response remains accepted-only.
+
+Frontend focused tests prove:
+
+- Archive calls the scope Workflow endpoint with only `scopeId/workflowId`;
+- the generic service API is not used;
+- a draft-only row exposes only `Delete draft`;
+- a published row with a draft exposes `Archive` but not `Delete draft`;
+- a committed-only published row exposes `Archive` but not `Delete draft`;
+- accepted commands still require observed `Deactivated` catalogue state.

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowArchiveCommandPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScopeWorkflowArchiveCommandPort.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public interface IScopeWorkflowArchiveCommandPort
+{
+    Task<ScopeWorkflowArchiveAcceptedResult> ArchiveAsync(
+        ScopeWorkflowArchiveRequest request,
+        CancellationToken ct = default);
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeWorkflows/ScopeWorkflowModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeWorkflows/ScopeWorkflowModels.cs
@@ -32,6 +32,10 @@ public sealed record ScopeWorkflowSaveAndBindRequest(
     public WorkflowCapabilityAdmissionContext? CapabilityAdmission { get; init; }
 }
 
+public sealed record ScopeWorkflowArchiveRequest(
+    string ScopeId,
+    string WorkflowId);
+
 public enum ScopeWorkflowLookupStatus
 {
     NotFound = 0,
@@ -121,5 +125,14 @@ public sealed record ScopeWorkflowSaveAndBindResult(
     string RevisionId,
     ScopeWorkflowUpsertResult Workflow,
     ScopeBindingUpsertResult Binding,
+    string AcceptanceStage = "accepted",
+    string PropagationStage = "readmodel_propagating");
+
+public sealed record ScopeWorkflowArchiveAcceptedResult(
+    string ScopeId,
+    string WorkflowId,
+    string DeploymentId,
+    ScopeWorkflowCommandAcceptedHandle CommandHandle,
+    string ReadModelUrl,
     string AcceptanceStage = "accepted",
     string PropagationStage = "readmodel_propagating");

--- a/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowArchiveApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowArchiveApplicationService.cs
@@ -58,7 +58,10 @@ public sealed class ScopeWorkflowArchiveApplicationService : IScopeWorkflowArchi
             throw IdentityUnavailable(workflowId, "The workflow read model resolved another scope or workflow identity.");
         }
 
-        if (!string.Equals(workflow.DeploymentStatus, "active", StringComparison.OrdinalIgnoreCase))
+        if (!string.Equals(
+                workflow.DeploymentStatus,
+                ServiceDeploymentStatus.Active.ToString(),
+                StringComparison.OrdinalIgnoreCase))
         {
             throw new ScopeWorkflowArchiveRejectedException(
                 ScopeWorkflowArchiveRejectionKind.Conflict,

--- a/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowArchiveApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowArchiveApplicationService.cs
@@ -1,0 +1,128 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+
+namespace Aevatar.GAgentService.Application.Workflows;
+
+public enum ScopeWorkflowArchiveRejectionKind
+{
+    NotFound = 0,
+    Conflict = 1,
+}
+
+public sealed class ScopeWorkflowArchiveRejectedException : InvalidOperationException
+{
+    public ScopeWorkflowArchiveRejectedException(
+        ScopeWorkflowArchiveRejectionKind kind,
+        string code,
+        string message)
+        : base(message)
+    {
+        Kind = kind;
+        Code = code;
+    }
+
+    public ScopeWorkflowArchiveRejectionKind Kind { get; }
+
+    public string Code { get; }
+}
+
+public sealed class ScopeWorkflowArchiveApplicationService : IScopeWorkflowArchiveCommandPort
+{
+    private readonly IScopeWorkflowQueryPort _workflowQueryPort;
+    private readonly IServiceCommandPort _serviceCommandPort;
+
+    public ScopeWorkflowArchiveApplicationService(
+        IScopeWorkflowQueryPort workflowQueryPort,
+        IServiceCommandPort serviceCommandPort)
+    {
+        _workflowQueryPort = workflowQueryPort ?? throw new ArgumentNullException(nameof(workflowQueryPort));
+        _serviceCommandPort = serviceCommandPort ?? throw new ArgumentNullException(nameof(serviceCommandPort));
+    }
+
+    public async Task<ScopeWorkflowArchiveAcceptedResult> ArchiveAsync(
+        ScopeWorkflowArchiveRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var scopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(request.ScopeId, nameof(request.ScopeId));
+        var workflowId = ScopeWorkflowCapabilityConventions.NormalizeWorkflowId(request.WorkflowId);
+        var lookup = await _workflowQueryPort.LookupByWorkflowIdAsync(scopeId, workflowId, ct);
+        if (!lookup.IsRunnable)
+            throw FromLookup(workflowId, lookup);
+
+        var workflow = lookup.Workflow!;
+        if (!string.Equals(workflow.ScopeId, scopeId, StringComparison.Ordinal) ||
+            !string.Equals(workflow.WorkflowId, workflowId, StringComparison.Ordinal))
+        {
+            throw IdentityUnavailable(workflowId, "The workflow read model resolved another scope or workflow identity.");
+        }
+
+        if (!string.Equals(workflow.DeploymentStatus, "active", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ScopeWorkflowArchiveRejectedException(
+                ScopeWorkflowArchiveRejectionKind.Conflict,
+                "WORKFLOW_NOT_ACTIVE",
+                $"Workflow '{workflowId}' does not have an active deployment.");
+        }
+
+        if (string.IsNullOrWhiteSpace(workflow.ServiceAppId) ||
+            string.IsNullOrWhiteSpace(workflow.ServiceNamespace) ||
+            string.IsNullOrWhiteSpace(workflow.PublishedServiceId) ||
+            string.IsNullOrWhiteSpace(workflow.DeploymentId))
+        {
+            throw IdentityUnavailable(workflowId, "Published service or deployment identity is unavailable.");
+        }
+
+        var identity = new ServiceIdentity
+        {
+            TenantId = ScopeWorkflowCapabilityOptions.NormalizeRequired(workflow.ScopeId, nameof(workflow.ScopeId)),
+            AppId = ScopeWorkflowCapabilityOptions.NormalizeRequired(workflow.ServiceAppId, nameof(workflow.ServiceAppId)),
+            Namespace = ScopeWorkflowCapabilityOptions.NormalizeRequired(workflow.ServiceNamespace, nameof(workflow.ServiceNamespace)),
+            ServiceId = ScopeWorkflowCapabilityOptions.NormalizeRequired(workflow.PublishedServiceId, nameof(workflow.PublishedServiceId)),
+        };
+        var deploymentId = ScopeWorkflowCapabilityOptions.NormalizeRequired(
+            workflow.DeploymentId,
+            nameof(workflow.DeploymentId));
+        var receipt = await _serviceCommandPort.DeactivateServiceDeploymentAsync(
+            new DeactivateServiceDeploymentCommand
+            {
+                Identity = identity,
+                DeploymentId = deploymentId,
+            },
+            ct);
+
+        var readModelUrl = $"/api/scopes/{Uri.EscapeDataString(scopeId)}/workflows/{Uri.EscapeDataString(workflowId)}";
+        return new ScopeWorkflowArchiveAcceptedResult(
+            scopeId,
+            workflowId,
+            deploymentId,
+            ScopeWorkflowCommandAcceptedHandle.FromReceipt("deactivate_deployment", receipt),
+            readModelUrl);
+    }
+
+    private static ScopeWorkflowArchiveRejectedException FromLookup(
+        string workflowId,
+        ScopeWorkflowLookupResult lookup) => lookup.Status switch
+        {
+            ScopeWorkflowLookupStatus.NotFound => new ScopeWorkflowArchiveRejectedException(
+                ScopeWorkflowArchiveRejectionKind.NotFound,
+                "SCOPE_WORKFLOW_NOT_FOUND",
+                $"Workflow '{workflowId}' was not found: {lookup.Reason}."),
+            ScopeWorkflowLookupStatus.NotReady => new ScopeWorkflowArchiveRejectedException(
+                ScopeWorkflowArchiveRejectionKind.Conflict,
+                "WORKFLOW_ARCHIVE_NOT_READY",
+                $"Workflow '{workflowId}' is not ready for archive: {lookup.Reason}."),
+            _ => new ScopeWorkflowArchiveRejectedException(
+                ScopeWorkflowArchiveRejectionKind.Conflict,
+                "WORKFLOW_ARCHIVE_STALE",
+                $"Workflow '{workflowId}' cannot be archived from stale identity facts: {lookup.Reason}."),
+        };
+
+    private static ScopeWorkflowArchiveRejectedException IdentityUnavailable(
+        string workflowId,
+        string reason) => new(
+            ScopeWorkflowArchiveRejectionKind.Conflict,
+            "WORKFLOW_ARCHIVE_IDENTITY_UNAVAILABLE",
+            $"Workflow '{workflowId}' cannot be archived. {reason}");
+}

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -192,6 +192,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IScopeWorkflowQueryPort>(sp => sp.GetRequiredService<ScopeWorkflowQueryApplicationService>());
         services.TryAddSingleton<IScopeWorkflowCatalogueCommittedSourcePort>(sp => sp.GetRequiredService<ScopeWorkflowQueryApplicationService>());
         services.TryAddSingleton<IScopeWorkflowCommandPort, ScopeWorkflowCommandApplicationService>();
+        services.TryAddSingleton<IScopeWorkflowArchiveCommandPort, ScopeWorkflowArchiveApplicationService>();
         services.TryAddSingleton<IScopeWorkflowSaveAndBindPort, ScopeWorkflowSaveAndBindApplicationService>();
         services.Replace(ServiceDescriptor.Singleton(
             typeof(SkillWorkflowMountAdapter),

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -255,13 +255,16 @@ public static class ScopeWorkflowEndpoints
         IScopeWorkflowArchiveCommandPort archiveCommandPort,
         CancellationToken ct)
     {
+        if (TryCreateArchiveRequestBadRequest(scopeId, workflowId, out var badRequest, out var normalizedScopeId, out var normalizedWorkflowId))
+            return badRequest;
+
         try
         {
-            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, normalizedScopeId, out var denied))
                 return denied;
 
             var result = await archiveCommandPort.ArchiveAsync(
-                new ScopeWorkflowArchiveRequest(scopeId, workflowId),
+                new ScopeWorkflowArchiveRequest(normalizedScopeId, normalizedWorkflowId),
                 ct);
             return Results.Accepted(result.ReadModelUrl, result);
         }
@@ -276,13 +279,35 @@ public static class ScopeWorkflowEndpoints
                 message = ex.Message,
             }, statusCode: statusCode);
         }
+    }
+
+    private static bool TryCreateArchiveRequestBadRequest(
+        string scopeId,
+        string workflowId,
+        out IResult badRequest,
+        out string normalizedScopeId,
+        out string normalizedWorkflowId)
+    {
+        try
+        {
+            normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(scopeId, nameof(scopeId));
+            normalizedWorkflowId = ScopeWorkflowCapabilityOptions.NormalizeRequired(workflowId, nameof(workflowId));
+            if (normalizedWorkflowId.Contains(':', StringComparison.Ordinal))
+                throw new InvalidOperationException("workflowId must not contain ':'.");
+
+            badRequest = Results.Empty;
+            return false;
+        }
         catch (InvalidOperationException ex)
         {
-            return Results.BadRequest(new
+            normalizedScopeId = string.Empty;
+            normalizedWorkflowId = string.Empty;
+            badRequest = Results.BadRequest(new
             {
                 code = "INVALID_USER_WORKFLOW_ARCHIVE_REQUEST",
                 message = ex.Message,
             });
+            return true;
         }
     }
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeWorkflowEndpoints.cs
@@ -39,6 +39,12 @@ public static class ScopeWorkflowEndpoints
         group.MapPost("/{scopeId}/workflows:save-and-bind", HandleSaveAndBindWorkflowAsync)
             .Produces<ScopeWorkflowSaveAndBindResult>(StatusCodes.Status202Accepted)
             .Produces(StatusCodes.Status400BadRequest);
+        group.MapPost("/{scopeId}/workflows/{workflowId}:archive", HandleArchiveWorkflowAsync)
+            .Produces<ScopeWorkflowArchiveAcceptedResult>(StatusCodes.Status202Accepted)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict);
         group.MapPost("/{scopeId}/workflows:explicit-request-preview", HandleExplicitRequestPreviewAsync)
             .Produces<ExplicitRequestPreviewHttpResult>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest);
@@ -75,6 +81,14 @@ public static class ScopeWorkflowEndpoints
         [FromServices] IScopeWorkflowSaveAndBindPort saveAndBindPort,
         CancellationToken ct)
         => await HandleSaveAndBindWorkflowAsyncCore(http, scopeId, request, saveAndBindPort, ct);
+
+    internal static async Task<IResult> HandleArchiveWorkflowAsync(
+        HttpContext http,
+        string scopeId,
+        string workflowId,
+        [FromServices] IScopeWorkflowArchiveCommandPort archiveCommandPort,
+        CancellationToken ct)
+        => await HandleArchiveWorkflowAsyncCore(http, scopeId, workflowId, archiveCommandPort, ct);
 
     internal static async Task<IResult> HandleExplicitRequestPreviewAsync(
         HttpContext http,
@@ -229,6 +243,44 @@ public static class ScopeWorkflowEndpoints
             return Results.BadRequest(new
             {
                 code = "INVALID_USER_WORKFLOW_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleArchiveWorkflowAsyncCore(
+        HttpContext http,
+        string scopeId,
+        string workflowId,
+        IScopeWorkflowArchiveCommandPort archiveCommandPort,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            var result = await archiveCommandPort.ArchiveAsync(
+                new ScopeWorkflowArchiveRequest(scopeId, workflowId),
+                ct);
+            return Results.Accepted(result.ReadModelUrl, result);
+        }
+        catch (ScopeWorkflowArchiveRejectedException ex)
+        {
+            var statusCode = ex.Kind == ScopeWorkflowArchiveRejectionKind.NotFound
+                ? StatusCodes.Status404NotFound
+                : StatusCodes.Status409Conflict;
+            return Results.Json(new
+            {
+                code = ex.Code,
+                message = ex.Message,
+            }, statusCode: statusCode);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_USER_WORKFLOW_ARCHIVE_REQUEST",
                 message = ex.Message,
             });
         }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -151,6 +151,77 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleArchiveWorkflowAsync_ShouldReturnAcceptedForMatchingScopeUser()
+    {
+        var http = CreateHttpContext("scope-alpha");
+        var port = new RecordingScopeWorkflowArchiveCommandPort();
+
+        var result = await ScopeWorkflowEndpoints.HandleArchiveWorkflowAsync(
+            http,
+            "scope-alpha",
+            "wf-alpha",
+            port,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        http.Response.Headers.Location.ToString().Should()
+            .Be("/api/scopes/scope-alpha/workflows/wf-alpha");
+        port.Request.Should().Be(new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+        body.Should().Contain("\"acceptanceStage\":\"accepted\"");
+        body.Should().Contain("\"stage\":\"deactivate_deployment\"");
+    }
+
+    [Fact]
+    public async Task HandleArchiveWorkflowAsync_ShouldReturnForbiddenWithoutDispatchForAnotherScope()
+    {
+        var http = CreateHttpContext("scope-other");
+        var port = new RecordingScopeWorkflowArchiveCommandPort();
+
+        var result = await ScopeWorkflowEndpoints.HandleArchiveWorkflowAsync(
+            http,
+            "scope-alpha",
+            "wf-alpha",
+            port,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        port.Request.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(ScopeWorkflowArchiveRejectionKind.NotFound, "SCOPE_WORKFLOW_NOT_FOUND", StatusCodes.Status404NotFound)]
+    [InlineData(ScopeWorkflowArchiveRejectionKind.Conflict, "WORKFLOW_NOT_ACTIVE", StatusCodes.Status409Conflict)]
+    public async Task HandleArchiveWorkflowAsync_ShouldMapTypedApplicationRejection(
+        ScopeWorkflowArchiveRejectionKind kind,
+        string code,
+        int expectedStatus)
+    {
+        var http = CreateHttpContext("scope-alpha");
+        var port = new RecordingScopeWorkflowArchiveCommandPort
+        {
+            Error = new ScopeWorkflowArchiveRejectedException(kind, code, "Archive rejected."),
+        };
+
+        var result = await ScopeWorkflowEndpoints.HandleArchiveWorkflowAsync(
+            http,
+            "scope-alpha",
+            "wf-alpha",
+            port,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(expectedStatus);
+        body.Should().Contain(code);
+    }
+
+    [Fact]
     public async Task HandleSaveAndBindWorkflowAsync_ShouldReturnAccepted_WithoutRequestRevisionId()
     {
         var http = CreateHttpContext();
@@ -1768,6 +1839,33 @@ public sealed class ScopeWorkflowEndpointsTests
                 "deployment-id",
                 DateTimeOffset.UtcNow,
                 [],
+                $"/api/scopes/{request.ScopeId}/workflows/{request.WorkflowId}"));
+        }
+    }
+
+    private sealed class RecordingScopeWorkflowArchiveCommandPort : IScopeWorkflowArchiveCommandPort
+    {
+        public ScopeWorkflowArchiveRequest? Request { get; private set; }
+
+        public Exception? Error { get; init; }
+
+        public Task<ScopeWorkflowArchiveAcceptedResult> ArchiveAsync(
+            ScopeWorkflowArchiveRequest request,
+            CancellationToken ct = default)
+        {
+            Request = request;
+            if (Error != null)
+                throw Error;
+
+            return Task.FromResult(new ScopeWorkflowArchiveAcceptedResult(
+                request.ScopeId,
+                request.WorkflowId,
+                "dep-alpha",
+                new ScopeWorkflowCommandAcceptedHandle(
+                    "deactivate_deployment",
+                    "deployment-actor",
+                    "cmd-archive",
+                    "corr-archive"),
                 $"/api/scopes/{request.ScopeId}/workflows/{request.WorkflowId}"));
         }
     }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -222,6 +222,47 @@ public sealed class ScopeWorkflowEndpointsTests
     }
 
     [Fact]
+    public async Task HandleArchiveWorkflowAsync_ShouldReturnBadRequestForInvalidArchiveRouteWithoutDispatch()
+    {
+        var http = CreateHttpContext("scope-alpha");
+        var port = new RecordingScopeWorkflowArchiveCommandPort();
+
+        var result = await ScopeWorkflowEndpoints.HandleArchiveWorkflowAsync(
+            http,
+            "scope-alpha",
+            "wf:alpha",
+            port,
+            CancellationToken.None);
+
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("INVALID_USER_WORKFLOW_ARCHIVE_REQUEST");
+        port.Request.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleArchiveWorkflowAsync_ShouldNotMapUnexpectedInvalidOperationExceptionToBadRequest()
+    {
+        var http = CreateHttpContext("scope-alpha");
+        var port = new RecordingScopeWorkflowArchiveCommandPort
+        {
+            Error = new InvalidOperationException("Command path failed unexpectedly."),
+        };
+
+        var act = () => ScopeWorkflowEndpoints.HandleArchiveWorkflowAsync(
+            http,
+            "scope-alpha",
+            "wf-alpha",
+            port,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Command path failed unexpectedly.");
+    }
+
+    [Fact]
     public async Task HandleSaveAndBindWorkflowAsync_ShouldReturnAccepted_WithoutRequestRevisionId()
     {
         var http = CreateHttpContext();

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowArchiveApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowArchiveApplicationServiceTests.cs
@@ -105,12 +105,17 @@ public sealed class ScopeWorkflowArchiveApplicationServiceTests
         commandPort.DeactivateCommand.Should().BeNull();
     }
 
-    [Fact]
-    public async Task ArchiveAsync_ShouldRejectMissingPublishedIdentityWithoutDispatch()
+    [Theory]
+    [InlineData(nameof(ScopeWorkflowSummary.PublishedServiceId))]
+    [InlineData(nameof(ScopeWorkflowSummary.ServiceAppId))]
+    [InlineData(nameof(ScopeWorkflowSummary.ServiceNamespace))]
+    [InlineData(nameof(ScopeWorkflowSummary.DeploymentId))]
+    public async Task ArchiveAsync_ShouldRejectMissingPublishedIdentityComponentWithoutDispatch(
+        string missingComponent)
     {
         var queryPort = new StubScopeWorkflowQueryPort(new ScopeWorkflowLookupResult(
             ScopeWorkflowLookupStatus.Runnable,
-            ActiveWorkflow() with { PublishedServiceId = string.Empty },
+            ActiveWorkflowWithMissingIdentityComponent(missingComponent),
             "runnable"));
         var commandPort = new RecordingServiceCommandPort();
         var service = new ScopeWorkflowArchiveApplicationService(queryPort, commandPort);
@@ -123,6 +128,19 @@ public sealed class ScopeWorkflowArchiveApplicationServiceTests
         commandPort.DeactivateCommand.Should().BeNull();
     }
 
+    private static ScopeWorkflowSummary ActiveWorkflowWithMissingIdentityComponent(string missingComponent)
+    {
+        var workflow = ActiveWorkflow();
+        return missingComponent switch
+        {
+            nameof(ScopeWorkflowSummary.PublishedServiceId) => workflow with { PublishedServiceId = string.Empty },
+            nameof(ScopeWorkflowSummary.ServiceAppId) => workflow with { ServiceAppId = string.Empty },
+            nameof(ScopeWorkflowSummary.ServiceNamespace) => workflow with { ServiceNamespace = string.Empty },
+            nameof(ScopeWorkflowSummary.DeploymentId) => workflow with { DeploymentId = string.Empty },
+            _ => throw new ArgumentOutOfRangeException(nameof(missingComponent), missingComponent, null),
+        };
+    }
+
     private static ScopeWorkflowSummary ActiveWorkflow() =>
         new(
             ScopeId: "scope-alpha",
@@ -133,7 +151,7 @@ public sealed class ScopeWorkflowArchiveApplicationServiceTests
             ActorId: "m-alpha",
             ActiveRevisionId: "rev-alpha",
             DeploymentId: "dep-alpha",
-            DeploymentStatus: "Active",
+            DeploymentStatus: ServiceDeploymentStatus.Active.ToString(),
             UpdatedAt: DateTimeOffset.Parse("2026-08-10T10:00:00Z"))
         {
             PublishedServiceId = "svc-alpha",

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowArchiveApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowArchiveApplicationServiceTests.cs
@@ -1,0 +1,247 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Commands;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Application.Workflows;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class ScopeWorkflowArchiveApplicationServiceTests
+{
+    [Fact]
+    public async Task ArchiveAsync_ShouldResolvePublishedIdentityAndDeactivateAuthoritativeDeployment()
+    {
+        var workflow = ActiveWorkflow();
+        var queryPort = new StubScopeWorkflowQueryPort(new ScopeWorkflowLookupResult(
+            ScopeWorkflowLookupStatus.Runnable,
+            workflow,
+            "runnable"));
+        var commandPort = new RecordingServiceCommandPort();
+        var service = new ScopeWorkflowArchiveApplicationService(queryPort, commandPort);
+
+        var result = await service.ArchiveAsync(
+            new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+
+        queryPort.Lookup.Should().Be(("scope-alpha", "wf-alpha"));
+        commandPort.DeactivateCommand.Should().NotBeNull();
+        commandPort.DeactivateCommand!.Identity.TenantId.Should().Be("scope-alpha");
+        commandPort.DeactivateCommand.Identity.AppId.Should().Be("workflow-app");
+        commandPort.DeactivateCommand.Identity.Namespace.Should().Be("workflow-namespace");
+        commandPort.DeactivateCommand.Identity.ServiceId.Should().Be("svc-alpha");
+        commandPort.DeactivateCommand.DeploymentId.Should().Be("dep-alpha");
+        result.ScopeId.Should().Be("scope-alpha");
+        result.WorkflowId.Should().Be("wf-alpha");
+        result.DeploymentId.Should().Be("dep-alpha");
+        result.CommandHandle.Stage.Should().Be("deactivate_deployment");
+        result.CommandHandle.CommandId.Should().Be("cmd-archive");
+        result.ReadModelUrl.Should().Be("/api/scopes/scope-alpha/workflows/wf-alpha");
+        result.AcceptanceStage.Should().Be("accepted");
+        result.PropagationStage.Should().Be("readmodel_propagating");
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_ShouldRejectWorkflowResolvedFromAnotherScopeWithoutDispatch()
+    {
+        var queryPort = new StubScopeWorkflowQueryPort(new ScopeWorkflowLookupResult(
+            ScopeWorkflowLookupStatus.Runnable,
+            ActiveWorkflow() with { ScopeId = "scope-other" },
+            "runnable"));
+        var commandPort = new RecordingServiceCommandPort();
+        var service = new ScopeWorkflowArchiveApplicationService(queryPort, commandPort);
+
+        var act = () => service.ArchiveAsync(
+            new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*another scope*");
+        commandPort.DeactivateCommand.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(ScopeWorkflowLookupStatus.NotFound, "service_catalog_missing")]
+    [InlineData(ScopeWorkflowLookupStatus.NotReady, "deployment_readmodel_missing")]
+    [InlineData(ScopeWorkflowLookupStatus.Stale, "published_service_descriptor_ambiguous")]
+    public async Task ArchiveAsync_ShouldRejectUnavailableWorkflowWithoutDispatch(
+        ScopeWorkflowLookupStatus status,
+        string reason)
+    {
+        var queryPort = new StubScopeWorkflowQueryPort(new ScopeWorkflowLookupResult(
+            status,
+            Workflow: null,
+            reason));
+        var commandPort = new RecordingServiceCommandPort();
+        var service = new ScopeWorkflowArchiveApplicationService(queryPort, commandPort);
+
+        var act = () => service.ArchiveAsync(
+            new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+
+        var error = await act.Should().ThrowAsync<ScopeWorkflowArchiveRejectedException>()
+            .WithMessage($"*{reason}*");
+        error.Which.Code.Should().Be(status switch
+        {
+            ScopeWorkflowLookupStatus.NotFound => "SCOPE_WORKFLOW_NOT_FOUND",
+            ScopeWorkflowLookupStatus.NotReady => "WORKFLOW_ARCHIVE_NOT_READY",
+            _ => "WORKFLOW_ARCHIVE_STALE",
+        });
+        commandPort.DeactivateCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_ShouldRejectNonActiveDeploymentWithoutDispatch()
+    {
+        var queryPort = new StubScopeWorkflowQueryPort(new ScopeWorkflowLookupResult(
+            ScopeWorkflowLookupStatus.Runnable,
+            ActiveWorkflow() with { DeploymentStatus = "Deactivated" },
+            "runnable"));
+        var commandPort = new RecordingServiceCommandPort();
+        var service = new ScopeWorkflowArchiveApplicationService(queryPort, commandPort);
+
+        var act = () => service.ArchiveAsync(
+            new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+
+        var error = await act.Should().ThrowAsync<ScopeWorkflowArchiveRejectedException>()
+            .WithMessage("*active deployment*");
+        error.Which.Code.Should().Be("WORKFLOW_NOT_ACTIVE");
+        commandPort.DeactivateCommand.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_ShouldRejectMissingPublishedIdentityWithoutDispatch()
+    {
+        var queryPort = new StubScopeWorkflowQueryPort(new ScopeWorkflowLookupResult(
+            ScopeWorkflowLookupStatus.Runnable,
+            ActiveWorkflow() with { PublishedServiceId = string.Empty },
+            "runnable"));
+        var commandPort = new RecordingServiceCommandPort();
+        var service = new ScopeWorkflowArchiveApplicationService(queryPort, commandPort);
+
+        var act = () => service.ArchiveAsync(
+            new ScopeWorkflowArchiveRequest("scope-alpha", "wf-alpha"));
+
+        var error = await act.Should().ThrowAsync<ScopeWorkflowArchiveRejectedException>();
+        error.Which.Code.Should().Be("WORKFLOW_ARCHIVE_IDENTITY_UNAVAILABLE");
+        commandPort.DeactivateCommand.Should().BeNull();
+    }
+
+    private static ScopeWorkflowSummary ActiveWorkflow() =>
+        new(
+            ScopeId: "scope-alpha",
+            WorkflowId: "wf-alpha",
+            DisplayName: "Alpha",
+            ServiceKey: "opaque-service-key",
+            WorkflowName: "alpha",
+            ActorId: "m-alpha",
+            ActiveRevisionId: "rev-alpha",
+            DeploymentId: "dep-alpha",
+            DeploymentStatus: "Active",
+            UpdatedAt: DateTimeOffset.Parse("2026-08-10T10:00:00Z"))
+        {
+            PublishedServiceId = "svc-alpha",
+            ServiceAppId = "workflow-app",
+            ServiceNamespace = "workflow-namespace",
+        };
+
+    private sealed class StubScopeWorkflowQueryPort(ScopeWorkflowLookupResult result)
+        : IScopeWorkflowQueryPort
+    {
+        public (string ScopeId, string WorkflowId)? Lookup { get; private set; }
+
+        public Task<ScopeWorkflowLookupResult> LookupByWorkflowIdAsync(
+            string scopeId,
+            string workflowId,
+            CancellationToken ct = default)
+        {
+            Lookup = (scopeId, workflowId);
+            return Task.FromResult(result);
+        }
+
+        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(
+            string scopeId,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>([]);
+
+        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(
+            string scopeId,
+            string workflowId,
+            CancellationToken ct = default) =>
+            Task.FromResult<ScopeWorkflowSummary?>(null);
+
+        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(
+            string scopeId,
+            string actorId,
+            CancellationToken ct = default) =>
+            Task.FromResult<ScopeWorkflowSummary?>(null);
+    }
+
+    private sealed class RecordingServiceCommandPort : IServiceCommandPort
+    {
+        public DeactivateServiceDeploymentCommand? DeactivateCommand { get; private set; }
+
+        public Task<ServiceCommandAcceptedReceipt> DeactivateServiceDeploymentAsync(
+            DeactivateServiceDeploymentCommand command,
+            CancellationToken ct = default)
+        {
+            DeactivateCommand = command;
+            return Task.FromResult(new ServiceCommandAcceptedReceipt(
+                "deployment-actor",
+                "cmd-archive",
+                "corr-archive"));
+        }
+
+        public Task<ServiceCommandAcceptedReceipt> CreateServiceAsync(
+            CreateServiceDefinitionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> UpdateServiceAsync(
+            UpdateServiceDefinitionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> CreateRevisionAsync(
+            CreateServiceRevisionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> PrepareRevisionAsync(
+            PrepareServiceRevisionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> PublishRevisionAsync(
+            PublishServiceRevisionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> RetireRevisionAsync(
+            RetireServiceRevisionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> SetDefaultServingRevisionAsync(
+            SetDefaultServingRevisionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> ActivateServiceRevisionAsync(
+            ActivateServiceRevisionCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> ReplaceServiceServingTargetsAsync(
+            ReplaceServiceServingTargetsCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> StartServiceRolloutAsync(
+            StartServiceRolloutCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> AdvanceServiceRolloutAsync(
+            AdvanceServiceRolloutCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> PauseServiceRolloutAsync(
+            PauseServiceRolloutCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> ResumeServiceRolloutAsync(
+            ResumeServiceRolloutCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ServiceCommandAcceptedReceipt> RollbackServiceRolloutAsync(
+            RollbackServiceRolloutCommand command,
+            CancellationToken ct = default) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## 问题与方案

Workflow Activity 的 Archive 原来只能从前端还原 published service identity，再调用受 service-identity 权限保护的通用 deployment endpoint，导致普通 scope 用户收到 `403 SERVICE_IDENTITY_ACCESS_DENIED`。

本 PR 在 scope workflow 边界新增 `POST /api/scopes/{scopeId}/workflows/{workflowId}:archive`：

- 仅接受 `scopeId + workflowId`，使用现有 scope access guard；
- 由后端从 workflow read model 解析 authoritative published service/deployment identity；
- 复用现有 `DeactivateServiceDeploymentCommand`，返回诚实的 `202 Accepted`；
- 将 not found / not ready / stale / inactive / identity missing 映射为稳定的 404/409 错误码；
- 不绕过或削弱 `ServiceIdentityEndpointAccess`。

Archive 的业务语义是停用已发布 deployment，并保留 draft、revision、committed facts 与 Activity；它不是物理删除。

## 影响路径

- Scope workflow API contract 与 application command port
- Workflow read-model identity resolution
- Scope Workflow endpoint 与 DI registration
- Application/endpoint regression tests
- Workflow catalogue canonical documentation and design/implementation notes

## Local verification

- Application service tests: `/Users/abigaildeng/.cache/codex-dotnet/10.0.100/dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter FullyQualifiedName~ScopeWorkflowArchiveApplicationServiceTests` - 7 passed
- Endpoint tests: `/Users/abigaildeng/.cache/codex-dotnet/10.0.100/dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter FullyQualifiedName~HandleArchiveWorkflowAsync` - 4 passed
- Stability guards: `PATH="<temporary Python 3.12 and .NET SDK shim>:$PATH" bash tools/ci/test_stability_guards.sh` - passed, including 9 NyxID semantic evaluation tests
- Cached diff whitespace check: `git diff --cached --check` - passed
