### PR TITLE
Fix workflow archive actions

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -275,6 +275,7 @@ jest.mock('@/shared/studio/explicitRequestConfirmation', () => ({
 
 jest.mock('@/shared/api/scopesApi', () => ({
   scopesApi: {
+    archiveWorkflow: jest.fn(),
     getWorkflowDetail: jest.fn(),
     listWorkflows: jest.fn(),
     queryWorkflowCatalogue: jest.fn(),
@@ -410,6 +411,7 @@ const mockCreateWorkflowRevisionIdentityCandidate = jest.requireMock(
   '@/shared/studio/explicitRequestConfirmation',
 ).createWorkflowRevisionIdentityCandidate as jest.Mock;
 const mockScopesApi = jest.requireMock('@/shared/api/scopesApi').scopesApi as {
+  archiveWorkflow: jest.Mock;
   getWorkflowDetail: jest.Mock;
   listWorkflows: jest.Mock;
   queryWorkflowCatalogue: jest.Mock;
@@ -448,6 +450,20 @@ describe('Workflow Activity vNext catalogue', () => {
     mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
       createCatalogueResponse([]),
     );
+    mockScopesApi.archiveWorkflow.mockResolvedValue({
+      scopeId: 'scope-alpha',
+      workflowId: 'wf-alpha',
+      deploymentId: 'dep-alpha',
+      commandHandle: {
+        stage: 'deactivate_deployment',
+        targetActorId: 'deployment-manager-alpha',
+        commandId: 'cmd-archive-alpha',
+        correlationId: 'corr-archive-alpha',
+      },
+      readModelUrl: '/api/scopes/scope-alpha/workflows/wf-alpha',
+      acceptanceStage: 'accepted',
+      propagationStage: 'readmodel_propagating',
+    });
     mockServicesApi.deactivateDeployment.mockResolvedValue({
       targetActorId: 'deployment-manager-alpha',
       commandId: 'cmd-archive-alpha',
@@ -947,6 +963,107 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
+  it('shows Delete draft without Archive for a draft-only workflow', async () => {
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({ workflowId: 'wf-draft', name: 'Draft workflow' }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Draft workflow')).closest('tr');
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Draft workflow in Workspace',
+      }),
+    );
+    expect(
+      await screen.findByRole('menuitem', { name: 'Delete draft' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Archive' })).toBeNull();
+  });
+
+  it('shows Archive without Delete draft for a published workflow that still has a draft', async () => {
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-published-draft',
+          name: 'Published draft workflow',
+          committed: {
+            serviceKey: 'opaque-service-key',
+            workflowName: 'published_draft',
+            actorId: 'm-alpha',
+            activeRevisionId: 'rev-alpha',
+            deploymentId: 'dep-alpha',
+            deploymentStatus: 'Active',
+          },
+          hasDraftSource: true,
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Published draft workflow')).closest(
+      'tr',
+    );
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Published draft workflow in Workspace',
+      }),
+    );
+    expect(
+      await screen.findByRole('menuitem', { name: 'Archive' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Delete draft' })).toBeNull();
+  });
+
+  it('shows Archive without Delete draft for a published-only workflow', async () => {
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-published',
+          name: 'Published workflow',
+          committed: {
+            serviceKey: 'opaque-service-key',
+            workflowName: 'published',
+            actorId: 'm-alpha',
+            activeRevisionId: 'rev-alpha',
+            deploymentId: 'dep-alpha',
+            deploymentStatus: 'Active',
+          },
+          hasDraftSource: false,
+          capabilities: {
+            open: { available: true, unavailableReason: null },
+            activity: { available: true, unavailableReason: null },
+            rename: {
+              available: false,
+              unavailableReason: 'draft_source_missing',
+            },
+            delete: {
+              available: false,
+              unavailableReason: 'draft_source_missing',
+            },
+          },
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (await screen.findByText('Published workflow')).closest('tr');
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Published workflow in Workspace',
+      }),
+    );
+    expect(
+      await screen.findByRole('menuitem', { name: 'Archive' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Delete draft' })).toBeNull();
+  });
+
   it('refreshes the catalogue after a successful rename', async () => {
     const originalYaml = 'name: support_triage\nroles: []\nsteps: []\n';
     const renamedYaml = 'name: APAC support triage\nroles: []\nsteps: []\n';
@@ -1046,7 +1163,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
   });
 
-  it('resolves archive identity and observes the exact row across catalogue pages', async () => {
+  it('archives by workflow identity and observes the exact row across catalogue pages', async () => {
     const activeCommitted = {
       serviceKey: 'svc-alpha',
       workflowName: 'workflow_alpha',
@@ -1060,26 +1177,6 @@ describe('Workflow Activity vNext catalogue', () => {
       deploymentStatus: 'Deactivated',
     };
     let archived = false;
-    mockScopesApi.getWorkflowDetail.mockResolvedValue({
-      available: true,
-      scopeId: 'scope-alpha',
-      workflow: {
-        scopeId: 'scope-alpha',
-        workflowId: 'wf-alpha',
-        displayName: 'Workflow Alpha',
-        serviceKey: 'opaque-service-key',
-        workflowName: 'workflow_alpha',
-        actorId: 'actor-alpha',
-        activeRevisionId: 'rev-alpha',
-        deploymentId: 'dep-authoritative',
-        deploymentStatus: 'Active',
-        updatedAt: '2026-08-04T10:00:00Z',
-        publishedServiceId: 'svc-alpha',
-        serviceAppId: 'workflow-app',
-        serviceNamespace: 'workflow-namespace',
-      },
-      source: null,
-    });
     mockScopesApi.queryWorkflowCatalogue.mockImplementation(
       (input: { cursor?: string; query?: string }) => {
         if (input.query === 'wf-alpha' && input.cursor !== 'archive-page-2') {
@@ -1145,15 +1242,12 @@ describe('Workflow Activity vNext catalogue', () => {
       take: 100,
     });
     expect(mockScopesApi.listWorkflows).not.toHaveBeenCalled();
-    expect(mockServicesApi.deactivateDeployment).toHaveBeenCalledWith(
-      'svc-alpha',
-      'dep-authoritative',
-      {
-        tenantId: 'scope-alpha',
-        appId: 'workflow-app',
-        namespace: 'workflow-namespace',
-      },
+    expect(mockScopesApi.archiveWorkflow).toHaveBeenCalledWith(
+      'scope-alpha',
+      'wf-alpha',
     );
+    expect(mockScopesApi.getWorkflowDetail).not.toHaveBeenCalled();
+    expect(mockServicesApi.deactivateDeployment).not.toHaveBeenCalled();
     expect(await screen.findByText('Archived')).toBeInTheDocument();
     expect(mockConsoleToast.success).toHaveBeenCalledWith('Workflow archived');
   });

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -13,7 +13,6 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { Button, Dropdown, Input, Modal, Popover, Select, Space } from 'antd';
 import React from 'react';
 import { scopesApi } from '@/shared/api/scopesApi';
-import { servicesApi } from '@/shared/api/servicesApi';
 import { t } from '@/shared/i18n/messages';
 import type {
   ScopeWorkflowCatalogueRow,
@@ -383,31 +382,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
 
     try {
       if (!accepted) {
-        const detail = await scopesApi.getWorkflowDetail(
-          scopeId,
-          target.workflowId,
-        );
-        const published = detail.workflow;
-        if (
-          !detail.available ||
-          !published ||
-          published.workflowId !== target.workflowId ||
-          !published.publishedServiceId.trim() ||
-          !published.serviceAppId.trim() ||
-          !published.serviceNamespace.trim() ||
-          !published.deploymentId.trim()
-        ) {
-          throw new Error('Published workflow identity is unavailable');
-        }
-        await servicesApi.deactivateDeployment(
-          published.publishedServiceId,
-          published.deploymentId,
-          {
-            tenantId: scopeId,
-            appId: published.serviceAppId,
-            namespace: published.serviceNamespace,
-          },
-        );
+        await scopesApi.archiveWorkflow(scopeId, target.workflowId);
         accepted = true;
         setArchiveSubmitted(true);
       }
@@ -707,6 +682,8 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 const description = row.description.trim();
                 const isArchived = isWorkflowArchived(row);
                 const isPublished = Boolean(row.activeRevisionId);
+                const canDeleteDraft =
+                  row.capabilities.delete.available && !row.hasCommittedSource;
                 const workflowName = (
                   <span className="wa-vnext__title">{row.name}</span>
                 );
@@ -869,11 +846,10 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                                   'Copy workflow reference',
                                 ),
                               },
-                              ...(row.capabilities.delete.available ||
-                              canArchiveWorkflow(row)
+                              ...(canDeleteDraft || canArchiveWorkflow(row)
                                 ? [{ type: 'divider' as const }]
                                 : []),
-                              ...(row.capabilities.delete.available
+                              ...(canDeleteDraft
                                 ? [
                                     {
                                       danger: true,

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
@@ -217,4 +217,43 @@ describe('scopesApi workflow catalogue', () => {
       expect.objectContaining({ headers: expect.any(Headers) }),
     );
   });
+
+  it('archives a workflow through the scope-owned command boundary', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => ({
+        scopeId: 'scope alpha',
+        workflowId: 'wf/alpha',
+        deploymentId: 'dep-alpha',
+        commandHandle: {
+          stage: 'deactivate_deployment',
+          targetActorId: 'deployment-actor-alpha',
+          commandId: 'cmd-archive-alpha',
+          correlationId: 'corr-archive-alpha',
+        },
+        readModelUrl: '/api/scopes/scope%20alpha/workflows/wf%2Falpha',
+        acceptanceStage: 'accepted',
+        propagationStage: 'readmodel_propagating',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      scopesApi.archiveWorkflow('scope alpha', 'wf/alpha'),
+    ).resolves.toMatchObject({
+      scopeId: 'scope alpha',
+      workflowId: 'wf/alpha',
+      deploymentId: 'dep-alpha',
+      commandHandle: {
+        stage: 'deactivate_deployment',
+        commandId: 'cmd-archive-alpha',
+      },
+      acceptanceStage: 'accepted',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope%20alpha/workflows/wf%2Falpha:archive',
+      expect.objectContaining({ method: 'POST', headers: expect.any(Headers) }),
+    );
+  });
 });

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.ts
@@ -3,6 +3,7 @@ import type {
   ScopeScriptDetail,
   ScopeScriptSource,
   ScopeScriptSummary,
+  ScopeWorkflowArchiveAcceptedResult,
   ScopeWorkflowCatalogueActionCapability,
   ScopeWorkflowCatalogueCommittedFacts,
   ScopeWorkflowCatalogueQuery,
@@ -501,6 +502,66 @@ const decodeScopeWorkflowSummaries: Decoder<ScopeWorkflowSummary[]> = (value) =>
 const decodeScopeWorkflowDetails: Decoder<ScopeWorkflowDetail[]> = (value) =>
   expectArray(value, 'ScopeWorkflowDetail[]', decodeScopeWorkflowDetail);
 
+const decodeScopeWorkflowArchiveAcceptedResult: Decoder<
+  ScopeWorkflowArchiveAcceptedResult
+> = (value, label = 'ScopeWorkflowArchiveAcceptedResult') => {
+  const record = expectRecord(value, label);
+  const commandHandle = expectRecord(
+    record.commandHandle ?? record.CommandHandle,
+    `${label}.commandHandle`,
+  );
+  return {
+    scopeId: readString(record, ['scopeId', 'ScopeId'], `${label}.scopeId`),
+    workflowId: readString(
+      record,
+      ['workflowId', 'WorkflowId'],
+      `${label}.workflowId`,
+    ),
+    deploymentId: readString(
+      record,
+      ['deploymentId', 'DeploymentId'],
+      `${label}.deploymentId`,
+    ),
+    commandHandle: {
+      stage: readString(
+        commandHandle,
+        ['stage', 'Stage'],
+        `${label}.commandHandle.stage`,
+      ),
+      targetActorId: readString(
+        commandHandle,
+        ['targetActorId', 'TargetActorId'],
+        `${label}.commandHandle.targetActorId`,
+      ),
+      commandId: readString(
+        commandHandle,
+        ['commandId', 'CommandId'],
+        `${label}.commandHandle.commandId`,
+      ),
+      correlationId: readString(
+        commandHandle,
+        ['correlationId', 'CorrelationId'],
+        `${label}.commandHandle.correlationId`,
+      ),
+    },
+    readModelUrl: readString(
+      record,
+      ['readModelUrl', 'ReadModelUrl'],
+      `${label}.readModelUrl`,
+    ),
+    acceptanceStage: readString(
+      record,
+      ['acceptanceStage', 'AcceptanceStage'],
+      `${label}.acceptanceStage`,
+    ),
+    propagationStage: readString(
+      record,
+      ['propagationStage', 'PropagationStage'],
+      `${label}.propagationStage`,
+    ),
+  };
+};
+
 const decodeScopeScriptSummaries: Decoder<ScopeScriptSummary[]> = (value) =>
   expectArray(value, 'ScopeScriptSummary[]', decodeScopeScriptSummary);
 
@@ -547,6 +608,19 @@ export const scopesApi = {
         scopeId,
       )}/workflows/${encodeURIComponent(workflowId)}`,
       decodeScopeWorkflowDetail,
+    );
+  },
+
+  archiveWorkflow(
+    scopeId: string,
+    workflowId: string,
+  ): Promise<ScopeWorkflowArchiveAcceptedResult> {
+    return requestJson(
+      `/api/scopes/${encodeURIComponent(scopeId)}/workflows/${encodeURIComponent(
+        workflowId,
+      )}:archive`,
+      decodeScopeWorkflowArchiveAcceptedResult,
+      { method: 'POST' },
     );
   },
 

--- a/apps/aevatar-console-web/src/shared/models/scopes.ts
+++ b/apps/aevatar-console-web/src/shared/models/scopes.ts
@@ -89,6 +89,23 @@ export interface ScopeWorkflowDetail {
   source: ScopeWorkflowSource | null;
 }
 
+export interface ScopeWorkflowArchiveCommandHandle {
+  stage: string;
+  targetActorId: string;
+  commandId: string;
+  correlationId: string;
+}
+
+export interface ScopeWorkflowArchiveAcceptedResult {
+  scopeId: string;
+  workflowId: string;
+  deploymentId: string;
+  commandHandle: ScopeWorkflowArchiveCommandHandle;
+  readModelUrl: string;
+  acceptanceStage: string;
+  propagationStage: string;
+}
+
 export interface ScopeScriptSummary {
   scopeId: string;
   scriptId: string;


### PR DESCRIPTION
## 问题与方案

Workflow Activity 的 destructive actions 同时存在两个问题：

- 前端 Archive 自行读取 workflow detail、还原 service identity，再调用通用 deployment endpoint，因此会触发 `403 SERVICE_IDENTITY_ACCESS_DENIED`；
- 已发布且仍有 draft 的 workflow 同时显示 `Delete draft` 和 `Archive`，没有表达 published 状态优先的产品语义。

本 PR 将行为收敛为：

- Draft-only：只显示 `Delete draft`；
- Published（无论是否仍有 draft）：只显示 `Archive`；
- Archived：不显示 destructive action。

Archive 现在只向 scope-owned endpoint 发送 `scopeId + workflowId`，不再在前端还原 published service identity，也不再调用 generic service deployment API。命令 accepted 后仍观察精确 workflow catalogue row，只有 read model 变为 `Deactivated` 才提示成功。

## Backend dependency

Depends on #3390, which targets `feature/integrate` and provides `POST /api/scopes/{scopeId}/workflows/{workflowId}:archive`.

## 影响路径

仅包含以下前端范围：

- Workflow Activity action visibility and Archive flow
- Scope workflow API client and runtime decoder
- Scope workflow response model
- Focused API/page regression tests

本分支不包含任何后端文件。

## Local verification

- Scope analysis: `/opt/homebrew/bin/python3.12 /Users/abigaildeng/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext` - one Jest package, 5 changed frontend files
- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx src/shared/api/scopesApi.ts src/shared/models/scopes.ts --runInBand` - 28 suites passed, 712 tests passed
- Changed test files: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx src/shared/api/scopesApi.test.ts --runInBand` - 2 suites passed, 103 tests passed
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx src/shared/api/scopesApi.test.ts src/shared/api/scopesApi.ts src/shared/models/scopes.ts` - 5 files passed
- Test stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
