### PR TITLE
Filter vNext LLM services without models

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1304,9 +1304,7 @@ describe('Workflow Activity vNext settings', () => {
   it('renders the same authoritative identity in the shell and Account while keeping support values secondary', async () => {
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
-    expect(
-      (await screen.findAllByText('System default')).length,
-    ).toBeGreaterThan(0);
+    await screen.findByRole('combobox', { name: 'Preferred service' });
     const accountLink = screen.getByRole('link', { name: 'Account' });
     expect(accountLink).toHaveAttribute(
       'href',
@@ -1470,20 +1468,6 @@ describe('Workflow Activity vNext settings', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeEnabled();
   });
 
-  it('explains service and model inheritance for System default', async () => {
-    renderWithQueryClient(<WorkflowActivityVNextPage />);
-
-    await screen.findByRole('combobox', { name: 'Preferred service' });
-    expect(screen.getAllByText('System default').length).toBeGreaterThan(0);
-    expect(screen.getByText('Default model')).toBeInTheDocument();
-    expect(
-      screen.getByText('Uses the system-selected service and model.'),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('combobox', { name: 'Default model' }),
-    ).not.toBeInTheDocument();
-  });
-
   it('keeps dirty save actions outside the scrolling AI defaults panel', async () => {
     mockStudioApi.getUserLlmSettings.mockResolvedValue({
       savedSelection: null,
@@ -1554,7 +1538,7 @@ describe('Workflow Activity vNext settings', () => {
     expect(mockStudioApi.saveUserLlmSettings).not.toHaveBeenCalled();
   });
 
-  it('only offers services that publish at least one model', async () => {
+  it('only offers backend services that publish at least one model', async () => {
     mockStudioApi.getUserLlmSettings.mockResolvedValue({
       savedSelection: null,
       savedRouteLabel: 'System default',
@@ -1631,6 +1615,7 @@ describe('Workflow Activity vNext settings', () => {
     });
     fireEvent.mouseDown(routeSelect);
     expect(await screen.findByText('Service alpha')).toBeInTheDocument();
+    expect(screen.queryByText('System default')).not.toBeInTheDocument();
     expect(screen.queryByText('Gateway')).not.toBeInTheDocument();
     expect(screen.queryByText('Storage alpha')).not.toBeInTheDocument();
   });

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1554,15 +1554,11 @@ describe('Workflow Activity vNext settings', () => {
     expect(mockStudioApi.saveUserLlmSettings).not.toHaveBeenCalled();
   });
 
-  it('keeps connected services selectable without an enumerated model catalogue', async () => {
+  it('only offers services that publish at least one model', async () => {
     mockStudioApi.getUserLlmSettings.mockResolvedValue({
-      savedSelection: {
-        routeKind: 'gateway',
-        routeValue: '/api/v1/llm/gateway/v1',
-        modelSelection: { kind: 'provider_default' },
-      },
-      savedRouteLabel: 'Gateway',
-      selectionStatus: 'ready',
+      savedSelection: null,
+      savedRouteLabel: 'System default',
+      selectionStatus: 'system_default',
       catalogDiagnostic: 'unspecified',
       remediation: 'none',
       catalogStatus: 'ready',
@@ -1633,29 +1629,10 @@ describe('Workflow Activity vNext settings', () => {
     const routeSelect = await screen.findByRole('combobox', {
       name: 'Preferred service',
     });
-    expect(
-      screen.queryByRole('combobox', { name: 'Default model' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText('Uses the service default model.'),
-    ).toBeInTheDocument();
     fireEvent.mouseDown(routeSelect);
     expect(await screen.findByText('Service alpha')).toBeInTheDocument();
-    fireEvent.click(await screen.findByText('Storage alpha'));
-    expect(
-      screen.queryByRole('combobox', { name: 'Default model' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText('Uses the service default model.'),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Save changes' })).toBeEnabled();
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Restore saved settings' }),
-    );
-    expect(
-      screen.queryByRole('button', { name: 'Save changes' }),
-    ).not.toBeInTheDocument();
-    expect(mockStudioApi.saveUserLlmSettings).not.toHaveBeenCalled();
+    expect(screen.queryByText('Gateway')).not.toBeInTheDocument();
+    expect(screen.queryByText('Storage alpha')).not.toBeInTheDocument();
   });
 
   it('guards dirty navigation with Stay and Discard and leave', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
@@ -143,7 +143,10 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   );
 
   const options = React.useMemo(
-    () => buildUserLlmSelectionOptions(llm.data?.routeOptions ?? []),
+    () =>
+      buildUserLlmSelectionOptions(llm.data?.routeOptions ?? []).filter(
+        (option) => option.modelCatalog.modelIds.length > 0,
+      ),
     [llm.data?.routeOptions],
   );
   const selectedOption = draft

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
@@ -362,13 +362,6 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
             disabled={!llm.data?.capabilities.canEditRoute}
             onChange={selectRoute}
             options={[
-              {
-                label: t(
-                  'workflowActivityVNext.settings.systemDefault',
-                  'System default',
-                ),
-                value: '',
-              },
               ...options.map((item) => ({
                 disabled: !item.allowed || !item.ready,
                 label: item.label,
@@ -387,7 +380,7 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                   ]
                 : []),
             ]}
-            value={draft ? encodeUserLlmSelectionValue(draft) : ''}
+            value={draft ? encodeUserLlmSelectionValue(draft) : undefined}
           />
         </div>
         {draft && modelIds.length > 0 ? (


### PR DESCRIPTION
## Problem and solution

The Workflow Activity vNext Settings page previously mixed two frontend-generated states into the Preferred service catalogue:

- every supported service route returned by `/api/user-config/llm`, including routes whose `modelCatalog.modelIds` was empty;
- a synthetic `System default` reset option that was not present in the backend `routeOptions` catalogue.

Preferred service now lists only backend route options that publish at least one model ID. The synthetic reset option is removed, and a missing saved selection is represented as an unselected control instead of a fabricated service. The existing disabled fallback for a previously saved service that is no longer available remains intact. The shared selection builder and the legacy Settings page remain unchanged.

## Affected paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`

## Test intent

The route integration test exercises the rendered Preferred service dropdown with three backend route classes:

- a gateway with an empty model catalogue;
- a user service with a populated `modelIds` catalogue;
- a user service with an empty model catalogue.

It verifies that only the backend service with a published model remains selectable and that the frontend does not inject `System default`. The obsolete test that required the synthetic option was removed.

## Local verification

- Scope analysis: `python3 /Users/abigaildeng/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext` (2 changed files, 1 source file, 1 test file)
- Regression test: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx --testNamePattern "only offers backend services that publish at least one model"` (1 passed)
- Changed test file: `pnpm exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx` (96 passed)
- Related-test preflight: `pnpm exec jest --listTests --findRelatedTests src/pages/workflow-activity-vnext/settings/SettingsPage.tsx` (1 test file selected)
- Related tests: `pnpm exec jest --runInBand --findRelatedTests src/pages/workflow-activity-vnext/settings/SettingsPage.tsx` (96 passed)
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/settings/SettingsPage.tsx` (passed)
- Test stability guard: `bash tools/ci/test_stability_guards.sh` (passed)
- Baseline integrity: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py` (17/17 frames, byte-identical, passed)
- Diff validation: `git diff --check` (passed)
- Browser smoke check: authenticated local vNext Settings loaded the real remote backend; Preferred service contained only `Chrono LLM` and `Chrono LLM (public)`, contained no synthetic `System default`, preserved the selected `Chrono LLM (public)` and `gpt-5.5`, and reported no console errors
- Affected typecheck: no repository-native affected target is available; skipped locally
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

## Documentation impact

No documentation or design-baseline change is required. The change makes the vNext UI follow the existing backend route catalogue without creating a second frontend-owned service concept.

## Design baseline

```text
Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py
```
