### PR TITLE
Refine console toast presentation

### DIFF
--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -2545,6 +2545,13 @@ ol {
   color: var(--studio-muted-text);
 }
 
+.aevatar-console-toast.ant-notification-notice {
+  .ant-notification-notice-close {
+    inset-inline-end: 12px;
+    top: 12px;
+  }
+}
+
 .studio-catalog-toast {
   position: fixed;
   left: 50%;

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
@@ -1,8 +1,14 @@
-import { act, renderHook } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from '@testing-library/react';
 import { App } from 'antd';
 import type { NotificationInstance } from 'antd/es/notification/interface';
 import React from 'react';
-import { useConsoleToast } from './ConsoleToast';
+import { ConsoleToastProvider, useConsoleToast } from './ConsoleToast';
 
 function createNotificationStub(): jest.Mocked<NotificationInstance> {
   return {
@@ -15,9 +21,51 @@ function createNotificationStub(): jest.Mocked<NotificationInstance> {
   };
 }
 
+const PublishToastTrigger: React.FC = () => {
+  const toast = useConsoleToast();
+  return (
+    <button
+      onClick={() =>
+        toast.success('Workflow published', {
+          duration: false,
+          key: 'workflow-published',
+        })
+      }
+      type="button"
+    >
+      Show publish status
+    </button>
+  );
+};
+
 describe('ConsoleToast', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('renders a compact status below the console header', async () => {
+    render(
+      <ConsoleToastProvider>
+        <PublishToastTrigger />
+      </ConsoleToastProvider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show publish status' }),
+    );
+
+    const status = await screen.findByRole('status');
+    const notice = status.closest('.ant-notification-notice');
+    const holder = notice?.closest('.ant-notification-topRight');
+
+    expect(notice).not.toBeNull();
+    expect(notice).toHaveStyle({
+      maxWidth: 'min(360px, calc(100vw - 32px))',
+      width: 'max-content',
+    });
+    expect(notice?.style.boxShadow).toBe('');
+    expect(holder).toHaveStyle({ top: '68px' });
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
   });
 
   it('opens a compact dismissible top-right error notification', () => {
@@ -52,13 +100,14 @@ describe('ConsoleToast', () => {
     expect(config.title).toBe(content);
     expect(config.styles).toMatchObject({
       root: {
-        maxWidth: 'calc(100vw - 32px)',
-        width: 360,
+        maxWidth: 'min(360px, calc(100vw - 32px))',
+        width: 'max-content',
       },
       title: {
         marginBottom: 0,
       },
     });
+    expect(config.styles?.root).not.toHaveProperty('boxShadow');
   });
 
   it('uses status semantics and the short default for success', () => {

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx
@@ -58,12 +58,14 @@ describe('ConsoleToast', () => {
     const notice = status.closest('.ant-notification-notice');
     const holder = notice?.closest('.ant-notification-topRight');
 
-    expect(notice).not.toBeNull();
+    if (!(notice instanceof HTMLElement)) {
+      throw new Error('Expected the notification notice to be an HTML element');
+    }
     expect(notice).toHaveStyle({
       maxWidth: 'min(360px, calc(100vw - 32px))',
       width: 'max-content',
     });
-    expect(notice?.style.boxShadow).toBe('');
+    expect(notice.style.boxShadow).toBe('');
     expect(holder).toHaveStyle({ top: '68px' });
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
   });
@@ -107,7 +109,12 @@ describe('ConsoleToast', () => {
         marginBottom: 0,
       },
     });
-    expect(config.styles?.root).not.toHaveProperty('boxShadow');
+    if (!config.styles || typeof config.styles === 'function') {
+      throw new Error(
+        'Expected notification styles to be a semantic style map',
+      );
+    }
+    expect(config.styles.root).not.toHaveProperty('boxShadow');
   });
 
   it('uses status semantics and the short default for success', () => {

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx
@@ -4,6 +4,7 @@ import type {
   NotificationInstance,
 } from 'antd/es/notification/interface';
 import React from 'react';
+import { AEVATAR_GLOBAL_UI_SPEC } from './aevatarWorkbench';
 
 type ConsoleToastOptions = Pick<ArgsProps, 'duration' | 'key' | 'onClose'>;
 type ConsoleToastIntent = 'error' | 'info' | 'success' | 'warning';
@@ -11,12 +12,12 @@ type ConsoleToastIntent = 'error' | 'info' | 'success' | 'warning';
 type ConsoleToastSurfaceToken = Pick<
   ReturnType<typeof theme.useToken>['token'],
   | 'borderRadiusLG'
-  | 'boxShadowSecondary'
   | 'colorBorderSecondary'
   | 'fontSize'
   | 'lineHeight'
   | 'padding'
   | 'paddingSM'
+  | 'paddingXL'
 >;
 
 export type ConsoleToastApi = {
@@ -32,6 +33,8 @@ const TOAST_DURATION: Readonly<Record<ConsoleToastIntent, number>> = {
   success: 3,
   warning: 5,
 };
+
+const CONSOLE_TOAST_TOP = AEVATAR_GLOBAL_UI_SPEC.tokens.headerHeight + 12;
 
 function createConsoleToastApi(
   notificationApi: NotificationInstance,
@@ -55,15 +58,15 @@ function createConsoleToastApi(
         root: {
           border: `1px solid ${token.colorBorderSecondary}`,
           borderRadius: token.borderRadiusLG,
-          boxShadow: token.boxShadowSecondary,
-          maxWidth: 'calc(100vw - 32px)',
+          maxWidth: 'min(360px, calc(100vw - 32px))',
           padding: `${token.paddingSM}px ${token.padding}px`,
-          width: 360,
+          width: 'max-content',
         },
         title: {
           fontSize: token.fontSize,
           lineHeight: token.lineHeight,
           marginBottom: 0,
+          paddingInlineEnd: token.paddingXL,
         },
       },
       title: content,
@@ -81,7 +84,11 @@ function createConsoleToastApi(
 export const ConsoleToastProvider: React.FC<{
   readonly children: React.ReactNode;
 }> = ({ children }) => (
-  <App component="div" style={{ display: 'contents' }}>
+  <App
+    component="div"
+    notification={{ placement: 'topRight', top: CONSOLE_TOAST_TOP }}
+    style={{ display: 'contents' }}
+  >
     {children}
   </App>
 );


### PR DESCRIPTION
## Problem and solution

The shared console notification forced every message into a 360px-wide, heavily elevated top-right surface. Short statuses such as `Workflow published` therefore left excessive empty space, placed the close action on a mismatched spacing grid, and covered the language/account header controls.

This change keeps the existing shared Ant Design notification behavior and publish flow intact while repairing presentation:

- make the notice content-sized with a responsive 360px maximum;
- place the holder below the global console header;
- remove the duplicate inner shadow while retaining the notification wrapper elevation;
- reserve title space for the close action and align it to the compact 12px grid;
- add a provider-backed DOM regression test for the rendered status surface.

No publish API, state transition, copy, duration, deduplication key, close behavior, or workflow logic changes.

## CI failure follow-up

The first `console-web` CI run failed during `tsc --noEmit`, not during Jest. The new test accessed `Element.style` without narrowing the `closest()` result to `HTMLElement`, and accessed `NotificationStylesType.root` without excluding Ant Design's resolver-function variant.

The test now uses explicit runtime guards for both contracts. This keeps the assertions meaningful, avoids unsafe type casts, and does not change production code.

## Affected paths

- `apps/aevatar-console-web/src/shared/ui/ConsoleToast.tsx`
- `apps/aevatar-console-web/src/shared/ui/ConsoleToast.test.tsx`
- `apps/aevatar-console-web/src/global.less`

## Local verification

- Scope analysis: `python3 /Users/abigaildeng/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext` (3 frontend files: 2 source/style, 1 test)
- Regression RED: `pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand` against the old presentation implementation (1 failed because the live notice rendered at fixed `width: 360px`; 2 existing tests passed)
- Related tests on the latest feature baseline: `pnpm exec jest --findRelatedTests src/global.less src/shared/ui/ConsoleToast.tsx --runInBand` (44 suites passed, 796 tests passed)
- CI typecheck RED reproduction: `CODEX_ALLOW_FULL_FRONTEND_VALIDATION=1 pnpm --dir apps/aevatar-console-web tsc` (failed with the same two `TS2339` errors reported by `console-web` CI)
- CI typecheck GREEN verification: `CODEX_ALLOW_FULL_FRONTEND_VALIDATION=1 pnpm --dir apps/aevatar-console-web tsc` (passed after explicit test type guards)
- Changed test file: `pnpm exec jest src/shared/ui/ConsoleToast.test.tsx --runInBand` (1 suite passed, 3 tests passed)
- Changed-file static checks: `pnpm exec biome check src/global.less src/shared/ui/ConsoleToast.test.tsx src/shared/ui/ConsoleToast.tsx` (passed; 2 supported files checked and LESS ignored by the configured unknown-file policy)
- Test stability guard: `bash tools/ci/test_stability_guards.sh` (passed)
- Baseline integrity: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py` (17/17 frames, byte-identical, passed)
- Diff validation: `git diff --check` and `git diff --cached --check` (passed)
- Browser smoke check: authenticated vNext workflow list and `incident_triage` editor loaded through the local frontend with the remote backend and no console errors. A clipboard-only `Copy workflow reference` success notification rendered at 279.48px wide with a 360px maximum, top 68px below the 52px header, no inner box shadow, 12px close inset, and no header overlap.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

## Documentation impact

No documentation or design-baseline update is required. This is a shared presentation correction that follows the existing global UI tokens and preserves the published workflow behavior.
