### PR TITLE
Fix workflow run logs and save action state

### DIFF
--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx
@@ -7,7 +7,6 @@ import WorkflowExecutionLogsPanel from '@/shared/workflows/WorkflowExecutionLogs
 
 type WorkflowStudioExecutionPanelProps = {
   readonly activeLogIndex?: number | null;
-  readonly clearDisabled?: boolean;
   readonly detail: StudioExecutionDetail | null;
   readonly error?: string;
   readonly height?: number;

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.test.tsx
@@ -4844,7 +4844,7 @@ describe('TeamMemberWorkflowStudioPage', () => {
     expect(consolePanel).toHaveTextContent('running');
     expect(
       within(consolePanel).getByRole('button', { name: 'Clear logs' }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     const executionPanelResponsiveRules = findRenderedStyleText(
       '.workflow-studio-execution-panel__body',
     );

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/index.tsx
@@ -229,7 +229,6 @@ const TeamMemberWorkflowStudioPage: React.FC = () => {
       ) : null}
       <WorkflowStudioExecutionPanel
         activeLogIndex={studio.activeExecutionLogIndex}
-        clearDisabled={studio.currentDraftRunPending}
         detail={studio.executionDetail}
         error={studio.executionError}
         height={executionPanelHeight}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -4133,6 +4133,56 @@ describe('Workflow Activity vNext editor', () => {
     } as unknown as Response);
   });
 
+  it('clears the published run console without aborting an active run', async () => {
+    let streamController:
+      | ReadableStreamDefaultController<Uint8Array>
+      | undefined;
+    let runSignal: AbortSignal | undefined;
+    mockRuntimeRunsApi.streamChat.mockImplementation(
+      (_scopeId, _request, signal) => {
+        runSignal = signal;
+        return Promise.resolve({
+          body: new ReadableStream({
+            start(controller) {
+              streamController = controller;
+            },
+          }),
+          ok: true,
+        } as Response);
+      },
+    );
+
+    await renderPublishedWorkflowPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+    fireEvent.change(
+      await screen.findByRole('textbox', { name: 'Published run input' }),
+      { target: { value: 'Review order 42' } },
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start published run' }),
+    );
+
+    const logs = await screen.findByRole('complementary', {
+      name: 'Workflow run console',
+    });
+    const clearLogs = within(logs).getByRole('button', {
+      name: 'Clear logs',
+    });
+    expect(clearLogs).toBeEnabled();
+    fireEvent.click(clearLogs);
+
+    expect(
+      screen.queryByRole('complementary', { name: 'Workflow run console' }),
+    ).not.toBeInTheDocument();
+    expect(runSignal?.aborted).toBe(false);
+    expect(mockRuntimeRunsApi.streamChat).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      streamController?.close();
+    });
+  });
+
   it('requires text or a file before invoking a published workflow', async () => {
     mockRuntimeRunsApi.streamChat.mockResolvedValue(createSseResponse([]));
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1946,6 +1946,35 @@ describe('Workflow Activity vNext editor', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('enables Save workflow only while the loaded workflow has unsaved changes', async () => {
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const workflowName = await screen.findByRole('textbox', {
+      name: 'Workflow name',
+    });
+    const saveWorkflowButton = screen.getByRole('button', {
+      name: 'Save workflow',
+    });
+    expect(
+      screen.getByRole('status', { name: 'Workflow save status' }),
+    ).toHaveTextContent('Saved at 2026-08-04 10:00:00 UTC');
+    expect(saveWorkflowButton).toBeDisabled();
+
+    fireEvent.change(workflowName, {
+      target: { value: 'Committed source updated' },
+    });
+    expect(saveWorkflowButton).toBeEnabled();
+    fireEvent.click(saveWorkflowButton);
+
+    await waitFor(() =>
+      expect(mockStudioApi.saveWorkflow).toHaveBeenCalledTimes(1),
+    );
+    await waitFor(() => expect(saveWorkflowButton).toBeDisabled());
+    expect(
+      screen.getByRole('status', { name: 'Workflow save status' }),
+    ).toHaveTextContent('Saved at 2026-08-04 10:01:00 UTC');
+  });
+
   it('publishes a saved workflow in one click and waits for observed evidence before showing Published', async () => {
     mockLocation =
       '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-draft-alpha';
@@ -3580,6 +3609,9 @@ describe('Workflow Activity vNext editor', () => {
       await screen.findByRole('button', { name: 'Insert LLM call node' }),
     ).toBeVisible();
 
+    fireEvent.change(screen.getByLabelText('Workflow name'), {
+      target: { value: 'Committed source updated' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Save workflow' }));
 
     await waitFor(() =>

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -978,6 +978,7 @@ const WorkflowEditorPage: React.FC<{
           />
           <Button
             disabled={
+              !editor.dirty ||
               editorWriteLocked ||
               editor.receiptPending ||
               hasUnappliedNodeChanges

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -906,7 +906,6 @@ const WorkflowEditorPage: React.FC<{
             />
             <WorkflowExecutionLogsPanel
               activeLogIndex={activeRunLogIndex}
-              clearDisabled={runBusy}
               collapseButtonRef={collapseRunConsoleButtonRef}
               collapseControlsId={PUBLISHED_RUN_CONSOLE_ID}
               error={runConsoleError}

--- a/apps/aevatar-console-web/src/shared/workflows/WorkflowExecutionLogsPanel.tsx
+++ b/apps/aevatar-console-web/src/shared/workflows/WorkflowExecutionLogsPanel.tsx
@@ -42,7 +42,6 @@ export type WorkflowExecutionLogsModel = {
 type WorkflowExecutionLogsPanelProps = {
   readonly activeLogIndex?: number | null;
   readonly ariaLabel?: string;
-  readonly clearDisabled?: boolean;
   readonly collapseButtonRef?: React.Ref<React.ElementRef<typeof Button>>;
   readonly collapseControlsId?: string;
   readonly error?: string;
@@ -943,7 +942,6 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
     'shared.workflowExecutionLogs.consoleAria',
     'Workflow run console',
   ),
-  clearDisabled = false,
   collapseButtonRef,
   collapseControlsId,
   error,
@@ -1206,7 +1204,6 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                       'teamMemberWorkflowStudio.executionPanel.clear',
                       'Clear logs',
                     )}
-                    disabled={clearDisabled}
                     icon={<CloseOutlined />}
                     onClick={onClear}
                     size="small"


### PR DESCRIPTION
## Problems

- The shared Clear logs action was disabled whenever a published or draft workflow run was still pending. Clearing the local console does not stop the remote run, so coupling the action to transport state prevented users from dismissing Logs while a run was active.
- The Workflow Activity vNext editor kept Save workflow enabled even when the workflow was already saved and had no local changes.

## Solution

- Remove the `clearDisabled` contract from the shared workflow execution logs panel and its Studio adapter.
- Keep Clear logs available for both published and draft runs while execution is active.
- Disable Save workflow whenever `editor.dirty` is false; enable it after a real edit and disable it again after the saved workflow becomes readable.
- Add a published-run regression test proving that clearing the console hides local presentation without aborting the active SSE request.
- Add a save-state regression covering initial Saved, edited, and materialized Saved states.
- Update the structural save-lock test to make a real edit before starting its save.

## Impact

- Workflow Activity vNext editor save action
- Workflow Activity vNext published-run Logs console
- Team Member Workflow Studio draft-run Logs console
- Shared workflow execution Logs panel API

## Local verification

- Workflow Activity vNext tests: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand` — 1 suite passed, 107 tests passed.
- Related Logs tests: `pnpm exec jest --findRelatedTests src/pages/team-member-workflow-studio/components/WorkflowStudioExecutionPanel.tsx src/pages/team-member-workflow-studio/index.tsx src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx src/shared/workflows/WorkflowExecutionLogsPanel.tsx --runInBand` — 3 suites passed, 194 tests passed.
- Changed-file static checks for the save update: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx` — 2 files checked, no fixes required.
- Test stability guard: `bash tools/ci/test_stability_guards.sh` — passed.
- Diff integrity: `git diff --check` and `git diff --cached --check` — passed.
- Browser user path on the authenticated local preview: Published + Saved loaded with Save workflow disabled; editing the workflow name changed the status to Unsaved changes and enabled Save.
- A reliable affected typecheck target is unavailable; full frontend typecheck is delegated to GitHub CI.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.