### PR TITLE
Refresh vNext lists when returning from detail pages

### DIFF
--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-11-vnext-list-return-refresh.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-11-vnext-list-return-refresh.md
@@ -112,4 +112,3 @@ Stage only this task's files, commit with an imperative single-purpose message,
 push the branch, and create a PR targeting
 `feat/2026-08-04_workflow-activity-vnext`. Record all focused commands and state
 that full frontend validation is delegated to GitHub CI.
-

--- a/apps/aevatar-console-web/docs/superpowers/plans/2026-08-11-vnext-list-return-refresh.md
+++ b/apps/aevatar-console-web/docs/superpowers/plans/2026-08-11-vnext-list-return-refresh.md
@@ -1,0 +1,115 @@
+# vNext List Return Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh Workflow Activity vNext collection data whenever users return from an editor or detail surface to Workflows or Activity.
+
+**Architecture:** Keep freshness policy with each list query by forcing a refetch whenever that query mounts. Reproduce the production 30-second cache window in route-level tests so detail-to-list navigation proves a second request is made while cached data is still fresh.
+
+**Tech Stack:** React, TypeScript, TanStack React Query, Jest, Testing Library, pnpm.
+
+---
+
+## File Map
+
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`: make catalogue data revalidate on every list entry.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx`: apply the same contract to the runs list.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`: cover Workflows route return with fresh cached data.
+- Modify `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx`: cover Activity remount with fresh cached data.
+- Existing `apps/aevatar-console-web/docs/superpowers/specs/2026-08-11-vnext-list-return-refresh-design.md`: approved behavior contract.
+
+### Task 1: Specify Workflows Return Freshness
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+- Test: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+
+- [ ] **Step 1: Add a production-cache route test**
+
+Render with a local `QueryClient` whose `staleTime` is `30_000`, enter the
+Workflows route, navigate to `/workflows/wf-alpha`, then return to `/workflows`.
+Assert `queryWorkflowCatalogue` has been called twice.
+
+- [ ] **Step 2: Run the exact test and verify RED**
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx --testNamePattern 'refreshes the workflow catalogue when returning from the editor'
+```
+
+Expected: FAIL because the current catalogue remains fresh and is requested
+only once.
+
+### Task 2: Specify Activity Return Freshness
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx`
+- Test: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx`
+
+- [ ] **Step 1: Add a production-cache remount test**
+
+Render Activity with a local `QueryClient` whose `staleTime` is `30_000`, wait
+for its first runs result, unmount and remount the page with the same client,
+then assert `listRuns` has been called twice.
+
+- [ ] **Step 2: Run the exact test and verify RED**
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx --testNamePattern 'refreshes runs when returning to activity'
+```
+
+Expected: FAIL because the fresh runs result is reused without a second call.
+
+### Task 3: Implement List-Owned Revalidation
+
+**Files:**
+
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx`
+
+- [ ] **Step 1: Add the explicit mount policy to both queries**
+
+```ts
+refetchOnMount: 'always',
+```
+
+Place the option beside `retry: false` in the catalogue and runs query options.
+
+- [ ] **Step 2: Run both exact regression tests and verify GREEN**
+
+Run the two commands from Tasks 1 and 2. Expected: PASS.
+
+- [ ] **Step 3: Run the changed test files**
+
+```bash
+pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
+```
+
+Expected: both suites pass.
+
+### Task 4: Focused Verification And Delivery
+
+**Files:**
+
+- Verify only the files listed in the File Map.
+
+- [ ] **Step 1: Analyze the frontend change scope against the requested base**
+
+```bash
+python3 ~/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext
+```
+
+- [ ] **Step 2: Run changed-file static checks and repository guards**
+
+Run the analyzer-approved Biome command, `bash tools/ci/test_stability_guards.sh`,
+the Workflow Activity vNext design-baseline verifier, and `git diff --check`.
+Expected: all pass.
+
+- [ ] **Step 3: Review and deliver**
+
+Stage only this task's files, commit with an imperative single-purpose message,
+push the branch, and create a PR targeting
+`feat/2026-08-04_workflow-activity-vnext`. Record all focused commands and state
+that full frontend validation is delegated to GitHub CI.
+

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-11-vnext-list-return-refresh-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-11-vnext-list-return-refresh-design.md
@@ -1,0 +1,57 @@
+# vNext List Return Refresh Design
+
+## Status
+
+Approved for implementation on 2026-08-11 under the user's standing direction
+to proceed with the recommended approach without another approval round.
+
+Implementation branch: `fix/2026-08-11_refresh-vnext-lists-on-return`.
+
+Base branch: `feat/2026-08-04_workflow-activity-vnext` at
+`4ea36e70f904680b05f90a27b66cf7b85cb14bbd`.
+
+## Problem
+
+The shared React Query client keeps successful query data fresh for 30 seconds.
+Workflow Activity vNext renders list and detail surfaces exclusively, so returning
+from a detail surface unmounts the detail and remounts the list. During the
+freshness window, React Query serves the cached list without issuing a request.
+
+This leaves the Workflows catalogue stale after returning from the workflow
+editor. The Activity runs list has the same lifecycle when returning from run
+detail and can show an outdated run status for the same reason.
+
+## Product Contract
+
+- Entering the Workflows list refreshes its catalogue from the server.
+- Entering the Activity list refreshes its runs from the server.
+- The rule covers editor, new-workflow, run-detail, browser-back, and sidebar
+  return paths without requiring each source surface to know the list query key.
+- Existing filters and pagination query keys remain unchanged.
+- Existing loading and error presentation remains unchanged.
+- Other cached queries keep the shared 30-second freshness policy.
+
+## Design
+
+Set `refetchOnMount: 'always'` on the Workflows catalogue query and the Activity
+runs query. This makes list ownership explicit: a list surface decides that its
+server-backed collection must be revalidated whenever the surface is entered.
+
+The alternative of setting `staleTime: 0` would depend on default remount
+behavior and obscure the product intent. Invalidating from editor/detail
+mutations would couple independent surfaces, miss no-mutation return paths, and
+require every navigation path to cooperate.
+
+## Verification
+
+Use production-like test clients with `staleTime: 30_000` so the tests reproduce
+the bug rather than passing because test data is immediately stale. Cover:
+
+- Workflows list -> workflow editor -> Workflows list, asserting a second
+  catalogue request.
+- Activity list -> run detail -> Activity list, asserting a second runs request.
+
+Run only the changed test files and affected frontend checks. The complete
+frontend suite, typecheck, and production build remain delegated to GitHub CI
+under the personal incremental frontend policy.
+

--- a/apps/aevatar-console-web/docs/superpowers/specs/2026-08-11-vnext-list-return-refresh-design.md
+++ b/apps/aevatar-console-web/docs/superpowers/specs/2026-08-11-vnext-list-return-refresh-design.md
@@ -54,4 +54,3 @@ the bug rather than passing because test data is immediately stale. Cover:
 Run only the changed test files and affected frontend checks. The complete
 frontend suite, typecheck, and production build remain delegated to GitHub CI
 under the personal incremental frontend policy.
-

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import * as React from 'react';
 import { history } from '@/shared/navigation/history';
@@ -102,6 +103,30 @@ describe('Workflow Activity vNext Activity ledger', () => {
       screen.getByRole('searchbox', { name: 'Search runs' }),
     ).toBeEnabled();
     expect(screen.queryByText('No runs yet')).not.toBeInTheDocument();
+  });
+
+  it('refreshes runs when returning to activity', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          refetchOnWindowFocus: false,
+          retry: false,
+          staleTime: 30_000,
+        },
+      },
+    });
+    const firstView = renderWithQueryClient(
+      <ActivityPage scopeId="scope-alpha" />,
+      queryClient,
+    );
+
+    await waitFor(() => expect(mockListRuns).toHaveBeenCalledTimes(1));
+    firstView.unmount();
+
+    renderWithQueryClient(<ActivityPage scopeId="scope-alpha" />, queryClient);
+
+    await waitFor(() => expect(mockListRuns).toHaveBeenCalledTimes(2));
   });
 
   it('renders the activity table skeleton while resolving a workflow filter', () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx
@@ -142,6 +142,7 @@ const ActivityPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         take: 100,
       }),
     enabled: workflowFilterReady,
+    refetchOnMount: 'always',
     retry: false,
   });
 

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query';
 import {
   act,
   fireEvent,
@@ -556,6 +557,59 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(
       screen.queryByRole('option', { name: 'Archived' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('refreshes the workflow catalogue when returning from the editor', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          refetchOnWindowFocus: false,
+          retry: false,
+          staleTime: 30_000,
+        },
+      },
+    });
+    mockStudioApi.getWorkspaceSettings.mockResolvedValue({
+      runtimeBaseUrl: '',
+      directories: [],
+    });
+    mockStudioApi.getWorkflow.mockResolvedValue({
+      workflowId: 'wf-alpha',
+      name: 'Workflow alpha',
+      fileName: 'workflow-alpha.yaml',
+      filePath: '/workflows/workflow-alpha.yaml',
+      directoryId: 'directory-alpha',
+      directoryLabel: 'Workflows',
+      yaml: 'name: workflow_alpha\nroles: []\nsteps: []\n',
+      updatedAtUtc: '2026-08-11T10:00:00Z',
+      document: { name: 'workflow_alpha', roles: [], steps: [] },
+      draftExists: true,
+      findings: [],
+    });
+    mockScopesApi.getWorkflowDetail.mockResolvedValue({
+      available: false,
+      scopeId: 'scope-alpha',
+      workflow: null,
+      source: null,
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />, queryClient);
+
+    await waitFor(() =>
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(1),
+    );
+
+    setMockLocation(
+      '/scopes/scope-alpha/workflow-activity-vnext/workflows/wf-alpha',
+    );
+    expect(await screen.findByDisplayValue('Workflow alpha')).toBeVisible();
+
+    setMockLocation('/scopes/scope-alpha/workflow-activity-vnext/workflows');
+
+    await waitFor(() =>
+      expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2),
+    );
   });
 
   it('maps unsupported legacy views to the backend all view', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -191,6 +191,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         signal,
       ),
     getNextPageParam: (lastPage) => lastPage.nextPageToken ?? undefined,
+    refetchOnMount: 'always',
     retry: false,
   });
 


### PR DESCRIPTION
## Problem and solution

The shared React Query client keeps successful data fresh for 30 seconds. Returning from the workflow editor remounted Workflows while its catalogue cache was still fresh, so no request was made and the list could remain stale.

- Make the Workflows catalogue revalidate whenever its list surface mounts.
- Apply the same list-owned freshness contract to Activity runs for the analogous Run Detail to Activity return path.
- Add production-cache regressions for both return paths and document the behavior contract.

## Impact paths

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/activity/ActivityPage.tsx`
- Focused vNext route and Activity tests
- vNext design and implementation documentation

## Local verification

- Related tests: `pnpm --dir apps/aevatar-console-web exec jest --findRelatedTests src/pages/workflow-activity-vnext/activity/ActivityPage.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx --runInBand` - 2 suites, 121 tests passed
- Changed tests: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx` - 2 suites, 121 tests passed
- Regression tests: both production-cache return tests passed after first failing with one request before the fix
- Changed-file static checks: `pnpm --dir apps/aevatar-console-web exec biome check src/pages/workflow-activity-vnext/activity/ActivityPage.test.tsx src/pages/workflow-activity-vnext/activity/ActivityPage.tsx src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx` - 4 files passed
- Stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Design baseline: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py` - 17/17 frames, byte-identical
- Docs lint: `bash tools/docs/lint.sh` - 87 files, 0 errors
- Whitespace: `git diff --check origin/feat/2026-08-04_workflow-activity-vnext` - passed
- A reliable affected TypeScript target is unavailable; full typecheck is delegated to GitHub CI
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy