### PR TITLE
Fix workflow template selection layout

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -182,6 +182,9 @@ export const workflowActivityVNextCss = `
 .wa-vnext__form > div > span:first-child { font-size: 12px; font-weight: 600; }
 .wa-vnext__form-actions { display: flex; flex-wrap: wrap; gap: 8px; }
 .wa-vnext__field-control { display: block; margin-top: 6px; width: 100%; }
+.wa-vnext__field-control.ant-select { align-items: center; display: flex; }
+.wa-vnext__field-control.ant-select .ant-select-content { align-items: center; display: flex; flex: 1 1 auto; min-width: 0; }
+.wa-vnext__field-control.ant-select .ant-select-suffix { align-items: center; display: flex; flex: 0 0 auto; }
 .wa-vnext__duplicate-warning { color: var(--wa-amber); font-size: 12px; line-height: 17px; margin: 6px 0 0; }
 .wa-vnext__modal-field { display: grid; font-size: 12px; font-weight: 600; gap: 6px; }
 .wa-vnext__mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx
@@ -252,18 +252,24 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
               .toLocaleLowerCase() === normalizedName,
         )),
   );
-  const templateName = t(
-    'workflowActivityVNext.new.templateName.incidentTriage',
-    'Incident triage',
-  );
-  const templateDescription = t(
-    'workflowActivityVNext.new.templateDescription.incidentTriage',
-    'Classify an incident, prepare a response, and request human approval.',
-  );
-  const templateCopyName = t(
-    'workflowActivityVNext.new.templateCopyName.incidentTriage',
-    'Incident triage copy',
-  );
+  const templateName = selectedTemplate
+    ? t(
+        selectedTemplate.nameMessage.id,
+        selectedTemplate.nameMessage.defaultMessage,
+      )
+    : '';
+  const templateDescription = selectedTemplate
+    ? t(
+        selectedTemplate.descriptionMessage.id,
+        selectedTemplate.descriptionMessage.defaultMessage,
+      )
+    : '';
+  const templateCopyName = selectedTemplate
+    ? t(
+        selectedTemplate.copyNameMessage.id,
+        selectedTemplate.copyNameMessage.defaultMessage,
+      )
+    : '';
   const saveTargetUnavailable = !directoryId;
   const workspaceAccessDenied =
     isStudioApiStatus(workspace.error, 401) ||
@@ -529,7 +535,10 @@ const NewWorkflowPage: React.FC<{ readonly scopeId: string }> = ({
                     )}
                     onChange={setTemplateId}
                     options={BUNDLED_WORKFLOW_TEMPLATES.map((item) => ({
-                      label: templateName,
+                      label: t(
+                        item.nameMessage.id,
+                        item.nameMessage.defaultMessage,
+                      ),
                       value: item.id,
                     }))}
                     className="wa-vnext__field-control"

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowCreation.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowCreation.ts
@@ -3,14 +3,35 @@ import type { StudioWorkflowDocument } from '@/shared/studio/models';
 export type WorkflowCreationMode = 'describe' | 'import' | 'template';
 
 export type BundledWorkflowTemplate = {
+  readonly copyNameMessage: WorkflowTemplateMessage;
+  readonly descriptionMessage: WorkflowTemplateMessage;
   readonly id: string;
+  readonly nameMessage: WorkflowTemplateMessage;
   readonly version: string;
   readonly yaml: string;
 };
 
+export type WorkflowTemplateMessage = {
+  readonly defaultMessage: string;
+  readonly id: string;
+};
+
 export const BUNDLED_WORKFLOW_TEMPLATES: readonly BundledWorkflowTemplate[] = [
   {
+    copyNameMessage: {
+      defaultMessage: 'Incident triage copy',
+      id: 'workflowActivityVNext.new.templateCopyName.incidentTriage',
+    },
+    descriptionMessage: {
+      defaultMessage:
+        'Classify an incident, prepare a response, and request human approval.',
+      id: 'workflowActivityVNext.new.templateDescription.incidentTriage',
+    },
     id: 'incident-triage',
+    nameMessage: {
+      defaultMessage: 'Incident triage',
+      id: 'workflowActivityVNext.new.templateName.incidentTriage',
+    },
     version: '2026.08.1',
     yaml: `name: incident_triage
 description: Classify an incident and prepare a reviewed response.


### PR DESCRIPTION
## Problem and solution

- Fix the Workflow Activity vNext template selector so its selected value, input layer, and chevron remain on one vertically centred row.
- The defect was caused by the generic field control applying block layout to the current Ant Design Select implementation, which stacked its suffix below the selected value.
- Scope the layout correction to creation-form Select controls, including the optional Save to selector. No backend contract or backend code changes.
- Move each bundled template display name, description, and independently created draft name into its own frontend template definition. The page now derives option labels, preview copy, and draft copy names from the selected template instead of hard-coding Incident triage.

## Template configuration

- Frontend-bundled templates live in apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowCreation.ts.
- To add one, append a BUNDLED_WORKFLOW_TEMPLATES entry with id, version, yaml, nameMessage, descriptionMessage, and copyNameMessage.
- Add the three message IDs to both en-US and zh-CN vNext locale catalogues.
- Template IDs remain frontend product content. A newly created draft always uses the authoritative workflowId returned by the draft API.

## Impact paths

- New workflow, Use template creation path.
- Optional creation Save to selector.
- Bundled template expansion and localization.

## Design baseline

- Design SHA-256: 30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
- Baseline verifier: apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py
- Production data source: real APIs and API-acknowledged user actions only; no mock fallback.

## Local verification

- pnpm exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
  Result: 1 suite, 12 tests passed.
- pnpm exec biome check src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.tsx src/pages/workflow-activity-vnext/workflows/workflowCreation.ts
  Result: passed, no fixes applied.
- python3 docs/design-baselines/workflow-activity-vnext/verify-baseline.py
  Result: 17/17 frames and byte-identical generator output.
- git diff --check origin/feat/2026-08-04_workflow-activity-vnext...HEAD
  Result: passed.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
- Full package TypeScript check: deferred to GitHub CI because no reliable affected typecheck target is available.
