### PR TITLE
Restore delete draft action for workflows with history

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1068,6 +1068,41 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(screen.queryByRole('menuitem', { name: 'Archive' })).toBeNull();
   });
 
+  it('shows Delete draft without Archive when committed history has no active revision', async () => {
+    mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
+      createCatalogueResponse([
+        createCatalogueRow({
+          workflowId: 'wf-draft-with-history',
+          name: 'Draft workflow with history',
+          committed: {
+            serviceKey: 'opaque-service-key',
+            workflowName: 'draft_with_history',
+            actorId: 'm-alpha',
+            activeRevisionId: '',
+            deploymentId: '',
+            deploymentStatus: '',
+          },
+          hasDraftSource: true,
+        }),
+      ]),
+    );
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const row = (
+      await screen.findByText('Draft workflow with history')
+    ).closest('tr');
+    fireEvent.click(
+      within(row as HTMLElement).getByRole('button', {
+        name: 'More actions for Draft workflow with history in Workspace',
+      }),
+    );
+    expect(
+      await screen.findByRole('menuitem', { name: 'Delete draft' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Archive' })).toBeNull();
+  });
+
   it('shows Archive without Delete draft for a published workflow that still has a draft', async () => {
     mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
       createCatalogueResponse([

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -684,7 +684,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 const isArchived = isWorkflowArchived(row);
                 const isPublished = Boolean(row.activeRevisionId);
                 const canDeleteDraft =
-                  row.capabilities.delete.available && !row.hasCommittedSource;
+                  row.capabilities.delete.available && !isPublished;
                 const workflowName = (
                   <span className="wa-vnext__title">{row.name}</span>
                 );


### PR DESCRIPTION
## 问题与方案

Workflow catalogue 允许一个 row 同时存在 draft source 和 committed history，但当前没有 active revision。此前 Archive 修复使用 `hasCommittedSource` 隐藏 `Delete draft`，导致这种仍显示为 Draft 的 workflow 没有删除入口。

本 PR 将 destructive action 的状态判断收敛为：

- 后端 `capabilities.delete.available` 必须允许删除 draft；
- 只有不存在 active revision 时显示 `Delete draft`；
- Published workflow 继续只显示 `Archive`；
- Archived workflow 继续不显示 destructive action。

同时新增 route integration 回归用例，覆盖 `hasDraftSource = true`、`hasCommittedSource = true`、`activeRevisionId = empty` 的重叠状态。

## 影响路径

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`

不涉及后端合同、API、路由、样式或文案变更。现有设计已定义 Draft、Published 和 Archive 的动作层级，无需更新文档。

## Local verification

- Scope analysis: `python3 /Users/abigaildeng/.codex/skills/frontend-incremental-pr/scripts/frontend_change_scope.py --repo . --base origin/feat/2026-08-04_workflow-activity-vnext` - one Jest package, 2 changed frontend files
- Dependency preflight: `pnpm exec jest --listTests --findRelatedTests src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx` - selected 1 owning-route test file
- Changed and related tests: `pnpm exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx` - 1 suite passed, 109 tests passed
- Destructive-action matrix after final formatting: `pnpm exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx --testNamePattern "shows (Delete draft|Archive)"` - 4 tests passed
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx` - 2 files passed
- Test stability guard: `bash tools/ci/test_stability_guards.sh` - passed
- Design baseline integrity: `python3 apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/verify-baseline.py` - 17/17 frames, byte-identical, passed
- A reliable affected typecheck target is unavailable, so local typecheck was skipped
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

## Design baseline

```text
Design baseline:
  apps/aevatar-console-web/docs/design-baselines/workflow-activity-vnext/
Primary design:
  aevatar-workflow-activity-vnext.excalidraw
Design SHA-256:
  30e74d7b410ae72c4c91432355436679033679c54c10b1702908435b001577de
Contract specification:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-design.md
User paths:
  apps/aevatar-console-web/docs/superpowers/specs/
  2026-08-04-workflow-activity-vnext-user-paths.md
Authentication and localization:
  Existing Aevatar login, callback, session, returnTo, and Umi locale logic;
  presentation may change, behavior may not.
Production data source:
  Real APIs and API-acknowledged user actions only; no mock fallback.
Baseline integrity:
  python3 apps/aevatar-console-web/docs/design-baselines/
  workflow-activity-vnext/verify-baseline.py
```