### PR TITLE
Allow empty workflow stream invocations

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1840,7 +1840,7 @@ public static class ScopeServiceEndpoints
             endpointId,
             multipartFileInputParser,
             appId,
-            false,
+            true,
             resolutionService,
             readinessErrorMapper,
             admissionAuthorizer,
@@ -1859,7 +1859,7 @@ public static class ScopeServiceEndpoints
         string endpointId,
         WorkflowMultipartFileInputParser multipartFileInputParser,
         string? appId,
-        bool allowEmptyInputForResolvedMemberWorkflow,
+        bool allowEmptyInputForResolvedWorkflowService,
         [FromServices] ServiceInvocationResolutionService resolutionService,
         [FromServices] ServiceInvokeReadinessErrorMapper readinessErrorMapper,
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
@@ -1990,7 +1990,7 @@ public static class ScopeServiceEndpoints
                             correlationId: receipt.CorrelationId,
                             targetActorId: receipt.ActorId,
                             token),
-                        allowEmptyInputForResolvedMemberWorkflow: allowEmptyInputForResolvedMemberWorkflow,
+                        allowEmptyInputForResolvedWorkflowService: allowEmptyInputForResolvedWorkflowService,
                         resolvedDefinitionBinding: resolvedDefinitionBinding);
                     break;
 

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatEndpoints.cs
@@ -76,7 +76,7 @@ public static class WorkflowCapabilityEndpoints
         Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerCredential? trustedCallerCredential = null,
         CancellationToken cancellationToken = default,
         string? trustedScopeId = null,
-        bool allowEmptyInputForResolvedMemberWorkflow = false) =>
+        bool allowEmptyInputForResolvedWorkflowService = false) =>
         ChatRunRequestNormalizer.NormalizeAsync(
             input,
             fileIngressPort,
@@ -84,7 +84,7 @@ public static class WorkflowCapabilityEndpoints
             trustedCallerCredential,
             cancellationToken,
             trustedScopeId,
-            allowEmptyInputForResolvedMemberWorkflow);
+            allowEmptyInputForResolvedWorkflowService);
 
     internal static async Task HandleChatPost(
         HttpContext http,
@@ -198,7 +198,7 @@ public static class WorkflowCapabilityEndpoints
         CancellationToken ct = default,
         Func<WorkflowChatRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedHook = null,
         IFileArtifactIngressPort? fileIngressPort = null,
-        bool allowEmptyInputForResolvedMemberWorkflow = false,
+        bool allowEmptyInputForResolvedWorkflowService = false,
         WorkflowDefinitionBinding? resolvedDefinitionBinding = null)
     {
         using var scope = ApiRequestScope.BeginHttp();
@@ -248,7 +248,7 @@ public static class WorkflowCapabilityEndpoints
                 trustedCallerCredential: callerCredential.Credential,
                 cancellationToken: ct,
                 trustedScopeId: trustedScopeId,
-                allowEmptyInputForResolvedMemberWorkflow: allowEmptyInputForResolvedMemberWorkflow);
+                allowEmptyInputForResolvedWorkflowService: allowEmptyInputForResolvedWorkflowService);
             if (!normalizedRequest.Succeeded)
             {
                 var (code, message) = ChatRunStartErrorMapper.ToCommandError(normalizedRequest.Error);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatRunRequestNormalizer.cs
@@ -35,7 +35,7 @@ internal static class ChatRunRequestNormalizer
         IReadOnlyDictionary<string, string>? defaultMetadata = null,
         WorkflowCallerCredential? trustedCallerCredential = null,
         string? trustedScopeId = null,
-        bool allowEmptyInputForResolvedMemberWorkflow = false)
+        bool allowEmptyInputForResolvedWorkflowService = false)
     {
         // Refactor (iter112/cluster-3): Old pattern: host passed normalized legacy mirror fields into Application commands. New principle: host normalizes wire aliases once into typed WorkflowChatSource.
         // Refactor (iter349/cluster-349):
@@ -49,7 +49,7 @@ internal static class ChatRunRequestNormalizer
             defaultMetadata,
             trustedCallerCredential,
             trustedScopeId,
-            allowEmptyInputForResolvedMemberWorkflow,
+            allowEmptyInputForResolvedWorkflowService,
             chatConversation: null);
     }
 
@@ -58,7 +58,7 @@ internal static class ChatRunRequestNormalizer
         IReadOnlyDictionary<string, string>? defaultMetadata = null,
         WorkflowCallerCredential? trustedCallerCredential = null,
         string? trustedScopeId = null,
-        bool allowEmptyInputForResolvedMemberWorkflow = false)
+        bool allowEmptyInputForResolvedWorkflowService = false)
     {
         ArgumentNullException.ThrowIfNull(input);
 
@@ -74,7 +74,7 @@ internal static class ChatRunRequestNormalizer
                 defaultMetadata,
                 trustedCallerCredential,
                 trustedScopeId,
-                allowEmptyInputForResolvedMemberWorkflow,
+                allowEmptyInputForResolvedWorkflowService,
                 conversationResult.Conversation),
             input.CommandId);
     }
@@ -163,7 +163,7 @@ internal static class ChatRunRequestNormalizer
         WorkflowCallerCredential? trustedCallerCredential = null,
         CancellationToken cancellationToken = default,
         string? trustedScopeId = null,
-        bool allowEmptyInputForResolvedMemberWorkflow = false)
+        bool allowEmptyInputForResolvedWorkflowService = false)
     {
         ArgumentNullException.ThrowIfNull(input);
         var normalizedInputParts = fileIngressPort == null
@@ -175,7 +175,7 @@ internal static class ChatRunRequestNormalizer
             defaultMetadata,
             trustedCallerCredential,
             trustedScopeId,
-            allowEmptyInputForResolvedMemberWorkflow,
+            allowEmptyInputForResolvedWorkflowService,
             chatConversation: null);
     }
 
@@ -186,7 +186,7 @@ internal static class ChatRunRequestNormalizer
         WorkflowCallerCredential? trustedCallerCredential = null,
         CancellationToken cancellationToken = default,
         string? trustedScopeId = null,
-        bool allowEmptyInputForResolvedMemberWorkflow = false)
+        bool allowEmptyInputForResolvedWorkflowService = false)
     {
         ArgumentNullException.ThrowIfNull(input);
 
@@ -204,7 +204,7 @@ internal static class ChatRunRequestNormalizer
                 defaultMetadata,
                 trustedCallerCredential,
                 trustedScopeId,
-                allowEmptyInputForResolvedMemberWorkflow,
+                allowEmptyInputForResolvedWorkflowService,
                 conversationResult.Conversation),
             input.CommandId);
     }
@@ -215,7 +215,7 @@ internal static class ChatRunRequestNormalizer
         IReadOnlyDictionary<string, string>? defaultMetadata,
         WorkflowCallerCredential? trustedCallerCredential,
         string? trustedScopeId,
-        bool allowEmptyInputForResolvedMemberWorkflow,
+        bool allowEmptyInputForResolvedWorkflowService,
         WorkflowChatConversationIntent? chatConversation)
     {
         if (normalizedInputPartsResult.Error != WorkflowChatRunStartError.None)
@@ -237,7 +237,7 @@ internal static class ChatRunRequestNormalizer
 
         var rawPrompt = ResolvePrompt(input.Prompt, normalizedInputParts);
         if (rawPrompt.Length == 0 &&
-            !CanStartWithoutInput(sourceResult.Source!, allowEmptyInputForResolvedMemberWorkflow))
+            !CanStartWithoutInput(sourceResult.Source!, allowEmptyInputForResolvedWorkflowService))
             return ChatRunRequestNormalizationResult.Failed(WorkflowChatRunStartError.PromptRequired);
 
         var callerCredentialResult = NormalizeCallerCredential(trustedCallerCredential);
@@ -904,8 +904,8 @@ internal static class ChatRunRequestNormalizer
 
     private static bool CanStartWithoutInput(
         WorkflowChatSource source,
-        bool allowEmptyInputForResolvedMemberWorkflow) =>
-        allowEmptyInputForResolvedMemberWorkflow &&
+        bool allowEmptyInputForResolvedWorkflowService) =>
+        allowEmptyInputForResolvedWorkflowService &&
         source.Kind == WorkflowChatSourceKind.DefinitionActor &&
         !string.IsNullOrWhiteSpace(source.DefinitionActorSource?.ActorId);
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
@@ -151,6 +151,20 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
     }
 
     [Fact]
+    public async Task ScopeInvokeStreamEndpoint_ShouldRejectEmptyInputForDefaultWorkflowRoute()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        await ConfigureWorkflowStreamServiceAsync(host, serviceId: "default", definitionActorId: "definition-actor-default");
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/invoke/chat:stream", new { });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "stream body: {0}", body);
+        body.Should().Contain("PROMPT_REQUIRED");
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ScopeInvokeStreamEndpoint_ShouldReturnInvalidCallerCredential_WhenBearerIsMalformed()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -840,6 +854,85 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
     }
 
     [Fact]
+    public async Task InvokeStreamEndpoint_ShouldAllowEmptyJsonObjectForWorkflowTarget()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        await ConfigureWorkflowStreamServiceAsync(host);
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/services/orders/invoke/chat:stream", new { });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        body.Should().Contain("aevatar.run.context");
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.Prompt.Should().BeEmpty();
+        host.InteractionService.LastRequest.Source.ActorId.Should().Be("definition-actor-orders");
+        host.ServiceRunRegistrationPort.RegisterCalls.Should().ContainSingle()
+            .Which.ImplementationKind.Should().Be(ServiceImplementationKind.Workflow);
+    }
+
+    [Fact]
+    public async Task InvokeStreamEndpoint_ShouldAllowEmptyPromptJsonForWorkflowTarget()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        await ConfigureWorkflowStreamServiceAsync(host);
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/services/orders/invoke/chat:stream", new
+        {
+            prompt = string.Empty,
+        });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        body.Should().Contain("aevatar.run.context");
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.Prompt.Should().BeEmpty();
+        host.InteractionService.LastRequest.Source.ActorId.Should().Be("definition-actor-orders");
+        host.ServiceRunRegistrationPort.RegisterCalls.Should().ContainSingle()
+            .Which.ImplementationKind.Should().Be(ServiceImplementationKind.Workflow);
+    }
+
+    [Fact]
+    public async Task InvokeStreamEndpoint_ShouldAllowEmptyMultipartForWorkflowTarget()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        await ConfigureWorkflowStreamServiceAsync(host);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/api/scopes/scope-a/services/orders/invoke/chat:stream")
+        {
+            Content = CreateMultipartScopeStreamContent("{}", []),
+        };
+
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        body.Should().Contain("aevatar.run.context");
+        host.WorkflowFileIngressPort.Requests.Should().BeEmpty();
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.Prompt.Should().BeEmpty();
+        host.InteractionService.LastRequest.InputParts.Should().BeNull();
+        host.InteractionService.LastRequest.Source.ActorId.Should().Be("definition-actor-orders");
+    }
+
+    [Fact]
+    public async Task InvokeStreamEndpoint_ShouldKeepEmptyInputOnStaticPath()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        await ConfigureStaticStreamServiceAsync(host);
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/services/static-agent/invoke/chat:stream", new { });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "stream body: {0}", body);
+        body.Should().Contain("INVALID_SERVICE_STREAM_REQUEST");
+        body.Should().Contain("GAgent kind could not be resolved");
+        host.InteractionService.LastRequest.Should().BeNull();
+        host.StaticGAgentStreamInvocationPort.Requests.Should().ContainSingle();
+        host.StaticGAgentStreamInvocationPort.Requests[0].Input.Prompt.Should().BeEmpty();
+        host.ServiceRunRegistrationPort.RegisterCalls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task MemberInvokeStreamEndpoint_ShouldIngestInlineFileIntoTypedFileRef()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -1344,6 +1437,26 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
     }
 
     [Fact]
+    public async Task TeamInvokeStreamEndpoint_ShouldRejectEmptyInputForWorkflowRoute()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Result = new TeamEntryMemberResolution(
+            "scope-a",
+            "team-a",
+            "member-a",
+            "member-a");
+        await ConfigureWorkflowStreamServiceAsync(host, serviceId: "member-a", definitionActorId: "definition-actor-member-a");
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-a/invoke/chat:stream", new { });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest, "stream body: {0}", body);
+        body.Should().Contain("PROMPT_REQUIRED");
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a", "chat"));
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task TeamInvokeStreamEndpoint_ShouldMapMissingEntryToConflict()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -1467,6 +1580,133 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
         host.InteractionService.LastRequest!.Source.ActorId.Should().Be("definition-actor-orders");
         host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
         host.InteractionService.LastRequest.Headers.Should().ContainKey("channel").WhoseValue.Should().Be("tests");
+    }
+
+    private static async Task ConfigureWorkflowStreamServiceAsync(
+        ScopeServiceEndpointTestHost host,
+        string serviceId = "orders",
+        string definitionActorId = "definition-actor-orders")
+    {
+        var revisionId = $"rev-{serviceId}-1";
+        var deploymentId = $"dep-{serviceId}-1";
+        var service = BuildService("scope-a", serviceId, definitionActorId);
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            deploymentId,
+                            revisionId,
+                            definitionActorId,
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.RevisionCatalog.UpsertRevisionAsync(
+            service.ServiceKey,
+            revisionId,
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = serviceId,
+                },
+                RevisionId = revisionId,
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    WorkflowPlan = BuildInteractiveWorkflowPlan(
+                        serviceId,
+                        $"name: {serviceId}\nsteps:\n  - run: echo {serviceId}",
+                        definitionActorId),
+                },
+            },
+            CancellationToken.None);
+        host.InteractionService.ResultFactory = async (request, emitAsync, onAcceptedAsync, ct) =>
+        {
+            var receipt = new WorkflowChatRunAcceptedReceipt($"run-actor-{serviceId}", serviceId, $"cmd-{serviceId}", $"corr-{serviceId}");
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+            return WorkflowChatRunInteractionResult
+                .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+        };
+    }
+
+    private static async Task ConfigureStaticStreamServiceAsync(ScopeServiceEndpointTestHost host)
+    {
+        var service = BuildService("scope-a", "static-agent", "definition-actor-static");
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            "dep-static-1",
+                            "rev-static-1",
+                            "definition-actor-static",
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.RevisionCatalog.UpsertRevisionAsync(
+            service.ServiceKey,
+            "rev-static-1",
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = "static-agent",
+                },
+                RevisionId = "rev-static-1",
+                ImplementationKind = ServiceImplementationKind.Static,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    StaticPlan = new StaticServiceDeploymentPlan
+                    {
+                        ActorTypeName = "Test.StaticAgent, Tests",
+                    },
+                },
+            },
+            CancellationToken.None);
     }
 
     private static WorkflowServiceDeploymentPlan BuildInteractiveWorkflowPlan(

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpoints/ScopeServiceStreamInvocationEndpointTests.cs
@@ -1443,9 +1443,9 @@ public sealed class ScopeServiceStreamInvocationEndpointTests : ScopeServiceEndp
         host.TeamEntryMemberResolver.Result = new TeamEntryMemberResolution(
             "scope-a",
             "team-a",
-            "member-a",
-            "member-a");
-        await ConfigureWorkflowStreamServiceAsync(host, serviceId: "member-a", definitionActorId: "definition-actor-member-a");
+            "m-alpha",
+            "svc-alpha");
+        await ConfigureWorkflowStreamServiceAsync(host, serviceId: "svc-alpha", definitionActorId: "definition-actor-svc-alpha");
 
         var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-a/invoke/chat:stream", new { });
         var body = await response.Content.ReadAsStringAsync();

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatEndpointsInternalTests.cs
@@ -497,7 +497,7 @@ public sealed class ChatEndpointsInternalTests
     }
 
     [Fact]
-    public async Task HandleChat_ShouldAcceptEmptyPromptForResolvedMemberWorkflowSource()
+    public async Task HandleChat_ShouldAcceptEmptyPromptForResolvedWorkflowServiceSource()
     {
         var capturedCommand = default(WorkflowChatRunRequest);
         var http = CreateHttpContext();
@@ -535,7 +535,7 @@ public sealed class ChatEndpointsInternalTests
             },
             interactionService,
             CancellationToken.None,
-            allowEmptyInputForResolvedMemberWorkflow: true);
+            allowEmptyInputForResolvedWorkflowService: true);
 
         var body = await ReadBodyAsync(http.Response);
         http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);

--- a/test/Aevatar.Workflow.Host.Api.Tests/ChatRunRequestNormalizerEmptyInputTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/ChatRunRequestNormalizerEmptyInputTests.cs
@@ -7,7 +7,7 @@ namespace Aevatar.Workflow.Host.Api.Tests;
 public sealed class ChatRunRequestNormalizerEmptyInputTests
 {
     [Fact]
-    public void Normalize_ShouldRejectEmptyInputForTypedDefinitionActorSourceWithoutResolvedMemberWorkflow()
+    public void Normalize_ShouldRejectEmptyInputForTypedDefinitionActorSourceWithoutResolvedWorkflowService()
     {
         var result = ChatRunRequestNormalizer.Normalize(new ChatInput
         {
@@ -28,7 +28,7 @@ public sealed class ChatRunRequestNormalizerEmptyInputTests
     }
 
     [Fact]
-    public void Normalize_ShouldAllowEmptyInputForResolvedMemberWorkflow()
+    public void Normalize_ShouldAllowEmptyInputForResolvedWorkflowService()
     {
         var result = ChatRunRequestNormalizer.Normalize(
             new ChatInput
@@ -44,7 +44,7 @@ public sealed class ChatRunRequestNormalizerEmptyInputTests
                     },
                 },
             },
-            allowEmptyInputForResolvedMemberWorkflow: true);
+            allowEmptyInputForResolvedWorkflowService: true);
 
         result.Succeeded.Should().BeTrue();
         result.Request!.Prompt.Should().BeEmpty();
@@ -53,11 +53,11 @@ public sealed class ChatRunRequestNormalizerEmptyInputTests
     }
 
     [Fact]
-    public void NormalizeHttp_ShouldAllowEmptyResolvedMemberInputAndPreserveCallerCommandId()
+    public void NormalizeHttp_ShouldAllowEmptyResolvedWorkflowServiceInputAndPreserveCallerCommandId()
     {
         var result = ChatRunRequestNormalizer.Normalize(
-            BuildEmptyResolvedMemberHttpInput(),
-            allowEmptyInputForResolvedMemberWorkflow: true);
+            BuildEmptyResolvedWorkflowServiceHttpInput(),
+            allowEmptyInputForResolvedWorkflowService: true);
 
         result.Succeeded.Should().BeTrue();
         result.Request!.Prompt.Should().BeEmpty();
@@ -67,12 +67,12 @@ public sealed class ChatRunRequestNormalizerEmptyInputTests
     }
 
     [Fact]
-    public async Task NormalizeHttpAsync_ShouldAllowEmptyResolvedMemberInputAndPreserveCallerCommandId()
+    public async Task NormalizeHttpAsync_ShouldAllowEmptyResolvedWorkflowServiceInputAndPreserveCallerCommandId()
     {
         var result = await ChatRunRequestNormalizer.NormalizeAsync(
-            BuildEmptyResolvedMemberHttpInput(),
+            BuildEmptyResolvedWorkflowServiceHttpInput(),
             fileIngressPort: null,
-            allowEmptyInputForResolvedMemberWorkflow: true);
+            allowEmptyInputForResolvedWorkflowService: true);
 
         result.Succeeded.Should().BeTrue();
         result.Request!.Prompt.Should().BeEmpty();
@@ -101,7 +101,7 @@ public sealed class ChatRunRequestNormalizerEmptyInputTests
         result.Error.Should().Be(WorkflowChatRunStartError.PromptRequired);
     }
 
-    private static HttpChatInput BuildEmptyResolvedMemberHttpInput() =>
+    private static HttpChatInput BuildEmptyResolvedWorkflowServiceHttpInput() =>
         new()
         {
             Prompt = "   ",


### PR DESCRIPTION
## Summary
- Allow empty input for the direct published-service workflow `chat:stream` route after service resolution/admission.
- Keep default, team, and non-authority member stream boundaries from inheriting the direct-route allowance.
- Add direct workflow empty JSON/empty prompt/empty multipart coverage plus boundary regressions for default/team/member/static paths.

Fixes #3402

## Test plan
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "FullyQualifiedName~ScopeServiceStreamInvocationEndpointTests|FullyQualifiedName~ScopeServiceTeamStreamMultipartTests"` - 27 passed
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "FullyQualifiedName~ChatRunRequestNormalizerEmptyInputTests|FullyQualifiedName~ChatEndpointsInternalTests"` - 87 passed
- [x] `git diff --check`
- [x] `PATH=/usr/bin:$PATH bash tools/ci/test_stability_guards.sh` - guard shell/meta checks passed through `NyxIdChat semantics guard tests passed`; final unittest stopped because `/usr/bin/python3` is 3.9 and cannot parse Python 3.10 union syntax
- [x] `python3 -m unittest tools/ci/tests/test_nyxid_semantic_evaluation.py` - 9 passed under Python 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)