### PR TITLE
Align workflow run detail artifacts by version

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -19,17 +19,20 @@ namespace Aevatar.GAgents.Channel.Identity;
 public sealed class AevatarOAuthClientBootstrapService : IHostedService
 {
     private readonly ICommandDispatchService<ProvisionAevatarOAuthClientCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> _provisioningDispatch;
+    private readonly ICommandDispatchService<RebuildAevatarOAuthClientProjectionCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> _projectionRebuildDispatch;
     private readonly AevatarOAuthClientOptions _clientOptions;
     private readonly AevatarOAuthClientBootstrapOptions _options;
     private readonly ILogger<AevatarOAuthClientBootstrapService> _logger;
 
     public AevatarOAuthClientBootstrapService(
         ICommandDispatchService<ProvisionAevatarOAuthClientCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> provisioningDispatch,
+        ICommandDispatchService<RebuildAevatarOAuthClientProjectionCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> projectionRebuildDispatch,
         IOptions<AevatarOAuthClientOptions> clientOptions,
         IOptions<AevatarOAuthClientBootstrapOptions> options,
         ILogger<AevatarOAuthClientBootstrapService> logger)
     {
         _provisioningDispatch = provisioningDispatch ?? throw new ArgumentNullException(nameof(provisioningDispatch));
+        _projectionRebuildDispatch = projectionRebuildDispatch ?? throw new ArgumentNullException(nameof(projectionRebuildDispatch));
         _clientOptions = clientOptions?.Value ?? throw new ArgumentNullException(nameof(clientOptions));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -87,13 +90,20 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         if (!accepted.Succeeded || accepted.Receipt is null)
             throw new InvalidOperationException($"Aevatar OAuth client bootstrap dispatch rejected: {accepted.Error}.");
 
+        var rebuildAccepted = await _projectionRebuildDispatch
+            .DispatchAsync(new RebuildAevatarOAuthClientProjectionCommand(), ct)
+            .ConfigureAwait(false);
+        if (!rebuildAccepted.Succeeded || rebuildAccepted.Receipt is null)
+            throw new InvalidOperationException($"Aevatar OAuth client projection rebuild dispatch rejected: {rebuildAccepted.Error}.");
+
         _logger.LogInformation(
-            "Configured Aevatar OAuth client provisioning accepted for {ActorId} (client_id={ClientId}, authority={Authority}, command_id={CommandId}). " +
+            "Configured Aevatar OAuth client provisioning accepted for {ActorId} (client_id={ClientId}, authority={Authority}, command_id={CommandId}, rebuild_command_id={RebuildCommandId}). " +
             "Production deployments must enable broker_capability_enabled on this client at NyxID admin (one-time per cluster).",
             AevatarOAuthClientGAgent.WellKnownId,
             command.ClientId,
             authority,
-            accepted.Receipt.CommandId);
+            accepted.Receipt.CommandId,
+            rebuildAccepted.Receipt.CommandId);
     }
 
     private void ValidateStartupProvisioningBoundary(string authority, string redirectUri)

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowArtifactQueryTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowArtifactQueryTool.cs
@@ -101,6 +101,7 @@ public sealed class WorkflowArtifactQueryTool : IAgentTool
             subgraph = new
             {
                 root = subgraph.RootNodeId,
+                source_state_version = subgraph.SourceStateVersion,
                 nodes = subgraph.Nodes.Select(n => new
                 {
                     id = n.NodeId, type = n.NodeType, updated_at = n.UpdatedAt,

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -686,6 +686,9 @@ message StepRequestEvent
   // Compiled external tool invocation for this call site. Present for direct external tool
   // steps and for the primitives that synthesize external sub-steps at runtime.
   ExternalToolInvocationSpec external_invocation = 11;
+  // Runtime copy of the workflow-node display name for this executed step. Falls back to step_id
+  // when the authoring model did not provide a distinct label.
+  string display_name = 12;
 }
 message WorkflowUsageMetrics {
   int32 prompt_tokens = 1;
@@ -705,6 +708,14 @@ message WorkflowFileItemResult {
 message WorkflowFileItemResultSet {
   repeated WorkflowFileItemResult results = 1;
 }
+
+enum WorkflowStepCompletionOutcome {
+  WORKFLOW_STEP_COMPLETION_OUTCOME_UNSPECIFIED = 0;
+  WORKFLOW_STEP_COMPLETION_OUTCOME_SUCCEEDED = 1;
+  WORKFLOW_STEP_COMPLETION_OUTCOME_FAILED = 2;
+  WORKFLOW_STEP_COMPLETION_OUTCOME_SKIPPED = 3;
+}
+
 message StepCompletedEvent {
   string step_id = 1;
   bool success = 2;
@@ -723,6 +734,7 @@ message StepCompletedEvent {
   WorkflowStepFailureOutcome failure_outcome = 15;
   WorkflowFileItemResultSet file_item_results = 16;
   WorkflowRecoveryFailureKind recovery_failure_kind = 17;
+  WorkflowStepCompletionOutcome outcome = 18;
 }
 message SubWorkflowInvokeRequestedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Observatory/IWorkflowRunObservatoryQueryService.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Observatory/IWorkflowRunObservatoryQueryService.cs
@@ -1,5 +1,6 @@
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
+using System.Text.Json.Serialization;
 
 namespace Aevatar.Workflow.Application.Abstractions.Observatory;
 
@@ -207,6 +208,12 @@ public sealed class ObservatoryRunDetail
 {
     public ObservatoryRunSummary Summary { get; init; } = new();
 
+    public WorkflowActivityRunInitiatorSummary Initiator { get; init; } = new();
+
+    public string InputSummary { get; init; } = string.Empty;
+
+    public ObservatoryRunDetailSectionVersions Sections { get; init; } = new();
+
     // 06-26 detail enrichment: the run's authoritative input + final result, surfaced from the committed
     // run-report artifact. These are NOT truncated by materialization (unlike per-step OutputPreview), so the
     // viewer can show the real final output/error honestly. FinalOutput is empty while a run is still running.
@@ -227,6 +234,8 @@ public sealed class ObservatoryRunDetail
 
     public IReadOnlyList<ObservatoryViewEvent> Timeline { get; init; } = [];
 
+    public ObservatoryRunGraph ExecutionPath { get; init; } = new();
+
     public ObservatoryRunStatistics Statistics { get; init; } = new();
 
     public ObservatoryUsageTotals UsageTotals { get; init; } = new();
@@ -234,6 +243,45 @@ public sealed class ObservatoryRunDetail
     public WorkflowRunRecoveryCapability RecoveryCapability { get; init; } = new();
 
     public WorkflowRunLineage Lineage { get; init; } = new();
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<ObservatoryRunDetailSectionVersionStatus>))]
+public enum ObservatoryRunDetailSectionVersionStatus
+{
+    [JsonStringEnumMemberName("unknown")]
+    Unknown = 0,
+
+    [JsonStringEnumMemberName("aligned")]
+    Aligned = 1,
+
+    [JsonStringEnumMemberName("unavailable")]
+    Unavailable = 2,
+
+    [JsonStringEnumMemberName("version_mismatch")]
+    VersionMismatch = 3,
+}
+
+public sealed class ObservatoryRunDetailSectionVersions
+{
+    public ObservatoryRunDetailSectionVersion Overview { get; init; } = new();
+
+    public ObservatoryRunDetailSectionVersion Steps { get; init; } = new();
+
+    public ObservatoryRunDetailSectionVersion Timeline { get; init; } = new();
+
+    public ObservatoryRunDetailSectionVersion ExecutionPath { get; init; } = new();
+}
+
+public sealed class ObservatoryRunDetailSectionVersion
+{
+    public long DetailStateVersion { get; init; }
+
+    public long SourceStateVersion { get; init; }
+
+    public ObservatoryRunDetailSectionVersionStatus VersionStatus { get; init; } =
+        ObservatoryRunDetailSectionVersionStatus.Unknown;
+
+    public string Reason { get; init; } = string.Empty;
 }
 
 public sealed class ObservatoryRunDiagnostic
@@ -262,6 +310,8 @@ public sealed class ObservatoryStepDetail
 {
     public string StepId { get; init; } = string.Empty;
 
+    public string DisplayName { get; init; } = string.Empty;
+
     public string StepType { get; init; } = string.Empty;
 
     public string TargetRole { get; init; } = string.Empty;
@@ -271,6 +321,9 @@ public sealed class ObservatoryStepDetail
     public DateTimeOffset? CompletedAtUtc { get; init; }
 
     public bool? Success { get; init; }
+
+    [JsonConverter(typeof(WorkflowRunStepOutcomeJsonConverter))]
+    public WorkflowRunStepOutcome Outcome { get; init; } = WorkflowRunStepOutcome.Unspecified;
 
     public double? DurationMs { get; init; }
 
@@ -385,6 +438,15 @@ public sealed class ObservatoryRunGraph
 {
     public string RootNodeId { get; init; } = string.Empty;
 
+    public long DetailStateVersion { get; init; }
+
+    public long SourceStateVersion { get; init; }
+
+    public ObservatoryRunDetailSectionVersionStatus VersionStatus { get; init; } =
+        ObservatoryRunDetailSectionVersionStatus.Unknown;
+
+    public string VersionReason { get; init; } = string.Empty;
+
     public IReadOnlyList<ObservatoryGraphNode> Nodes { get; init; } = [];
 
     public IReadOnlyList<ObservatoryGraphEdge> Edges { get; init; } = [];
@@ -395,6 +457,8 @@ public sealed class ObservatoryGraphNode
     public string NodeId { get; init; } = string.Empty;
 
     public string NodeType { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
 
     // Bare workflow step id for WorkflowStep nodes (empty for run / actor topology nodes). The graph node
     // id is a composite key (step:{actor}:{cmd}:{stepId}); this surfaces the plain stepId so the viewer can

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Observatory/WorkflowRunStepOutcomeJsonConverter.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Observatory/WorkflowRunStepOutcomeJsonConverter.cs
@@ -1,0 +1,39 @@
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Aevatar.Workflow.Application.Abstractions.Observatory;
+
+public sealed class WorkflowRunStepOutcomeJsonConverter : JsonConverter<WorkflowRunStepOutcome>
+{
+    public override WorkflowRunStepOutcome Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return value switch
+        {
+            "succeeded" => WorkflowRunStepOutcome.Succeeded,
+            "failed" => WorkflowRunStepOutcome.Failed,
+            "waiting" => WorkflowRunStepOutcome.Waiting,
+            "skipped" => WorkflowRunStepOutcome.Skipped,
+            _ => WorkflowRunStepOutcome.Unspecified,
+        };
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        WorkflowRunStepOutcome value,
+        JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value switch
+        {
+            WorkflowRunStepOutcome.Succeeded => "succeeded",
+            WorkflowRunStepOutcome.Failed => "failed",
+            WorkflowRunStepOutcome.Waiting => "waiting",
+            WorkflowRunStepOutcome.Skipped => "skipped",
+            _ => "unspecified",
+        });
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowExecutionQueryModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowExecutionQueryModels.cs
@@ -179,6 +179,7 @@ public sealed class WorkflowRunStatistics
 public sealed class WorkflowRunStepTrace
 {
     public string StepId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
     public string StepType { get; set; } = string.Empty;
     public string TargetRole { get; set; } = string.Empty;
     public DateTimeOffset? RequestedAt { get; set; }
@@ -200,6 +201,7 @@ public sealed class WorkflowRunStepTrace
     public string RequestedVariableName { get; set; } = string.Empty;
     public WorkflowRunToolApproval? ToolApproval { get; set; }
     public WorkflowRunUsageMetrics Usage { get; set; } = new();
+    public WorkflowRunStepOutcome Outcome { get; set; } = WorkflowRunStepOutcome.Unspecified;
     public double? DurationMs => RequestedAt.HasValue && CompletedAt.HasValue
         ? Math.Max(0, (CompletedAt.Value - RequestedAt.Value).TotalMilliseconds)
         : null;

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/workflow_projection_query_models.proto
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/workflow_projection_query_models.proto
@@ -38,6 +38,14 @@ enum WorkflowRecoveryRecommendedAction {
   WORKFLOW_RECOVERY_RECOMMENDED_ACTION_TECHNICAL_DETAILS = 7;
 }
 
+enum WorkflowRunStepOutcome {
+  WORKFLOW_RUN_STEP_OUTCOME_UNSPECIFIED = 0;
+  WORKFLOW_RUN_STEP_OUTCOME_SUCCEEDED = 1;
+  WORKFLOW_RUN_STEP_OUTCOME_FAILED = 2;
+  WORKFLOW_RUN_STEP_OUTCOME_WAITING = 3;
+  WORKFLOW_RUN_STEP_OUTCOME_SKIPPED = 4;
+}
+
 message WorkflowRecoveryActionCapability {
   WorkflowRecoveryEligibility eligibility = 1;
   WorkflowRecoveryUnavailableReasonCode unavailable_reason_code = 2;
@@ -176,4 +184,5 @@ message WorkflowRunGraphExportSubgraph {
   string root_node_id = 1;
   repeated WorkflowRunGraphExportNode nodes = 2;
   repeated WorkflowRunGraphExportEdge edges = 3;
+  int64 source_state_version = 4;
 }

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Security/WorkflowAuditReportSanitizer.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Security/WorkflowAuditReportSanitizer.cs
@@ -47,6 +47,7 @@ public static class WorkflowAuditReportSanitizer
         new()
         {
             StepId = WorkflowAuditTextSanitizer.Sanitize(step.StepId),
+            DisplayName = WorkflowAuditTextSanitizer.Sanitize(step.DisplayName),
             StepType = WorkflowAuditTextSanitizer.Sanitize(step.StepType),
             TargetRole = WorkflowAuditTextSanitizer.Sanitize(step.TargetRole),
             RequestedAt = step.RequestedAt,
@@ -74,8 +75,9 @@ public static class WorkflowAuditReportSanitizer
                     ToolName = WorkflowAuditTextSanitizer.Sanitize(step.ToolApproval.ToolName),
                     ToolCallId = WorkflowAuditTextSanitizer.Sanitize(step.ToolApproval.ToolCallId),
                     ApprovalRequestId = WorkflowAuditTextSanitizer.Sanitize(step.ToolApproval.ApprovalRequestId),
-                },
+            },
             Usage = SanitizeUsage(step.Usage),
+            Outcome = step.Outcome,
         };
 
     private static WorkflowRunRoleReply SanitizeRoleReply(WorkflowRunRoleReply reply)

--- a/src/workflow/Aevatar.Workflow.Application/Observatory/WorkflowRunObservatoryQueryService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Observatory/WorkflowRunObservatoryQueryService.cs
@@ -264,17 +264,35 @@ public sealed class WorkflowRunObservatoryQueryService
         WorkflowActorSnapshot snapshot,
         CancellationToken ct)
     {
+        var summary = ToRunSummary(snapshot);
+        var graph = await BuildRunGraphAsync(snapshot, ct);
         // One read gives the committed timeline + authoritative usage aggregate (no usage in the timeline
         // data map). Falls back to the snapshot summary if the run-isolated report has not materialized yet.
         var report = await _artifactQueryPort.GetWorkflowRunReportArtifactAsync(snapshot.ActorId, ct);
-        if (report == null)
+        if (report == null || report.StateVersion != snapshot.StateVersion)
         {
+            var reportSectionStatus = report == null
+                ? UnavailableSection(snapshot.StateVersion, "Run report artifact has not materialized.")
+                : VersionMismatchSection(
+                    snapshot.StateVersion,
+                    report.StateVersion,
+                    "Run report artifact source version does not match the current-state detail version.");
             return new ObservatoryRunDetail
             {
-                Summary = ToRunSummary(snapshot),
+                Summary = summary,
+                Initiator = ToActivityInitiatorSummary(snapshot.ActivityInitiator),
+                InputSummary = snapshot.InputSummary,
+                Sections = new ObservatoryRunDetailSectionVersions
+                {
+                    Overview = AlignedSection(snapshot.StateVersion),
+                    Steps = reportSectionStatus,
+                    Timeline = reportSectionStatus,
+                    ExecutionPath = ToSectionVersion(graph),
+                },
                 Timeline = [],
                 Diagnostics = BuildDiagnostics(snapshot, report: null, steps: [], viewEvents: []),
                 UsageTotals = new ObservatoryUsageTotals(),
+                ExecutionPath = graph,
                 RecoveryCapability = CloneRecoveryCapability(snapshot),
                 Lineage = CloneLineage(snapshot),
             };
@@ -301,7 +319,16 @@ public sealed class WorkflowRunObservatoryQueryService
 
         return new ObservatoryRunDetail
         {
-            Summary = ToRunSummary(snapshot),
+            Summary = summary,
+            Initiator = ToActivityInitiatorSummary(snapshot.ActivityInitiator),
+            InputSummary = snapshot.InputSummary,
+            Sections = new ObservatoryRunDetailSectionVersions
+            {
+                Overview = AlignedSection(snapshot.StateVersion),
+                Steps = AlignedSection(snapshot.StateVersion),
+                Timeline = AlignedSection(snapshot.StateVersion),
+                ExecutionPath = ToSectionVersion(graph),
+            },
             // Final result is fully materialized (not truncated), so the viewer can show it honestly.
             Input = report.Input,
             FinalOutput = report.FinalOutput,
@@ -309,6 +336,7 @@ public sealed class WorkflowRunObservatoryQueryService
             Diagnostics = BuildDiagnostics(snapshot, report, steps, viewEvents),
             Steps = steps,
             Timeline = viewEvents,
+            ExecutionPath = graph,
             Statistics = ToStatistics(report.Summary),
             UsageTotals = WorkflowRunObservatoryTimelineMapper.ToUsageTotals(report.Usage),
             RecoveryCapability = CloneRecoveryCapability(snapshot),
@@ -350,14 +378,34 @@ public sealed class WorkflowRunObservatoryQueryService
             snapshot.ActorId,
             ct: ct);
 
+        var status = ResolveGraphVersionStatus(snapshot.StateVersion, subgraph.SourceStateVersion);
+        if (status.VersionStatus != ObservatoryRunDetailSectionVersionStatus.Aligned)
+        {
+            return new ObservatoryRunGraph
+            {
+                RootNodeId = subgraph.RootNodeId,
+                DetailStateVersion = status.DetailStateVersion,
+                SourceStateVersion = status.SourceStateVersion,
+                VersionStatus = status.VersionStatus,
+                VersionReason = status.Reason,
+            };
+        }
+
         return new ObservatoryRunGraph
         {
             RootNodeId = subgraph.RootNodeId,
+            DetailStateVersion = status.DetailStateVersion,
+            SourceStateVersion = status.SourceStateVersion,
+            VersionStatus = status.VersionStatus,
+            VersionReason = status.Reason,
             Nodes = subgraph.Nodes
                 .Select(node => new ObservatoryGraphNode
                 {
                     NodeId = node.NodeId,
                     NodeType = node.NodeType,
+                    DisplayName = node.Properties != null && node.Properties.TryGetValue("displayName", out var displayName)
+                        ? displayName
+                        : string.Empty,
                     // WorkflowStep nodes carry the bare stepId in their properties; surface it so the
                     // viewer can join the node to its committed timeline steps (run / actor nodes have none).
                     StepId = node.Properties != null && node.Properties.TryGetValue("stepId", out var stepId)
@@ -379,6 +427,62 @@ public sealed class WorkflowRunObservatoryQueryService
                 .ToList(),
         };
     }
+
+    private static ObservatoryRunDetailSectionVersion ResolveGraphVersionStatus(
+        long detailStateVersion,
+        long sourceStateVersion)
+    {
+        if (sourceStateVersion <= 0)
+        {
+            return UnavailableSection(
+                detailStateVersion,
+                "Execution path graph source version is unavailable.");
+        }
+
+        return sourceStateVersion == detailStateVersion
+            ? AlignedSection(detailStateVersion)
+            : VersionMismatchSection(
+                detailStateVersion,
+                sourceStateVersion,
+                "Execution path graph source version does not match the current-state detail version.");
+    }
+
+    private static ObservatoryRunDetailSectionVersion ToSectionVersion(ObservatoryRunGraph graph) =>
+        new()
+        {
+            DetailStateVersion = graph.DetailStateVersion,
+            SourceStateVersion = graph.SourceStateVersion,
+            VersionStatus = graph.VersionStatus,
+            Reason = graph.VersionReason,
+        };
+
+    private static ObservatoryRunDetailSectionVersion AlignedSection(long stateVersion) =>
+        new()
+        {
+            DetailStateVersion = stateVersion,
+            SourceStateVersion = stateVersion,
+            VersionStatus = ObservatoryRunDetailSectionVersionStatus.Aligned,
+        };
+
+    private static ObservatoryRunDetailSectionVersion UnavailableSection(long detailStateVersion, string reason) =>
+        new()
+        {
+            DetailStateVersion = detailStateVersion,
+            VersionStatus = ObservatoryRunDetailSectionVersionStatus.Unavailable,
+            Reason = reason,
+        };
+
+    private static ObservatoryRunDetailSectionVersion VersionMismatchSection(
+        long detailStateVersion,
+        long sourceStateVersion,
+        string reason) =>
+        new()
+        {
+            DetailStateVersion = detailStateVersion,
+            SourceStateVersion = sourceStateVersion,
+            VersionStatus = ObservatoryRunDetailSectionVersionStatus.VersionMismatch,
+            Reason = reason,
+        };
 
     // Ownership gate: the run is visible only when its scope-stamped current-state snapshot matches the
     // caller scope. Returning null on mismatch (or missing run) lets the endpoint answer 404 uniformly.
@@ -533,11 +637,13 @@ public sealed class WorkflowRunObservatoryQueryService
         new()
         {
             StepId = step.StepId,
+            DisplayName = string.IsNullOrWhiteSpace(step.DisplayName) ? step.StepId : step.DisplayName,
             StepType = step.StepType,
             TargetRole = step.TargetRole,
             RequestedAtUtc = step.RequestedAt,
             CompletedAtUtc = step.CompletedAt,
             Success = step.Success,
+            Outcome = ResolveStepOutcome(step),
             DurationMs = step.DurationMs,
             OutputPreview = step.OutputPreview,
             Error = step.Error,
@@ -565,6 +671,30 @@ public sealed class WorkflowRunObservatoryQueryService
                 Cost = step.Usage.Cost,
             },
         };
+
+    private static WorkflowRunStepOutcome ResolveStepOutcome(WorkflowRunStepTrace step)
+    {
+        if (step.Outcome != WorkflowRunStepOutcome.Unspecified)
+            return step.Outcome;
+        if (HasSkippedAnnotation(step.CompletionAnnotations))
+            return WorkflowRunStepOutcome.Skipped;
+        if (step.Success == true)
+            return WorkflowRunStepOutcome.Succeeded;
+        if (step.Success == false || !string.IsNullOrWhiteSpace(step.Error))
+            return WorkflowRunStepOutcome.Failed;
+        if (!string.IsNullOrWhiteSpace(step.SuspensionType) ||
+            (step.RequestedAt.HasValue && !step.CompletedAt.HasValue))
+        {
+            return WorkflowRunStepOutcome.Waiting;
+        }
+
+        return WorkflowRunStepOutcome.Unspecified;
+    }
+
+    private static bool HasSkippedAnnotation(IReadOnlyDictionary<string, string> annotations) =>
+        annotations.Any(static item =>
+            item.Key.EndsWith(".skipped", StringComparison.Ordinal) &&
+            string.Equals(item.Value, "true", StringComparison.OrdinalIgnoreCase));
 
     private static ObservatoryRunStatistics ToStatistics(WorkflowRunStatistics summary) =>
         new()
@@ -834,6 +964,8 @@ public sealed class WorkflowRunObservatoryQueryService
 
     private static string StepDisplayName(ObservatoryStepDetail step)
     {
+        if (!string.IsNullOrWhiteSpace(step.DisplayName))
+            return step.DisplayName;
         if (!string.IsNullOrWhiteSpace(step.StepId))
             return step.StepId;
         if (!string.IsNullOrWhiteSpace(step.StepType))

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -1957,6 +1957,7 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
             RunId = state.RunId,
             Input = input,
             TargetRole = effectiveTargetRole,
+            DisplayName = ResolveStepDisplayName(step),
         };
         request.InputFileRefs.Add(inputFileRefs.Select(static fileRef => fileRef.Clone()));
 
@@ -2002,6 +2003,12 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         ApplyInteractionPresentation(request, step.Presentation, state);
 
         return request;
+    }
+
+    private static string ResolveStepDisplayName(StepDefinition step)
+    {
+        var displayName = step.DisplayName?.Trim() ?? string.Empty;
+        return displayName.Length == 0 ? step.Id : displayName;
     }
 
     // The call-site identity a step carries at runtime must be the one admission committed, so both

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -742,6 +742,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             RunId = request.RunId,
             Success = true,
             Output = request.Input,
+            Outcome = WorkflowStepCompletionOutcome.Skipped,
         };
         skipped.Annotations["connector.skipped"] = "true";
         skipped.Annotations["connector.skip_reason"] = reason;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/GuardModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/GuardModule.cs
@@ -46,7 +46,11 @@ public sealed class GuardModule : IEventModule<IWorkflowExecutionContext>
         {
             var completed = new StepCompletedEvent
             {
-                StepId = request.StepId, RunId = request.RunId, Success = true, Output = input,
+                StepId = request.StepId,
+                RunId = request.RunId,
+                Success = true,
+                Output = input,
+                Outcome = WorkflowStepCompletionOutcome.Skipped,
             };
             completed.Annotations["guard.skipped"] = "true";
             completed.Annotations["guard.reason"] = reason;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -598,6 +598,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             IdempotencyKey = request.IdempotencyKey ?? string.Empty,
             ExternalInvocation = request.ExternalInvocation?.Clone(),
             IssuedAtUnixMs = issuedAtUnixMs,
+            DisplayName = ResolveStepDisplayName(request.DisplayName, request.StepId),
         };
         pendingState.InputFileRefs.Add(request.InputFileRefs.Select(static fileRef => fileRef.Clone()));
         pendingState.Suspension = BuildSuspension(pendingState);
@@ -1253,6 +1254,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             ExecutionId = pending.ExecutionId,
             Input = pending.ArgumentsJson,
             IdempotencyKey = pending.IdempotencyKey,
+            DisplayName = ResolveStepDisplayName(pending.DisplayName, pending.StepId),
             Parameters = { ["tool"] = pending.ToolName },
             InputFileRefs = { pending.InputFileRefs.Select(static fileRef => fileRef.Clone()) },
             ExternalInvocation = pending.ExternalInvocation?.Clone(),
@@ -1303,6 +1305,12 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 
     private static string NormalizeRequired(string? value) =>
         string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    private static string ResolveStepDisplayName(string? displayName, string? stepId)
+    {
+        var normalized = displayName?.Trim() ?? string.Empty;
+        return normalized.Length == 0 ? NormalizeRequired(stepId) : normalized;
+    }
 
     private static string BuildPendingKey(PendingToolCallApprovalState pending) =>
         BuildPendingKey(

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/StepDefinition.cs
@@ -13,6 +13,11 @@ public sealed class StepDefinition
     public required string Id { get; init; }
 
     /// <summary>
+    /// Authoring-owned display label for the workflow node. Runtime projections fall back to <see cref="Id"/>.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
     /// 步骤类型（如 llm_call、parallel、loop、conditional 等）。
     /// </summary>
     public required string Type { get; init; }

--- a/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Primitives/WorkflowParser.cs
@@ -190,6 +190,7 @@ public sealed class WorkflowParser
         return new StepDefinition
         {
             Id = s.Id ?? throw new InvalidOperationException("step 缺 id"),
+            DisplayName = NormalizeText(s.DisplayName),
             Type = canonicalType,
             TargetRole = s.TargetRole ?? s.Role,
             Parameters = WorkflowPrimitiveCatalog.CanonicalizeStepTypeParameters(parameters),
@@ -1435,6 +1436,8 @@ public sealed class WorkflowParser
     private sealed class RawStep
     {
         public string? Id { get; set; }
+        [YamlMember(Alias = "display_name")]
+        public string? DisplayName { get; set; }
         public string? Type { get; set; }
         public string? TargetRole { get; set; }
         public string? Role { get; set; }

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -493,6 +493,7 @@ message PendingToolCallApprovalState
   int64 issued_at_unix_ms = 12;
   WorkflowSuspendedEvent suspension = 13;
   bool suspension_published = 14;
+  string display_name = 15;
 }
 
 enum WorkflowToolCallTerminalDecision

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/ChatQueryEndpoints.cs
@@ -377,6 +377,7 @@ public static class ChatQueryEndpoints
     private static WorkflowRunGraphExportSubgraphHttpResponse MapGraphSubgraph(WorkflowRunGraphExportSubgraph subgraph) =>
         new(
             subgraph.RootNodeId,
+            subgraph.SourceStateVersion,
             subgraph.Nodes.Select(MapGraphNode).ToList(),
             subgraph.Edges.Select(MapGraphEdge).ToList());
 
@@ -518,6 +519,7 @@ public sealed record WorkflowRunGraphExportEdgeHttpResponse(
 //   New principle: HTTP graph responses expose workflow-run graph export artifact semantics.
 public sealed record WorkflowRunGraphExportSubgraphHttpResponse(
     string RootNodeId,
+    long SourceStateVersion,
     List<WorkflowRunGraphExportNodeHttpResponse> Nodes,
     List<WorkflowRunGraphExportEdgeHttpResponse> Edges);
 

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionArtifactQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionArtifactQueryPort.cs
@@ -110,6 +110,7 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
         var boundedTake = Math.Clamp(take, 1, 2000);
         var direction = MapDirection(options?.Direction ?? WorkflowRunGraphExportDirection.Both);
         var edgeTypes = NormalizeEdgeTypes(options?.EdgeTypes);
+        var sourceStateVersion = await ResolveGraphSourceStateVersionAsync(workflowRunIdValue, ct);
         var subgraph = await _graphStore.GetSubgraphAsync(
             new ProjectionGraphQuery
             {
@@ -121,8 +122,42 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
                 Take = boundedTake,
             },
             ct);
-        return _mapper.ToWorkflowRunGraphExportSubgraph(workflowRunIdValue, subgraph);
+        return _mapper.ToWorkflowRunGraphExportSubgraph(workflowRunIdValue, subgraph, sourceStateVersion);
     }
+
+    private async Task<long> ResolveGraphSourceStateVersionAsync(string workflowRunId, CancellationToken ct)
+    {
+        var sourceSubgraph = await _graphStore.GetSubgraphAsync(
+            new ProjectionGraphQuery
+            {
+                Scope = WorkflowExecutionGraphConstants.Scope,
+                RootNodeId = workflowRunId,
+                Direction = ProjectionGraphDirection.Outbound,
+                EdgeTypes = [WorkflowExecutionGraphConstants.EdgeTypeOwns],
+                Depth = 1,
+                Take = 2000,
+            },
+            ct);
+
+        var sourceVersions = sourceSubgraph.Nodes
+            .Where(node => string.Equals(node.NodeType, WorkflowExecutionGraphConstants.RunNodeType, StringComparison.Ordinal))
+            .Where(node =>
+                node.Properties.TryGetValue(WorkflowExecutionGraphConstants.RootActorIdPropertyKey, out var rootActorId) &&
+                string.Equals(rootActorId, workflowRunId, StringComparison.Ordinal))
+            .Select(ReadSourceStateVersion)
+            .Where(version => version > 0)
+            .Distinct()
+            .ToList();
+
+        return sourceVersions.Count == 1 ? sourceVersions[0] : 0;
+    }
+
+    private static long ReadSourceStateVersion(ProjectionGraphNode node) =>
+        node.Properties.TryGetValue(WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey, out var value) &&
+        long.TryParse(value, out var parsed) &&
+        parsed > 0
+            ? parsed
+            : 0;
 
     private static ProjectionGraphDirection MapDirection(WorkflowRunGraphExportDirection direction)
     {

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
@@ -225,9 +225,11 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
     {
         var step = GetOrCreateStep(readModel.Steps, evt.StepId);
         step.StepId = evt.StepId ?? string.Empty;
+        step.DisplayName = ResolveStepDisplayName(evt.DisplayName, step.StepId);
         step.StepType = evt.StepType ?? string.Empty;
         step.TargetRole = evt.TargetRole ?? string.Empty;
         step.RequestedAt = observedAt;
+        step.Outcome = WorkflowExecutionStepOutcomeReadModel.Waiting;
         var parameters = WorkflowStepParameterProjectionSource.From(evt);
         ReplaceMap(step.RequestParameters, parameters);
         AddTimeline(
@@ -252,6 +254,7 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
         step.StepId = evt.StepId ?? string.Empty;
         step.CompletedAt = observedAt;
         step.Success = evt.Success;
+        step.Outcome = ResolveStepOutcome(evt);
         step.OutputPreview = SanitizeAuditTextForDisplay(evt.Output, 240);
         step.Error = SanitizeAuditText(evt.Error);
         step.WorkerId = evt.WorkerId ?? string.Empty;
@@ -655,6 +658,7 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
         return new WorkflowExecutionStepTrace
         {
             StepId = source.StepId,
+            DisplayName = source.DisplayName,
             StepType = source.StepType,
             TargetRole = source.TargetRole,
             RequestedAt = source.RequestedAt,
@@ -676,8 +680,34 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
             RequestedVariableName = source.RequestedVariableName,
             ToolApprovalValue = source.ToolApprovalValue?.Clone(),
             Usage = CloneUsage(source.Usage),
+            Outcome = source.Outcome,
         };
     }
+
+    private static string ResolveStepDisplayName(string? displayName, string stepId)
+    {
+        var normalized = displayName?.Trim() ?? string.Empty;
+        return normalized.Length == 0 ? stepId : normalized;
+    }
+
+    private static WorkflowExecutionStepOutcomeReadModel ResolveStepOutcome(StepCompletedEvent evt)
+    {
+        if (evt.Outcome == WorkflowStepCompletionOutcome.Skipped || HasSkippedAnnotation(evt.Annotations))
+            return WorkflowExecutionStepOutcomeReadModel.Skipped;
+        if (evt.Outcome == WorkflowStepCompletionOutcome.Succeeded)
+            return WorkflowExecutionStepOutcomeReadModel.Succeeded;
+        if (evt.Outcome == WorkflowStepCompletionOutcome.Failed)
+            return WorkflowExecutionStepOutcomeReadModel.Failed;
+
+        return evt.Success
+            ? WorkflowExecutionStepOutcomeReadModel.Succeeded
+            : WorkflowExecutionStepOutcomeReadModel.Failed;
+    }
+
+    private static bool HasSkippedAnnotation(IDictionary<string, string> annotations) =>
+        annotations.Any(static item =>
+            item.Key.EndsWith(".skipped", StringComparison.Ordinal) &&
+            string.Equals(item.Value, "true", StringComparison.OrdinalIgnoreCase));
 
     private static void RefreshSummary(WorkflowRunInsightReportDocument readModel)
     {

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionGraphConstants.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionGraphConstants.cs
@@ -19,4 +19,8 @@ public static class WorkflowExecutionGraphConstants
     // Step -> next-step execution flow (from the step trace's NextStepId), so the topology graph carries the
     // real run order instead of only run -> step containment. The branch taken is on the edge's branchKey.
     public const string EdgeTypeNext = "NEXT";
+
+    public const string RootActorIdPropertyKey = "rootActorId";
+
+    public const string SourceStateVersionPropertyKey = "sourceStateVersion";
 }

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
@@ -249,11 +249,35 @@ public sealed class WorkflowExecutionReadModelMapper
         var subgraph = new WorkflowRunGraphExportSubgraph
         {
             RootNodeId = rootNodeId,
+            SourceStateVersion = ResolveGraphSourceStateVersion(rootNodeId, source),
         };
         subgraph.Nodes.Add(source.Nodes.Select(ToWorkflowRunGraphExportNode));
         subgraph.Edges.Add(source.Edges.Select(ToWorkflowRunGraphExportEdge));
         return subgraph;
     }
+
+    private static long ResolveGraphSourceStateVersion(string rootNodeId, ProjectionGraphSubgraph source)
+    {
+        var rootNodeIdValue = rootNodeId.Trim();
+        var versions = source.Nodes
+            .Where(node => string.Equals(node.NodeType, WorkflowExecutionGraphConstants.RunNodeType, StringComparison.Ordinal))
+            .Where(node =>
+                node.Properties.TryGetValue(WorkflowExecutionGraphConstants.RootActorIdPropertyKey, out var nodeRootActorId) &&
+                string.Equals(nodeRootActorId, rootNodeIdValue, StringComparison.Ordinal))
+            .Select(ReadSourceStateVersion)
+            .Where(version => version > 0)
+            .Distinct()
+            .ToList();
+
+        return versions.Count == 1 ? versions[0] : 0;
+    }
+
+    private static long ReadSourceStateVersion(ProjectionGraphNode node) =>
+        node.Properties.TryGetValue(WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey, out var value) &&
+        long.TryParse(value, out var parsed) &&
+        parsed > 0
+            ? parsed
+            : 0;
 
     private static WorkflowRunCompletionStatus MapCompletionStatus(string? status)
     {
@@ -387,6 +411,7 @@ public sealed class WorkflowExecutionReadModelMapper
         new()
         {
             StepId = source.StepId,
+            DisplayName = source.DisplayName,
             StepType = source.StepType,
             TargetRole = source.TargetRole,
             RequestedAt = source.RequestedAtUtcValue?.ToDateTimeOffset(),
@@ -416,6 +441,17 @@ public sealed class WorkflowExecutionReadModelMapper
                     ApprovalRequestId = source.ToolApprovalValue.ApprovalRequestId,
                 },
             Usage = MapUsage(source.Usage),
+            Outcome = MapStepOutcome(source.Outcome),
+        };
+
+    private static WorkflowRunStepOutcome MapStepOutcome(WorkflowExecutionStepOutcomeReadModel outcome) =>
+        outcome switch
+        {
+            WorkflowExecutionStepOutcomeReadModel.Succeeded => WorkflowRunStepOutcome.Succeeded,
+            WorkflowExecutionStepOutcomeReadModel.Failed => WorkflowRunStepOutcome.Failed,
+            WorkflowExecutionStepOutcomeReadModel.Waiting => WorkflowRunStepOutcome.Waiting,
+            WorkflowExecutionStepOutcomeReadModel.Skipped => WorkflowRunStepOutcome.Skipped,
+            _ => WorkflowRunStepOutcome.Unspecified,
         };
 
     private static WorkflowRunRoleReply MapRoleReply(WorkflowExecutionRoleReply source) =>

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
@@ -244,12 +244,15 @@ public sealed class WorkflowExecutionReadModelMapper
     //   New principle: graph mapper methods produce workflow-run graph export subgraphs.
     public WorkflowRunGraphExportSubgraph ToWorkflowRunGraphExportSubgraph(
         string rootNodeId,
-        ProjectionGraphSubgraph source)
+        ProjectionGraphSubgraph source,
+        long sourceStateVersion = 0)
     {
         var subgraph = new WorkflowRunGraphExportSubgraph
         {
             RootNodeId = rootNodeId,
-            SourceStateVersion = ResolveGraphSourceStateVersion(rootNodeId, source),
+            SourceStateVersion = sourceStateVersion > 0
+                ? sourceStateVersion
+                : ResolveGraphSourceStateVersion(rootNodeId, source),
         };
         subgraph.Nodes.Add(source.Nodes.Select(ToWorkflowRunGraphExportNode));
         subgraph.Edges.Add(source.Edges.Select(ToWorkflowRunGraphExportEdge));

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunGraphArtifactMaterializer.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowRunGraphArtifactMaterializer.cs
@@ -30,9 +30,10 @@ public sealed class WorkflowRunGraphArtifactMaterializer
         var updatedAt = readModel.UpdatedAt == default ? DateTimeOffset.UtcNow : readModel.UpdatedAt;
         var rootActorId = NormalizeToken(readModel.RootActorId);
         var runNodeId = BuildRunNodeId(rootActorId, readModel.CommandId);
+        var sourceStateVersion = readModel.StateVersion.ToString();
         var nodes = new Dictionary<string, ProjectionGraphNode>(StringComparer.Ordinal);
 
-        nodes[rootActorId] = CreateActorNode(rootActorId, readModel.WorkflowName, updatedAt);
+        nodes[rootActorId] = CreateActorNode(rootActorId, rootActorId, readModel.WorkflowName, updatedAt);
         nodes[runNodeId] = new ProjectionGraphNode
         {
             Scope = WorkflowExecutionGraphConstants.Scope,
@@ -40,17 +41,19 @@ public sealed class WorkflowRunGraphArtifactMaterializer
             NodeType = WorkflowExecutionGraphConstants.RunNodeType,
             Properties = new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["rootActorId"] = rootActorId,
+                [WorkflowExecutionGraphConstants.RootActorIdPropertyKey] = rootActorId,
                 ["workflowName"] = readModel.WorkflowName ?? string.Empty,
                 ["commandId"] = NormalizeToken(readModel.CommandId),
                 ["input"] = readModel.Input ?? string.Empty,
+                [WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey] = sourceStateVersion,
             },
             UpdatedAt = updatedAt,
         };
 
         foreach (var step in readModel.Steps)
         {
-            var stepNodeId = BuildStepNodeId(rootActorId, readModel.CommandId, step.StepId);
+            var stepId = step.StepId ?? string.Empty;
+            var stepNodeId = BuildStepNodeId(rootActorId, readModel.CommandId, stepId);
             nodes[stepNodeId] = new ProjectionGraphNode
             {
                 Scope = WorkflowExecutionGraphConstants.Scope,
@@ -60,11 +63,12 @@ public sealed class WorkflowRunGraphArtifactMaterializer
                 {
                     ["rootActorId"] = rootActorId,
                     ["commandId"] = NormalizeToken(readModel.CommandId),
-                    ["stepId"] = NormalizeToken(step.StepId),
+                    ["stepId"] = NormalizeToken(stepId),
                     ["stepType"] = step.StepType ?? string.Empty,
                     ["targetRole"] = step.TargetRole ?? string.Empty,
                     ["workerId"] = step.WorkerId ?? string.Empty,
                     ["success"] = step.Success?.ToString() ?? string.Empty,
+                    ["displayName"] = string.IsNullOrWhiteSpace(step.DisplayName) ? stepId : step.DisplayName,
                 },
                 UpdatedAt = updatedAt,
             };
@@ -72,13 +76,13 @@ public sealed class WorkflowRunGraphArtifactMaterializer
 
         foreach (var topologyEdge in readModel.Topology)
         {
-            var parentId = NormalizeToken(topologyEdge.Parent);
-            var childId = NormalizeToken(topologyEdge.Child);
+            var parentId = BuildTopologyActorNodeId(rootActorId, readModel.CommandId, topologyEdge.Parent);
+            var childId = BuildTopologyActorNodeId(rootActorId, readModel.CommandId, topologyEdge.Child);
             if (!nodes.ContainsKey(parentId))
-                nodes[parentId] = CreateActorNode(parentId, readModel.WorkflowName, updatedAt);
+                nodes[parentId] = CreateActorNode(parentId, topologyEdge.Parent, readModel.WorkflowName, updatedAt);
 
             if (!nodes.ContainsKey(childId))
-                nodes[childId] = CreateActorNode(childId, readModel.WorkflowName, updatedAt);
+                nodes[childId] = CreateActorNode(childId, topologyEdge.Child, readModel.WorkflowName, updatedAt);
         }
 
         return nodes.Values.ToList();
@@ -105,14 +109,15 @@ public sealed class WorkflowRunGraphArtifactMaterializer
 
         foreach (var step in readModel.Steps)
         {
-            var stepNodeId = BuildStepNodeId(rootActorId, readModel.CommandId, step.StepId);
+            var stepId = step.StepId ?? string.Empty;
+            var stepNodeId = BuildStepNodeId(rootActorId, readModel.CommandId, stepId);
             var containsEdge = CreateEdge(
                 WorkflowExecutionGraphConstants.EdgeTypeContainsStep,
                 runNodeId,
                 stepNodeId,
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
-                    ["stepId"] = NormalizeToken(step.StepId),
+                    ["stepId"] = NormalizeToken(stepId),
                     ["stepType"] = step.StepType ?? string.Empty,
                 },
                 updatedAt);
@@ -137,8 +142,8 @@ public sealed class WorkflowRunGraphArtifactMaterializer
 
         foreach (var topologyEdge in readModel.Topology)
         {
-            var parentId = NormalizeToken(topologyEdge.Parent);
-            var childId = NormalizeToken(topologyEdge.Child);
+            var parentId = BuildTopologyActorNodeId(rootActorId, readModel.CommandId, topologyEdge.Parent);
+            var childId = BuildTopologyActorNodeId(rootActorId, readModel.CommandId, topologyEdge.Child);
             var childOfEdge = CreateEdge(
                 WorkflowExecutionGraphConstants.EdgeTypeChildOf,
                 parentId,
@@ -152,17 +157,20 @@ public sealed class WorkflowRunGraphArtifactMaterializer
     }
 
     private static ProjectionGraphNode CreateActorNode(
-        string actorId,
+        string nodeId,
+        string? actorId,
         string? workflowName,
         DateTimeOffset updatedAt)
     {
+        var normalizedActorId = NormalizeToken(actorId);
         return new ProjectionGraphNode
         {
             Scope = WorkflowExecutionGraphConstants.Scope,
-            NodeId = actorId,
+            NodeId = nodeId,
             NodeType = WorkflowExecutionGraphConstants.ActorNodeType,
             Properties = new Dictionary<string, string>(StringComparer.Ordinal)
             {
+                ["actorId"] = normalizedActorId,
                 ["workflowName"] = workflowName ?? string.Empty,
             },
             UpdatedAt = updatedAt,
@@ -205,6 +213,17 @@ public sealed class WorkflowRunGraphArtifactMaterializer
         var normalizedCommandId = NormalizeToken(commandId);
         var normalizedStepId = NormalizeToken(stepId);
         return $"step:{normalizedRootActorId}:{normalizedCommandId}:{normalizedStepId}";
+    }
+
+    private static string BuildTopologyActorNodeId(string rootActorId, string commandId, string actorId)
+    {
+        var normalizedRootActorId = NormalizeToken(rootActorId);
+        var normalizedActorId = NormalizeToken(actorId);
+        if (string.Equals(normalizedActorId, normalizedRootActorId, StringComparison.Ordinal))
+            return normalizedRootActorId;
+
+        var normalizedCommandId = NormalizeToken(commandId);
+        return $"actor:{normalizedRootActorId}:{normalizedCommandId}:{normalizedActorId}";
     }
 
     private static string BuildEdgeId(string relationType, string fromNodeId, string toNodeId)

--- a/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
+++ b/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
@@ -37,6 +37,14 @@ enum WorkflowRecoveryRecommendedActionReadModel {
   WORKFLOW_RECOVERY_RECOMMENDED_ACTION_READ_MODEL_TECHNICAL_DETAILS = 7;
 }
 
+enum WorkflowExecutionStepOutcomeReadModel {
+  WORKFLOW_EXECUTION_STEP_OUTCOME_READ_MODEL_UNSPECIFIED = 0;
+  WORKFLOW_EXECUTION_STEP_OUTCOME_READ_MODEL_SUCCEEDED = 1;
+  WORKFLOW_EXECUTION_STEP_OUTCOME_READ_MODEL_FAILED = 2;
+  WORKFLOW_EXECUTION_STEP_OUTCOME_READ_MODEL_WAITING = 3;
+  WORKFLOW_EXECUTION_STEP_OUTCOME_READ_MODEL_SKIPPED = 4;
+}
+
 message WorkflowRecoveryActionCapabilityReadModel {
   WorkflowRecoveryEligibilityReadModel eligibility = 1;
   WorkflowRecoveryUnavailableReasonCodeReadModel unavailable_reason_code = 2;
@@ -233,6 +241,8 @@ message WorkflowExecutionStepTrace {
   WorkflowUsageMetricsReadModel usage_value = 20;
   string suspension_content = 21;
   WorkflowToolApprovalReadModel tool_approval_value = 22;
+  string display_name = 23;
+  WorkflowExecutionStepOutcomeReadModel outcome = 24;
 }
 
 message WorkflowToolApprovalReadModel {

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
@@ -408,6 +408,7 @@ public sealed class WorkflowRunToolContractTests
             GraphSubgraph = new WorkflowRunGraphExportSubgraph
             {
                 RootNodeId = "run-1",
+                SourceStateVersion = 12,
                 Nodes =
                 {
                     new WorkflowRunGraphExportNode
@@ -437,6 +438,7 @@ public sealed class WorkflowRunToolContractTests
         root.GetProperty("workflow_run_id").GetString().Should().Be("run-1");
         root.GetProperty("artifact").GetString().Should().Be("graph_subgraph");
         root.GetProperty("subgraph").GetProperty("root").GetString().Should().Be("run-1");
+        root.GetProperty("subgraph").GetProperty("source_state_version").GetInt64().Should().Be(12);
         root.GetProperty("subgraph").GetProperty("node_count").GetInt32().Should().Be(1);
         root.GetProperty("subgraph").GetProperty("edge_count").GetInt32().Should().Be(1);
         root.GetProperty("subgraph").GetProperty("edges")[0].GetProperty("to").GetString().Should().Be("child-1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
@@ -35,11 +35,14 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         using var environment = new OAuthBootstrapEnvironment();
         var dispatch = new RecordingCommandDispatch<ProvisionAevatarOAuthClientCommand>(
             static _ => OAuthClientReceipt());
-        var service = NewService(dispatch);
+        var projectionRebuildDispatch = new RecordingCommandDispatch<RebuildAevatarOAuthClientProjectionCommand>(
+            static _ => OAuthClientReceipt());
+        var service = NewService(dispatch, projectionRebuildDispatch);
 
         await service.StartAsync(CancellationToken.None);
 
         dispatch.Commands.Should().ContainSingle();
+        projectionRebuildDispatch.Commands.Should().ContainSingle();
         var command = dispatch.Commands[0];
         command.ClientId.Should().Be(ConfiguredClientId);
         command.ClientIdIssuedAtUnix.Should().BeGreaterThan(0);
@@ -70,11 +73,14 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         using var environment = new OAuthBootstrapEnvironment();
         var dispatch = new RecordingCommandDispatch<ProvisionAevatarOAuthClientCommand>(
             static _ => OAuthClientReceipt());
-        var service = NewService(dispatch);
+        var projectionRebuildDispatch = new RecordingCommandDispatch<RebuildAevatarOAuthClientProjectionCommand>(
+            static _ => OAuthClientReceipt());
+        var service = NewService(dispatch, projectionRebuildDispatch);
 
         await service.DispatchBootstrapIntentAsync(CancellationToken.None);
 
         dispatch.Commands.Should().ContainSingle();
+        projectionRebuildDispatch.Commands.Should().ContainSingle();
         var command = dispatch.Commands[0];
         command.ClientId.Should().Be(ConfiguredClientId);
         command.NyxidAuthority.Should().Be(environment.Authority);
@@ -94,6 +100,24 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         await act.Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*InvalidTarget*");
+    }
+
+    [Fact]
+    public async Task DispatchBootstrapIntentAsync_Throws_WhenProjectionRebuildDispatchRejects()
+    {
+        using var environment = new OAuthBootstrapEnvironment();
+        var dispatch = new RecordingCommandDispatch<ProvisionAevatarOAuthClientCommand>(
+            static _ => OAuthClientReceipt());
+        var service = NewService(
+            dispatch,
+            new RejectingCommandDispatch<RebuildAevatarOAuthClientProjectionCommand>());
+
+        var act = () => service.DispatchBootstrapIntentAsync(CancellationToken.None);
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*projection rebuild dispatch rejected*InvalidTarget*");
+        dispatch.Commands.Should().ContainSingle();
     }
 
     [Fact]
@@ -247,10 +271,12 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
 
     private static AevatarOAuthClientBootstrapService NewService(
         ICommandDispatchService<ProvisionAevatarOAuthClientCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> dispatch,
+        ICommandDispatchService<RebuildAevatarOAuthClientProjectionCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>? projectionRebuildDispatch = null,
         bool enabled = true,
         string clientId = ConfiguredClientId) =>
         new(
             dispatch,
+            projectionRebuildDispatch ?? new RecordingCommandDispatch<RebuildAevatarOAuthClientProjectionCommand>(static _ => OAuthClientReceipt()),
             Options.Create(new AevatarOAuthClientOptions { ClientId = clientId }),
             Options.Create(new AevatarOAuthClientBootstrapOptions { Enabled = enabled }),
             NullLogger<AevatarOAuthClientBootstrapService>.Instance);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientOrleansDispatchProjectionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientOrleansDispatchProjectionTests.cs
@@ -1,0 +1,441 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Credentials.Testing;
+using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.DependencyInjection;
+using Aevatar.Tests.Shared;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans.Hosting;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+public sealed class AevatarOAuthClientOrleansDispatchProjectionTests
+{
+    [Fact]
+    public async Task ProvisionDispatch_ShouldReplayCommittedEventToReadModel()
+    {
+        var forwardingObserver = new ObservingStreamForwardingRegistry();
+        var documentObserver = new ObservingAevatarOAuthClientWriter();
+        using var host = await StartSiloHostAsync(forwardingObserver, documentObserver);
+        await EnsureProjectionReadyAsync(host, forwardingObserver);
+
+        var dispatch = host.Services.GetRequiredService<
+            ICommandDispatchService<ProvisionAevatarOAuthClientCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError>>();
+
+        var result = await dispatch.DispatchAsync(new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "configured-client",
+            ClientIdIssuedAtUnix = 1_700_000_000,
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://api.test/api/oauth/nyxid-callback",
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        });
+
+        result.Succeeded.Should().BeTrue();
+        var document = await documentObserver.WaitForProvisionedClientWithKeyAsync(
+            AevatarOAuthClientGAgent.WellKnownId,
+            TestTimeout);
+
+        document.Id.Should().Be(AevatarOAuthClientGAgent.WellKnownId);
+        document.ClientId.Should().Be("configured-client");
+        document.IsProvisioned.Should().BeTrue();
+        document.HmacKeyRef.Should().NotBeNull();
+        document.StateVersion.Should().Be(2);
+    }
+
+    private static TimeSpan TestTimeout => TimeSpan.FromSeconds(20);
+
+    private static async Task EnsureProjectionReadyAsync(
+        IHost host,
+        ObservingStreamForwardingRegistry forwardingObserver)
+    {
+        var targetActorId = ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+            AevatarOAuthClientGAgent.WellKnownId,
+            ChannelIdentityCommittedStateProjectionActivationPlanProvider.AevatarOAuthClientProjectionKind,
+            ProjectionRuntimeMode.DurableMaterialization));
+        var relayReady = forwardingObserver.WaitForUpsertAsync(
+            AevatarOAuthClientGAgent.WellKnownId,
+            targetActorId,
+            TestTimeout);
+        var activation = host.Services.GetRequiredService<
+            IProjectionScopeActivationService<AevatarOAuthClientMaterializationRuntimeLease>>();
+        await activation.EnsureAsync(new ProjectionScopeStartRequest
+        {
+            RootActorId = AevatarOAuthClientGAgent.WellKnownId,
+            ProjectionKind = ChannelIdentityCommittedStateProjectionActivationPlanProvider.AevatarOAuthClientProjectionKind,
+            Mode = ProjectionRuntimeMode.DurableMaterialization,
+        });
+
+        await relayReady;
+    }
+
+    private static Task<IHost> StartSiloHostAsync(
+        ObservingStreamForwardingRegistry forwardingObserver,
+        ObservingAevatarOAuthClientWriter documentObserver) =>
+        SharedOrleansPortAllocator.StartHostAsync(ports => Host.CreateDefaultBuilder()
+            .UseOrleans(siloBuilder =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: ports.SiloPort,
+                    gatewayPort: ports.GatewayPort,
+                    serviceId: $"aevatar-oauth-client-dispatch-service-{Guid.NewGuid():N}",
+                    clusterId: $"aevatar-oauth-client-dispatch-cluster-{Guid.NewGuid():N}");
+                siloBuilder.AddAevatarFoundationRuntimeOrleans(options =>
+                {
+                    options.StreamBackend = AevatarOrleansRuntimeOptions.StreamBackendInMemory;
+                    options.PersistenceBackend = AevatarOrleansRuntimeOptions.PersistenceBackendInMemory;
+                });
+                siloBuilder.ConfigureServices(services =>
+                {
+                    var configuration = new ConfigurationBuilder()
+                        .AddInMemoryCollection(new Dictionary<string, string?>
+                        {
+                            [$"{AevatarOAuthClientBootstrapOptions.SectionName}:Enabled"] = "false",
+                            [AevatarOAuthClientOptions.ClientIdConfigurationKey] = "configured-client",
+                        })
+                        .Build();
+                    services.AddChannelIdentity(configuration);
+                    services.AddSingleton<ISecretVault, InMemorySecretVault>();
+                    services.AddInMemoryDocumentProjectionStore<AevatarOAuthClientDocument, string>(
+                        static document => document.Id,
+                        static key => key);
+                    services.DecorateStreamForwardingRegistry(forwardingObserver);
+                    services.DecorateAevatarOAuthClientWriter(documentObserver);
+                });
+            })
+            .Build());
+
+    internal sealed class ObservingStreamForwardingRegistry : IStreamForwardingRegistry
+    {
+        private readonly object _gate = new();
+        private readonly HashSet<(string SourceStreamId, string TargetStreamId)> _observedUpserts = [];
+        private readonly Dictionary<(string SourceStreamId, string TargetStreamId), TaskCompletionSource<StreamForwardingBinding>>
+            _nextUpsertsByKey = new();
+        private IStreamForwardingRegistry? _inner;
+
+        public void SetInner(IStreamForwardingRegistry inner) =>
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+
+        public async Task UpsertAsync(StreamForwardingBinding binding, CancellationToken ct = default)
+        {
+            EnsureInner();
+            await _inner!.UpsertAsync(binding, ct);
+
+            TaskCompletionSource<StreamForwardingBinding> completion;
+            var key = (binding.SourceStreamId, binding.TargetStreamId);
+            lock (_gate)
+            {
+                _observedUpserts.Add(key);
+                completion = ConsumeNextUpsertCompletion(key);
+            }
+
+            completion.TrySetResult(binding);
+        }
+
+        public Task RemoveAsync(string sourceStreamId, string targetStreamId, CancellationToken ct = default)
+        {
+            EnsureInner();
+            return _inner!.RemoveAsync(sourceStreamId, targetStreamId, ct);
+        }
+
+        public Task<IReadOnlyList<StreamForwardingBinding>> ListBySourceAsync(
+            string sourceStreamId,
+            CancellationToken ct = default)
+        {
+            EnsureInner();
+            return _inner!.ListBySourceAsync(sourceStreamId, ct);
+        }
+
+        public Task<StreamForwardingBinding> WaitForUpsertAsync(
+            string sourceStreamId,
+            string targetStreamId,
+            TimeSpan timeout)
+        {
+            var key = (sourceStreamId, targetStreamId);
+            TaskCompletionSource<StreamForwardingBinding> completion;
+            lock (_gate)
+            {
+                if (_observedUpserts.Contains(key))
+                    return Task.FromResult(new StreamForwardingBinding
+                    {
+                        SourceStreamId = sourceStreamId,
+                        TargetStreamId = targetStreamId,
+                    });
+
+                completion = GetOrCreateNextUpsertCompletion(key);
+            }
+
+            return completion.Task.WaitAsync(timeout);
+        }
+
+        private void EnsureInner()
+        {
+            if (_inner == null)
+                throw new InvalidOperationException("Inner stream forwarding registry has not been assigned.");
+        }
+
+        private TaskCompletionSource<StreamForwardingBinding> GetOrCreateNextUpsertCompletion(
+            (string SourceStreamId, string TargetStreamId) key)
+        {
+            if (!_nextUpsertsByKey.TryGetValue(key, out var completion))
+            {
+                completion = new TaskCompletionSource<StreamForwardingBinding>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _nextUpsertsByKey[key] = completion;
+            }
+
+            return completion;
+        }
+
+        private TaskCompletionSource<StreamForwardingBinding> ConsumeNextUpsertCompletion(
+            (string SourceStreamId, string TargetStreamId) key)
+        {
+            var completion = GetOrCreateNextUpsertCompletion(key);
+            _nextUpsertsByKey.Remove(key);
+            return completion;
+        }
+    }
+
+    internal sealed class ObservingAevatarOAuthClientWriter
+    {
+        private readonly object _gate = new();
+        private readonly Dictionary<string, AevatarOAuthClientDocument> _latestUpsertsById = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TaskCompletionSource<AevatarOAuthClientDocument>> _nextUpsertsById = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, TaskCompletionSource<AevatarOAuthClientDocument>> _nextProvisionedKeyUpsertsById = new(StringComparer.Ordinal);
+
+        public void ObserveUpsert(AevatarOAuthClientDocument document)
+        {
+            TaskCompletionSource<AevatarOAuthClientDocument> completion;
+            TaskCompletionSource<AevatarOAuthClientDocument>? provisionedKeyCompletion = null;
+            var documentSnapshot = document.Clone();
+            lock (_gate)
+            {
+                _latestUpsertsById[document.Id] = documentSnapshot;
+                completion = ConsumeNextUpsertCompletion(document.Id);
+                if (IsProvisionedClientWithKey(documentSnapshot) &&
+                    _nextProvisionedKeyUpsertsById.Remove(document.Id, out var keyedCompletion))
+                {
+                    provisionedKeyCompletion = keyedCompletion;
+                }
+            }
+
+            completion.TrySetResult(documentSnapshot.Clone());
+            provisionedKeyCompletion?.TrySetResult(documentSnapshot.Clone());
+        }
+
+        public Task<AevatarOAuthClientDocument> WaitForUpsertAsync(string id, TimeSpan timeout)
+        {
+            TaskCompletionSource<AevatarOAuthClientDocument> completion;
+            lock (_gate)
+            {
+                if (_latestUpsertsById.TryGetValue(id, out var latest))
+                    return Task.FromResult(latest.Clone());
+                completion = GetOrCreateNextUpsertCompletion(id);
+            }
+
+            return completion.Task.WaitAsync(timeout);
+        }
+
+        public Task<AevatarOAuthClientDocument> WaitForProvisionedClientWithKeyAsync(string id, TimeSpan timeout)
+        {
+            TaskCompletionSource<AevatarOAuthClientDocument> completion;
+            lock (_gate)
+            {
+                if (_latestUpsertsById.TryGetValue(id, out var latest) && IsProvisionedClientWithKey(latest))
+                    return Task.FromResult(latest.Clone());
+
+                completion = GetOrCreateNextProvisionedKeyUpsertCompletion(id);
+            }
+
+            return completion.Task.WaitAsync(timeout);
+        }
+
+        private static bool IsProvisionedClientWithKey(AevatarOAuthClientDocument document) =>
+            document.IsProvisioned &&
+            document.StateVersion >= 2 &&
+            (document.HmacKeyRef != null || !document.HmacKey.IsEmpty);
+
+        private TaskCompletionSource<AevatarOAuthClientDocument> GetOrCreateNextUpsertCompletion(string id)
+        {
+            if (!_nextUpsertsById.TryGetValue(id, out var completion))
+            {
+                completion = new TaskCompletionSource<AevatarOAuthClientDocument>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _nextUpsertsById[id] = completion;
+            }
+
+            return completion;
+        }
+
+        private TaskCompletionSource<AevatarOAuthClientDocument> GetOrCreateNextProvisionedKeyUpsertCompletion(string id)
+        {
+            if (!_nextProvisionedKeyUpsertsById.TryGetValue(id, out var completion))
+            {
+                completion = new TaskCompletionSource<AevatarOAuthClientDocument>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _nextProvisionedKeyUpsertsById[id] = completion;
+            }
+
+            return completion;
+        }
+
+        private TaskCompletionSource<AevatarOAuthClientDocument> ConsumeNextUpsertCompletion(string id)
+        {
+            var completion = GetOrCreateNextUpsertCompletion(id);
+            _nextUpsertsById.Remove(id);
+            return completion;
+        }
+    }
+
+    internal sealed class ObservingAevatarOAuthClientProjectionDocumentWriter(
+        IProjectionDocumentWriter<AevatarOAuthClientDocument> inner,
+        ObservingAevatarOAuthClientWriter observer)
+        : IProjectionDocumentWriter<AevatarOAuthClientDocument>
+    {
+        public async Task<ProjectionWriteResult> UpsertAsync(
+            AevatarOAuthClientDocument readModel,
+            CancellationToken ct = default)
+        {
+            var result = await inner.UpsertAsync(readModel, ct);
+            if (result.IsApplied)
+                observer.ObserveUpsert(readModel);
+            return result;
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
+            inner.DeleteAsync(id, ct);
+    }
+
+    private static IProjectionDocumentWriter<AevatarOAuthClientDocument> ResolveOriginalWriter(
+        IServiceProvider provider,
+        ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is IProjectionDocumentWriter<AevatarOAuthClientDocument> instance)
+            return instance;
+
+        if (descriptor.ImplementationFactory is not null)
+            return (IProjectionDocumentWriter<AevatarOAuthClientDocument>)descriptor.ImplementationFactory(provider);
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (IProjectionDocumentWriter<AevatarOAuthClientDocument>)ActivatorUtilities.CreateInstance(
+                provider,
+                descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("Unable to resolve original AevatarOAuthClientDocument writer.");
+    }
+
+    private static IStreamForwardingRegistry ResolveOriginalStreamForwardingRegistry(
+        IServiceProvider provider,
+        ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is IStreamForwardingRegistry instance)
+            return instance;
+
+        if (descriptor.ImplementationFactory is not null)
+            return (IStreamForwardingRegistry)descriptor.ImplementationFactory(provider);
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (IStreamForwardingRegistry)ActivatorUtilities.CreateInstance(
+                provider,
+                descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("Unable to resolve original stream forwarding registry.");
+    }
+}
+
+internal static class AevatarOAuthClientOrleansDispatchProjectionTestServiceCollectionExtensions
+{
+    public static IServiceCollection DecorateStreamForwardingRegistry(
+        this IServiceCollection services,
+        AevatarOAuthClientOrleansDispatchProjectionTests.ObservingStreamForwardingRegistry observer)
+    {
+        var descriptors = services
+            .Where(static descriptor => descriptor.ServiceType == typeof(IStreamForwardingRegistry))
+            .ToArray();
+        descriptors.Should().ContainSingle();
+
+        foreach (var descriptor in descriptors)
+            services.Remove(descriptor);
+
+        services.AddSingleton<IStreamForwardingRegistry>(provider =>
+        {
+            observer.SetInner(ResolveOriginalStreamForwardingRegistry(provider, descriptors[0]));
+            return observer;
+        });
+        return services;
+    }
+
+    public static IServiceCollection DecorateAevatarOAuthClientWriter(
+        this IServiceCollection services,
+        AevatarOAuthClientOrleansDispatchProjectionTests.ObservingAevatarOAuthClientWriter observer)
+    {
+        var descriptors = services
+            .Where(static descriptor => descriptor.ServiceType == typeof(IProjectionDocumentWriter<AevatarOAuthClientDocument>))
+            .ToArray();
+        descriptors.Should().ContainSingle();
+
+        foreach (var descriptor in descriptors)
+            services.Remove(descriptor);
+
+        services.AddSingleton<IProjectionDocumentWriter<AevatarOAuthClientDocument>>(provider =>
+            new AevatarOAuthClientOrleansDispatchProjectionTests.ObservingAevatarOAuthClientProjectionDocumentWriter(
+                ResolveOriginalWriter(provider, descriptors[0]),
+                observer));
+        return services;
+    }
+
+    private static IProjectionDocumentWriter<AevatarOAuthClientDocument> ResolveOriginalWriter(
+        IServiceProvider provider,
+        ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is IProjectionDocumentWriter<AevatarOAuthClientDocument> instance)
+            return instance;
+
+        if (descriptor.ImplementationFactory is not null)
+            return (IProjectionDocumentWriter<AevatarOAuthClientDocument>)descriptor.ImplementationFactory(provider);
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (IProjectionDocumentWriter<AevatarOAuthClientDocument>)ActivatorUtilities.CreateInstance(
+                provider,
+                descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("Unable to resolve original AevatarOAuthClientDocument writer.");
+    }
+
+    private static IStreamForwardingRegistry ResolveOriginalStreamForwardingRegistry(
+        IServiceProvider provider,
+        ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is IStreamForwardingRegistry instance)
+            return instance;
+
+        if (descriptor.ImplementationFactory is not null)
+            return (IStreamForwardingRegistry)descriptor.ImplementationFactory(provider);
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (IStreamForwardingRegistry)ActivatorUtilities.CreateInstance(
+                provider,
+                descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("Unable to resolve original stream forwarding registry.");
+    }
+}

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunObservatoryQueryServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunObservatoryQueryServiceTests.cs
@@ -5,6 +5,7 @@ using Aevatar.Workflow.Application.Observatory;
 using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
+using System.Text.Json;
 
 namespace Aevatar.Workflow.Application.Tests;
 
@@ -403,6 +404,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         };
         var report = new WorkflowRunReport
         {
+            StateVersion = 7,
             Usage = new WorkflowRunUsageMetrics { PromptTokens = 10, CompletionTokens = 5, TotalTokens = 15, Cost = 0.004 },
             Timeline =
             [
@@ -457,6 +459,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         var currentState = new FakeCurrentStateQueryPort { SingleResult = snapshot };
         var report = new WorkflowRunReport
         {
+            StateVersion = 7,
             Steps =
             [
                 new WorkflowRunStepTrace
@@ -497,6 +500,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         var currentState = new FakeCurrentStateQueryPort { SingleResult = snapshot };
         var report = new WorkflowRunReport
         {
+            StateVersion = 7,
             Steps =
             [
                 new WorkflowRunStepTrace
@@ -553,6 +557,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         rejection.Data["reason"] = "IdentityMismatch";
         var report = new WorkflowRunReport
         {
+            StateVersion = 7,
             Timeline = [rejection],
         };
         var service = new WorkflowRunObservatoryQueryService(
@@ -575,12 +580,22 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
     [Fact]
     public async Task GetRunForScopeAsync_ShouldSurfaceFinalResultStepsAndStatistics_WhenOwned()
     {
+        var snapshot = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Completed);
+        snapshot.ActivityInitiator = new WorkflowRunActivityInitiatorSnapshot
+        {
+            Platform = "nyxid",
+            ExternalUserId = "m-alpha",
+            DisplayValue = "alice@example.com",
+            Availability = "available",
+        };
+        snapshot.InputSummary = "redacted prompt summary";
         var currentState = new FakeCurrentStateQueryPort
         {
-            SingleResult = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Completed),
+            SingleResult = snapshot,
         };
         var report = new WorkflowRunReport
         {
+            StateVersion = 7,
             Input = "do the thing",
             FinalOutput = "the thing is done",
             FinalError = string.Empty,
@@ -589,6 +604,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
                 new WorkflowRunStepTrace
                 {
                     StepId = "draft",
+                    DisplayName = "Draft answer",
                     StepType = "llm_call",
                     TargetRole = "planner",
                     RequestedAt = DateTimeOffset.UnixEpoch,
@@ -618,16 +634,23 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         var detail = await service.GetRunForScopeAsync(CallerScope, "run-1");
 
         detail.Should().NotBeNull();
-        detail!.Input.Should().Be("do the thing");
+        detail!.Initiator.DisplayValue.Should().Be("alice@example.com");
+        detail.InputSummary.Should().Be("redacted prompt summary");
+        detail.Sections.Overview.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Aligned);
+        detail.Sections.Steps.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Aligned);
+        detail.Sections.Timeline.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Aligned);
+        detail.Input.Should().Be("do the thing");
         detail.FinalOutput.Should().Be("the thing is done");
         detail.FinalError.Should().BeEmpty();
 
         detail.Steps.Should().ContainSingle();
         var step = detail.Steps[0];
         step.StepId.Should().Be("draft");
+        step.DisplayName.Should().Be("Draft answer");
         step.StepType.Should().Be("llm_call");
         step.TargetRole.Should().Be("planner");
         step.Success.Should().BeTrue();
+        step.Outcome.Should().Be(WorkflowRunStepOutcome.Succeeded);
         step.OutputPreview.Should().Be("preview of the step output");
         step.DurationMs.Should().Be(2000);
         step.Usage.TotalTokens.Should().Be(10);
@@ -636,6 +659,85 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         detail.Statistics.CompletedSteps.Should().Be(1);
         detail.Statistics.RoleReplyCount.Should().Be(1);
         detail.Statistics.StepTypeCounts["llm_call"].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetRunForScopeAsync_ShouldExposeVersionMismatch_WhenReportVersionDiffersFromSummary()
+    {
+        var snapshot = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Completed);
+        var report = new WorkflowRunReport
+        {
+            StateVersion = 6,
+            Input = "stale input",
+            FinalOutput = "stale output",
+            Steps = [new WorkflowRunStepTrace { StepId = "stale", Success = true }],
+            Timeline = [TimelineEvent("workflow.completed", "stale")],
+        };
+        var service = new WorkflowRunObservatoryQueryService(
+            new FakeCurrentStateQueryPort { SingleResult = snapshot },
+            new FakeArtifactQueryPort { Report = report });
+
+        var detail = await service.GetRunForScopeAsync(CallerScope, "run-1");
+
+        detail.Should().NotBeNull();
+        detail!.Summary.StateVersion.Should().Be(7);
+        detail.Sections.Steps.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.VersionMismatch);
+        detail.Sections.Steps.DetailStateVersion.Should().Be(7);
+        detail.Sections.Steps.SourceStateVersion.Should().Be(6);
+        detail.Sections.Timeline.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.VersionMismatch);
+        detail.Input.Should().BeEmpty();
+        detail.FinalOutput.Should().BeEmpty();
+        detail.Steps.Should().BeEmpty();
+        detail.Timeline.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetRunForScopeAsync_ShouldMapWaitingFailedAndSkippedStepOutcomes()
+    {
+        var skipped = new WorkflowRunStepTrace
+        {
+            StepId = "optional_connector",
+            CompletedAt = DateTimeOffset.UnixEpoch.AddSeconds(1),
+            Success = true,
+            CompletionAnnotations = new Dictionary<string, string> { ["connector.skipped"] = "true" },
+        };
+        var service = new WorkflowRunObservatoryQueryService(
+            new FakeCurrentStateQueryPort
+            {
+                SingleResult = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Running),
+            },
+            new FakeArtifactQueryPort
+            {
+                Report = new WorkflowRunReport
+                {
+                    StateVersion = 7,
+                    Steps =
+                    [
+                        new WorkflowRunStepTrace { StepId = "approval", RequestedAt = DateTimeOffset.UnixEpoch, SuspensionType = "tool_approval" },
+                        new WorkflowRunStepTrace { StepId = "publish", CompletedAt = DateTimeOffset.UnixEpoch, Success = false },
+                        skipped,
+                    ],
+                },
+            });
+
+        var detail = await service.GetRunForScopeAsync(CallerScope, "run-1");
+
+        detail.Should().NotBeNull();
+        detail!.Steps.Single(step => step.StepId == "approval").Outcome.Should().Be(WorkflowRunStepOutcome.Waiting);
+        detail.Steps.Single(step => step.StepId == "publish").Outcome.Should().Be(WorkflowRunStepOutcome.Failed);
+        detail.Steps.Single(step => step.StepId == "optional_connector").Outcome.Should().Be(WorkflowRunStepOutcome.Skipped);
+    }
+
+    [Fact]
+    public void ObservatoryStepDetail_ShouldSerializeOutcomeAsContractValue()
+    {
+        var json = JsonSerializer.Serialize(new ObservatoryStepDetail
+        {
+            StepId = "draft",
+            Outcome = WorkflowRunStepOutcome.Succeeded,
+        });
+
+        json.Should().Contain("\"Outcome\":\"succeeded\"");
     }
 
     [Fact]
@@ -652,7 +754,14 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         var detail = await service.GetRunForScopeAsync(CallerScope, "run-1");
 
         detail.Should().NotBeNull();
-        detail!.Timeline.Should().BeEmpty();
+        detail!.Sections.Steps.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Unavailable);
+        detail.Sections.Steps.DetailStateVersion.Should().Be(7);
+        detail.Sections.Steps.SourceStateVersion.Should().Be(0);
+        detail.Sections.Timeline.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Unavailable);
+        detail.Sections.ExecutionPath.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Unavailable);
+        detail.Sections.ExecutionPath.DetailStateVersion.Should().Be(7);
+        detail.Sections.ExecutionPath.SourceStateVersion.Should().Be(0);
+        detail.Timeline.Should().BeEmpty();
         detail.UsageTotals.TotalTokens.Should().Be(0);
         // Enriched fields degrade to empty when the report artifact has not materialized yet.
         detail.FinalOutput.Should().BeEmpty();
@@ -670,7 +779,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         snapshot.RecoveryCapability = RecoveryCapability();
         var service = new WorkflowRunObservatoryQueryService(
             new FakeCurrentStateQueryPort { SingleResult = snapshot },
-            new FakeArtifactQueryPort { Report = new WorkflowRunReport { FinalError = "boom" } });
+            new FakeArtifactQueryPort { Report = new WorkflowRunReport { StateVersion = 7, FinalError = "boom" } });
 
         var detail = await service.GetRunForScopeAsync(CallerScope, "run-1");
 
@@ -693,6 +802,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         var currentState = new FakeCurrentStateQueryPort { SingleResult = snapshot };
         var report = new WorkflowRunReport
         {
+            StateVersion = 7,
             FinalError = "final report failure",
             EndedAt = DateTimeOffset.UnixEpoch.AddSeconds(9),
             Steps =
@@ -834,7 +944,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         {
             SingleResult = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Running),
         };
-        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-1" };
+        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-1", SourceStateVersion = 7 };
         subgraph.Nodes.Add(new WorkflowRunGraphExportNode { NodeId = "n1", NodeType = "role" });
         subgraph.Edges.Add(new WorkflowRunGraphExportEdge { EdgeId = "e1", FromNodeId = "run-1", ToNodeId = "n1", EdgeType = "child" });
         var artifact = new FakeArtifactQueryPort { Subgraph = subgraph };
@@ -844,8 +954,33 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
 
         graph.Should().NotBeNull();
         graph!.RootNodeId.Should().Be("run-1");
+        graph.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.Aligned);
+        graph.SourceStateVersion.Should().Be(7);
         graph.Nodes.Should().ContainSingle().Which.NodeId.Should().Be("n1");
         graph.Edges.Should().ContainSingle().Which.EdgeType.Should().Be("child");
+    }
+
+    [Fact]
+    public async Task GetRunGraphForScopeAsync_ShouldExposeMismatchAndHideStaleGraph_WhenSourceVersionDiffers()
+    {
+        var currentState = new FakeCurrentStateQueryPort
+        {
+            SingleResult = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Running),
+        };
+        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-1", SourceStateVersion = 6 };
+        subgraph.Nodes.Add(new WorkflowRunGraphExportNode { NodeId = "stale-node", NodeType = "WorkflowRun" });
+        var service = new WorkflowRunObservatoryQueryService(
+            currentState,
+            new FakeArtifactQueryPort { Subgraph = subgraph });
+
+        var graph = await service.GetRunGraphForScopeAsync(CallerScope, "run-1");
+
+        graph.Should().NotBeNull();
+        graph!.VersionStatus.Should().Be(ObservatoryRunDetailSectionVersionStatus.VersionMismatch);
+        graph.DetailStateVersion.Should().Be(7);
+        graph.SourceStateVersion.Should().Be(6);
+        graph.Nodes.Should().BeEmpty();
+        graph.Edges.Should().BeEmpty();
     }
 
     // 06-21: graph node ids are composite (step:{actor}:{cmd}:{stepId}); the viewer can only join a node
@@ -858,9 +993,10 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         {
             SingleResult = Snapshot("run-1", CallerScope, WorkflowRunCompletionStatus.Completed),
         };
-        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-1" };
+        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-1", SourceStateVersion = 7 };
         var stepNode = new WorkflowRunGraphExportNode { NodeId = "step:run-1:cmd:answer", NodeType = "WorkflowStep" };
         stepNode.Properties.Add("stepId", "answer");
+        stepNode.Properties.Add("displayName", "Answer customer");
         subgraph.Nodes.Add(stepNode);
         subgraph.Nodes.Add(new WorkflowRunGraphExportNode { NodeId = "run:run-1:cmd", NodeType = "WorkflowRun" });
         var artifact = new FakeArtifactQueryPort { Subgraph = subgraph };
@@ -870,6 +1006,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
 
         graph.Should().NotBeNull();
         graph!.Nodes.Single(node => node.NodeType == "WorkflowStep").StepId.Should().Be("answer");
+        graph.Nodes.Single(node => node.NodeType == "WorkflowStep").DisplayName.Should().Be("Answer customer");
         graph.Nodes.Single(node => node.NodeType == "WorkflowRun").StepId.Should().BeEmpty();
     }
 
@@ -929,7 +1066,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
         };
         var artifact = new FakeArtifactQueryPort
         {
-            Report = new WorkflowRunReport { FinalOutput = "done" },
+            Report = new WorkflowRunReport { StateVersion = 7, FinalOutput = "done" },
         };
         var service = new WorkflowRunObservatoryQueryService(currentState, artifact);
 
@@ -971,7 +1108,7 @@ public sealed class WorkflowRunObservatoryQueryServiceTests
                 Snapshot("run-foreign", OtherScope, WorkflowRunCompletionStatus.Completed),
             ],
         };
-        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-foreign" };
+        var subgraph = new WorkflowRunGraphExportSubgraph { RootNodeId = "run-foreign", SourceStateVersion = 7 };
         subgraph.Nodes.Add(new WorkflowRunGraphExportNode { NodeId = "run-foreign", NodeType = "WorkflowRun" });
         var artifact = new FakeArtifactQueryPort { Subgraph = subgraph };
         var service = new WorkflowRunObservatoryQueryService(currentState, artifact);

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleApprovalTests.cs
@@ -101,10 +101,12 @@ public sealed class ToolCallModuleApprovalTests
             "exec-1",
             [fileRef],
             "idem-approval-1",
-            issuedAt);
-        ctx.LoadState<ToolCallModuleState>("tool_call")
-            .PendingApprovals.Values.Should().ContainSingle()
-            .Which.IssuedAtUnixMs.Should().Be(issuedAt.ToUnixTimeMilliseconds());
+            issuedAt,
+            displayName: "Dangerous step");
+        var pendingState = ctx.LoadState<ToolCallModuleState>("tool_call")
+            .PendingApprovals.Values.Should().ContainSingle().Subject;
+        pendingState.IssuedAtUnixMs.Should().Be(issuedAt.ToUnixTimeMilliseconds());
+        pendingState.DisplayName.Should().Be("Dangerous step");
         ctx.Published.Clear();
 
         var resumed = new WorkflowResumedEvent
@@ -509,7 +511,8 @@ public sealed class ToolCallModuleApprovalTests
         string executionId,
         IReadOnlyList<WorkflowFileRef>? inputFileRefs = null,
         string idempotencyKey = "",
-        DateTimeOffset? issuedAt = null)
+        DateTimeOffset? issuedAt = null,
+        string displayName = "")
     {
         var request = new StepRequestEvent
         {
@@ -519,6 +522,7 @@ public sealed class ToolCallModuleApprovalTests
             ExecutionId = executionId,
             IdempotencyKey = idempotencyKey,
             Input = input,
+            DisplayName = displayName,
             Parameters = { ["tool"] = toolName },
         };
         request.InputFileRefs.Add(inputFileRefs?.Select(static fileRef => fileRef.Clone()) ?? []);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
@@ -923,7 +923,10 @@ public sealed class WorkflowExecutionProjectionProjectorTests
 
         var graph = new WorkflowRunInsightReportGraphMaterializer().Materialize(report);
         graph.Nodes.Should().Contain(x => x.NodeId == "root-actor");
-        graph.Edges.Should().Contain(x => x.ToNodeId == "child-1");
+        graph.Nodes.Should().Contain(x =>
+            x.NodeId == "actor:root-actor:cmd-3:child-1" &&
+            x.Properties["actorId"] == "child-1");
+        graph.Edges.Should().Contain(x => x.ToNodeId == "actor:root-actor:cmd-3:child-1");
     }
 
     [Fact]
@@ -1566,7 +1569,9 @@ public sealed class WorkflowExecutionProjectionProjectorTests
         materialization.Nodes.Should().Contain(x => x.NodeId == "unknown" && x.NodeType == WorkflowExecutionGraphConstants.ActorNodeType);
         materialization.Nodes.Should().Contain(x => x.NodeId == "run:unknown:unknown" && x.NodeType == WorkflowExecutionGraphConstants.RunNodeType);
         materialization.Nodes.Should().Contain(x => x.NodeId == "step:unknown:unknown:unknown" && x.NodeType == WorkflowExecutionGraphConstants.StepNodeType);
-        materialization.Nodes.Should().Contain(x => x.NodeId == "child-1");
+        materialization.Nodes.Should().Contain(x =>
+            x.NodeId == "actor:unknown:unknown:child-1" &&
+            x.Properties["actorId"] == "child-1");
 
         materialization.Edges.Should().Contain(x =>
             x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeOwns &&
@@ -1578,7 +1583,7 @@ public sealed class WorkflowExecutionProjectionProjectorTests
         materialization.Edges.Count(x =>
                 x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf &&
                 x.FromNodeId == "unknown" &&
-                x.ToNodeId == "child-1")
+                x.ToNodeId == "actor:unknown:unknown:child-1")
             .Should()
             .Be(1);
     }
@@ -1738,6 +1743,16 @@ public sealed class WorkflowExecutionProjectionProjectorTests
                         NodeId = "node-1",
                         NodeType = "Actor",
                     },
+                    new ProjectionGraphNode
+                    {
+                        NodeId = "run:node-1:cmd-1",
+                        NodeType = WorkflowExecutionGraphConstants.RunNodeType,
+                        Properties =
+                        {
+                            [WorkflowExecutionGraphConstants.RootActorIdPropertyKey] = "node-1",
+                            [WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey] = "12",
+                        },
+                    },
                 ],
                 Edges =
                 [
@@ -1767,7 +1782,8 @@ public sealed class WorkflowExecutionProjectionProjectorTests
         node.Properties.Should().Contain(new KeyValuePair<string, string>("key", "value"));
         edge.Properties.Should().Contain(new KeyValuePair<string, string>("kind", "runtime"));
         subgraph.RootNodeId.Should().Be("node-1");
-        subgraph.Nodes.Should().ContainSingle();
+        subgraph.SourceStateVersion.Should().Be(12);
+        subgraph.Nodes.Should().HaveCount(2);
         subgraph.Edges.Should().ContainSingle();
 
         var mappedReport = mapper.ToRunReport(report);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -461,6 +461,17 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
                             NodeId = "actor-1",
                             NodeType = "Actor",
                         },
+                        new ProjectionGraphNode
+                        {
+                            Scope = WorkflowExecutionGraphConstants.Scope,
+                            NodeId = "run:actor-1:cmd-1",
+                            NodeType = WorkflowExecutionGraphConstants.RunNodeType,
+                            Properties = new Dictionary<string, string>(StringComparer.Ordinal)
+                            {
+                                [WorkflowExecutionGraphConstants.RootActorIdPropertyKey] = "actor-1",
+                                [WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey] = "12",
+                            },
+                        },
                     ],
                 },
             },

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -464,6 +464,14 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
                     ],
                 },
             },
+            reportReader: new RecordingDocumentReader<WorkflowRunInsightReportDocument>
+            {
+                Item = new WorkflowRunInsightReportDocument
+                {
+                    Id = "actor-1",
+                    StateVersion = 12,
+                },
+            },
             currentStateReader: new RecordingDocumentReader<WorkflowExecutionCurrentStateDocument>
             {
                 Item = new WorkflowExecutionCurrentStateDocument
@@ -488,6 +496,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
 
         edges.Should().ContainSingle(x => x.EdgeId == "edge-1");
         subgraph.RootNodeId.Should().Be("actor-1");
+        subgraph.SourceStateVersion.Should().Be(12);
 
         harness.GraphStore.LastGraphEdgesQuery.Should().NotBeNull();
         harness.GraphStore.LastGraphEdgesQuery!.RootNodeId.Should().Be("actor-1");

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionReportReadModelTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionReportReadModelTests.cs
@@ -52,6 +52,7 @@ public sealed class WorkflowRunInsightReportDocumentReadModelTests
             RootActorId = " actor-1 ",
             CommandId = " cmd-1 ",
             WorkflowName = "direct",
+            StateVersion = 12,
             Input = "hello",
             UpdatedAt = new DateTimeOffset(2026, 3, 11, 8, 30, 0, TimeSpan.Zero),
             Steps =
@@ -59,6 +60,7 @@ public sealed class WorkflowRunInsightReportDocumentReadModelTests
                 new WorkflowExecutionStepTrace
                 {
                     StepId = "step-1",
+                    DisplayName = "Draft response",
                     StepType = "llm_call",
                     TargetRole = "assistant",
                     WorkerId = "worker-1",
@@ -76,14 +78,26 @@ public sealed class WorkflowRunInsightReportDocumentReadModelTests
         var edges = graph.Edges;
 
         nodes.Should().Contain(x => x.NodeId == "actor-1" && x.NodeType == WorkflowExecutionGraphConstants.ActorNodeType);
-        nodes.Should().Contain(x => x.NodeType == WorkflowExecutionGraphConstants.RunNodeType && x.Properties["input"] == "hello");
-        nodes.Should().Contain(x => x.NodeType == WorkflowExecutionGraphConstants.StepNodeType && x.Properties["stepId"] == "step-1");
-        nodes.Should().Contain(x => x.NodeId == "child-1" && x.NodeType == WorkflowExecutionGraphConstants.ActorNodeType);
+        nodes.Should().Contain(x =>
+            x.NodeType == WorkflowExecutionGraphConstants.RunNodeType &&
+            x.Properties["input"] == "hello" &&
+            x.Properties[WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey] == "12");
+        nodes.Should().Contain(x =>
+            x.NodeType == WorkflowExecutionGraphConstants.StepNodeType &&
+            x.Properties["stepId"] == "step-1" &&
+            x.Properties["displayName"] == "Draft response");
+        nodes.Should().Contain(x =>
+            x.NodeId == "actor:actor-1:cmd-1:child-1" &&
+            x.NodeType == WorkflowExecutionGraphConstants.ActorNodeType &&
+            x.Properties["actorId"] == "child-1");
         edges.Should().Contain(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeOwns);
         edges.Should().Contain(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeContainsStep && x.Properties["stepType"] == "llm_call");
+        nodes.Where(x => x.NodeType != WorkflowExecutionGraphConstants.RunNodeType)
+            .Should().OnlyContain(x => !x.Properties.ContainsKey(WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey));
+        edges.Should().OnlyContain(x => !x.Properties.ContainsKey(WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey));
         edges.Should().ContainSingle(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf);
         edges.Single(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf).FromNodeId.Should().Be("actor-1");
-        edges.Single(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf).ToNodeId.Should().Be("child-1");
+        edges.Single(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf).ToNodeId.Should().Be("actor:actor-1:cmd-1:child-1");
     }
 
     [Fact]
@@ -116,9 +130,13 @@ public sealed class WorkflowRunInsightReportDocumentReadModelTests
         nodes.Should().Contain(x => x.NodeType == WorkflowExecutionGraphConstants.RunNodeType);
         nodes.Should().Contain(x => x.NodeType == WorkflowExecutionGraphConstants.StepNodeType && x.Properties["stepId"] == "unknown");
         edges.Should().Contain(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeOwns);
+        nodes.Should().Contain(x =>
+            x.NodeId == "actor:unknown:unknown:child-1" &&
+            x.NodeType == WorkflowExecutionGraphConstants.ActorNodeType &&
+            x.Properties["actorId"] == "child-1");
         edges.Should().Contain(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeContainsStep);
         edges.Should().ContainSingle(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf);
         edges.Single(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf).FromNodeId.Should().Be("unknown");
-        edges.Single(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf).ToNodeId.Should().Be("child-1");
+        edges.Single(x => x.EdgeType == WorkflowExecutionGraphConstants.EdgeTypeChildOf).ToNodeId.Should().Be("actor:unknown:unknown:child-1");
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
@@ -782,6 +782,49 @@ public sealed class WorkflowProjectionMaterializationTests
     }
 
     [Fact]
+    public async Task WorkflowRunInsightReportArtifactProjector_ShouldMaterializeTypedSkippedOutcome()
+    {
+        var reportStore = new RecordingDocumentStore<WorkflowRunInsightReportDocument>(x => x.Id);
+        var graphWriter = new RecordingGraphWriter<WorkflowRunInsightReportDocument>(x => x.Id);
+        var projector = new WorkflowRunInsightReportArtifactProjector(reportStore, reportStore, graphWriter);
+        var context = new WorkflowExecutionMaterializationContext
+        {
+            RootActorId = "actor-1",
+            ProjectionKind = "workflow-execution-materialization",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                1,
+                new StepRequestEvent
+                {
+                    RunId = "run-1",
+                    StepId = "optional-step",
+                    StepType = "connector_call",
+                    DisplayName = "Optional connector",
+                },
+                BuildState("running")));
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                2,
+                new StepCompletedEvent
+                {
+                    RunId = "run-1",
+                    StepId = "optional-step",
+                    Success = true,
+                    Output = "unchanged input",
+                    Outcome = WorkflowStepCompletionOutcome.Skipped,
+                },
+                BuildState("running")));
+
+        reportStore.Stored["actor-1"].Steps.Should().ContainSingle();
+        reportStore.Stored["actor-1"].Steps[0].DisplayName.Should().Be("Optional connector");
+        reportStore.Stored["actor-1"].Steps[0].Outcome.Should().Be(WorkflowExecutionStepOutcomeReadModel.Skipped);
+    }
+
+    [Fact]
     public async Task WorkflowRunInsightReportArtifactProjector_ShouldIgnoreRelayedChildStateRoot()
     {
         var reportStore = new RecordingDocumentStore<WorkflowRunInsightReportDocument>(x => x.Id);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunGraphExportVersionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunGraphExportVersionTests.cs
@@ -62,6 +62,60 @@ public sealed class WorkflowRunGraphExportVersionTests
     }
 
     [Fact]
+    public async Task ArtifactQueryPort_ShouldPreserveGraphVersion_WhenFilteredTraversalOmitsRunNode()
+    {
+        var port = new WorkflowExecutionArtifactQueryPort(
+            new SingleDocumentReader<WorkflowRunInsightReportDocument>(new WorkflowRunInsightReportDocument
+            {
+                Id = "actor-1",
+                StateVersion = 12,
+            }),
+            new WorkflowExecutionReadModelMapper(),
+            new StaticProjectionGraphStore(
+                new ProjectionGraphSubgraph
+                {
+                    Nodes =
+                    [
+                        new ProjectionGraphNode
+                        {
+                            NodeId = "actor-1",
+                            NodeType = WorkflowExecutionGraphConstants.ActorNodeType,
+                        },
+                    ],
+                },
+                new ProjectionGraphSubgraph
+                {
+                    Nodes =
+                    [
+                        new ProjectionGraphNode
+                        {
+                            NodeId = "run:actor-1:cmd-1",
+                            NodeType = WorkflowExecutionGraphConstants.RunNodeType,
+                            Properties = new Dictionary<string, string>(StringComparer.Ordinal)
+                            {
+                                [WorkflowExecutionGraphConstants.RootActorIdPropertyKey] = "actor-1",
+                                [WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey] = "12",
+                            },
+                        },
+                    ],
+                }),
+            new WorkflowExecutionProjectionOptions { Enabled = true, WorkflowArtifactQueryEnabled = true });
+
+        var subgraph = await port.GetWorkflowRunGraphExportSubgraphAsync(
+            "actor-1",
+            depth: 1,
+            take: 1,
+            options: new WorkflowRunGraphExportQueryOptions
+            {
+                Direction = WorkflowRunGraphExportDirection.Inbound,
+                EdgeTypes = [WorkflowExecutionGraphConstants.EdgeTypeChildOf],
+            });
+
+        subgraph.Nodes.Should().NotContain(node => node.NodeType == WorkflowExecutionGraphConstants.RunNodeType);
+        subgraph.SourceStateVersion.Should().Be(12);
+    }
+
+    [Fact]
     public async Task ArtifactQueryPort_ShouldKeepOwnerGraphVersionAndRunScopedActorNode_WhenSharedActorAppearsInAnotherRun()
     {
         var graphStore = new InMemoryProjectionGraphStore();
@@ -132,7 +186,9 @@ public sealed class WorkflowRunGraphExportVersionTests
         }
     }
 
-    private sealed class StaticProjectionGraphStore(ProjectionGraphSubgraph subgraph) : IProjectionGraphStore
+    private sealed class StaticProjectionGraphStore(
+        ProjectionGraphSubgraph subgraph,
+        ProjectionGraphSubgraph? sourceVersionSubgraph = null) : IProjectionGraphStore
     {
         public Task ReplaceOwnerGraphAsync(ProjectionOwnedGraph graph, CancellationToken ct = default) =>
             throw new NotSupportedException();
@@ -174,9 +230,17 @@ public sealed class WorkflowRunGraphExportVersionTests
             ProjectionGraphQuery query,
             CancellationToken ct = default)
         {
-            _ = query;
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult(subgraph);
+            return Task.FromResult(IsSourceVersionQuery(query)
+                ? sourceVersionSubgraph ?? subgraph
+                : subgraph);
         }
+
+        private static bool IsSourceVersionQuery(ProjectionGraphQuery query) =>
+            query.Direction == ProjectionGraphDirection.Outbound &&
+            query.Depth == 1 &&
+            query.Take == 2000 &&
+            query.EdgeTypes.Count == 1 &&
+            string.Equals(query.EdgeTypes[0], WorkflowExecutionGraphConstants.EdgeTypeOwns, StringComparison.Ordinal);
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunGraphExportVersionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunGraphExportVersionTests.cs
@@ -1,0 +1,182 @@
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
+using Aevatar.CQRS.Projection.Runtime.Runtime;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Workflow.Application.Abstractions.Projections;
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using Aevatar.Workflow.Projection.Configuration;
+using Aevatar.Workflow.Projection.Orchestration;
+using Aevatar.Workflow.Projection.ReadModels;
+using FluentAssertions;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowRunGraphExportVersionTests
+{
+    [Fact]
+    public async Task ArtifactQueryPort_ShouldUseGraphRunNodeVersion_WhenSharedGraphNodePropertiesDiffer()
+    {
+        var port = new WorkflowExecutionArtifactQueryPort(
+            new SingleDocumentReader<WorkflowRunInsightReportDocument>(new WorkflowRunInsightReportDocument
+            {
+                Id = "actor-1",
+                StateVersion = 12,
+            }),
+            new WorkflowExecutionReadModelMapper(),
+            new StaticProjectionGraphStore(new ProjectionGraphSubgraph
+            {
+                Nodes =
+                [
+                    new ProjectionGraphNode
+                    {
+                        NodeId = "run:actor-1:cmd-1",
+                        NodeType = WorkflowExecutionGraphConstants.RunNodeType,
+                        Properties = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            [WorkflowExecutionGraphConstants.RootActorIdPropertyKey] = "actor-1",
+                            [WorkflowExecutionGraphConstants.SourceStateVersionPropertyKey] = "12",
+                        },
+                    },
+                    new ProjectionGraphNode
+                    {
+                        NodeId = "actor-1",
+                        Properties = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["sourceStateVersion"] = "99",
+                        },
+                    },
+                    new ProjectionGraphNode
+                    {
+                        NodeId = "step-1",
+                        Properties = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["sourceStateVersion"] = "11",
+                        },
+                    },
+                ],
+            }),
+            new WorkflowExecutionProjectionOptions { Enabled = true, WorkflowArtifactQueryEnabled = true });
+
+        var subgraph = await port.GetWorkflowRunGraphExportSubgraphAsync("actor-1");
+
+        subgraph.SourceStateVersion.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task ArtifactQueryPort_ShouldKeepOwnerGraphVersionAndRunScopedActorNode_WhenSharedActorAppearsInAnotherRun()
+    {
+        var graphStore = new InMemoryProjectionGraphStore();
+        var graphWriter = new ProjectionGraphWriter<WorkflowRunInsightReportDocument>(
+            graphStore,
+            new WorkflowRunInsightReportGraphMaterializer());
+        await graphWriter.UpsertAsync(new WorkflowRunInsightReportDocument
+        {
+            Id = "actor-1",
+            RootActorId = "actor-1",
+            CommandId = "cmd-1",
+            WorkflowName = "first",
+            StateVersion = 12,
+            Topology =
+            {
+                new WorkflowExecutionTopologyEdge("actor-1", "shared-actor"),
+            },
+        });
+        await graphWriter.UpsertAsync(new WorkflowRunInsightReportDocument
+        {
+            Id = "actor-2",
+            RootActorId = "actor-2",
+            CommandId = "cmd-2",
+            WorkflowName = "second",
+            StateVersion = 99,
+            Topology =
+            {
+                new WorkflowExecutionTopologyEdge("actor-2", "shared-actor"),
+            },
+        });
+        var port = new WorkflowExecutionArtifactQueryPort(
+            new SingleDocumentReader<WorkflowRunInsightReportDocument>(new WorkflowRunInsightReportDocument
+            {
+                Id = "actor-1",
+                StateVersion = 12,
+            }),
+            new WorkflowExecutionReadModelMapper(),
+            graphStore,
+            new WorkflowExecutionProjectionOptions { Enabled = true, WorkflowArtifactQueryEnabled = true });
+
+        var subgraph = await port.GetWorkflowRunGraphExportSubgraphAsync("actor-1");
+
+        subgraph.SourceStateVersion.Should().Be(12);
+        subgraph.Nodes.Should().Contain(node =>
+            node.NodeId == "actor:actor-1:cmd-1:shared-actor" &&
+            node.Properties["actorId"] == "shared-actor" &&
+            node.Properties["workflowName"] == "first");
+    }
+
+    private sealed class SingleDocumentReader<TReadModel>(TReadModel? document)
+        : IProjectionDocumentReader<TReadModel, string>
+        where TReadModel : class, IProjectionReadModel
+    {
+        public Task<TReadModel?> GetAsync(string key, CancellationToken ct = default)
+        {
+            _ = key;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(document);
+        }
+
+        public Task<ProjectionDocumentQueryResult<TReadModel>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default)
+        {
+            _ = query;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new ProjectionDocumentQueryResult<TReadModel>());
+        }
+    }
+
+    private sealed class StaticProjectionGraphStore(ProjectionGraphSubgraph subgraph) : IProjectionGraphStore
+    {
+        public Task ReplaceOwnerGraphAsync(ProjectionOwnedGraph graph, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UpsertNodeAsync(ProjectionGraphNode node, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UpsertEdgeAsync(ProjectionGraphEdge edge, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteNodeAsync(string scope, string nodeId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteEdgeAsync(string scope, string edgeId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ProjectionGraphNode>> ListNodesByOwnerAsync(
+            string scope,
+            string ownerId,
+            int skip = 0,
+            int take = 5000,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ProjectionGraphEdge>> ListEdgesByOwnerAsync(
+            string scope,
+            string ownerId,
+            int skip = 0,
+            int take = 5000,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ProjectionGraphEdge>> GetNeighborsAsync(
+            ProjectionGraphQuery query,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ProjectionGraphEdge>>([]);
+
+        public Task<ProjectionGraphSubgraph> GetSubgraphAsync(
+            ProjectionGraphQuery query,
+            CancellationToken ct = default)
+        {
+            _ = query;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(subgraph);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add version-aligned workflow run detail sections for overview, steps, timeline, and execution path with explicit `aligned`, `unavailable`, and `version_mismatch` statuses.
- Surface initiator, redacted input summary, typed step outcomes, runtime display names, and graph source versions through observatory, HTTP, and tool export surfaces.
- Keep graph source version owned by the graph artifact via run-scoped graph nodes, avoiding report-derived graph alignment and shared actor node overwrite.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~WorkflowRunObservatoryQueryServiceTests -v q`
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~ToolCallModuleApprovalTests -v q`
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~WorkflowRunGraphExportVersionTests|FullyQualifiedName~WorkflowRunInsightReportDocumentReadModelTests|FullyQualifiedName~WorkflowExecutionProjectionProjectorTests" -v q`
- [x] `dotnet test test/Aevatar.AI.ToolProviders.Workflow.Tests/Aevatar.AI.ToolProviders.Workflow.Tests.csproj --nologo --no-restore --filter FullyQualifiedName~WorkflowArtifactQueryTool_Subgraph_ShouldUseWorkflowRunGraphExportSubgraph -v q`
- [x] `git diff --check`
- [x] `bash tools/ci/query_projection_priming_guard.sh`
- [x] `bash tools/ci/projection_state_version_guard.sh`
- [x] `bash tools/ci/projection_route_mapping_guard.sh`
- [ ] `bash tools/ci/test_stability_guards.sh` blocked locally after passing polling wait and coverage-file checks by Homebrew Python 3.12 `pyexpat` / system `libexpat` mismatch.

Fixes aevatarAI/aevatar#3253

🤖 Generated with [Claude Code](https://claude.com/claude-code)