### PR TITLE
Unify Workflow Activity account identity

### DIFF
--- a/apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx
@@ -171,6 +171,29 @@ describe('NyxID callback page', () => {
     expect(await findByRole('alert')).toHaveTextContent(message);
   });
 
+  it('requests consent when sign-in is missing required service access', async () => {
+    handleRedirectCallback.mockRejectedValue(
+      Object.assign(new Error('required_service_access_missing'), {
+        flow: 'signIn',
+        reason: 'requiredServiceAccessMissing',
+        returnTo: '/scopes/scope-1/workflow-activity-vnext/workflows',
+      }),
+    );
+
+    const { findByRole } = render(React.createElement(CallbackPage));
+    const retryButton = await findByRole('button', {
+      name: 'Try sign-in again',
+    });
+
+    fireEvent.click(retryButton);
+
+    expect(loginWithRedirect).toHaveBeenCalledWith({
+      flow: 'signIn',
+      prompt: 'consent',
+      returnTo: '/scopes/scope-1/workflow-activity-vnext/workflows',
+    });
+  });
+
   it('keeps service access review retryable when authorization restart fails', async () => {
     handleRedirectCallback.mockRejectedValue(Object.assign(new Error('raw'), {
       flow: 'serviceAccessReview', reason: 'serviceAccessReviewUnavailable',

--- a/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
@@ -130,6 +130,9 @@ const CallbackPage: React.FC = () => {
       const client = new NyxIDAuthClient(config);
       await client.loginWithRedirect({
         flow: callbackError.flow,
+        ...(callbackError.reason === "requiredServiceAccessMissing"
+          ? { prompt: "consent" as const }
+          : {}),
         returnTo: callbackError.returnTo,
       });
     } catch (error) {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx
@@ -12,6 +12,7 @@ import {
   ConsoleAuthActions,
   ConsoleLanguageSwitch,
 } from '@/shared/ui/ConsoleHeaderActions';
+import { useWorkflowActivityAccount } from './account/useWorkflowActivityAccount';
 import {
   buildWorkflowActivitySectionHref,
   type WorkflowActivitySection,
@@ -19,11 +20,6 @@ import {
 import { workflowActivityVNextCss } from './styles';
 
 type ShellProps = {
-  readonly accountPrincipal?: {
-    readonly authenticated: boolean;
-    readonly displayName: string;
-    readonly picture: string | null;
-  } | null;
   readonly activeSection: WorkflowActivitySection;
   readonly children: React.ReactNode;
   readonly description?: string;
@@ -108,7 +104,6 @@ function Navigation({
 }
 
 const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
-  accountPrincipal,
   activeSection,
   children,
   description,
@@ -120,6 +115,7 @@ const WorkflowActivityVNextShell: React.FC<ShellProps> = ({
   scopeId,
   title,
 }) => {
+  const { principal: accountPrincipal } = useWorkflowActivityAccount();
   const [mobileNavigationOpen, setMobileNavigationOpen] = React.useState(false);
   const activeItem = items.find((item) => item.key === activeSection);
   const activeLabel = activeItem

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts
@@ -1,0 +1,104 @@
+import type { NyxIDAuthSession } from '@/shared/auth/session';
+import type { StudioAuthSession } from '@/shared/studio/models';
+import { resolveWorkflowActivityAccount } from './resolveWorkflowActivityAccount';
+
+function createStoredSession(sub = 'user-abigail'): NyxIDAuthSession {
+  return {
+    tokens: {
+      accessToken: 'token',
+      expiresAt: Date.now() + 60_000,
+      expiresIn: 60,
+      tokenType: 'Bearer',
+    },
+    user: {
+      email: 'abigail@example.test',
+      email_verified: true,
+      groups: ['platform'],
+      name: 'Abigail Deng',
+      picture: 'https://example.test/abigail.png',
+      roles: ['operator'],
+      sub,
+    },
+  };
+}
+
+function createBackendSession(
+  overrides: Partial<StudioAuthSession> = {},
+): StudioAuthSession {
+  return {
+    authenticated: true,
+    enabled: true,
+    providerDisplayName: 'NyxID',
+    session: {
+      authenticated: true,
+      expiresAtUtc: '2099-08-05T10:00:00Z',
+      scopeId: 'scope-alpha',
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveWorkflowActivityAccount', () => {
+  it('fills missing profile fields from a stored session with the same subject', () => {
+    const result = resolveWorkflowActivityAccount(
+      createBackendSession({ subject: 'user-abigail', profile: null }),
+      createStoredSession(),
+    );
+
+    expect(result.principal).toEqual({
+      authenticated: true,
+      displayName: 'Abigail Deng',
+      picture: 'https://example.test/abigail.png',
+    });
+    expect(result.auth?.profile).toEqual({
+      email: 'abigail@example.test',
+      emailVerified: true,
+      groups: ['platform'],
+      name: 'Abigail Deng',
+      picture: 'https://example.test/abigail.png',
+      roles: ['operator'],
+      subject: 'user-abigail',
+    });
+  });
+
+  it('does not reuse a stored profile for a different backend subject', () => {
+    const result = resolveWorkflowActivityAccount(
+      createBackendSession({ subject: 'user-calvin', profile: null }),
+      createStoredSession(),
+    );
+
+    expect(result.principal).toEqual({
+      authenticated: true,
+      displayName: '',
+      picture: null,
+    });
+    expect(result.auth?.profile).toBeNull();
+  });
+
+  it('keeps an explicit backend sign-out authoritative over stored state', () => {
+    const result = resolveWorkflowActivityAccount(
+      createBackendSession({
+        authenticated: false,
+        subject: 'user-abigail',
+        session: { authenticated: false },
+      }),
+      createStoredSession(),
+    );
+
+    expect(result.principal).toBeNull();
+  });
+
+  it('uses the stored profile while backend account facts are unavailable', () => {
+    const result = resolveWorkflowActivityAccount(
+      undefined,
+      createStoredSession(),
+    );
+
+    expect(result.auth).toBeUndefined();
+    expect(result.principal).toEqual({
+      authenticated: true,
+      displayName: 'Abigail Deng',
+      picture: 'https://example.test/abigail.png',
+    });
+  });
+});

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts
@@ -1,0 +1,107 @@
+import type { NyxIDAuthSession, NyxIDUserInfo } from '@/shared/auth/session';
+import type {
+  StudioAuthProfile,
+  StudioAuthSession,
+} from '@/shared/studio/models';
+
+export type WorkflowActivityAccountPrincipal = {
+  readonly authenticated: boolean;
+  readonly displayName: string;
+  readonly picture: string | null;
+};
+
+export type ResolvedWorkflowActivityAccount = {
+  readonly auth: StudioAuthSession | undefined;
+  readonly principal: WorkflowActivityAccountPrincipal | null;
+};
+
+function normalize(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function firstValue(
+  ...values: readonly (string | null | undefined)[]
+): string | undefined {
+  return values.map(normalize).find(Boolean);
+}
+
+function storedPrincipal(
+  storedSession: NyxIDAuthSession | null,
+): WorkflowActivityAccountPrincipal | null {
+  if (!storedSession) return null;
+  return {
+    authenticated: true,
+    displayName:
+      firstValue(
+        storedSession.user.name,
+        storedSession.user.email,
+        storedSession.user.sub,
+      ) || '',
+    picture: normalize(storedSession.user.picture) || null,
+  };
+}
+
+function mergeProfile(
+  auth: StudioAuthSession,
+  subject: string | undefined,
+  fallback: NyxIDUserInfo | undefined,
+): StudioAuthProfile | null | undefined {
+  const profile = auth.profile;
+  if (!profile && !fallback) return profile;
+
+  return {
+    subject: subject || null,
+    name: firstValue(profile?.name, auth.name, fallback?.name) || null,
+    email: firstValue(profile?.email, auth.email, fallback?.email) || null,
+    emailVerified: profile?.emailVerified ?? fallback?.email_verified ?? null,
+    picture:
+      firstValue(profile?.picture, auth.picture, fallback?.picture) || null,
+    roles: profile?.roles ?? fallback?.roles ?? [],
+    groups: profile?.groups ?? fallback?.groups ?? [],
+  };
+}
+
+export function resolveWorkflowActivityAccount(
+  auth: StudioAuthSession | undefined,
+  storedSession: NyxIDAuthSession | null,
+): ResolvedWorkflowActivityAccount {
+  if (!auth) {
+    return { auth: undefined, principal: storedPrincipal(storedSession) };
+  }
+
+  const subject = firstValue(auth.profile?.subject, auth.subject);
+  const storedSubject = normalize(storedSession?.user.sub);
+  const fallback =
+    subject && storedSubject === subject ? storedSession?.user : undefined;
+  const profile = mergeProfile(auth, subject, fallback);
+  const resolvedAuth: StudioAuthSession = {
+    ...auth,
+    subject: subject || null,
+    name: firstValue(profile?.name, auth.name, fallback?.name),
+    email: firstValue(profile?.email, auth.email, fallback?.email),
+    picture: firstValue(profile?.picture, auth.picture, fallback?.picture),
+    profile,
+  };
+  const authenticated =
+    resolvedAuth.authenticated && resolvedAuth.session?.authenticated !== false;
+
+  return {
+    auth: resolvedAuth,
+    principal: authenticated
+      ? {
+          authenticated: true,
+          displayName:
+            firstValue(
+              resolvedAuth.profile?.name,
+              resolvedAuth.name,
+              resolvedAuth.profile?.email,
+              resolvedAuth.email,
+            ) || '',
+          picture:
+            firstValue(resolvedAuth.profile?.picture, resolvedAuth.picture) ||
+            null,
+        }
+      : null,
+  };
+}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/useWorkflowActivityAccount.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/useWorkflowActivityAccount.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { loadRestorableAuthSession } from '@/shared/auth/session';
+import { studioApi } from '@/shared/studio/api';
+import { resolveWorkflowActivityAccount } from './resolveWorkflowActivityAccount';
+
+export const WORKFLOW_ACTIVITY_ACCOUNT_QUERY_KEY = [
+  'workflow-activity-vnext',
+  'account',
+] as const;
+
+export function useWorkflowActivityAccount() {
+  const query = useQuery({
+    queryKey: WORKFLOW_ACTIVITY_ACCOUNT_QUERY_KEY,
+    queryFn: () => studioApi.getAuthSession(),
+    retry: false,
+  });
+  const resolved = resolveWorkflowActivityAccount(
+    query.data,
+    loadRestorableAuthSession(),
+  );
+
+  return { query, ...resolved };
+}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -8,6 +8,10 @@ import {
   within,
 } from '@testing-library/react';
 import * as React from 'react';
+import {
+  clearStoredAuthSession,
+  persistAuthSession,
+} from '@/shared/auth/session';
 import { history } from '@/shared/navigation/history';
 import {
   cleanupTestQueryClients,
@@ -252,7 +256,13 @@ jest.mock('@/shared/studio/api', () => ({
     createWorkflowDraft: jest.fn(),
     deleteWorkflowDraft: jest.fn(),
     getWorkspaceSettings: jest.fn(),
-    getAuthSession: jest.fn(),
+    getAuthSession: jest.fn(async () => ({
+      authenticated: true,
+      enabled: true,
+      profile: null,
+      session: { authenticated: true },
+      subject: 'test-user',
+    })),
     getUserConfigRuntime: jest.fn(),
     getUserLlmSettings: jest.fn(),
     getWorkflow: jest.fn(),
@@ -346,10 +356,13 @@ jest.mock('@/shared/ui/ConsoleHeaderActions', () => ({
     principal?: {
       authenticated: boolean;
       displayName: string;
+      picture: string | null;
     } | null;
   }) => (
     <button
       data-auth-source={principal === undefined ? 'stored' : 'account'}
+      data-picture={principal?.picture ?? ''}
+      title={principal?.displayName}
       type="button"
     >
       {principal?.authenticated ? principal.displayName : 'Account'}
@@ -1433,6 +1446,7 @@ describe('Workflow Activity vNext settings', () => {
   beforeEach(() => {
     mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/settings';
     jest.clearAllMocks();
+    clearStoredAuthSession();
     mockStudioApi.getUserLlmSettings.mockResolvedValue({
       savedSelection: null,
       savedRouteLabel: 'System default',
@@ -1484,7 +1498,48 @@ describe('Workflow Activity vNext settings', () => {
     mockObserveUserLlmSave.mockResolvedValue({ phase: 'observed' });
   });
 
-  afterEach(() => cleanupTestQueryClients());
+  afterEach(() => {
+    clearStoredAuthSession();
+    cleanupTestQueryClients();
+  });
+
+  it('uses the matching NyxID profile when the account endpoint omits header fields', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'token',
+        expiresAt: Date.now() + 60_000,
+        expiresIn: 60,
+        tokenType: 'Bearer',
+      },
+      user: {
+        email: 'abigail@example.test',
+        name: 'Abigail Deng',
+        picture: 'https://example.test/abigail.png',
+        sub: 'user-abigail',
+      },
+    });
+    mockStudioApi.getAuthSession.mockResolvedValue({
+      enabled: true,
+      authenticated: true,
+      providerDisplayName: 'NyxID',
+      subject: 'user-abigail',
+      profile: null,
+      session: {
+        authenticated: true,
+        scopeId: 'scope-alpha',
+        scopeSource: 'nyxid-session',
+        expiresAtUtc: '2099-08-05T10:00:00Z',
+      },
+    });
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    expect(await screen.findByTitle('Abigail Deng')).toBeInTheDocument();
+    expect(screen.getByTitle('Abigail Deng')).toHaveAttribute(
+      'data-picture',
+      'https://example.test/abigail.png',
+    );
+  });
 
   it('renders authoritative identity and the effective workflow execution target', async () => {
     renderWithQueryClient(<WorkflowActivityVNextPage />);

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx
@@ -25,6 +25,7 @@ import { t } from '@/shared/i18n/messages';
 import { history } from '@/shared/navigation/history';
 import { isStudioApiStatus, studioApi } from '@/shared/studio/api';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
+import { useWorkflowActivityAccount } from '../account/useWorkflowActivityAccount';
 import { useConsoleLocation } from '../hooks/useConsoleLocation';
 import TechnicalDetails from '../TechnicalDetails';
 import WorkflowActivityVNextShell from '../WorkflowActivityVNextShell';
@@ -107,11 +108,7 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
     queryFn: ({ signal }) => studioApi.getUserLlmSettings(signal),
     retry: false,
   });
-  const auth = useQuery({
-    queryKey: ['workflow-activity-vnext', 'settings', 'auth'],
-    queryFn: () => studioApi.getAuthSession(),
-    retry: false,
-  });
+  const { auth: resolvedAuth, query: auth } = useWorkflowActivityAccount();
   const runtime = useQuery({
     queryKey: ['workflow-activity-vnext', 'settings', 'runtime'],
     queryFn: () => studioApi.getUserConfigRuntime(),
@@ -119,10 +116,10 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
   });
   const accountIdentity = React.useMemo(
     () =>
-      auth.data
-        ? buildAccountIdentity(auth.data, Date.now(), getLocale())
+      resolvedAuth
+        ? buildAccountIdentity(resolvedAuth, Date.now(), getLocale())
         : null,
-    [auth.data],
+    [resolvedAuth],
   );
   const [draft, setDraft] = React.useState<UserLlmSelectionDraft | undefined>(
     undefined,
@@ -536,7 +533,7 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
       onRetry={() => void auth.refetch()}
       title={t('workflowActivityVNext.settings.notLoaded', 'Not loaded')}
     />
-  ) : auth.data && accountIdentity ? (
+  ) : resolvedAuth && accountIdentity ? (
     <AccountPanel
       identity={accountIdentity}
       returnTo={`${location.pathname}?section=account`}
@@ -691,20 +688,6 @@ const SettingsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
 
   return (
     <WorkflowActivityVNextShell
-      accountPrincipal={
-        accountIdentity
-          ? {
-              authenticated:
-                accountIdentity.sessionState === 'active' ||
-                accountIdentity.sessionState === 'expiring_soon',
-              displayName:
-                accountIdentity.displayName.kind === 'value'
-                  ? accountIdentity.displayName.value
-                  : t('workflowActivityVNext.settings.account', 'Account'),
-              picture: accountIdentity.picture,
-            }
-          : null
-      }
       activeSection="settings"
       description={t(
         'workflowActivityVNext.settings.description',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.ts
@@ -113,7 +113,7 @@ export function buildAccountIdentity(
     support: {
       groups: auth.profile?.groups ?? [],
       roles: auth.profile?.roles ?? [],
-      subject: auth.profile?.subject?.trim() || null,
+      subject: auth.profile?.subject?.trim() || auth.subject?.trim() || null,
     },
   };
 }

--- a/apps/aevatar-console-web/src/shared/auth/client.test.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.test.ts
@@ -290,6 +290,38 @@ describe("NyxIDAuthClient", () => {
     expect(loadStoredAuthSession()?.tokens.accessToken).toBe("review-access-token");
   });
 
+  it("recognizes a plain-text required service access failure during sign-in", async () => {
+    const pendingKey = "aevatar-console:nyxid:pending:broker-client-1";
+    window.localStorage.setItem(
+      pendingKey,
+      JSON.stringify({
+        clientId: "broker-client-1",
+        codeVerifier: "pkce-verifier",
+        redirectUri: "http://localhost:8000/auth/callback",
+        returnTo: "/scopes/scope-1/workflow-activity-vnext/workflows",
+        scope: "openid urn:nyxid:scope:broker_binding proxy",
+        state: "state-1",
+        flow: "signIn",
+      }),
+    );
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: async () => "required_service_access_missing",
+    } as Response) as typeof global.fetch;
+
+    await expect(
+      new NyxIDAuthClient(runtimeConfig).handleRedirectCallback(
+        "http://localhost:8000/auth/callback?code=auth-code&state=state-1",
+      ),
+    ).rejects.toMatchObject({
+      flow: "signIn",
+      reason: "requiredServiceAccessMissing",
+      returnTo: "/scopes/scope-1/workflow-activity-vnext/workflows",
+    });
+  });
+
   it.each<[number, string, NyxIDAuthCallbackErrorReason]>([
     [409, "required_service_access_missing", "requiredServiceAccessMissing"],
     [503, "issued_binding_invalid", "issuedBindingInvalid"],

--- a/apps/aevatar-console-web/src/shared/auth/client.ts
+++ b/apps/aevatar-console-web/src/shared/auth/client.ts
@@ -123,14 +123,19 @@ function resolveFinalizationErrorReason(
   flow: AuthFlow,
   error: unknown,
 ): NyxIDAuthCallbackErrorReason {
-  if (flow !== "serviceAccessReview") return "signInFailed";
   if (!(error instanceof NyxIDLoginFinalizationError)) {
-    return "serviceAccessReviewFailed";
+    return flow === "serviceAccessReview"
+      ? "serviceAccessReviewFailed"
+      : "signInFailed";
   }
 
-  switch (error.code) {
-    case "required_service_access_missing":
-      return "requiredServiceAccessMissing";
+  const errorCode = error.code ?? error.message;
+  if (errorCode === "required_service_access_missing") {
+    return "requiredServiceAccessMissing";
+  }
+  if (flow !== "serviceAccessReview") return "signInFailed";
+
+  switch (errorCode) {
     case "issued_binding_invalid":
       return "issuedBindingInvalid";
     case "issued_binding_probe_failed":

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -52,6 +52,7 @@ export interface StudioAppContext {
 export interface StudioAuthSession {
   readonly enabled: boolean;
   readonly authenticated: boolean;
+  readonly subject?: string | null;
   readonly providerDisplayName?: string;
   readonly loginUrl?: string;
   readonly logoutUrl?: string;

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.test.tsx
@@ -120,6 +120,32 @@ describe('ConsoleHeaderActions', () => {
     expect(screen.queryByText('Stale Browser Name')).not.toBeInTheDocument();
   });
 
+  it('clears a stale stored session before authoritative sign-in recovery', () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'stale-token',
+        expiresAt: Date.now() + 60_000,
+        expiresIn: 60,
+        tokenType: 'Bearer',
+      },
+      user: {
+        name: 'Stale Browser Name',
+        sub: 'stored-user',
+      },
+    });
+
+    render(React.createElement(ConsoleAuthActions, { principal: null }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    expect(
+      window.localStorage.getItem('aevatar-console:nyxid:session'),
+    ).toBeNull();
+    expect(mockedHistoryPush).toHaveBeenCalledWith(
+      '/login?redirect=%2Fruntime%2Fmission-wall%3FfocusRunId%3Drun-1',
+    );
+  });
+
   it('applies an optional dropdown root class to action menus', async () => {
     persistAuthSession({
       tokens: {

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
@@ -123,6 +123,9 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
         className="console-header-actions__login"
         icon={<LoginOutlined />}
         onClick={() => {
+          if (hasAuthoritativePrincipal && storedSession) {
+            clearStoredAuthSession();
+          }
           history.push(buildLoginRoute(getCurrentReturnTo()));
         }}
         type="link"

--- a/docs/superpowers/plans/2026-08-11-workflow-account-identity.md
+++ b/docs/superpowers/plans/2026-08-11-workflow-account-identity.md
@@ -45,4 +45,4 @@
 - [x] **Step 2: Run dependency-related Jest tests and explicit changed test files**
 - [x] **Step 3: Run Biome only on analyzer `staticCheckFiles`; skip local full typecheck/build**
 - [x] **Step 4: Inspect the complete diff and browser-smoke Settings and Workflows in the user's Chrome**
-- [ ] **Step 5: Stage only task files, commit, push, and create the follow-up PR with exact validation evidence**
+- [x] **Step 5: Stage only task files, commit, push, and create the follow-up PR with exact validation evidence**

--- a/docs/superpowers/plans/2026-08-11-workflow-account-identity.md
+++ b/docs/superpowers/plans/2026-08-11-workflow-account-identity.md
@@ -1,0 +1,48 @@
+# Workflow Activity Account Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every Workflow Activity vNext route render one subject-safe account identity in the global header and Settings account surface.
+
+**Architecture:** A shared React Query hook owns `/api/auth/me` for the vNext surface. A pure resolver merges missing presentation fields from the stored NyxID session only when backend and stored subjects match, and exposes the same resolved data to the shell and Settings.
+
+**Tech Stack:** React 19, TypeScript, TanStack React Query, Jest, Testing Library
+
+---
+
+### Task 1: Specify identity resolution
+
+**Files:**
+- Create: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts`
+- Create: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts`
+- Modify: `apps/aevatar-console-web/src/shared/studio/models.ts`
+
+- [x] **Step 1: Write failing tests for matching subject fallback, subject mismatch, and authoritative sign-out**
+- [x] **Step 2: Run the new Jest file and confirm it fails because the resolver does not exist**
+- [x] **Step 3: Add the top-level auth subject type and implement the minimal pure resolver**
+- [x] **Step 4: Run the new Jest file and confirm all resolver cases pass**
+
+### Task 2: Make the vNext shell the identity consumer
+
+**Files:**
+- Create: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/useWorkflowActivityAccount.ts`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/SettingsPage.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/settings/accountIdentity.ts`
+
+- [x] **Step 1: Add a failing Settings integration test that reproduces the missing avatar with a matching stored session**
+- [x] **Step 2: Run the focused integration test and confirm the header still renders `Account`**
+- [x] **Step 3: Add the shared account hook, remove the route-level shell prop, and feed Settings the resolved auth session**
+- [x] **Step 4: Run the integration and resolver tests and confirm they pass**
+
+### Task 3: Focused validation and delivery
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`
+- Modify: pull request description for the follow-up identity-fix PR
+
+- [x] **Step 1: Run the frontend scope analyzer against `origin/feat/2026-08-04_workflow-activity-vnext`**
+- [x] **Step 2: Run dependency-related Jest tests and explicit changed test files**
+- [x] **Step 3: Run Biome only on analyzer `staticCheckFiles`; skip local full typecheck/build**
+- [x] **Step 4: Inspect the complete diff and browser-smoke Settings and Workflows in the user's Chrome**
+- [ ] **Step 5: Stage only task files, commit, push, and create the follow-up PR with exact validation evidence**

--- a/docs/superpowers/specs/2026-08-11-workflow-account-identity-design.md
+++ b/docs/superpowers/specs/2026-08-11-workflow-account-identity-design.md
@@ -1,0 +1,22 @@
+# Workflow Activity Account Identity Design
+
+## Problem
+
+Workflow Activity vNext currently lets each route choose the header identity source. Settings passes `/api/auth/me` data into the shell, while Workflows, Activity, and editor routes omit that prop and let the header read the stored NyxID session. Because the current backend response does not include profile fields, the same browser session renders `Account` without an avatar on Settings and the real name and avatar elsewhere.
+
+## Decision
+
+Workflow Activity vNext will have one account identity owner. A shared hook will query `/api/auth/me`, combine it with the restorable NyxID session, and provide both the resolved backend session and the header principal. The shell will always consume this principal; individual routes will no longer provide account identity props.
+
+The backend response remains authoritative for authentication state. Stored NyxID profile fields may fill missing name, email, verification, picture, roles, and groups only when the backend subject exactly matches the stored NyxID `sub`. A mismatched or unknown subject must not reuse cached profile data. An explicitly unauthenticated backend response must render signed-out state even when a restorable browser session exists.
+
+## Components
+
+- `useWorkflowActivityAccount` owns the shared React Query request and identity resolution.
+- `resolveWorkflowActivityAccount` is a pure function that validates subject ownership and merges missing profile presentation fields.
+- `WorkflowActivityVNextShell` always renders the resolved principal from the shared hook.
+- `SettingsPage` reuses the hook's query state and resolved auth session for the Account panel.
+
+## Verification
+
+Focused tests will cover matching-subject fallback, mismatched-subject rejection, explicit signed-out authority, and the Settings route regression where the backend omits profile fields but the matching NyxID session contains the real name and avatar. Browser verification will use the user's existing Chrome session on both Settings and Workflows.


### PR DESCRIPTION
## Problem

Workflow Activity vNext selected the header identity source per route. Settings passed `/api/auth/me` data into the shell, while Workflows, Activity, and editor routes fell back to the stored NyxID session. Because the current backend response omits profile name and picture, the same signed-in user appeared as `Account` without an avatar on Settings and as the real user elsewhere.

A follow-up browser regression also exposed an unrecoverable stale-session state: when `/api/auth/me` authoritatively reported signed out but an apparently active local NyxID session remained, the header showed `Sign in`, the workflow catalogue returned `401`, and the login page immediately redirected back using the stale session. If finalization returned `required_service_access_missing`, a normal retry did not request consent and repeated the same failure.

Follow-up to #3411. Backend profile contract completion remains tracked by #3410.

## Solution

- Add one shared vNext account hook that owns `/api/auth/me` and header identity resolution.
- Merge missing NyxID profile presentation fields only when the backend subject exactly matches the stored session `sub`.
- Keep explicit backend sign-out authoritative and reject mismatched or unknown cached subjects.
- Remove the Settings-only shell principal prop so every vNext route consumes the same identity owner.
- Reuse the resolved auth session in the Settings Account panel.
- Clear a conflicting local NyxID session when an authoritative signed-out header starts sign-in recovery, preventing the login-page redirect loop.
- Recognize `required_service_access_missing` during ordinary sign-in, including plain-text backend responses, and retry with `prompt=consent` while preserving the original return route.

## Impact

- Workflow Activity vNext global header across Settings, Workflows, Activity, and editor surfaces
- Settings Account profile presentation while `/api/auth/me` omits optional profile fields
- Shared console sign-in recovery when the local NyxID session disagrees with the authoritative Studio session
- NyxID callback recovery when required proxy service access must be re-approved
- Adds the top-level auth `subject` field already returned by the backend to the frontend contract
- No backend endpoint or contract changes

## Local verification

- Related tests: `pnpm exec jest --findRelatedTests src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts src/pages/workflow-activity-vnext/account/useWorkflowActivityAccount.ts src/pages/workflow-activity-vnext/settings/AccountPanel.tsx src/pages/workflow-activity-vnext/settings/SettingsPage.tsx src/pages/workflow-activity-vnext/settings/accountIdentity.ts src/pages/workflow-activity-vnext/styles.ts src/shared/studio/models.ts --runInBand` - passed (105 suites, 1292 tests)
- Changed identity tests: `pnpm exec jest src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/settings/AccountPanel.test.tsx src/pages/workflow-activity-vnext/settings/accountIdentity.test.ts --runInBand` - passed (4 suites, 124 tests; Jest emitted its existing post-run open-handle notice)
- Focused account recovery tests: `pnpm test src/pages/auth/callback/index.test.tsx src/shared/auth/client.test.ts src/shared/ui/ConsoleHeaderActions.test.tsx --runInBand` - passed (3 suites, 31 tests)
- Focused identity resolver: `pnpm exec jest src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts --runInBand` - passed (4 tests)
- Changed identity-file static checks: `pnpm exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/WorkflowActivityVNextShell.tsx src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts src/pages/workflow-activity-vnext/account/useWorkflowActivityAccount.ts src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/settings/AccountPanel.test.tsx src/pages/workflow-activity-vnext/settings/AccountPanel.tsx src/pages/workflow-activity-vnext/settings/SettingsPage.tsx src/pages/workflow-activity-vnext/settings/accountIdentity.test.ts src/pages/workflow-activity-vnext/settings/accountIdentity.ts src/pages/workflow-activity-vnext/styles.ts src/shared/studio/models.ts` - passed (14 files)
- Focused recovery lint: `pnpm biome lint src/shared/ui/ConsoleHeaderActions.tsx src/shared/ui/ConsoleHeaderActions.test.tsx src/shared/auth/client.ts src/shared/auth/client.test.ts src/pages/auth/callback/index.tsx src/pages/auth/callback/index.test.tsx` - passed (6 files)
- Test guard: `bash tools/ci/test_stability_guards.sh` - passed
- Diff check: `git diff --check` - passed
- Initial Chrome smoke on `http://localhost:5175` with the remote backend - passed; Settings and Workflows both rendered `Abigail Deng`, used the same avatar URL, and loaded initial API data.
- Stale-session Chrome regression on the same user-owned tab - reproduced the authoritative signed-out state and catalogue `401`; after the follow-up fix, `Sign in` reaches the login page without bouncing, required-service-access errors receive localized guidance, and retry reaches NyxID consent with `prompt=consent`, the complete required scope set, and `http://localhost:5175/auth/callback`. Final post-consent Workflows/Settings verification requires the account owner to approve the displayed service grant.
- Affected typecheck: unavailable; full type verification delegated to GitHub CI.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
