### PR TITLE
Separate NyxID internal transport from public authority

### DIFF
--- a/.claude/skills/frontend-refactor-team/browser-qa-reviewer-prompt.md
+++ b/.claude/skills/frontend-refactor-team/browser-qa-reviewer-prompt.md
@@ -38,7 +38,7 @@ If the report is missing the information needed to find or exercise the feature,
 
 ## Auth Injection Protocol
 
-This app stores auth session in `localStorage` under key `aevatar-console:nyxid:session`. The session contains OAuth2 tokens from NyxID (`https://nyx.chrono-ai.fun`).
+This app stores auth session in `localStorage` under key `aevatar-console:nyxid:session`. The session contains OAuth2 tokens from NyxID (`https://nyx-api.chrono-ai.fun`).
 
 **Before navigating to any protected route**, inject a valid session:
 
@@ -46,7 +46,7 @@ This app stores auth session in `localStorage` under key `aevatar-console:nyxid:
 
 2. Refresh the access token:
 ```bash
-curl -s -X POST "https://nyx.chrono-ai.fun/oauth/token" \
+curl -s -X POST "https://nyx-api.chrono-ai.fun/oauth/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=refresh_token&refresh_token=$REFRESH_TOKEN"
 ```
@@ -54,7 +54,7 @@ If this fails (401/400), the refresh token is expired. Return `BLOCKED` with `bl
 
 3. Fetch user info:
 ```bash
-curl -s "https://nyx.chrono-ai.fun/oauth/userinfo" \
+curl -s "https://nyx-api.chrono-ai.fun/oauth/userinfo" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/.claude/skills/setup-browser-auth/SKILL.md
+++ b/.claude/skills/setup-browser-auth/SKILL.md
@@ -47,7 +47,7 @@ If the user provides a full session JSON instead of just the token, extract `tok
 ## Phase 2: Refresh Token via NyxID
 
 ```bash
-NYXID_BASE_URL="${NYXID_BASE_URL:-https://nyx.chrono-ai.fun}"
+NYXID_BASE_URL="${NYXID_BASE_URL:-https://nyx-api.chrono-ai.fun}"
 
 TOKEN_RESPONSE=$(curl -s -X POST "${NYXID_BASE_URL}/oauth/token" \
   -H "Content-Type: application/x-www-form-urlencoded" \
@@ -130,7 +130,7 @@ console.log('Auth:', s?.user?.email, 'expires:', new Date(s?.tokens?.expiresAt).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NYXID_BASE_URL` | `https://nyx.chrono-ai.fun` | NyxID OAuth server |
+| `NYXID_BASE_URL` | `https://nyx-api.chrono-ai.fun` | NyxID OAuth server |
 | `NYXID_REFRESH_TOKEN` | (none) | Refresh token for auto-injection |
 | target URL arg | `http://127.0.0.1:5173` | App URL to open after auth |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,7 +2,7 @@
 
 **Aevatar** 是基于**虚拟 Actor 模型**构建的自主 Agent 平台。它提供三种核心原语 — **GAgent**、**Workflow**、**Script** — 每一种都可以发布为 **Service**，并通过 **Aevatar Mainnet** 上的虚拟 Actor 对外提供服务。与 **[NyxID](https://github.com/ChronoAIProject/NyxID)** 平台的深度集成，为所有服务提供了身份感知的访问控制、凭证托管和跨平台连接能力。
 
-**Mainnet 控制台：** [aevatar-console.aevatar.ai](https://aevatar-console.aevatar.ai/) | **NyxID 平台：** [nyx.chrono-ai.fun](https://nyx.chrono-ai.fun/)
+**Mainnet 控制台：** [aevatar-console.aevatar.ai](https://aevatar-console.aevatar.ai/) | **NyxID 平台：** [nyx-api.chrono-ai.fun](https://nyx-api.chrono-ai.fun/)
 
 > [English Version](README.md)
 
@@ -239,7 +239,7 @@ Runtime:
 
 ## NyxID 集成
 
-Aevatar 与 **[NyxID](https://github.com/ChronoAIProject/NyxID)**（[nyx.chrono-ai.fun](https://nyx.chrono-ai.fun/)）— 一个身份与凭证托管平台 — 深度集成。NyxID 为 Mainnet 上的所有服务提供身份层、LLM 网关、工具访问控制和跨平台连接能力。
+Aevatar 与 **[NyxID](https://github.com/ChronoAIProject/NyxID)**（[nyx-api.chrono-ai.fun](https://nyx-api.chrono-ai.fun/)）— 一个身份与凭证托管平台 — 深度集成。NyxID 为 Mainnet 上的所有服务提供身份层、LLM 网关、工具访问控制和跨平台连接能力。
 
 ### 身份与认证
 

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdBrokerOptions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdBrokerOptions.cs
@@ -9,11 +9,20 @@ namespace Aevatar.GAgents.Channel.Identity.Broker;
 /// </summary>
 public sealed class NyxIdBrokerOptions
 {
-    public const string ResourceServerBaseUrlConfigurationKey = "Aevatar:NyxId:ApiBaseUrl";
+    public const string InternalApiBaseUrlConfigurationKey = "Aevatar:NyxId:InternalApiBaseUrl";
+    public const string ApiBaseUrlConfigurationKey = "Aevatar:NyxId:ApiBaseUrl";
+    public const string ResourceServerBaseUrlConfigurationKey = "Aevatar:NyxId:Authority";
 
     /// <summary>
-    /// Canonical NyxID backend base URL used for RFC 8707 resource indicators.
-    /// This is independent from the OAuth authority stored by the OAuth client actor.
+    /// Effective NyxID HTTP transport base URL used for server-to-server API calls.
+    /// This prefers the internal cluster address and must not be used as an
+    /// OAuth issuer, audience, or RFC 8707 resource identity.
+    /// </summary>
+    public string TransportBaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Canonical public NyxID authority used for RFC 8707 resource indicators.
+    /// This remains independent from the HTTP transport base URL.
     /// </summary>
     public string ResourceServerBaseUrl { get; set; } = string.Empty;
 

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdBrokerOptionsValidator.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdBrokerOptionsValidator.cs
@@ -9,6 +9,14 @@ internal sealed class NyxIdBrokerOptionsValidator : IValidateOptions<NyxIdBroker
         ArgumentNullException.ThrowIfNull(options);
 
         var failures = new List<string>();
+        ValidateBaseUrl(
+            options.TransportBaseUrl,
+            nameof(NyxIdBrokerOptions.TransportBaseUrl),
+            failures);
+        ValidateBaseUrl(
+            options.ResourceServerBaseUrl,
+            nameof(NyxIdBrokerOptions.ResourceServerBaseUrl),
+            failures);
         ValidateServiceSlug(
             options.RequiredLlmServiceSlug,
             nameof(NyxIdBrokerOptions.RequiredLlmServiceSlug),
@@ -34,6 +42,19 @@ internal sealed class NyxIdBrokerOptionsValidator : IValidateOptions<NyxIdBroker
         return failures.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static void ValidateBaseUrl(
+        string? baseUrl,
+        string optionName,
+        ICollection<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl) ||
+            !Uri.TryCreate(baseUrl, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            failures.Add($"{optionName} must be an absolute HTTP or HTTPS URL.");
+        }
     }
 
     private static void ValidateServiceSlug(

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -614,7 +614,7 @@ public sealed class NyxIdRemoteCapabilityBroker :
     {
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
-            $"{_options.ResourceServerBaseUrl.Trim().TrimEnd('/')}{UserServicesEndpoint}");
+            $"{_options.TransportBaseUrl.Trim().TrimEnd('/')}{UserServicesEndpoint}");
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
         var http = CreateHttpClient();

--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -260,6 +260,14 @@ public static class IdentityServiceCollectionExtensions
         {
             services.Configure<NyxIdBrokerOptions>(options =>
             {
+                var internalApiBaseUrl =
+                    configuration[NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey];
+                options.TransportBaseUrl =
+                    (!string.IsNullOrWhiteSpace(internalApiBaseUrl)
+                        ? internalApiBaseUrl
+                        : configuration[NyxIdBrokerOptions.ApiBaseUrlConfigurationKey] ?? string.Empty)
+                    .Trim()
+                    .TrimEnd('/');
                 options.ResourceServerBaseUrl =
                     (configuration[NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] ?? string.Empty)
                     .Trim()

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdAuthorityResolver.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/NyxIdAuthorityResolver.cs
@@ -16,7 +16,7 @@ public static class NyxIdAuthorityResolver
     /// hidden config dependencies. Override via the environment variable
     /// <c>AEVATAR_NYXID_AUTHORITY</c> for staging / dev / test deploys.
     /// </summary>
-    public const string DefaultAuthority = "https://nyx.chrono-ai.fun";
+    public const string DefaultAuthority = "https://nyx-api.chrono-ai.fun";
 
     public const string OverrideEnvVar = "AEVATAR_NYXID_AUTHORITY";
 

--- a/apps/aevatar-console-web/.env.example
+++ b/apps/aevatar-console-web/.env.example
@@ -21,7 +21,7 @@ AEVATAR_PROXY_PRESERVE_AUTH_HOST=true
 
 # NyxID login
 # Register a public client in NyxID and keep redirect URI aligned with the frontend port.
-NYXID_BASE_URL=https://nyx.chrono-ai.fun
+NYXID_BASE_URL=https://nyx-api.chrono-ai.fun
 NYXID_CLIENT_ID=
 NYXID_REDIRECT_URI=http://127.0.0.1:5173/auth/callback
 NYXID_SCOPE="openid profile email offline_access urn:nyxid:scope:broker_binding proxy"

--- a/apps/aevatar-console-web/README.md
+++ b/apps/aevatar-console-web/README.md
@@ -48,7 +48,7 @@ through `/api/auth/nyxid/finalize`, so keep `/api/auth/*` proxied to the Studio
 backend. Configure all four browser OAuth values before building:
 
 ```bash
-NYXID_BASE_URL=https://nyx.chrono-ai.fun
+NYXID_BASE_URL=https://nyx-api.chrono-ai.fun
 NYXID_CLIENT_ID=replace-with-public-client-id
 NYXID_SCOPE="openid profile email offline_access urn:nyxid:scope:broker_binding proxy"
 NYXID_REDIRECT_URI=http://127.0.0.1:5173/auth/callback

--- a/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
+++ b/docs/adr/0018-per-user-nyxid-binding-via-oauth-broker.md
@@ -125,7 +125,7 @@ NyxID 2026-07-06 至 2026-07-08 的 OAuth 更新把第三方应用 service acces
 
 `aevatar`、部署默认 LLM、Ornn 与 Sandbox service 是 Studio 登录、channel binding 和后续对话/skill/code execution 正常工作的必要资源,不是可选 UI 偏好. 因此最终 contract 为:
 
-- channel `/init` 的 `/oauth/authorize` 请求显式携带配置化必需 resource 集合. `nyxid_api_base_url` 对应 NyxID backend `BASE_URL` / Aevatar `Aevatar:NyxId:ApiBaseUrl`,不得从浏览器 OAuth authority 或 JWT issuer 派生；各 service slug 由对应 provider 配置注入.控制台登录不发送该集合.
+- channel `/init` 的 `/oauth/authorize` 请求显式携带配置化必需 resource 集合. resource identity 对应 NyxID backend `BASE_URL` / Aevatar `Aevatar:NyxId:Authority`;服务端 HTTP 客户端优先使用 `Aevatar:NyxId:InternalApiBaseUrl`,未配置时才回退到现有公网 `Aevatar:NyxId:ApiBaseUrl`.内部传输地址不得参与 resource URI、issuer 或 audience 构造；各 service slug 由对应 provider 配置注入.控制台登录不发送该集合.
 - NyxID authorization decision 必须在服务端校验前端提交的 service ID 是否存在且可由当前用户授权;前端异步加载的 service picker 负责选择体验,不能单独成为授权事实源.带 RFC 8707 `resource` 的 flow 还必须由服务端解析并合并对应必需 service ID.
 - authorization-code exchange、控制台 refresh 与 broker 的主 token-exchange 都省略 `resource`,继承完整 Consent 边界;Aevatar 不把用户在前端选择的完整 grant 收窄为部署最低集合.
 - broker 每次拿到完整 grant token 后先校验 `resources` claim.若 claim 未枚举必需 resource,使用 token 的 `allow_all_services/allowed_service_ids` 与 NyxID `/api/v1/user-services` 的权威 ID/resource 映射校验;catalog 中存在但 token 未授权的 ID 不计入显式 grant.校验只读,返回给 runtime 的仍是原始完整 grant token.

--- a/docs/canon/backend-console.md
+++ b/docs/canon/backend-console.md
@@ -41,13 +41,31 @@ Nyx/OIDC deployment facts are host configuration, not page source:
 | `Aevatar:BackendConsole:OidcClientId` | Canonical public OAuth client id used by embedded-console PKCE, Studio login/finalization, broker token-exchange, and binding revoke. Bootstrap materializes this value into the OAuth Client Actor; no runtime path may fall back to an older projected client id. |
 | `Aevatar:BackendConsole:OidcScope` | Browser OIDC scope. The host adds `offline_access` to every non-empty configured scope to obtain the rotating refresh token required for a durable console session. |
 | `Aevatar:BackendConsole:OidcResources` | Additional RFC 8707 resource indicators. The host always includes `{NyxApiBaseUrl}/api/v1/proxy/s/aevatar` and the Ornn proxy resource resolved from `Aevatar:Ornn:NyxIdSlug` (default `ornn-api`). |
-| `Aevatar:BackendConsole:NyxApiBaseUrl` | Canonical NyxID API/resource-server base. It falls back only to `Aevatar:NyxId:ApiBaseUrl`, never to the browser OIDC authority. |
+| `Aevatar:BackendConsole:NyxApiBaseUrl` | Canonical public NyxID API/resource-server base. It falls back to `Aevatar:NyxId:Authority`, never to the internal `Aevatar:NyxId:InternalApiBaseUrl` transport address. |
 | `Aevatar:BackendConsole:StorageKey` | Shared browser localStorage/sessionStorage prefix. |
 | `Aevatar:BackendConsole:DefaultReturnPath` | Safe default redirect path after `/auto/callback`. |
 
 Each configurable HTML asset contains `__BACKEND_CONSOLE_CONFIG__`. The serving helper replaces that placeholder with JSON rendered from `BackendConsoleOptions`. The six `HOST_BACKEND_CONSOLE_*` environment variables are optional overrides for host deployment, but `.refactor-loop/host.env` is not a production configuration source.
 
-The OIDC client id and resource indicators are public browser values, not secrets. Every configurable console page appends each injected resource to both `/oauth/authorize` and the authorization-code exchange at `/oauth/token`; the shared `/auto/callback` follows the same contract. The host normalizes the configured scope and adds `offline_access` exactly once, including after environment overrides, because NyxID access tokens expire after 15 minutes and broker-capable clients return a refresh token only when that scope is granted. The OIDC authority owns browser authorization, while `NyxApiBaseUrl` owns RFC 8707 resource identity and NyxID REST/admin routing; these hosts may differ and must not be substituted for each other. Secrets still belong in the existing host secret/config mechanisms and must not be injected into page assets.
+The OIDC client id and resource indicators are public browser values, not secrets. Every configurable console page appends each injected resource to both `/oauth/authorize` and the authorization-code exchange at `/oauth/token`; the shared `/auto/callback` follows the same contract. The host normalizes the configured scope and adds `offline_access` exactly once, including after environment overrides, because NyxID access tokens expire after 15 minutes and broker-capable clients return a refresh token only when that scope is granted. `Aevatar:NyxId:Authority` owns the public OAuth issuer and RFC 8707 resource identity. `Aevatar:NyxId:ApiBaseUrl` retains the existing public API address, while server-side clients prefer `Aevatar:NyxId:InternalApiBaseUrl` when configured. Browser assets must never receive that internal transport address. Secrets still belong in the existing host secret/config mechanisms and must not be injected into page assets.
+
+Mainnet production keeps the public identity and internal transport explicit:
+
+```json
+{
+  "Aevatar": {
+    "NyxId": {
+      "Authority": "https://nyx-api.chrono-ai.fun",
+      "ApiBaseUrl": "https://nyx-api.chrono-ai.fun",
+      "InternalApiBaseUrl": "http://nyxid-backend-production-api-svc.chronoai-platform.svc.cluster.local:3001"
+    },
+    "BackendConsole": {
+      "OidcAuthority": "https://nyx-api.chrono-ai.fun",
+      "NyxApiBaseUrl": "https://nyx-api.chrono-ai.fun"
+    }
+  }
+}
+```
 
 Studio's `/api/auth/nyxid/config` still returns an actor-backed snapshot so authority, callback/scope contract, HMAC state, and broker observation remain cluster-coherent. Its `clientId` must match `Aevatar:BackendConsole:OidcClientId`; while Actor projection still carries another id, the provider fails closed instead of combining new configuration with stale runtime facts. Startup and the admin reconcile endpoint materialize the configured id into Actor state, but neither DCR output nor an API request body is an alternative client-id authority.
 

--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "6eddfeb6098c3d9eba3f98d62fd234216af6c22b",
-    "contract_files_sha256": "59207432060b12f33f0e8ce89ee749a6fb64fe5c2ae18d8f6e934d175b8dee31",
+    "revision": "4cd91b91ba0628b1eade84d351419efc964ca748",
+    "contract_files_sha256": "860f860871ece240b202bc767dda631b3fad146ffb3fe131445846b215cfd988",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "ce28ba40efc8f863ae6cc42d35442d3c9cc30a4aa0be548394939a556497881e",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "f8c456438acb106c39517be55fe926870c2da7b6990a633b44a28efe20c5a66a",
@@ -14,7 +14,7 @@
       "src/Aevatar.AI.Abstractions/ai_messages.proto": "6643404463d455585d702d6f6c9bdfccf8abb2707632ef59f5afbf4bb847c874",
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1cebe5e4eb0939f157015a42149aad46ed8ca94aaa884d10baca0a2b9cd80a47",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "5552659efc5d43770fd0a4a284b82266f4ed2cca04d881c5b2e04a290758e0dd",
-      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "1f03542b3aeae67f6700aba7cabdf7d5242d9a62e30acb36f07f9fdfee0f2b50"
+      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "5d5e030d6d4b07c8d05181f884e0c8234c3f060aba1aa5fa807f03e7d241b7a2"
     }
   },
   "nyxid": {

--- a/docs/operations/2026-04-29-daily-card-github-oauth-setup.md
+++ b/docs/operations/2026-04-29-daily-card-github-oauth-setup.md
@@ -48,10 +48,9 @@ Before any user can connect GitHub, the following must already be true:
   ```
   https://<your-nyx-api-host>/api/v1/providers/callback
   ```
-  Note the host is the **API/backend host**, not the dashboard host. In our
-  production environment this is `nyx-api.chrono-ai.fun`, while the dashboard
-  is served from `nyx.chrono-ai.fun` — both reach the same backend, but the
-  redirect URI registered on GitHub must use the API host.
+  Note the host is the **API/backend host**. In our production environment this
+  is `nyx-api.chrono-ai.fun`, and the redirect URI registered on GitHub must use
+  that API host.
 - The aevatar host is configured with the matching NyxID Authority
   (`appsettings.json` → `Aevatar:NyxId:Authority`) and the Lark relay path is
   live. See [`lark-nyx-cutover-runbook.md`](2026-04-22-lark-nyx-cutover-runbook.md)

--- a/docs/superpowers/specs/2026-07-21-nyxid-scheduled-agent-key-scope-plan-design.md
+++ b/docs/superpowers/specs/2026-07-21-nyxid-scheduled-agent-key-scope-plan-design.md
@@ -85,7 +85,7 @@ NyxID key creation performs the final current-state recomputation. A stale route
 
 NyxID API access registration is independently reusable by scheduled dispatch, Studio, and the full NyxID tool package. Singleton consumers depend on `INyxIdApiClientFactory` and create a client per operation; they do not capture a transient typed client.
 
-REST calls prefer `Aevatar:NyxId:ApiBaseUrl`, then the configured authority aliases, then the existing NyxID default.
+REST calls prefer `Aevatar:NyxId:InternalApiBaseUrl`, then `Aevatar:NyxId:ApiBaseUrl`, then the configured authority aliases, then the existing NyxID default.
 
 ## Verification Contract
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
@@ -135,11 +135,11 @@ public sealed class NyxIdToolOptions
     public const int DefaultMaxRequestDurationSeconds = 330;
 
     /// <summary>
-    /// Default NyxID REST API base URL. Deployments may configure a dedicated API/resource-server
-    /// base independently from their browser/OIDC authority; the production default remains usable
+    /// Default NyxID REST API transport base URL. Deployments may configure an internal transport
+    /// independently from their public browser/OIDC authority; the production default remains usable
     /// when no override is supplied.
     /// </summary>
-    public const string DefaultBaseUrl = "https://nyx.chrono-ai.fun/";
+    public const string DefaultBaseUrl = "https://nyx-api.chrono-ai.fun/";
 
     /// <summary>NyxID REST API base URL. Defaults to <see cref="DefaultBaseUrl"/>.</summary>
     public string? BaseUrl { get; set; } = DefaultBaseUrl;

--- a/src/Aevatar.AI.ToolProviders.NyxId/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/ServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ public static class ServiceCollectionExtensions
 
         var configuredBaseUrl = FirstConfiguredValue(
             configuration,
+            "Aevatar:NyxId:InternalApiBaseUrl",
             "Aevatar:NyxId:ApiBaseUrl",
             "Aevatar:NyxId:Authority",
             "Cli:App:NyxId:Authority",

--- a/src/Aevatar.BackendConsole.Hosting/BackendConsoleHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.BackendConsole.Hosting/BackendConsoleHostingServiceCollectionExtensions.cs
@@ -58,15 +58,15 @@ public static class BackendConsoleHostingServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace(options.OidcAuthority))
         {
             options.OidcAuthority =
-                configuration["Aevatar:Authentication:Authority"]
-                ?? configuration["Aevatar:NyxId:Authority"]
+                configuration["Aevatar:NyxId:Authority"]
+                ?? configuration["Aevatar:Authentication:Authority"]
                 ?? string.Empty;
         }
 
         if (string.IsNullOrWhiteSpace(options.NyxApiBaseUrl))
         {
             options.NyxApiBaseUrl =
-                configuration["Aevatar:NyxId:ApiBaseUrl"]
+                configuration["Aevatar:NyxId:Authority"]
                 ?? string.Empty;
         }
 

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -102,7 +102,7 @@ public static class MainnetHostBuilderExtensions
         "AgentToolAdmission:KeyPrefix";
     internal const string DefaultAgentToolAdmissionKeyPrefix =
         "aevatar:mainnet:agent-tool-admission:v1:";
-    private const string NyxIdApiBaseUrlKey = "Aevatar:NyxId:ApiBaseUrl";
+    private const string NyxIdAuthorityKey = "Aevatar:NyxId:Authority";
     private const string DeviceInboundDirectExternalEventTypeUrl =
         "type.googleapis.com/aevatar.gagents.household.DeviceInbound";
 
@@ -350,12 +350,15 @@ public static class MainnetHostBuilderExtensions
         {
             // Override the single default (NyxIdToolOptions.DefaultBaseUrl) only when config provides a
             // non-empty value; an absent/empty config key must NOT clobber the default to null.
-            var nyxAuthority = builder.Configuration["Aevatar:NyxId:ApiBaseUrl"]
-                               ?? builder.Configuration["Aevatar:NyxId:Authority"]
-                               ?? builder.Configuration["Cli:App:NyxId:Authority"]
-                               ?? builder.Configuration["Aevatar:Authentication:Authority"];
-            if (!string.IsNullOrWhiteSpace(nyxAuthority))
-                o.BaseUrl = nyxAuthority;
+            var nyxTransportBaseUrl = FirstConfiguredValue(
+                builder.Configuration,
+                "Aevatar:NyxId:InternalApiBaseUrl",
+                "Aevatar:NyxId:ApiBaseUrl",
+                "Aevatar:NyxId:Authority",
+                "Cli:App:NyxId:Authority",
+                "Aevatar:Authentication:Authority");
+            if (nyxTransportBaseUrl is not null)
+                o.BaseUrl = nyxTransportBaseUrl;
             // SSH-backed tools are disabled unless the deployment opts in explicitly.
             // Even when exposed, their contract always requires a durable actor-owned grant.
             if (bool.TryParse(builder.Configuration["Aevatar:NyxId:EnableSshExecTool"], out var enableSsh))
@@ -526,6 +529,7 @@ public static class MainnetHostBuilderExtensions
             NyxIdBaseUrl = FirstConfiguredValue(
                 builder.Configuration,
                 "Aevatar:Web:NyxIdBaseUrl",
+                "Aevatar:NyxId:InternalApiBaseUrl",
                 "Aevatar:NyxId:ApiBaseUrl",
                 "Aevatar:NyxId:Authority",
                 "Cli:App:NyxId:Authority",
@@ -672,15 +676,15 @@ public static class MainnetHostBuilderExtensions
         if (!string.IsNullOrWhiteSpace(builder.Configuration[audienceKey]))
             return;
 
-        // NyxID access tokens use its API BASE_URL as their audience. Identity assertions use
+        // NyxID access tokens use its public authority/BASE_URL as their audience. Identity assertions use
         // a separate audience and must not be reused for bearer-token validation.
-        var nyxIdApiBaseUrl = builder.Configuration[NyxIdApiBaseUrlKey];
-        if (string.IsNullOrWhiteSpace(nyxIdApiBaseUrl))
+        var nyxIdAuthority = builder.Configuration[NyxIdAuthorityKey];
+        if (string.IsNullOrWhiteSpace(nyxIdAuthority))
             return;
 
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            [audienceKey] = nyxIdApiBaseUrl.Trim(),
+            [audienceKey] = nyxIdAuthority.Trim(),
         });
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.json
@@ -2,7 +2,7 @@
   "Aevatar": {
     "Authentication": {
       "Enabled": true,
-      "Authority": "https://nyx.chrono-ai.fun",
+      "Authority": "https://nyx-api.chrono-ai.fun",
       "Audience": "https://nyx-api.chrono-ai.fun",
       "RequireHttpsMetadata": true,
       "NyxIdIdentityAssertion": {
@@ -14,9 +14,10 @@
       }
     },
     "NyxId": {
-      "Authority": "https://nyx.chrono-ai.fun",
+      "Authority": "https://nyx-api.chrono-ai.fun",
       "ApiBaseUrl": "https://nyx-api.chrono-ai.fun",
-      "GatewayEndpoint": "https://nyx.chrono-ai.fun/api/v1/llm/gateway/v1",
+      "InternalApiBaseUrl": "http://nyxid-backend-production-api-svc.chronoai-platform.svc.cluster.local:3001",
+      "GatewayEndpoint": "https://nyx-api.chrono-ai.fun/api/v1/llm/gateway/v1",
       "ChronoLlmEndpoint": "https://llm.aelf.dev/v1",
       "AdditionalRequiredServiceSlugs": [],
       "Relay": {
@@ -39,10 +40,10 @@
       }
     },
     "BackendConsole": {
-      "OidcAuthority": "",
+      "OidcAuthority": "https://nyx-api.chrono-ai.fun",
       "OidcClientId": "a6ff2946-f02f-4c35-8203-1ec46132b660",
       "OidcScope": "openid profile email offline_access proxy",
-      "NyxApiBaseUrl": "",
+      "NyxApiBaseUrl": "https://nyx-api.chrono-ai.fun",
       "StorageKey": "aevatar-console:nyxid:pkce",
       "DefaultReturnPath": "/admin",
       "EnableStudioWireInspector": false
@@ -95,7 +96,7 @@
         "ChronoStorage": {
           "Enabled": true,
           "UseNyxProxy": true,
-          "NyxProxyBaseUrl": "https://nyx.chrono-ai.fun",
+          "NyxProxyBaseUrl": "https://nyx-api.chrono-ai.fun",
           "NyxProxyServiceSlug": "chrono-storage-service",
           "BaseUrl": "http://chrono-storage.chronoai-platform.svc.cluster.local:3805",
           "Bucket": "chrono-platform-aevatar-studio"

--- a/src/workflow/Aevatar.Workflow.Host.Api/Program.cs
+++ b/src/workflow/Aevatar.Workflow.Host.Api/Program.cs
@@ -41,12 +41,15 @@ builder.Services.AddNyxIdTools(options =>
 {
     // Override the single default (NyxIdToolOptions.DefaultBaseUrl) only when config provides a
     // non-empty value; an absent/empty config key must NOT clobber the default to null.
-    var nyxAuthority = builder.Configuration["Aevatar:NyxId:ApiBaseUrl"]
-                       ?? builder.Configuration["Aevatar:NyxId:Authority"]
-                       ?? builder.Configuration["Cli:App:NyxId:Authority"]
-                       ?? builder.Configuration["Aevatar:Authentication:Authority"];
-    if (!string.IsNullOrWhiteSpace(nyxAuthority))
-        options.BaseUrl = nyxAuthority;
+    var nyxTransportBaseUrl = FirstConfiguredValue(
+        builder.Configuration,
+        "Aevatar:NyxId:InternalApiBaseUrl",
+        "Aevatar:NyxId:ApiBaseUrl",
+        "Aevatar:NyxId:Authority",
+        "Cli:App:NyxId:Authority",
+        "Aevatar:Authentication:Authority");
+    if (nyxTransportBaseUrl is not null)
+        options.BaseUrl = nyxTransportBaseUrl;
     if (long.TryParse(builder.Configuration["Aevatar:NyxId:ProxyFileArtifactMaxBytes"], out var maxBytes))
         options.ProxyFileArtifactMaxBytes = maxBytes;
 });
@@ -58,3 +61,15 @@ var app = builder.Build();
 app.UseAevatarDefaultHost();
 
 app.Run();
+
+static string? FirstConfiguredValue(IConfiguration configuration, params string[] keys)
+{
+    foreach (var key in keys)
+    {
+        var value = configuration[key];
+        if (!string.IsNullOrWhiteSpace(value))
+            return value.Trim();
+    }
+
+    return null;
+}

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/AevatarPlatformHostBuilderExtensions.cs
@@ -78,6 +78,7 @@ public static class AevatarPlatformHostBuilderExtensions
                     FirstConfiguredValue(
                         builder.Configuration,
                         "Aevatar:Web:NyxIdBaseUrl",
+                        "Aevatar:NyxId:InternalApiBaseUrl",
                         "Aevatar:NyxId:ApiBaseUrl",
                         "Aevatar:NyxId:Authority",
                         "Cli:App:NyxId:Authority",

--- a/test/Aevatar.AI.Tests/NyxIdApiAccessContractTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiAccessContractTests.cs
@@ -682,6 +682,7 @@ public sealed class NyxIdApiAccessContractTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
+                ["Aevatar:NyxId:InternalApiBaseUrl"] = " ",
                 ["Aevatar:NyxId:ApiBaseUrl"] = " https://api.nyx.test/ ",
                 ["Aevatar:NyxId:Authority"] = "https://authority.nyx.test",
                 ["Cli:App:NyxId:Authority"] = "https://cli.nyx.test",
@@ -698,6 +699,26 @@ public sealed class NyxIdApiAccessContractTests
         provider.GetRequiredService<INyxIdApiClientFactory>().CreateClient().Should().NotBeNull();
         provider.GetRequiredService<INyxIdActionEvidenceReadPort>()
             .Should().BeOfType<NyxIdActionEvidenceReadPort>();
+    }
+
+    [Fact]
+    public void AddNyxIdApiAccess_ShouldPreferInternalApiBaseUrl()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Aevatar:NyxId:InternalApiBaseUrl"] = " http://nyxid.internal:3001/ ",
+                ["Aevatar:NyxId:ApiBaseUrl"] = "https://api.nyx.test",
+                ["Aevatar:NyxId:Authority"] = "https://authority.nyx.test",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddNyxIdApiAccess(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<NyxIdToolOptions>().BaseUrl.Should()
+            .Be("http://nyxid.internal:3001/");
     }
 
     [Theory]

--- a/test/Aevatar.Capabilities.Tests/BackendConsoleAssetServiceTests.cs
+++ b/test/Aevatar.Capabilities.Tests/BackendConsoleAssetServiceTests.cs
@@ -98,6 +98,7 @@ public sealed class BackendConsoleAssetServiceTests
                 ["Aevatar:Authentication:Authority"] = "https://auth.example.test",
                 ["Aevatar:NyxId:Authority"] = "https://nyx.example.test",
                 ["Aevatar:NyxId:ApiBaseUrl"] = "https://nyx-api.example.test",
+                ["Aevatar:NyxId:InternalApiBaseUrl"] = "http://nyxid.internal:3001",
             })
             .Build();
         services.AddBackendConsoleStaticAssets(configuration);
@@ -111,12 +112,13 @@ public sealed class BackendConsoleAssetServiceTests
             "text/html",
             InjectHostConfiguration: true));
 
-        html.Should().Contain("\"authority\":\"https://auth.example.test\"");
+        html.Should().Contain("\"authority\":\"https://nyx.example.test\"");
         html.Should().Contain("\"clientId\":\"client-example\"");
         html.Should().Contain("\"scope\":\"openid profile offline_access\"");
         html.Should().Contain(
-            "\"resources\":[\"https://nyx-api.example.test/api/v1/proxy/s/aevatar\",\"https://nyx-api.example.test/api/v1/proxy/s/ornn-api\"]");
-        html.Should().Contain("\"nyxidApi\":\"https://nyx-api.example.test\"");
+            "\"resources\":[\"https://nyx.example.test/api/v1/proxy/s/aevatar\",\"https://nyx.example.test/api/v1/proxy/s/ornn-api\"]");
+        html.Should().Contain("\"nyxidApi\":\"https://nyx.example.test\"");
+        html.Should().NotContain("http://nyxid.internal:3001");
         html.Should().Contain("\"storageKey\":\"console:test\"");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");
     }

--- a/test/Aevatar.Capabilities.Tests/BackendConsoleStaticAssetEndpointTests.cs
+++ b/test/Aevatar.Capabilities.Tests/BackendConsoleStaticAssetEndpointTests.cs
@@ -38,7 +38,6 @@ public sealed class BackendConsoleStaticAssetEndpointTests
         html.Should().Contain(
             "\"resources\":[\"https://api.example.test/api/v1/proxy/s/aevatar\",\"https://api.example.test/api/v1/proxy/s/ornn-api\"]");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");
-        html.Should().NotContain("https://nyx.chrono-ai.fun");
         html.Should().NotContain("https://nyx-api.chrono-ai.fun");
         html.Should().NotContain("37a93189-2734-406e-bca1-7dbdf25c5a53");
         if (path == "/cqrs")

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -1091,6 +1091,36 @@ public sealed class MainnetHostCompositionTests
     }
 
     [Fact]
+    public void AddAevatarMainnetHost_ShouldPreferInternalNyxIdTransportWithoutExposingItAsAuthority()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        using var internalApiBaseUrl = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__InternalApiBaseUrl",
+            " http://nyxid.internal:3001/ ");
+        using var apiBaseUrl = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__ApiBaseUrl",
+            "https://nyx-api.example.test");
+        using var authority = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__Authority",
+            "https://nyx-authority.example.test");
+        var builder = CreateBuilder();
+
+        builder.AddAevatarMainnetHost(options =>
+        {
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+        });
+
+        using var app = builder.Build();
+        app.Services.GetRequiredService<NyxIdToolOptions>().BaseUrl
+            .Should().Be("http://nyxid.internal:3001/");
+        app.Services.GetRequiredService<WebToolOptions>().NyxIdBaseUrl
+            .Should().Be("http://nyxid.internal:3001/");
+        builder.Configuration["Aevatar:NyxId:Authority"]
+            .Should().Be("https://nyx-authority.example.test");
+    }
+
+    [Fact]
     public async Task AddAevatarMainnetHost_ShouldShipConnectedServiceEffects()
     {
         using var home = new TemporaryAevatarHomeScope();
@@ -1469,18 +1499,24 @@ public sealed class MainnetHostCompositionTests
     [Theory]
     [InlineData(" ", " https://nyx-api.example.test ", "https://nyx-api.example.test")]
     [InlineData("urn:custom:aevatar-api", "https://nyx-api.example.test", "urn:custom:aevatar-api")]
-    public void AddAevatarMainnetHost_ShouldUseNyxIdApiAudienceWhenDeploymentOmitsIt(
+    public void AddAevatarMainnetHost_ShouldUseNyxIdAuthorityAsAudienceWhenDeploymentOmitsIt(
         string configuredAudience,
-        string nyxIdApiBaseUrl,
+        string nyxIdAuthority,
         string expectedAudience)
     {
         using var home = new TemporaryAevatarHomeScope();
         using var audience = new EnvironmentVariableScope(
             "AEVATAR_Aevatar__Authentication__Audience",
             configuredAudience);
+        using var authority = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__Authority",
+            nyxIdAuthority);
         using var apiBaseUrl = new EnvironmentVariableScope(
             "AEVATAR_Aevatar__NyxId__ApiBaseUrl",
-            nyxIdApiBaseUrl);
+            "https://nyx-api.example.test");
+        using var internalApiBaseUrl = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__InternalApiBaseUrl",
+            "http://nyxid.internal:3001");
         var audienceKey = $"{AevatarAuthenticationOptions.SectionName}:Audience";
         var builder = CreateBuilder(environmentName: Environments.Production);
 
@@ -1494,15 +1530,21 @@ public sealed class MainnetHostCompositionTests
     }
 
     [Fact]
-    public void AddAevatarMainnetHost_WhenAudienceAndNyxIdApiBaseUrlAreMissingInProduction_ShouldFailClosed()
+    public void AddAevatarMainnetHost_WhenAudienceAndNyxIdAuthorityAreMissingInProduction_ShouldFailClosed()
     {
         using var home = new TemporaryAevatarHomeScope();
         using var audience = new EnvironmentVariableScope(
             "AEVATAR_Aevatar__Authentication__Audience",
             " ");
+        using var authority = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__Authority",
+            " ");
         using var apiBaseUrl = new EnvironmentVariableScope(
             "AEVATAR_Aevatar__NyxId__ApiBaseUrl",
-            " ");
+            "https://nyx-api.example.test");
+        using var internalApiBaseUrl = new EnvironmentVariableScope(
+            "AEVATAR_Aevatar__NyxId__InternalApiBaseUrl",
+            "http://nyxid.internal:3001");
         var builder = CreateBuilder(environmentName: Environments.Production);
 
         var act = () => builder.AddAevatarMainnetHost(options =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -22,6 +22,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
     private static readonly byte[] HmacKey =
         Convert.FromHexString("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
     private const string OAuthAuthority = "https://id.example.test";
+    private const string InternalApiBaseUrl = "http://nyxid.internal:3001";
     private const string ResourceServerBaseUrl = "https://api.example.test";
     private const string RequiredLlmServiceSlug = "chrono-llm-public";
     private const string RequiredOrnnServiceSlug = "ornn-api";
@@ -433,7 +434,7 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
 
         result.AccessToken.Should().Be(accessToken);
         handler.Requests.Should().HaveCount(2);
-        handler.Requests[1].Uri.Should().Be($"{ResourceServerBaseUrl}/api/v1/user-services");
+        handler.Requests[1].Uri.Should().Be($"{InternalApiBaseUrl}/api/v1/user-services");
         handler.Requests[1].Authorization.Should().Be($"Bearer {accessToken}");
     }
 
@@ -589,10 +590,13 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         var provider = new FakeOAuthClientProvider(snapshot);
         options ??= new NyxIdBrokerOptions
         {
+            TransportBaseUrl = $" {InternalApiBaseUrl}/// ",
             ResourceServerBaseUrl = $" {ResourceServerBaseUrl}/// ",
             RequiredLlmServiceSlug = RequiredLlmServiceSlug,
             AdditionalRequiredServiceSlugs = [RequiredOrnnServiceSlug, RequiredSandboxServiceSlug],
         };
+        if (string.IsNullOrWhiteSpace(options.TransportBaseUrl))
+            options.TransportBaseUrl = $" {InternalApiBaseUrl}/// ";
         if (string.IsNullOrWhiteSpace(options.ResourceServerBaseUrl))
             options.ResourceServerBaseUrl = $" {ResourceServerBaseUrl}/// ";
         return new NyxIdRemoteCapabilityBroker(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -217,6 +217,10 @@ public sealed class ServiceCollectionExtensionsTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
+                [NyxIdBrokerOptions.ApiBaseUrlConfigurationKey] =
+                    " https://api.example.test/// ",
+                [NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey] =
+                    " http://nyxid.internal:3001/// ",
                 [NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] =
                     " https://api.example.test/// ",
             })
@@ -227,11 +231,59 @@ public sealed class ServiceCollectionExtensionsTests
 
         AssertProjectionActivationProviderRegistered<ChannelIdentityCommittedStateProjectionActivationPlanProvider>(
             services);
-        provider.GetRequiredService<IOptions<NyxIdBrokerOptions>>()
-            .Value.ResourceServerBaseUrl.Should().Be("https://api.example.test");
+        var options = provider.GetRequiredService<IOptions<NyxIdBrokerOptions>>().Value;
+        options.TransportBaseUrl.Should().Be("http://nyxid.internal:3001");
+        options.ResourceServerBaseUrl.Should().Be("https://api.example.test");
         services.Should().NotContain(descriptor =>
             descriptor.ServiceType == typeof(IHostedService) &&
             descriptor.ImplementationType == typeof(AevatarOAuthClientEsAclStartupGuard));
+    }
+
+    [Theory]
+    [InlineData(NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey, "not-a-url", "TransportBaseUrl")]
+    [InlineData(NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey, " ", "ResourceServerBaseUrl")]
+    public void AddChannelIdentity_WithInvalidNyxIdBaseUrl_ShouldFailOptionsValidation(
+        string configurationKey,
+        string configuredValue,
+        string expectedOptionName)
+    {
+        var configurationValues = new Dictionary<string, string?>
+        {
+            [NyxIdBrokerOptions.ApiBaseUrlConfigurationKey] = "https://api.example.test",
+            [NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey] = "http://nyxid.internal:3001",
+            [NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] = "https://api.example.test",
+            [configurationKey] = configuredValue,
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationValues)
+            .Build();
+        var services = new ServiceCollection();
+        services.AddChannelIdentity(configuration);
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptions<NyxIdBrokerOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage($"*{expectedOptionName}*absolute HTTP or HTTPS URL*");
+    }
+
+    [Fact]
+    public void AddChannelIdentity_WithBlankInternalApiBaseUrl_ShouldUsePublicApiBaseUrlForTransport()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey] = " ",
+                [NyxIdBrokerOptions.ApiBaseUrlConfigurationKey] = " https://api.example.test/ ",
+                [NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] = "https://authority.example.test",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddChannelIdentity(configuration);
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<NyxIdBrokerOptions>>().Value.TransportBaseUrl
+            .Should().Be("https://api.example.test");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConsoleStaticAssetEndpointTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConsoleStaticAssetEndpointTests.cs
@@ -39,7 +39,6 @@ public sealed class WorkflowConsoleStaticAssetEndpointTests
         html.Should().Contain("https://api.example.test/api/v1/proxy/s/aevatar");
         html.Should().Contain("\"nyxidWeb\":\"https://web.example.test\"");
         html.Should().NotContain("__BACKEND_CONSOLE_CONFIG__");
-        html.Should().NotContain("https://nyx.chrono-ai.fun");
         html.Should().NotContain("37a93189-2734-406e-bca1-7dbdf25c5a53");
         if (endpoint == "admin-observatory")
         {
@@ -245,8 +244,6 @@ public sealed class WorkflowConsoleStaticAssetEndpointTests
         transport.Should().Contain("backendConfig.enableStudioWireInspector === true");
         app.Should().NotContain("https://aevatar-console-backend-api.aevatar.ai");
         app.Should().NotContain("https://nyx-api.chrono-ai.fun");
-        app.Should().NotContain("https://nyx.chrono-ai.fun");
-        transport.Should().NotContain("https://nyx.chrono-ai.fun");
         app.Should().Contain("cc-progress-step");
         app.Should().NotContain("function setStudioTab(tab)");
         app.Should().NotContain("尚未取得必需能力的有效证明");

--- a/tools/ci/main_flow_runtime_smoke.sh
+++ b/tools/ci/main_flow_runtime_smoke.sh
@@ -55,6 +55,8 @@ start_host() {
     ASPNETCORE_ENVIRONMENT=Development \
     ASPNETCORE_URLS="http://127.0.0.1:${HTTP_PORT}" \
     AEVATAR_NYXID_AUTHORITY="http://127.0.0.1:${NYXID_PORT}" \
+    AEVATAR_Aevatar__NyxId__Authority="http://127.0.0.1:${NYXID_PORT}" \
+    AEVATAR_Aevatar__NyxId__InternalApiBaseUrl="http://127.0.0.1:${NYXID_PORT}" \
     AEVATAR_Aevatar__NyxId__ApiBaseUrl="http://127.0.0.1:${NYXID_PORT}" \
     AEVATAR_Aevatar__NyxId__AssistantActions__Enabled=false \
     AEVATAR_OAUTH_REDIRECT_BASE_URL="http://127.0.0.1:${HTTP_PORT}" \

--- a/tools/ci/tests/test_backend_console_static_asset_guard.sh
+++ b/tools/ci/tests/test_backend_console_static_asset_guard.sh
@@ -126,7 +126,7 @@ bash "${GUARD}" --scan "${passing}" >/dev/null
 
 hardcoded="${TMP_DIR}/hardcoded"
 write_fixture "${hardcoded}"
-printf '<script>const authority = "https://nyx.chrono-ai.fun";</script>\n' \
+printf '<script>const authority = "https://nyx-api.chrono-ai.fun";</script>\n' \
   >> "${hardcoded}/src/Aevatar.Mainnet.Host.Api/BackendConsole/admin.html"
 assert_fails_with "hardcode Nyx/OIDC host facts" "${hardcoded}"
 


### PR DESCRIPTION
## Problem

Aevatar previously reused one NyxID base URL for both server-side transport and public OAuth/resource identity. Pointing that setting at the in-cluster NyxID Service bypassed Cloudflare for long-running execution, but also exposed the internal address to browser auth configuration and broke Backend Console login. The obsolete production host `nyx.chrono-ai.fun` also remained in repository defaults and documentation.

## Solution

- add `NyxId:InternalApiBaseUrl` as the preferred server-side transport base
- retain `NyxId:Authority` for OAuth issuer, audience fallback, and RFC 8707 resource identity
- retain `NyxId:ApiBaseUrl` as the public API fallback
- resolve server transport in this order: internal base, public API base, authority aliases, default
- keep browser Backend Console configuration on the public authority only
- persist the three-address mainnet configuration, with the internal Kubernetes Service at port 3001
- remove every `nyx.chrono-ai.fun` reference from the repository
- cover internal preference, blank-value fallback, resource identity, and browser non-disclosure with tests

## Impact

NyxID tools, workflow execution, web tooling, and user-service broker calls can use the in-cluster transport without changing token issuer/audience/resource semantics or exposing cluster-local DNS to browsers.

## Verification

- Channel broker/config tests: 38/38 passed
- NyxID API access tests: 53/53 passed
- Mainnet/Backend Console tests: 114/114 passed
- Mainnet internal transport fixture: 1/1 passed
- post-rebase code execution contract tests: 81/81 passed
- Workflow Host build: passed, 0 errors
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/backend_console_static_asset_guard.sh`
- `bash tools/ci/tests/test_backend_console_static_asset_guard.sh`
- `bash tools/docs/lint.sh`
- `bash tools/ci/architecture_guards.sh`
- `git diff --check`
- mainnet appsettings JSON validation
- obsolete NyxID production host full-repository scan: zero matches

Related: #3349