### PR TITLE
Align key create catalog coverage

### DIFF
--- a/test/Aevatar.AI.Tests/NyxIdChatTurnGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatTurnGAgentTests.cs
@@ -2220,15 +2220,22 @@ public sealed partial class NyxIdChatTurnGAgentTests
     }
 
     [Theory]
-    [InlineData("general_nyxid_assistant")]
-    [InlineData(NyxIdChatTurnIntentClassifier.ServiceConnectIntentId)]
-    public async Task OperationExecutor_ProfiledServiceConnectIntent_ShouldNarrowToAdmissionTools(
+    [InlineData(NyxIdChatTurnIntent.ServiceConnect, "general_nyxid_assistant")]
+    [InlineData(
+        NyxIdChatTurnIntent.ServiceConnect,
+        NyxIdChatTurnIntentClassifier.ServiceConnectIntentId)]
+    [InlineData(
+        NyxIdChatTurnIntent.KeyCreate,
+        NyxIdChatTurnIntentClassifier.KeyCreateIntentId)]
+    public async Task OperationExecutor_ProfiledBuiltInIntent_ShouldNarrowToIntentTools(
+        NyxIdChatTurnIntent intent,
         string candidateIntentId)
     {
         IAgentTool[] tools =
         [
             new NamedProfileTool("use_skill"),
             new NamedProfileTool("nyxid_services"),
+            new NamedProfileTool("nyxid_request_key_create"),
             new NamedProfileTool("nyxid_catalog"),
             new NamedProfileTool("nyxid_require_service"),
             new NamedProfileTool("github_get_current_user"),
@@ -2246,6 +2253,7 @@ public sealed partial class NyxIdChatTurnGAgentTests
                 {
                     "use_skill",
                     "nyxid_services",
+                    "nyxid_request_key_create",
                     "nyxid_catalog",
                     "nyxid_require_service",
                     "github_get_current_user",
@@ -2284,12 +2292,14 @@ public sealed partial class NyxIdChatTurnGAgentTests
                 Key = CreateKey(),
                 Llm = new NyxIdChatLLMOperationInput
                 {
-                    Intent = NyxIdChatTurnIntent.ServiceConnect,
+                    Intent = intent,
                     AgentProfile = profile,
                     AgentProfileTurnAuthority = authority,
                     Request = new ChatRequestEvent
                     {
-                        Prompt = "Connect GitHub and verify the connection",
+                        Prompt = intent == NyxIdChatTurnIntent.ServiceConnect
+                            ? "Connect GitHub and verify the connection"
+                            : "Create a least-scope key for one exact service",
                         SessionId = "turn-alpha",
                     },
                 },
@@ -2299,14 +2309,15 @@ public sealed partial class NyxIdChatTurnGAgentTests
             CancellationToken.None);
 
         generationExecutor.LastTurnCatalog.Should().NotBeNull();
-        generationExecutor.LastTurnCatalog!.FinalAllowedToolNames.Should().BeEquivalentTo(
-            "nyxid_catalog",
-            "nyxid_require_service");
-        generationExecutor.LastTurnCatalog.RouteOwnedTools.Keys.Should().BeEquivalentTo(
-            "nyxid_catalog",
-            "nyxid_require_service");
+        var expected = intent == NyxIdChatTurnIntent.ServiceConnect
+            ? new[] { "nyxid_catalog", "nyxid_require_service" }
+            : ["nyxid_services", "nyxid_request_key_create"];
+        generationExecutor.LastTurnCatalog!.FinalAllowedToolNames.Should()
+            .BeEquivalentTo(expected);
+        generationExecutor.LastTurnCatalog.RouteOwnedTools.Keys.Should()
+            .BeEquivalentTo(expected);
         generationExecutor.LastTurnCatalog.FinalAllowedToolNames.Should().NotContain(
-            ["use_skill", "nyxid_services", "github_get_current_user"]);
+            ["use_skill", "github_get_current_user"]);
     }
 
     [Fact]

--- a/test/Aevatar.Capabilities.Tests/MainnetSettingsEndpointSecurityTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetSettingsEndpointSecurityTests.cs
@@ -336,6 +336,10 @@ public sealed class MainnetSettingsEndpointSecurityTests
                     options.EnableConnectorBootstrap = false;
                     options.EnableCors = false;
                 });
+                builder.Services
+                    .AddHttpClient("NyxIdAssistantActionRegistry")
+                    .ConfigurePrimaryHttpMessageHandler(static () =>
+                        new NyxIdAssistantActionRegistryHandler());
                 builder.Services.PostConfigure<JwtBearerOptions>(
                     JwtBearerDefaults.AuthenticationScheme,
                     options => ConfigureTestTokenValidation(options, signingKey));
@@ -495,6 +499,88 @@ public sealed class MainnetSettingsEndpointSecurityTests
             string provisionEndpointId,
             CancellationToken ct) =>
             throw new NotSupportedException("Provisioning is not part of the owner-scope security test.");
+    }
+
+    private sealed class NyxIdAssistantActionRegistryHandler : HttpMessageHandler
+    {
+        private const string RegistryJson = """
+            {
+              "schema_version": 4,
+              "revision": "nyxid-assistant-actions.v4",
+              "actions": [
+                {
+                  "action": "service.connect",
+                  "description": "Connect a service through the NyxID browser journey.",
+                  "params_schema": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["catalogService"],
+                        "properties": {
+                          "catalogService": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["serviceSlug"],
+                            "properties": {
+                              "serviceSlug": {"type": "string"},
+                              "requestedScopes": {
+                                "type": "array",
+                                "items": {"type": "string"}
+                              },
+                              "viaNodeId": {"type": "string"},
+                              "targetOrgId": {"type": "string"}
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["customService"],
+                        "properties": {
+                          "customService": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["name", "endpointUrl", "authMethod"],
+                            "properties": {
+                              "name": {"type": "string"},
+                              "endpointUrl": {"type": "string"},
+                              "authMethod": {"type": "string"},
+                              "authKeyName": {"type": "string"},
+                              "viaNodeId": {"type": "string"},
+                              "targetOrgId": {"type": "string"}
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "risk": "grant",
+                  "tier": "v1",
+                  "remember_eligible": true
+                }
+              ]
+            }
+            """;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (request.Method != HttpMethod.Get ||
+                request.RequestUri?.AbsolutePath != "/api/v1/assistant/actions" ||
+                request.Headers.Authorization is not null)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(RegistryJson, Encoding.UTF8, "application/json"),
+            });
+        }
     }
 
     private sealed class TemporaryAevatarHomeScope : IDisposable

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -1058,6 +1058,7 @@ public sealed class ConversationReplyGeneratorTests
             "nyxid_profile",
             "nyxid_providers",
             "nyxid_require_service",
+            "nyxid_request_key_create",
             "nyxid_service_pools",
             "nyxid_services",
             "nyxid_sessions",
@@ -1157,6 +1158,7 @@ public sealed class ConversationReplyGeneratorTests
             "nyxid_catalog",
             "nyxid_llm_status",
             "nyxid_require_service",
+            "nyxid_request_key_create",
             "use_skill");
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientOrleansDispatchProjectionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientOrleansDispatchProjectionTests.cs
@@ -10,6 +10,7 @@ using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
 using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Aevatar.GAgents.Channel.Identity.DependencyInjection;
 using Aevatar.Tests.Shared;
 using FluentAssertions;
@@ -103,6 +104,8 @@ public sealed class AevatarOAuthClientOrleansDispatchProjectionTests
                         {
                             [$"{AevatarOAuthClientBootstrapOptions.SectionName}:Enabled"] = "false",
                             [AevatarOAuthClientOptions.ClientIdConfigurationKey] = "configured-client",
+                            [NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey] = "http://nyxid.internal.test",
+                            [NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] = "https://nyxid.test",
                         })
                         .Build();
                     services.AddChannelIdentity(configuration);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityOrleansDispatchProjectionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityOrleansDispatchProjectionTests.cs
@@ -10,6 +10,7 @@ using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
 using Aevatar.GAgents.Channel.Identity.DependencyInjection;
 using Aevatar.Tests.Shared;
 using FluentAssertions;
@@ -229,6 +230,8 @@ public sealed class ChannelIdentityOrleansDispatchProjectionTests
                         {
                             [$"{AevatarOAuthClientBootstrapOptions.SectionName}:Enabled"] = "false",
                             [AevatarOAuthClientOptions.ClientIdConfigurationKey] = "channel-identity-projection-test-client",
+                            [NyxIdBrokerOptions.InternalApiBaseUrlConfigurationKey] = "http://nyxid.internal.test",
+                            [NyxIdBrokerOptions.ResourceServerBaseUrlConfigurationKey] = "https://nyxid.test",
                         })
                         .Build();
                     services.AddSingleton(forwardingObserver);


### PR DESCRIPTION
## Problem and solution

The least-scope key-create producer is now part of the pinned NyxID Assistant catalog, but two exact-catalog tests still asserted the pre-producer set. The profiled built-in catalog test also covered service-connect only.

This updates the exact human/non-human catalog contracts and verifies profiled key-create narrows to `nyxid_services` plus `nyxid_request_key_create`.

Closes #3387 after production acceptance is recorded.

## Impact

- NyxID Assistant catalog contract tests
- Built-in intent catalog narrowing tests
- No additional production behavior beyond `6a69fbdef`

## Verification

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --no-restore --no-build --filter FullyQualifiedName~OperationExecutor_UnprofiledBuiltInIntent|FullyQualifiedName~OperationExecutor_ProfiledBuiltInIntent --nologo` (5 passed)
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --no-restore --no-build --nologo` (2013 passed)
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --no-restore --no-build --nologo` (3018 passed before rebasing the identical implementation already present in `6a69fbdef`)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`