### PR TITLE
Enable Studio least-scope key creation

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Frozen;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aevatar.AI.Abstractions;
 
 namespace Aevatar.GAgents.NyxidChat;
 
@@ -468,6 +469,47 @@ public sealed class NyxIdAssistantActionRegistry
         return new NyxIdAssistantActionValidation(
             entry.Definition.Clone(),
             new NyxIdAssistantActionParams { CatalogServiceConnect = value });
+    }
+
+    public NyxIdAssistantActionValidation ResolveKeyCreate(
+        NyxIdKeyCreateActionRequirement requirement)
+    {
+        ArgumentNullException.ThrowIfNull(requirement);
+        if (!_entries.TryGetValue("key.create", out var entry) ||
+            !_executableActions.Contains("key.create") ||
+            entry.Definition.Action != NyxIdAssistantActionKind.KeyCreate)
+        {
+            throw Error(ActionUnsupported, "Key creation is not present in the pinned registry.");
+        }
+
+        var name = NormalizeString(requirement.Name, 256, required: true);
+        var platform = NormalizeString(requirement.Platform, 128, required: true);
+        if (requirement.AllowedServiceIds.Count is < 1 or > 64)
+            throw Error(ParamsInvalid, "Key creation requires an exact nonempty service set.");
+
+        var allowedServiceIds = new List<string>(requirement.AllowedServiceIds.Count);
+        var distinct = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var serviceId in requirement.AllowedServiceIds)
+        {
+            var normalized = NormalizeString(serviceId, 256, required: true);
+            if (!string.Equals(serviceId, normalized, StringComparison.Ordinal) ||
+                !distinct.Add(normalized))
+            {
+                throw Error(ParamsInvalid, "The key creation service identities are invalid.");
+            }
+
+            allowedServiceIds.Add(normalized);
+        }
+
+        var value = new NyxIdKeyCreateParams
+        {
+            Name = name,
+            Platform = platform,
+        };
+        value.AllowedServiceIds.Add(allowedServiceIds);
+        return new NyxIdAssistantActionValidation(
+            entry.Definition.Clone(),
+            new NyxIdAssistantActionParams { KeyCreate = value });
     }
 
     private static NyxIdAssistantActionParams ParseServiceConnect(JsonElement root)

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs
@@ -55,12 +55,14 @@ public static class NyxIdChatBrowserActions
         var receipt = signal.Tool?.Receipt;
         var blocker = receipt?.AuthorizationRequired;
         var sourceStep = FindStep(state, signalKey?.StepId);
+        var hasCatalogServiceConnect = !string.IsNullOrWhiteSpace(blocker?.ServiceSlug);
+        var hasKeyCreate = blocker?.KeyCreate is not null;
         if (receipt?.Status != AgentToolReceiptStatus.AuthorizationRequired ||
             blocker is null ||
             signalKey is null ||
             sourceStep?.Operation?.Key is null ||
             !KeysEqual(sourceStep.Operation.Key, signalKey) ||
-            string.IsNullOrWhiteSpace(blocker.ServiceSlug) ||
+            hasCatalogServiceConnect == hasKeyCreate ||
             state.ActiveTurn is null ||
             state.ActiveTask is null)
         {
@@ -81,9 +83,11 @@ public static class NyxIdChatBrowserActions
             sourceStep = FindStep(actionState, signalKey.StepId)!;
         }
 
-        var validated = registry.ResolveCatalogServiceConnect(
-            blocker.ServiceSlug,
-            blocker.RequestedScopes);
+        var validated = hasKeyCreate
+            ? registry.ResolveKeyCreate(blocker.KeyCreate)
+            : registry.ResolveCatalogServiceConnect(
+                blocker.ServiceSlug,
+                blocker.RequestedScopes);
         var actionRequestId = BuildStableIdentity(
             "action",
             actionState.ConversationActorId,

--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,18 +2,18 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "b3b44dbfc70a31bf006e7e7ad03b28c99d4cd630",
-    "contract_files_sha256": "4df2db28041555ed6000d7e9ff44139f74527ab8b1bd84c1286b1de01f68898c",
+    "revision": "f10d4efb928d184786c73772085b4a9a7fa0d003",
+    "contract_files_sha256": "4309ad993074da11fb8c5aa7b232b11fe03b2ab755ed957c629cd4c7ce882374",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "ce28ba40efc8f863ae6cc42d35442d3c9cc30a4aa0be548394939a556497881e",
-      "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "f8c456438acb106c39517be55fe926870c2da7b6990a633b44a28efe20c5a66a",
-      "agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs": "3d4984d81f58a65e4c3484d2b089ccf932078dc8b29e3765d05b5333241d16b7",
+      "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "59c1340e8b570e89a8483bb0fa23a14cbaf143490bf77c8cb8c2da902cad2ce9",
+      "agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs": "9f585bc478510e7186aaf51e44b78b8b030fe0e0f5e51e0357a4292a50b68c98",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationAguiFrameBuilder.cs": "9ed222347912cfca42d9bd84b658b4a1076f9ed01e6b5dcf349fc8ea924c3757",
       "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto": "c6ccff202d846ac598ee2e6b820c2bf74d496ae5c88598ee7746408cf3ec2740",
       "docs/adr/0048-nyxid-assistant-operation-class-boundary.md": "30c9de6c6e77a7aee14f0eb4a2f74bd15b8874bcfed88ba957cdd8213b9114eb",
       "src/Aevatar.AI.Abstractions/ai_messages.proto": "6643404463d455585d702d6f6c9bdfccf8abb2707632ef59f5afbf4bb847c874",
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1cebe5e4eb0939f157015a42149aad46ed8ca94aaa884d10baca0a2b9cd80a47",
-      "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "5552659efc5d43770fd0a4a284b82266f4ed2cca04d881c5b2e04a290758e0dd",
+      "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "7b860f59aafaf66f26b6b7a3a0885902f4d8760047b49cd6a9303cb8e4a210b2",
       "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "3e6ac92b555d2c0b2c83b2d0cc029788e03174f12fe4bc8feb06599469836c26"
     }
   },

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdAgentToolSource.cs
@@ -76,6 +76,7 @@ public sealed class NyxIdAgentToolSource : IAgentToolSource
             new NyxIdChannelEventsTool(_client),
             new NyxIdAdminTool(_client),
             new NyxIdRequireServiceTool(_client),
+            new NyxIdRequestKeyCreateTool(_client),
         };
 
         if (_options.EnableSshExecTool)

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs
@@ -4,7 +4,7 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.ToolProviders.NyxId.Tools;
 
-public sealed class NyxIdRequestKeyCreateTool : INyxIdBuiltInTool
+public sealed class NyxIdRequestKeyCreateTool : INyxIdBuiltInTool, IAgentToolCapabilityDescriptor
 {
     private const int MaxAllowedServiceIds = 64;
     private const string ArgumentsInvalidCode = "NYXID_KEY_CREATE_ARGUMENTS_INVALID";
@@ -17,6 +17,8 @@ public sealed class NyxIdRequestKeyCreateTool : INyxIdBuiltInTool
         "Create the least-scope NyxID API key in the secure browser action.";
 
     private readonly NyxIdApiClient _client;
+
+    public IReadOnlyCollection<string> Capabilities => NyxIdToolSurfaces.HumanSessionOnly;
 
     public NyxIdRequestKeyCreateTool(NyxIdApiClient client)
     {

--- a/test/Aevatar.AI.Tests/NyxIdAgentToolSourceHumanSessionGatingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdAgentToolSourceHumanSessionGatingTests.cs
@@ -27,7 +27,7 @@ public class NyxIdAgentToolSourceHumanSessionGatingTests
         "nyxid_account", "nyxid_profile", "nyxid_mfa", "nyxid_sessions", "nyxid_api_keys",
         "nyxid_external_keys", "nyxid_nodes", "nyxid_endpoints", "nyxid_notifications",
         "nyxid_providers", "nyxid_orgs", "nyxid_admin", "nyxid_channel_bots", "nyxid_status",
-        "nyxid_services", "nyxid_approvals",
+        "nyxid_services", "nyxid_approvals", "nyxid_request_key_create",
     };
 
     private static readonly HashSet<string> RelaySafeTools = new(StringComparer.Ordinal)

--- a/test/Aevatar.AI.Tests/NyxIdChatBrowserActionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatBrowserActionTests.cs
@@ -70,6 +70,50 @@ public sealed class NyxIdChatBrowserActionTests
     }
 
     [Fact]
+    public void KeyCreateAuthorizationRequired_ShouldCommitExactLeastScopeActionRequest()
+    {
+        var state = AuthorizationWaitingState();
+        var signal = AuthorizationRequiredSignal(state);
+        signal.Tool.Receipt.ToolName = "nyxid_request_key_create";
+        signal.Tool.Receipt.AuthorizationRequired.ServiceSlug = string.Empty;
+        signal.Tool.Receipt.AuthorizationRequired.RequestedScopes.Clear();
+        signal.Tool.Receipt.AuthorizationRequired.KeyCreate =
+            new NyxIdKeyCreateActionRequirement
+            {
+                Name = "agent-alpha",
+                Platform = "codex",
+                AllowedServiceIds = { "us-github-alpha" },
+            };
+
+        var decision = NyxIdChatBrowserActions.RequestAuthorization(
+            state,
+            signal,
+            LeastScopeRegistry(),
+            Now);
+
+        decision.ShouldCommit.Should().BeTrue();
+        decision.Outcome.Should().Be(NyxIdChatTransitionOutcome.Accepted);
+        decision.Request.RegistryRevision.Should().Be(
+            NyxIdAssistantActionRegistry.SupportedRegistryRevision);
+        decision.Request.Action.Should().Be(NyxIdAssistantActionKind.KeyCreate);
+        decision.Request.Params.ParamsCase.Should().Be(
+            NyxIdAssistantActionParams.ParamsOneofCase.KeyCreate);
+        decision.Request.Params.KeyCreate.Name.Should().Be("agent-alpha");
+        decision.Request.Params.KeyCreate.Platform.Should().Be("codex");
+        decision.Request.Params.KeyCreate.AllowedServiceIds.Should()
+            .Equal("us-github-alpha");
+        decision.Request.RememberEligible.Should().BeFalse();
+        decision.State.PendingActions.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(decision.Request);
+        decision.State.ActiveTask.Status.Should().Be(NyxIdChatTaskStatus.Blocked);
+        decision.State.ActiveTurn.Status.Should().Be(NyxIdChatTurnStatus.Blocked);
+        decision.State.ActiveTask.Steps.Should().ContainSingle(step =>
+            step.Kind == NyxIdChatStepKind.BrowserAction &&
+            step.Source.BrowserAction.Action == NyxIdAssistantActionKind.KeyCreate &&
+            step.ActionRequestId == decision.Request.ActionRequestId);
+    }
+
+    [Fact]
     public void ExactActionPlanConfirm_ShouldSatisfyOnlyLocalGateWithoutDispatchOrRevision()
     {
         var state = BlockedActionStateWithPendingGate();
@@ -1284,6 +1328,88 @@ public sealed class NyxIdChatBrowserActionTests
               "risk": "grant",
               "tier": "v1",
               "remember_eligible": true
+            }
+          ]
+        }
+        """);
+
+    private static NyxIdAssistantActionRegistry LeastScopeRegistry() =>
+        NyxIdAssistantActionRegistry.Load("""
+        {
+          "schema_version": 4,
+          "revision": "nyxid-assistant-actions.v6",
+          "actions": [
+            {
+              "action": "service.connect",
+              "description": "Connect a catalog service in the NyxID browser.",
+              "params_schema": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["catalogService"],
+                    "properties": {
+                      "catalogService": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["serviceSlug"],
+                        "properties": {
+                          "serviceSlug": {"type": "string"},
+                          "requestedScopes": {"type": "array", "items": {"type": "string"}},
+                          "viaNodeId": {"type": "string"},
+                          "targetOrgId": {"type": "string"}
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["customService"],
+                    "properties": {
+                      "customService": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["name", "endpointUrl", "authMethod"],
+                        "properties": {
+                          "name": {"type": "string"},
+                          "endpointUrl": {"type": "string"},
+                          "authMethod": {"type": "string"},
+                          "authKeyName": {"type": "string"},
+                          "viaNodeId": {"type": "string"},
+                          "targetOrgId": {"type": "string"}
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "risk": "grant",
+              "tier": "v1",
+              "remember_eligible": true
+            },
+            {
+              "action": "key.create",
+              "description": "Create a least-scope API key.",
+              "params_schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name", "platform", "allowedServiceIds"],
+                "properties": {
+                  "name": {"type": "string"},
+                  "platform": {"type": "string"},
+                  "allowedServiceIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 64,
+                    "uniqueItems": true,
+                    "items": {"type": "string"}
+                  }
+                }
+              },
+              "risk": "grant",
+              "tier": "v1",
+              "remember_eligible": false
             }
           ]
         }


### PR DESCRIPTION
## Problem and solution

New NyxID Assistant sessions enter the built-in Studio workflow. Its generic NyxID tool source did not register the human-session-only least-scope key-create tool, so the advertised action could never materialize or execute.

This change registers `nyxid_request_key_create` on the Studio tool source, scopes it to human sessions, and materializes the typed key-create authorization blocker through the pinned action registry with exact nonempty service identities.

Refs #3387

## Impact

- NyxID Studio tool discovery and human-session capability gating
- typed key-create browser-action request materialization
- no secret material is persisted or rendered

## Verification

- focused Aevatar.AI tests for tool gating, action registry, and browser actions - 66 passed
- `bash tools/ci/test_stability_guards.sh` - passed
- `bash tools/ci/architecture_guards.sh` - passed
- `git diff --check` - passed

## Documentation

No documentation change is required; the pinned registry and existing Studio workflow already define the least-scope action.
