### PR TITLE
Complete UC2 research, steer, stop, and restart journey

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatControlCommands.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatControlCommands.cs
@@ -59,9 +59,6 @@ public static class NyxIdChatControlCommands
     public const string ActiveTurnRequiresSteeringMessage =
         "This conversation already has active work. Submit a steering command for the active turn.";
 
-    private const string StopAcceptedMessage = "The active chat turn was stopped.";
-    private const string StopUncancellableMessage =
-        "The chat turn was fenced, but the in-flight operation could not be proven cancelled.";
     private const string SteeringAcceptedMessage =
         "The steering instruction was accepted at a safe checkpoint.";
     private const string SteeringAcceptedForLaterMessage =
@@ -518,6 +515,7 @@ public static class NyxIdChatControlCommands
         var outcome = physicallyInFlight
             ? NyxIdChatControlOutcome.Uncancellable
             : NyxIdChatControlOutcome.Accepted;
+        var receipt = BuildStopReceipt(state, physicallyInFlight);
         var fence = BuildResult(
             state,
             NyxIdChatControlKind.Stop,
@@ -525,7 +523,7 @@ public static class NyxIdChatControlCommands
             command.ClientRequestId,
             outcome,
             physicallyInFlight ? StopUncancellable : StopAccepted,
-            physicallyInFlight ? StopUncancellableMessage : StopAcceptedMessage,
+            receipt,
             now);
         var next = ApplyTerminalFence(state, fence, now);
         return new NyxIdChatControlDecision(
@@ -1344,6 +1342,72 @@ public static class NyxIdChatControlCommands
         state.ActiveTask?.Steps.Any(step =>
             IsPhysicallyInFlight(step.Operation?.Phase ??
                                  NyxIdChatOperationPhase.Unspecified)) == true;
+
+    private static string BuildStopReceipt(
+        NyxIdChatConversationGAgentState state,
+        bool physicallyInFlight)
+    {
+        var steps = state.ActiveTask?.Steps ?? [];
+        var completed = steps.Where(static step =>
+            step.Status == NyxIdChatStepStatus.Done).ToArray();
+        var unfinishedSteps = steps.Where(static step =>
+            step.Status is NyxIdChatStepStatus.Planned or
+                NyxIdChatStepStatus.Waiting or
+                NyxIdChatStepStatus.Running).ToArray();
+        var retained = completed.Length switch
+        {
+            0 => "No completed steps were retained.",
+            1 => "1 completed step was retained.",
+            _ => $"{completed.Length} completed steps were retained.",
+        };
+        var retainedDetails = BuildReceiptStepList(completed);
+        if (retainedDetails.Length > 0)
+            retained += $" Retained: {retainedDetails}.";
+        var unfinished = physicallyInFlight
+            ? "Unfinished work was fenced; the in-flight operation could not be proven cancelled."
+            : "Unfinished work was cancelled.";
+        var unfinishedDetails = BuildReceiptStepList(unfinishedSteps);
+        if (unfinishedDetails.Length > 0)
+            unfinished += physicallyInFlight
+                ? $" Fenced: {unfinishedDetails}."
+                : $" Cancelled: {unfinishedDetails}.";
+        var uncertainExternalEffect = steps.Any(static step =>
+            step.ExternalEffect == NyxIdChatEffectEvidence.MayHaveChanged) ||
+            steps.Any(step =>
+                step.Kind == NyxIdChatStepKind.Tool &&
+                step.MayChangeExternalState &&
+                IsPhysicallyInFlight(step.Operation?.Phase ??
+                                     NyxIdChatOperationPhase.Unspecified));
+        var confirmedExternalEffect = steps.Any(static step =>
+            step.MayChangeExternalState &&
+            step.ExternalEffect == NyxIdChatEffectEvidence.Confirmed);
+        var effectReceipt = uncertainExternalEffect
+            ? "An external operation may have changed state; inspect its committed evidence before retrying."
+            : confirmedExternalEffect
+                ? "Completed external effects remain recorded in the committed step evidence."
+                : "No external effect was applied.";
+
+        return $"Stopped. Partial-work receipt: {retained} {unfinished} {effectReceipt} " +
+               "Late evidence cannot advance this stopped task.";
+    }
+
+    private static string BuildReceiptStepList(IEnumerable<NyxIdChatTaskStepState> steps) =>
+        string.Join("; ", steps
+            .Select(static step => ReceiptStepLabel(step))
+            .Where(static label => label.Length > 0)
+            .Take(3));
+
+    private static string ReceiptStepLabel(NyxIdChatTaskStepState step)
+    {
+        var label = string.Join(" ", (step.Description ?? string.Empty)
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            .TrimEnd('.', ';', ':');
+        if (label.Length == 0 && step.Source?.SourceCase == NyxIdChatStepSource.SourceOneofCase.Tool)
+            label = step.Source.Tool.ToolName;
+        if (label.Length == 0)
+            label = step.Kind.ToString();
+        return label.Length <= 96 ? label : string.Concat(label.AsSpan(0, 93), "...");
+    }
 
     private static bool IsPhysicallyInFlight(NyxIdChatOperationPhase phase) =>
         phase is NyxIdChatOperationPhase.Dispatched or NyxIdChatOperationPhase.Running;

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTurnOperationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTurnOperationExecutor.cs
@@ -328,6 +328,7 @@ public sealed class NyxIdChatTurnOperationExecutor
         "The action postcondition input was invalid.";
     private const string PrepareOperationSubstepId = "prepare-operation";
     private const string ExecuteOperationSubstepId = "execute-operation";
+    private const string WebSearchToolName = "web_search";
     internal const int StreamingProgressBatchBytes = 64 * 1024;
     internal static readonly TimeSpan StreamingProgressBatchInterval = TimeSpan.FromSeconds(1);
 
@@ -868,10 +869,11 @@ public sealed class NyxIdChatTurnOperationExecutor
                 NyxIdChatEffectEvidence.NotStarted);
         }
 
+        var phaseTitles = ResolveToolPhaseTitles(toolInput.ToolName);
         await ReportPhaseAsync(
                 command.Key,
                 PrepareOperationSubstepId,
-                "Prepare operation",
+                phaseTitles.Prepare,
                 NyxIdChatSubstepStatus.Running,
                 session,
                         reportProgressAsync,
@@ -917,7 +919,7 @@ public sealed class NyxIdChatTurnOperationExecutor
         await ReportPhaseAsync(
                 command.Key,
                 PrepareOperationSubstepId,
-                "Prepare operation",
+                phaseTitles.Prepare,
                 NyxIdChatSubstepStatus.Done,
                 session,
                 reportProgressAsync,
@@ -946,7 +948,7 @@ public sealed class NyxIdChatTurnOperationExecutor
         await ReportPhaseAsync(
                 command.Key,
                 ExecuteOperationSubstepId,
-                "Execute operation",
+                phaseTitles.Execute,
                 NyxIdChatSubstepStatus.Running,
                 session,
                 reportProgressAsync,
@@ -983,7 +985,7 @@ public sealed class NyxIdChatTurnOperationExecutor
         await ReportPhaseAsync(
                 command.Key,
                 ExecuteOperationSubstepId,
-                "Execute operation",
+                phaseTitles.Execute,
                 NyxIdChatSubstepStatus.Done,
                 session,
                 reportProgressAsync,
@@ -2246,6 +2248,11 @@ public sealed class NyxIdChatTurnOperationExecutor
                 Status = status,
             },
         }, ct);
+
+    private static (string Prepare, string Execute) ResolveToolPhaseTitles(string toolName) =>
+        string.Equals(toolName, WebSearchToolName, StringComparison.Ordinal)
+            ? ("Build search query", "Search current web results")
+            : ("Prepare operation", "Execute operation");
 
     private static bool IsValidLlmExecution(
         AgentRunLlmStepExecution execution,

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-skill-overlay-default.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-skill-overlay-default.md
@@ -68,6 +68,14 @@ Quick reference:
 
 **Channel Bots** — Use the provider-specific typed tool or connected bot service exposed in the current turn. Copy the exact `user_service_id` and route snapshot from the same trusted entry; never infer a bot identity from a display label or remembered slug.
 
+### Read-only research fallback and artifacts
+
+- If an unavailable requested effect can be narrowed to a read-only research or drafting outcome, include that scope change in the single composite `ask_user` question and require the user's free-text consent before any tool runs. Never infer consent to the narrower scope.
+- For an agreed research-only task, communicate the exact executor from the final tool schema before calling it. When the mounted Aevatar search capability is present, name it as Aevatar `web_search`; do not describe it as a NyxID connected service or as the reserved browser-driving `web` executor.
+- Describe a read-and-draft-only plan as eligible for the actor-derived `auto` gate because it cannot book, spend, publish, or otherwise mutate external state. The committed actor gate remains authoritative.
+- A research artifact must separate facts supported by successful reads from facts that `cannot check right now`. Do not turn missing fields, failed reads, or unavailable reads into claims that a resource is absent, closed, unavailable, or unsuitable.
+- End every research-only artifact with an explicit statement that no reservation, publication, or other external mutation occurred. A stopped research task returns only a partial-work receipt based on committed step evidence, never a completed artifact; claim no external effect only when the committed evidence proves it, and state that late evidence cannot advance the stopped task.
+
 ### Aevatar-specific tool details
 
 These are **aevatar-internal** tools, not part of the external NyxID service skills — they manage state local to this aevatar deployment.

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -897,21 +897,52 @@ describe('ChatPage canonical NyxID Assistant', () => {
     (chatHistoryApi.listConversationMetas as jest.Mock).mockResolvedValue([
       serverConversation,
     ]);
-    const original = taskStep('step-original', {
-      description: 'Compare original candidates',
-    });
-    const completedEvidence = taskStep('step-completed-search', {
-      order: 2,
-      kind: 'web',
+    const completedInput = taskStep('step-uc2-gaps', {
+      kind: 'input',
       status: 'done',
-      description: 'Completed search evidence: Marina Bay options',
-      source: { web: {} },
+      description: 'Answer logistics and agree to research-only scope',
+      source: { input: { requestId: 'input-uc2-gaps' } },
       externalEffect: 'not_applied',
       availableActions: undefined,
       operation: null,
     });
+    const original = taskStep('step-original', {
+      order: 3,
+      description: 'Compare original candidates',
+    });
+    const completedEvidence = taskStep('step-uc2-search', {
+      order: 2,
+      status: 'done',
+      description: 'Aevatar web_search found the candidate set',
+      source: { tool: { toolName: 'web_search' } },
+      externalEffect: 'not_applied',
+      availableActions: undefined,
+      operation: {
+        conversationActorId: 'conversation-alpha',
+        turnId: 'turn-alpha',
+        taskId: 'task-alpha',
+        stepId: 'step-uc2-search',
+        operationId: 'operation-uc2-search',
+        operationGeneration: 1,
+        kind: 'tool',
+        phase: 'succeeded',
+      },
+      substeps: [
+        {
+          substepId: 'prepare-operation',
+          title: 'Build search query',
+          status: 'done',
+        },
+        {
+          substepId: 'execute-operation',
+          title: 'Search current web results',
+          status: 'done',
+        },
+      ],
+    });
     const steered = taskPlan(
       [
+        completedInput,
         completedEvidence,
         {
           ...original,
@@ -933,7 +964,7 @@ describe('ChatPage canonical NyxID Assistant', () => {
           {
             planRevision: 1,
             revisionCause: 'initial',
-            addedStepIds: ['step-original', 'step-completed-search'],
+            addedStepIds: ['step-uc2-gaps', 'step-original', 'step-uc2-search'],
             cancelledStepIds: [],
           },
           {
@@ -946,6 +977,13 @@ describe('ChatPage canonical NyxID Assistant', () => {
         title: 'Dinner research',
       },
     );
+    const stopReceipt =
+      'Stopped. Partial-work receipt: 2 completed steps were retained. ' +
+      'Retained: Answer logistics and agree to research-only scope; ' +
+      'Aevatar web_search found the candidate set. ' +
+      'Unfinished work was fenced; the in-flight operation could not be proven cancelled. ' +
+      'Fenced: Compare for 7 PM and a private room. No external effect was applied. ' +
+      'Late evidence cannot advance this stopped task.';
     const stopped = {
       ...steered,
       status: 'stopped',
@@ -954,7 +992,6 @@ describe('ChatPage canonical NyxID Assistant', () => {
         ...step,
         status: step.status === 'running' ? 'cancelled' : step.status,
         availableActions: undefined,
-        operation: null,
       })),
     };
     const stoppedState = currentState(
@@ -963,38 +1000,47 @@ describe('ChatPage canonical NyxID Assistant', () => {
           turnId: 'turn-alpha',
           taskId: 'task-alpha',
           status: 'stopped',
-          safeMessage: 'Partial research preserved.',
+          safeMessage: stopReceipt,
         },
         activeTask: stopped,
-        latestControlResult: { outcome: 'stopped' },
+        controlFence: {
+          kind: 'stop',
+          requestId: 'stop-uc2-1',
+          clientRequestId: 'client-stop-uc2-1',
+          turnId: 'turn-alpha',
+          taskId: 'task-alpha',
+          outcome: 'uncancellable',
+          safeMessage: stopReceipt,
+        },
       },
       12,
     );
-    const newGoalStep = taskStep('step-new-search', {
+    const newGoalStep = taskStep('step-uc2b-search', {
       description: 'Find Friday dinner options',
+      source: { tool: { toolName: 'web_search' } },
       operation: {
         conversationActorId: 'conversation-alpha',
-        turnId: 'turn-beta',
-        taskId: 'task-beta',
-        stepId: 'step-new-search',
-        operationId: 'operation-new-search',
+        turnId: 'turn-uc2b-1',
+        taskId: 'task-uc2b',
+        stepId: 'step-uc2b-search',
+        operationId: 'operation-uc2b-search',
         operationGeneration: 1,
-        kind: 'web',
+        kind: 'tool',
         phase: 'running',
       },
     });
     const newGoalPlan = taskPlan([newGoalStep], {
-      taskId: 'task-beta',
-      turnId: 'turn-beta',
-      planId: 'plan-beta',
+      taskId: 'task-uc2b',
+      turnId: 'turn-uc2b-1',
+      planId: 'plan-uc2b',
       title: 'Friday dinner research',
     });
     const newGoalState = {
       ...currentState(
         {
           activeTurn: {
-            turnId: 'turn-beta',
-            taskId: 'task-beta',
+            turnId: 'turn-uc2b-1',
+            taskId: 'task-uc2b',
             status: 'active',
           },
           latestTurn: null,
@@ -1003,19 +1049,21 @@ describe('ChatPage canonical NyxID Assistant', () => {
               turnId: 'turn-alpha',
               taskId: 'task-alpha',
               status: 'stopped',
-              safeMessage: 'Partial research preserved.',
+              safeMessage: stopReceipt,
             },
           ],
           activeTask: newGoalPlan,
         },
         13,
       ),
-      turnId: 'turn-beta',
+      turnId: 'turn-uc2b-1',
     };
     (chatHistoryApi.loadConversationState as jest.Mock)
       .mockResolvedValueOnce(
         activeTaskState(
-          taskPlan([original, completedEvidence], { title: 'Dinner research' }),
+          taskPlan([completedInput, original, completedEvidence], {
+            title: 'Dinner research',
+          }),
           10,
         ),
       )
@@ -1031,7 +1079,7 @@ describe('ChatPage canonical NyxID Assistant', () => {
             ? completedStream(
                 'Friday dinner research started.',
                 'conversation-alpha',
-                'turn-beta',
+                'turn-uc2b-1',
                 [
                   {
                     type: 'CUSTOM',
@@ -1073,16 +1121,29 @@ describe('ChatPage canonical NyxID Assistant', () => {
       within(taskRow('Compare original candidates')).getByText('cancelled'),
     ).toBeInTheDocument();
     expect(
-      within(
-        taskRow('Completed search evidence: Marina Bay options'),
-      ).getByText('done'),
+      within(taskRow('Aevatar web_search found the candidate set')).getByText(
+        'done',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(taskRow('Aevatar web_search found the candidate set')).getByText(
+        'web_search',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(taskRow('Aevatar web_search found the candidate set')).getByText(
+        'Build search query · done',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(taskRow('Aevatar web_search found the candidate set')).getByText(
+        'Search current web results · done',
+      ),
     ).toBeInTheDocument();
     const stop = screen.getByRole('button', { name: 'Stop task' });
     await waitFor(() => expect(stop).toBeEnabled());
     fireEvent.click(stop);
-    expect(
-      await screen.findByText('Partial research preserved.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(stopReceipt)).toBeInTheDocument();
     expect(requestBodies()).toEqual([
       {
         type: 'task.steer',
@@ -1106,14 +1167,12 @@ describe('ChatPage canonical NyxID Assistant', () => {
     firstView.unmount();
     renderWithQueryClient(<ChatPage />);
     await openCanonicalConversation();
-    expect(
-      await screen.findByText('Partial research preserved.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(stopReceipt)).toBeInTheDocument();
     expect(screen.getAllByText('Task result')).toHaveLength(1);
     expect(
-      within(
-        taskRow('Completed search evidence: Marina Bay options'),
-      ).getByText('done'),
+      within(taskRow('Aevatar web_search found the candidate set')).getByText(
+        'done',
+      ),
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Stop task' }),
@@ -1127,8 +1186,8 @@ describe('ChatPage canonical NyxID Assistant', () => {
     expect(newGoalState).toEqual(
       expect.objectContaining({
         snapshot: expect.objectContaining({
-          activeTurn: expect.objectContaining({ taskId: 'task-beta' }),
-          activeTask: expect.objectContaining({ taskId: 'task-beta' }),
+          activeTurn: expect.objectContaining({ taskId: 'task-uc2b' }),
+          activeTask: expect.objectContaining({ taskId: 'task-uc2b' }),
         }),
       }),
     );

--- a/test/Aevatar.AI.Tests/Fixtures/NyxIdChat/v1/README.md
+++ b/test/Aevatar.AI.Tests/Fixtures/NyxIdChat/v1/README.md
@@ -43,3 +43,12 @@ field-for-field identical, while the step-changed frame carries the complete
 `taskId / planRevision / step / changeKind` envelope. The fixture covers every
 v1 step source, including producer-authored tool readiness, approval, reserved
 web, and the postcondition `check` contract.
+
+`uc2-research-journey.json` freezes target journey UC2 from support-spec gist
+revision `f45febb057a7182dab2495d4c739d2bb8d7026f5`. It keeps `task-uc2` stable
+across steering while changing the continuation turn, preserves the completed
+`web_search` evidence and substeps, fences the stopped task with a no-effect
+partial receipt, and starts `turn-uc2b-1 / task-uc2b` as a distinct task. The
+final artifact is ordinary assistant content, not a new wire object; the
+fixture records its verified/cannot-check/no-reservation obligations for
+deterministic conformance tests.

--- a/test/Aevatar.AI.Tests/Fixtures/NyxIdChat/v1/uc2-research-journey.json
+++ b/test/Aevatar.AI.Tests/Fixtures/NyxIdChat/v1/uc2-research-journey.json
@@ -1,0 +1,407 @@
+{
+  "specRevision": "f45febb057a7182dab2495d4c739d2bb8d7026f5",
+  "conversationActorId": "conversation-uc2",
+  "initialInput": {
+    "stateVersion": 11,
+    "snapshot": {
+      "actorId": "conversation-uc2",
+      "stateVersion": 11,
+      "progressSequence": 11,
+      "activeTurn": { "turnId": "turn-uc2-1", "taskId": "task-uc2", "status": "active" },
+      "activeTask": {
+        "schemaVersion": 4,
+        "actorId": "conversation-uc2",
+        "turnId": "turn-uc2-1",
+        "taskId": "task-uc2",
+        "planId": "plan-uc2",
+        "planRevision": 1,
+        "title": "Scope the dinner request",
+        "status": "active",
+        "gate": { "mode": "auto", "reason": null },
+        "steps": [
+          {
+            "stepId": "step-uc2-gaps",
+            "order": 1,
+            "kind": "input",
+            "status": "waiting",
+            "description": "Answer party size, dietary needs, budget, and research-only scope together.",
+            "source": { "input": { "requestId": "input-uc2-gaps" } },
+            "externalEffect": "not_started",
+            "addedBy": "initial",
+            "availableActions": { "retry": false, "skip": false, "stop": true }
+          }
+        ]
+      },
+      "pendingInput": {
+        "requestId": "input-uc2-gaps",
+        "turnId": "turn-uc2-1",
+        "taskId": "task-uc2",
+        "stepId": "step-uc2-gaps",
+        "prompt": "Please answer together: party size, dietary restrictions, budget cap, and whether you accept a research-only shortlist because no reservation can be placed.",
+        "options": [],
+        "allowFreeText": true,
+        "multiSelect": false
+      },
+      "controlFence": null
+    }
+  },
+  "researchRunning": {
+    "stateVersion": 20,
+    "snapshot": {
+      "actorId": "conversation-uc2",
+      "stateVersion": 20,
+      "progressSequence": 20,
+      "activeTurn": { "turnId": "turn-uc2-1", "taskId": "task-uc2", "status": "active" },
+      "activeTask": {
+        "schemaVersion": 4,
+        "actorId": "conversation-uc2",
+        "turnId": "turn-uc2-1",
+        "taskId": "task-uc2",
+        "planId": "plan-uc2",
+        "planRevision": 2,
+        "title": "Research a ready-to-book dinner shortlist",
+        "status": "active",
+        "gate": { "mode": "auto", "reason": "Read and draft only." },
+        "steps": [
+          {
+            "stepId": "step-uc2-gaps",
+            "order": 1,
+            "kind": "input",
+            "status": "done",
+            "description": "Answer logistics and agree to research-only scope.",
+            "source": { "input": { "requestId": "input-uc2-gaps" } },
+            "externalEffect": "not_applied",
+            "addedBy": "initial",
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-search",
+            "order": 2,
+            "kind": "tool",
+            "status": "running",
+            "description": "Aevatar web search - find Greek dinner candidates.",
+            "source": { "tool": { "toolName": "web_search" } },
+            "externalEffect": "not_started",
+            "operation": {
+              "key": {
+                "conversationActorId": "conversation-uc2",
+                "turnId": "turn-uc2-1",
+                "taskId": "task-uc2",
+                "stepId": "step-uc2-search",
+                "operationId": "operation-uc2-search",
+                "operationGeneration": 1
+              },
+              "kind": "tool",
+              "phase": "running",
+              "mayChangeExternalState": false,
+              "idempotent": true,
+              "idempotencyKey": "operation-uc2-search"
+            },
+            "addedBy": "replan",
+            "dependsOn": ["step-uc2-gaps"],
+            "substeps": [
+              { "substepId": "prepare-operation", "title": "Build search query", "status": "done" },
+              { "substepId": "execute-operation", "title": "Search current web results", "status": "running" }
+            ],
+            "availableActions": { "retry": false, "skip": false, "stop": true }
+          },
+          {
+            "stepId": "step-uc2-compare",
+            "order": 3,
+            "kind": "llm",
+            "status": "planned",
+            "description": "Compare shortlist fit for six people and one vegetarian.",
+            "source": { "llm": {} },
+            "externalEffect": "not_started",
+            "addedBy": "replan",
+            "dependsOn": ["step-uc2-search"],
+            "availableActions": { "retry": false, "skip": false, "stop": true }
+          }
+        ]
+      },
+      "pendingInput": null,
+      "controlFence": null
+    }
+  },
+  "steered": {
+    "stateVersion": 31,
+    "snapshot": {
+      "actorId": "conversation-uc2",
+      "stateVersion": 31,
+      "progressSequence": 31,
+      "activeTurn": { "turnId": "turn-uc2-2", "taskId": "task-uc2", "status": "active" },
+      "activeTask": {
+        "schemaVersion": 4,
+        "actorId": "conversation-uc2",
+        "turnId": "turn-uc2-2",
+        "taskId": "task-uc2",
+        "planId": "plan-uc2",
+        "planRevision": 3,
+        "title": "Refine the shortlist for 7 pm and a private room",
+        "status": "active",
+        "gate": { "mode": "auto", "reason": "Read and draft only." },
+        "steps": [
+          {
+            "stepId": "step-uc2-gaps",
+            "order": 1,
+            "kind": "input",
+            "status": "done",
+            "description": "Answer logistics and agree to research-only scope.",
+            "source": { "input": { "requestId": "input-uc2-gaps" } },
+            "externalEffect": "not_applied",
+            "addedBy": "initial",
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-search",
+            "order": 2,
+            "kind": "tool",
+            "status": "done",
+            "description": "Aevatar web search - find Greek dinner candidates.",
+            "source": { "tool": { "toolName": "web_search" } },
+            "externalEffect": "not_applied",
+            "operation": {
+              "key": {
+                "conversationActorId": "conversation-uc2",
+                "turnId": "turn-uc2-1",
+                "taskId": "task-uc2",
+                "stepId": "step-uc2-search",
+                "operationId": "operation-uc2-search",
+                "operationGeneration": 1
+              },
+              "kind": "tool",
+              "phase": "succeeded",
+              "mayChangeExternalState": false,
+              "idempotent": true,
+              "idempotencyKey": "operation-uc2-search"
+            },
+            "addedBy": "replan",
+            "dependsOn": ["step-uc2-gaps"],
+            "substeps": [
+              { "substepId": "prepare-operation", "title": "Build search query", "status": "done" },
+              { "substepId": "execute-operation", "title": "Search current web results", "status": "done" }
+            ],
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-compare",
+            "order": 3,
+            "kind": "llm",
+            "status": "cancelled",
+            "description": "Compare the original shortlist fit.",
+            "source": { "llm": {} },
+            "externalEffect": "not_started",
+            "addedBy": "replan",
+            "dependsOn": ["step-uc2-search"],
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-refine",
+            "order": 4,
+            "kind": "llm",
+            "status": "running",
+            "description": "Refine for 7 pm and a private room.",
+            "source": { "llm": {} },
+            "externalEffect": "not_started",
+            "operation": {
+              "key": {
+                "conversationActorId": "conversation-uc2",
+                "turnId": "turn-uc2-2",
+                "taskId": "task-uc2",
+                "stepId": "step-uc2-refine",
+                "operationId": "operation-uc2-refine",
+                "operationGeneration": 1
+              },
+              "kind": "llm",
+              "phase": "running",
+              "mayChangeExternalState": false,
+              "idempotent": true,
+              "idempotencyKey": "operation-uc2-refine"
+            },
+            "addedBy": "steering",
+            "dependsOn": ["step-uc2-search"],
+            "availableActions": { "retry": false, "skip": false, "stop": true }
+          }
+        ]
+      },
+      "pendingInput": null,
+      "controlFence": null
+    }
+  },
+  "stopped": {
+    "stateVersion": 36,
+    "snapshot": {
+      "actorId": "conversation-uc2",
+      "stateVersion": 36,
+      "progressSequence": 36,
+      "activeTurn": { "turnId": "turn-uc2-2", "taskId": "task-uc2", "status": "stopped" },
+      "activeTask": {
+        "schemaVersion": 4,
+        "actorId": "conversation-uc2",
+        "turnId": "turn-uc2-2",
+        "taskId": "task-uc2",
+        "planId": "plan-uc2",
+        "planRevision": 3,
+        "title": "Refine the shortlist for 7 pm and a private room",
+        "status": "stopped",
+        "safeMessage": "Stopped. Partial-work receipt: 2 completed steps were retained. Retained: Answer logistics and agree to research-only scope; Aevatar web search - find Greek dinner candidates. Unfinished work was fenced; the in-flight operation could not be proven cancelled. Fenced: Refine for 7 pm and a private room. No external effect was applied. Late evidence cannot advance this stopped task.",
+        "gate": { "mode": "auto", "reason": "Read and draft only." },
+        "steps": [
+          {
+            "stepId": "step-uc2-gaps",
+            "order": 1,
+            "kind": "input",
+            "status": "done",
+            "source": { "input": { "requestId": "input-uc2-gaps" } },
+            "externalEffect": "not_applied",
+            "addedBy": "initial",
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-search",
+            "order": 2,
+            "kind": "tool",
+            "status": "done",
+            "source": { "tool": { "toolName": "web_search" } },
+            "externalEffect": "not_applied",
+            "operation": {
+              "key": {
+                "conversationActorId": "conversation-uc2",
+                "turnId": "turn-uc2-1",
+                "taskId": "task-uc2",
+                "stepId": "step-uc2-search",
+                "operationId": "operation-uc2-search",
+                "operationGeneration": 1
+              },
+              "kind": "tool",
+              "phase": "succeeded",
+              "mayChangeExternalState": false,
+              "idempotent": true,
+              "idempotencyKey": "operation-uc2-search"
+            },
+            "addedBy": "replan",
+            "substeps": [
+              { "substepId": "prepare-operation", "title": "Build search query", "status": "done" },
+              { "substepId": "execute-operation", "title": "Search current web results", "status": "done" }
+            ],
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-compare",
+            "order": 3,
+            "kind": "llm",
+            "status": "cancelled",
+            "source": { "llm": {} },
+            "externalEffect": "not_started",
+            "addedBy": "replan",
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2-refine",
+            "order": 4,
+            "kind": "llm",
+            "status": "cancelled",
+            "source": { "llm": {} },
+            "externalEffect": "not_applied",
+            "operation": {
+              "key": {
+                "conversationActorId": "conversation-uc2",
+                "turnId": "turn-uc2-2",
+                "taskId": "task-uc2",
+                "stepId": "step-uc2-refine",
+                "operationId": "operation-uc2-refine",
+                "operationGeneration": 1
+              },
+              "kind": "llm",
+              "phase": "running",
+              "mayChangeExternalState": false,
+              "idempotent": true,
+              "idempotencyKey": "operation-uc2-refine"
+            },
+            "addedBy": "steering",
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          }
+        ]
+      },
+      "pendingInput": null,
+      "controlFence": {
+        "kind": "stop",
+        "requestId": "stop-uc2-1",
+        "clientRequestId": "client-stop-uc2-1",
+        "turnId": "turn-uc2-2",
+        "taskId": "task-uc2",
+        "outcome": "uncancellable",
+        "safeMessage": "Stopped. Partial-work receipt: 2 completed steps were retained. Retained: Answer logistics and agree to research-only scope; Aevatar web search - find Greek dinner candidates. Unfinished work was fenced; the in-flight operation could not be proven cancelled. Fenced: Refine for 7 pm and a private room. No external effect was applied. Late evidence cannot advance this stopped task."
+      }
+    }
+  },
+  "restart": {
+    "stateVersion": 48,
+    "snapshot": {
+      "actorId": "conversation-uc2",
+      "stateVersion": 48,
+      "progressSequence": 48,
+      "activeTurn": { "turnId": "turn-uc2b-1", "taskId": "task-uc2b", "status": "succeeded" },
+      "activeTask": {
+        "schemaVersion": 4,
+        "actorId": "conversation-uc2",
+        "turnId": "turn-uc2b-1",
+        "taskId": "task-uc2b",
+        "planId": "plan-uc2b",
+        "planRevision": 1,
+        "title": "Finish the research shortlist",
+        "status": "succeeded",
+        "gate": { "mode": "auto", "reason": "Read and draft only." },
+        "steps": [
+          {
+            "stepId": "step-uc2b-search",
+            "order": 1,
+            "kind": "tool",
+            "status": "done",
+            "source": { "tool": { "toolName": "web_search" } },
+            "externalEffect": "not_applied",
+            "operation": {
+              "key": {
+                "conversationActorId": "conversation-uc2",
+                "turnId": "turn-uc2b-1",
+                "taskId": "task-uc2b",
+                "stepId": "step-uc2b-search",
+                "operationId": "operation-uc2b-search",
+                "operationGeneration": 1
+              },
+              "kind": "tool",
+              "phase": "succeeded",
+              "mayChangeExternalState": false,
+              "idempotent": true,
+              "idempotencyKey": "operation-uc2b-search"
+            },
+            "addedBy": "initial",
+            "substeps": [
+              { "substepId": "prepare-operation", "title": "Build search query", "status": "done" },
+              { "substepId": "execute-operation", "title": "Search current web results", "status": "done" }
+            ],
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          },
+          {
+            "stepId": "step-uc2b-draft",
+            "order": 2,
+            "kind": "llm",
+            "status": "done",
+            "source": { "llm": {} },
+            "externalEffect": "not_applied",
+            "addedBy": "initial",
+            "dependsOn": ["step-uc2b-search"],
+            "availableActions": { "retry": false, "skip": false, "stop": false }
+          }
+        ]
+      },
+      "pendingInput": null,
+      "controlFence": null
+    },
+    "assistantMessage": {
+      "turnId": "turn-uc2b-1",
+      "taskId": "task-uc2b",
+      "content": "Verified facts:\n- North Olive lists a private room for 6, vegetarian choices, and Friday 7 pm.\n- Agora Table lists vegetarian choices and Friday 7 pm; its private room is on request.\n\nCannot check right now: Atlas Taverna's Friday hours are not stated in the successful search results.\n\nResearch artifact only: no reservation was made."
+    }
+  }
+}

--- a/test/Aevatar.AI.Tests/NyxIdChatControlCommandTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatControlCommandTests.cs
@@ -515,6 +515,80 @@ public sealed class NyxIdChatControlCommandTests
             .Attention.AttentionKind.Should().Be(NyxIdChatAttentionKind.None);
     }
 
+    [Fact]
+    public void Uc2Stop_ShouldReturnDurablePartialWorkReceiptWithNoExternalEffect()
+    {
+        var state = FailedStepState(
+            NyxIdChatStepKind.Llm,
+            required: true,
+            safeToSkip: false,
+            retryInputRebuildable: true);
+        var active = state.ActiveTask.Steps.Single();
+        active.Order = 3;
+        active.Status = NyxIdChatStepStatus.Running;
+        active.Operation.Phase = NyxIdChatOperationPhase.Running;
+        active.Operation.CompletedAt = null;
+        active.ExternalEffect = NyxIdChatEffectEvidence.NotStarted;
+        active.FailureCode = string.Empty;
+        active.SafeMessage = string.Empty;
+        active.Description = "Refine the shortlist for 7 pm and a private room.";
+        state.ActiveTask.Steps.Insert(0, CompletedReadOnlyStep(
+            "step-uc2-input",
+            1,
+            NyxIdChatStepKind.Input,
+            "Collect all dinner constraints and accept research-only scope."));
+        state.ActiveTask.Steps.Insert(1, CompletedReadOnlyStep(
+            "step-uc2-search",
+            2,
+            NyxIdChatStepKind.Tool,
+            "Aevatar web_search found the candidate set."));
+        state.ActiveTask.Steps[1].Source = new NyxIdChatStepSource
+        {
+            Tool = new NyxIdChatToolStepSource { ToolName = "web_search" },
+        };
+        var completedBytes = state.ActiveTask.Steps.Take(2)
+            .Select(static step => step.ToByteString())
+            .ToArray();
+
+        var decision = NyxIdChatControlCommands.Stop(
+            state,
+            new NyxIdChatStopCommand
+            {
+                ScopeId = "scope-alpha",
+                ConversationActorId = "conversation-alpha",
+                TurnId = "turn-alpha",
+                StopRequestId = "stop-uc2-1",
+                ClientRequestId = "client-stop-uc2-1",
+                ExpectedStateVersion = 17,
+            },
+            stateVersion: 17,
+            Now);
+
+        decision.ShouldCommit.Should().BeTrue();
+        decision.Result.Outcome.Should().Be(NyxIdChatControlOutcome.Uncancellable);
+        decision.Result.SafeMessage.Should().Contain("Partial-work receipt");
+        decision.Result.SafeMessage.Should().Contain("2 completed steps were retained");
+        decision.Result.SafeMessage.Should().Contain(
+            "Retained: Collect all dinner constraints and accept research-only scope; " +
+            "Aevatar web_search found the candidate set.");
+        decision.Result.SafeMessage.Should().Contain(
+            "Fenced: Refine the shortlist for 7 pm and a private room.");
+        decision.Result.SafeMessage.Should().Contain("No external effect was applied");
+        decision.Result.SafeMessage.Should().Contain("Late evidence cannot advance this stopped task");
+        decision.State.ActiveTask.Status.Should().Be(NyxIdChatTaskStatus.Stopped);
+        decision.State.ActiveTask.Steps[2].Status.Should().Be(NyxIdChatStepStatus.Cancelled);
+        decision.State.ActiveTask.Steps.Take(2).Select(static step => step.ToByteString())
+            .Should().Equal(completedBytes);
+
+        var reloaded = NyxIdChatConversationGAgentState.Parser.ParseFrom(
+            decision.State.ToByteArray());
+        reloaded.ControlFence.SafeMessage.Should().Be(decision.Result.SafeMessage);
+        reloaded.ActiveTask.SafeMessage.Should().Be(decision.Result.SafeMessage);
+        reloaded.LatestTurn.SafeMessage.Should().Be(decision.Result.SafeMessage);
+        reloaded.ActiveTask.Steps.Single(step => step.StepId == "step-uc2-search")
+            .Source.Tool.ToolName.Should().Be("web_search");
+    }
+
     [Theory]
     [InlineData(NyxIdChatControlKind.Stop)]
     [InlineData(NyxIdChatControlKind.Steering)]
@@ -755,6 +829,39 @@ public sealed class NyxIdChatControlCommandTests
         state.ActiveTask.ActiveStepId = step.StepId;
         return state;
     }
+
+    private static NyxIdChatTaskStepState CompletedReadOnlyStep(
+        string stepId,
+        int order,
+        NyxIdChatStepKind kind,
+        string description) => new()
+    {
+        StepId = stepId,
+        Order = order,
+        Kind = kind,
+        Status = NyxIdChatStepStatus.Done,
+        Required = true,
+        Description = description,
+        ExternalEffect = NyxIdChatEffectEvidence.NotApplied,
+        Operation = new NyxIdChatOperationState
+        {
+            Key = new NyxIdChatOperationKey
+            {
+                ConversationActorId = "conversation-alpha",
+                TurnId = "turn-alpha",
+                TaskId = "task-alpha",
+                StepId = stepId,
+                OperationId = $"operation-{stepId}",
+                OperationGeneration = 1,
+            },
+            Kind = kind,
+            Phase = NyxIdChatOperationPhase.Succeeded,
+            Idempotent = true,
+            CompletedAt = Now.Clone(),
+        },
+        AddedBy = NyxIdChatStepAddedBy.Initial,
+        UpdatedAt = Now.Clone(),
+    };
 
     private static NyxIdChatConversationGAgentState TerminalFailedStepState(
         NyxIdChatStepKind kind,

--- a/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatConversationGAgentTests.cs
@@ -4190,9 +4190,17 @@ public sealed partial class NyxIdChatConversationGAgentTests
     }
 
     [Fact]
-    public async Task StoppedTask_ShouldNeverResumeAndNewGoalShouldUseNewTaskIdentity()
+    public async Task Uc2StoppedTask_ShouldNeverResumeAndDistinctRestartShouldPublishHonestArtifact()
     {
-        const string conversationActorId = "conversation-stopped-new-goal";
+        const string conversationActorId = "conversation-uc2";
+        const string artifact = """
+            Verified facts:
+            - North Olive lists a private room for 6, vegetarian choices, and Friday 7 pm.
+
+            Cannot check right now: Atlas Taverna's Friday hours were not present in the successful search evidence.
+
+            Research artifact only: no reservation was made.
+            """;
         var eventStore = new InMemoryEventStoreForTests();
         using var services = BuildEventSourcingServices(eventStore);
         var dispatch = new RecordingActorDispatchPort([], static (_, _) => Task.CompletedTask);
@@ -4200,27 +4208,43 @@ public sealed partial class NyxIdChatConversationGAgentTests
         await agent.ActivateAsync();
         var original = CreateStartTurnCommand();
         original.ConversationActorId = conversationActorId;
+        original.TurnId = "turn-uc2-2";
+        original.TaskId = "task-uc2";
+        original.ClientRequestId = "client-uc2-2";
+        original.CommandId = "command-uc2-2";
+        original.CorrelationId = "correlation-uc2-2";
+        original.Prompt = "Refine the dinner shortlist for 7 pm and a private room.";
         await agent.HandleEventAsync(CreateEnvelope(conversationActorId, original));
         var beforeStop = await eventStore.GetEventsAsync(conversationActorId);
         var stop = CreateStopCommand(beforeStop[^1].Version);
         stop.ConversationActorId = conversationActorId;
+        stop.TurnId = original.TurnId;
+        stop.StopRequestId = "stop-uc2-1";
+        stop.ClientRequestId = "client-stop-uc2-1";
+        stop.CommandId = "command-stop-uc2-1";
+        stop.CorrelationId = "correlation-stop-uc2-1";
 
         await agent.HandleEventAsync(CreateEnvelope(conversationActorId, stop));
 
         agent.State.ActiveTask.Status.Should().Be(NyxIdChatTaskStatus.Stopped);
         var stoppedTask = agent.State.ActiveTask.Clone();
+        var stoppedTerminalDispatch = dispatch.Calls.Should().ContainSingle(call =>
+                call.Envelope.Payload.Is(NyxIdChatHistoryTerminalDispatchRequested.Descriptor))
+            .Which.Envelope.Clone();
+        await agent.HandleEventAsync(stoppedTerminalDispatch);
+        agent.State.PendingHistoryTerminal.Should().BeNull();
         var next = CreateStartTurnCommand();
         next.ConversationActorId = conversationActorId;
-        next.TurnId = "turn-new-goal";
-        next.TaskId = "task-new-goal";
-        next.ClientRequestId = "client-new-goal";
-        next.CommandId = "command-new-goal";
-        next.CorrelationId = "correlation-new-goal";
-        next.Prompt = "Dinner is back on.";
+        next.TurnId = "turn-uc2b-1";
+        next.TaskId = "task-uc2b";
+        next.ClientRequestId = "client-uc2b-1";
+        next.CommandId = "command-uc2b-1";
+        next.CorrelationId = "correlation-uc2b-1";
+        next.Prompt = "Finish the research-only dinner shortlist; do not place a reservation.";
 
         await agent.HandleEventAsync(CreateEnvelope(conversationActorId, next));
 
-        agent.State.ActiveTask.TaskId.Should().Be("task-new-goal");
+        agent.State.ActiveTask.TaskId.Should().Be("task-uc2b");
         agent.State.ActiveTask.TaskId.Should().NotBe(stoppedTask.TaskId);
         agent.State.ActiveTask.Status.Should().Be(NyxIdChatTaskStatus.Active);
         agent.State.ActiveTask.Steps.Should().NotContain(step =>
@@ -4231,6 +4255,33 @@ public sealed partial class NyxIdChatConversationGAgentTests
             summary.Status == NyxIdChatTurnStatus.Stopped);
         dispatch.OperationCalls.Should().HaveCount(2,
             "the new goal starts one new operation and never redispatches the stopped task");
+
+        var restartKey = agent.State.ActiveTask.Steps.Single().Operation.Key.Clone();
+        await agent.HandleEventAsync(CreateEnvelope(
+            conversationActorId,
+            new NyxIdChatOperationResultSignal
+            {
+                Key = restartKey,
+                Llm = new NyxIdChatLLMOperationResult
+                {
+                    Content = artifact,
+                    FinishReason = "stop",
+                },
+            }));
+
+        agent.State.ActiveTask.TaskId.Should().Be("task-uc2b");
+        agent.State.ActiveTask.Status.Should().Be(NyxIdChatTaskStatus.Succeeded);
+        agent.State.ActiveTurn.Status.Should().Be(NyxIdChatTurnStatus.Succeeded);
+        agent.State.PendingHistoryTerminal.Should().NotBeNull();
+        agent.State.PendingHistoryTerminal.TurnId.Should().Be("turn-uc2b-1");
+        agent.State.PendingHistoryTerminal.Text.Should().Be(artifact)
+            .And.Contain("Verified facts:")
+            .And.Contain("Cannot check right now:")
+            .And.EndWith("Research artifact only: no reservation was made.");
+        agent.State.RecentTerminalTurns.Should().Contain(summary =>
+            summary.TurnId == "turn-uc2-2" &&
+            summary.TaskId == "task-uc2" &&
+            summary.Status == NyxIdChatTurnStatus.Stopped);
     }
 
     [Fact]
@@ -4515,18 +4566,27 @@ public sealed partial class NyxIdChatConversationGAgentTests
     }
 
     [Fact]
-    public async Task SteeringRevision_ShouldPreserveCompletedEffectEvidenceAndEmitFullTaskSnapshot()
+    public async Task Uc2SteeringRevision_ShouldPreserveCompletedSearchEvidenceAndEmitFullTaskSnapshot()
     {
-        const string conversationActorId = "conversation-alpha";
+        const string conversationActorId = "conversation-uc2";
+        const string originalTurnId = "turn-uc2-1";
         var eventStore = new InMemoryEventStoreForTests();
         using var services = BuildEventSourcingServices(eventStore);
         var dispatch = new RecordingActorDispatchPort([], static (_, _) => Task.CompletedTask);
         var agent = CreateController(services, conversationActorId, dispatch);
         await agent.ActivateAsync();
         agent.State.OwnerSubject = "owner-alpha";
+        var start = CreateStartTurnCommand();
+        start.ConversationActorId = conversationActorId;
+        start.TurnId = originalTurnId;
+        start.TaskId = "task-uc2";
+        start.ClientRequestId = "client-uc2-1";
+        start.CommandId = "command-uc2-1";
+        start.CorrelationId = "correlation-uc2-1";
+        start.Prompt = "Research Greek dinner options for Friday in northern Singapore.";
         await agent.HandleEventAsync(CreateEnvelope(
             conversationActorId,
-            WithOwner(CreateStartTurnCommand(), "owner-alpha")));
+            WithOwner(start, "owner-alpha")));
 
         var task = agent.State.ActiveTask;
         var superseded = task.Steps.Should().ContainSingle().Which;
@@ -4534,7 +4594,10 @@ public sealed partial class NyxIdChatConversationGAgentTests
         superseded.AddedBy = NyxIdChatStepAddedBy.Replan;
         superseded.AddedInPlanRevision = 2;
         superseded.Description = "Compare the current service state.";
-        var completed = CreateCompletedEffectStep(task.TaskId);
+        var completed = CreateCompletedReadOnlySearchStep(
+            conversationActorId,
+            originalTurnId,
+            task.TaskId);
         task.Steps.Insert(0, completed);
         task.PlanRevision = 2;
         task.PlanRevisionHistoryStart = 1;
@@ -4559,6 +4622,13 @@ public sealed partial class NyxIdChatConversationGAgentTests
         var supersededKey = superseded.Operation.Key.Clone();
         var committedBeforeSteering = await eventStore.GetEventsAsync(conversationActorId);
         var steering = CreateSteeringCommand(committedBeforeSteering[^1].Version);
+        steering.ConversationActorId = conversationActorId;
+        steering.TurnId = originalTurnId;
+        steering.SteeringId = "steering-uc2-1";
+        steering.ClientRequestId = "client-steering-uc2-1";
+        steering.CommandId = "command-steering-uc2-1";
+        steering.CorrelationId = "correlation-steering-uc2-1";
+        steering.Instruction = "Use 7 pm sharp and require a private room.";
         steering.ToolContext.Caller = new Aevatar.AI.Abstractions.AgentToolCallerContextPayload
         {
             OwnerSubject = "owner-alpha",
@@ -4591,8 +4661,11 @@ public sealed partial class NyxIdChatConversationGAgentTests
         preserved.Source.ToByteString().Should().Equal(completedSourceBytes,
             "provider-authored service and operation provenance must remain verbatim");
         preserved.Status.Should().Be(NyxIdChatStepStatus.Done);
-        preserved.ExternalEffect.Should().Be(NyxIdChatEffectEvidence.Confirmed);
+        preserved.Source.Tool.ToolName.Should().Be("web_search");
+        preserved.ExternalEffect.Should().Be(NyxIdChatEffectEvidence.NotApplied);
         preserved.Operation.Phase.Should().Be(NyxIdChatOperationPhase.Succeeded);
+        preserved.Substeps.Should().OnlyContain(substep =>
+            substep.Status == NyxIdChatSubstepStatus.Done);
         var cancelled = agent.State.ActiveTask.Steps.Single(step =>
             step.StepId == supersededKey.StepId);
         cancelled.Status.Should().Be(NyxIdChatStepStatus.Cancelled);
@@ -4621,6 +4694,11 @@ public sealed partial class NyxIdChatConversationGAgentTests
         snapshot.Steps.Should().HaveCount(3);
         snapshot.Steps.Single(step => step.StepId == completed.StepId)
             .ToByteString().Should().Equal(completedBytes);
+        var continuation = dispatch.OperationCalls.Last().Envelope.Payload
+            .Unpack<NyxIdChatOperationDispatchCommand>();
+        continuation.Key.TurnId.Should().NotBe(originalTurnId);
+        continuation.Llm.Request.Prompt.Should().Be(
+            "Use 7 pm sharp and require a private room.");
     }
 
     [Theory]
@@ -6035,21 +6113,28 @@ public sealed partial class NyxIdChatConversationGAgentTests
     }
 
     [Fact]
-    public async Task AskUserFreeTextOnly_ShouldPreserveOneCompositeQuestionAndResumeExactInputStep()
+    public async Task Uc2CompositeInput_ShouldResolveResearchScopeOnceAndResumeAfterReload()
     {
-        const string conversationActorId = "conversation-alpha";
+        const string conversationActorId = "conversation-uc2";
         const string compositeQuestion =
-            "Which region, budget, and launch date should I use for this deployment?";
+            "Please answer together: party size, dietary restrictions, budget cap, and whether you accept a research-only shortlist because no reservation can be placed.";
         const string rawAnswer =
-            "Singapore; budget SGD 200; launch 2026-08-20. Keep those defaults editable.";
+            "Party of 6, one vegetarian, no budget cap. Yes - research and prepare a ready-to-book shortlist.";
         var eventStore = new InMemoryEventStoreForTests();
         var dispatch = new RecordingActorDispatchPort([], static (_, _) => Task.CompletedTask);
         using var services = BuildEventSourcingServices(eventStore);
         var initial = CreateController(services, conversationActorId, dispatch);
         await initial.ActivateAsync();
-        await initial.HandleEventAsync(CreateEnvelope(
-            conversationActorId,
-            CreateStartTurnCommand()));
+        var start = CreateStartTurnCommand();
+        start.ConversationActorId = conversationActorId;
+        start.TurnId = "turn-uc2-1";
+        start.TaskId = "task-uc2";
+        start.ClientRequestId = "client-uc2-1";
+        start.CommandId = "command-uc2-1";
+        start.CorrelationId = "correlation-uc2-1";
+        start.Prompt =
+            "Book a dinner reservation for the team on Friday - Greek food, northern Singapore, 6-7 pm.";
+        await initial.HandleEventAsync(CreateEnvelope(conversationActorId, start));
         var llmKey = initial.State.ActiveTask.Steps.Single().Operation.Key.Clone();
         await initial.HandleEventAsync(CreateEnvelope(
             conversationActorId,
@@ -6087,6 +6172,8 @@ public sealed partial class NyxIdChatConversationGAgentTests
         initial.State.PendingInput.Should().NotBeNull();
         var pending = initial.State.PendingInput!;
         pending.Prompt.Should().Be(compositeQuestion);
+        pending.TurnId.Should().Be("turn-uc2-1");
+        pending.TaskId.Should().Be("task-uc2");
         pending.Options.Should().BeEmpty();
         pending.AllowFreeText.Should().BeTrue();
         pending.MultiSelect.Should().BeFalse();
@@ -6120,6 +6207,8 @@ public sealed partial class NyxIdChatConversationGAgentTests
             step.Kind == NyxIdChatStepKind.Llm &&
             step.Status == NyxIdChatStepStatus.Running &&
             step.AddedBy == NyxIdChatStepAddedBy.Replan);
+        recovered.State.ActiveTask.TaskId.Should().Be("task-uc2");
+        recovered.State.ActiveTask.PlanRevision.Should().Be(3);
         var continuation = recoveryDispatch.OperationCalls.Should().ContainSingle().Which.Envelope.Payload
             .Unpack<NyxIdChatOperationDispatchCommand>();
         continuation.InputCase.Should().Be(
@@ -6127,7 +6216,72 @@ public sealed partial class NyxIdChatConversationGAgentTests
         continuation.InputContinuation.Answer.FreeText.Should().Be(rawAnswer);
         continuation.InputContinuation.ToolCallId.Should().Be("call-ask-user-composite");
 
+        const string searchArguments =
+            "{\"query\":\"Greek dinner northern Singapore Friday 6 to 7 pm\",\"max_results\":5}";
+        const string communicatedPlan =
+            "Plan: use Aevatar web_search, then draft a verified research-only shortlist. " +
+            "Gate: auto (read and draft only). No reservation will be made by this task.";
+        await recovered.HandleOperationProgressAsync(new NyxIdChatOperationProgressSignal
+        {
+            Key = continuation.Key.Clone(),
+            Sequence = 1,
+            Text = new NyxIdChatTextProgress { Delta = communicatedPlan },
+        });
+        var planProgress = (await eventStore.GetEventsAsync(conversationActorId))[^1]
+            .EventData.Unpack<NyxIdChatOperationProgressedEvent>();
+        NyxIdChatConversationAguiFrameBuilder.BuildProgressed("turn-uc2-1", planProgress)
+            .Should().ContainSingle(frame =>
+                frame.TextMessageContent != null &&
+                frame.TextMessageContent.Delta == communicatedPlan);
+        await recovered.HandleEventAsync(CreateEnvelope(
+            conversationActorId,
+            new NyxIdChatOperationResultSignal
+            {
+                Key = continuation.Key.Clone(),
+                Llm = new NyxIdChatLLMOperationResult
+                {
+                    Content = communicatedPlan,
+                    ToolCalls =
+                    {
+                        new NyxIdChatToolCall
+                        {
+                            CallId = "call-uc2-search",
+                            ToolName = "web_search",
+                            ArgumentsJson = searchArguments,
+                            Safety = new NyxIdChatToolCallSafety
+                            {
+                                IsReadOnly = true,
+                                MayChangeExternalState = false,
+                                SideEffectKind = "web.search",
+                            },
+                        },
+                    },
+                },
+            }));
+
+        recovered.State.ActiveTask.Gate.Mode.Should().Be(NyxIdChatPlanGateMode.Auto);
+        recovered.State.ActiveTask.Gate.Status.Should().Be(NyxIdChatPlanGateStatus.Satisfied);
+        var search = recovered.State.ActiveTask.Steps.Single(step =>
+            step.Source?.SourceCase == NyxIdChatStepSource.SourceOneofCase.Tool &&
+            step.Source.Tool.ToolName == "web_search");
+        search.MayChangeExternalState.Should().BeFalse();
+        search.Status.Should().Be(NyxIdChatStepStatus.Running);
+        var searchDispatch = recoveryDispatch.OperationCalls.Last().Envelope.Payload
+            .Unpack<NyxIdChatOperationDispatchCommand>();
+        searchDispatch.InputCase.Should().Be(
+            NyxIdChatOperationDispatchCommand.InputOneofCase.Tool);
+        searchDispatch.Tool.ToolName.Should().Be("web_search");
+        searchDispatch.Tool.ArgumentsJson.Should().Be(searchArguments);
+        recoveryDispatch.OperationCalls.Should().HaveCount(2,
+            "one input continuation and one exact read-only search must run after consent");
+
         var committed = await eventStore.GetEventsAsync(conversationActorId);
+        var indexedEvents = committed.Select(static (item, index) => (item, index)).ToArray();
+        indexedEvents.Single(entry =>
+                entry.item.EventData.Is(NyxIdChatOperationProgressedEvent.Descriptor)).index
+            .Should().BeLessThan(indexedEvents.Last(entry =>
+                    entry.item.EventData.Is(NyxIdChatOperationReconciledEvent.Descriptor)).index,
+                "the communicated plan must be observable before the tool plan dispatches");
         committed.Should().ContainSingle(item =>
             item.EventData.Is(NyxIdChatInputResolutionCommittedEvent.Descriptor));
         committed.Should().OnlyContain(item =>
@@ -6303,49 +6457,46 @@ public sealed partial class NyxIdChatConversationGAgentTests
         },
     };
 
-    private static NyxIdChatTaskStepState CreateCompletedEffectStep(string taskId)
+    private static NyxIdChatTaskStepState CreateCompletedReadOnlySearchStep(
+        string conversationActorId,
+        string turnId,
+        string taskId)
     {
         var completedAt = Timestamp.FromDateTimeOffset(
             new DateTimeOffset(2026, 7, 24, 7, 59, 0, TimeSpan.Zero));
-        var operationAdmission = CreateEffectAdmissionWithReadBack();
-        return new NyxIdChatTaskStepState
+        var step = new NyxIdChatTaskStepState
         {
-            StepId = "step-completed-effect-alpha",
+            StepId = "step-uc2-search",
             Order = 1,
             Kind = NyxIdChatStepKind.Tool,
             Status = NyxIdChatStepStatus.Done,
             Required = true,
-            Description = "Update the repository settings.",
+            Description = "Aevatar web search - find Greek dinner candidates.",
             Source = new NyxIdChatStepSource
             {
                 Tool = new NyxIdChatToolStepSource
                 {
-                    ToolName = "repository_update",
-                    ServiceSlug = "repository-service",
-                    ServiceId = "svc-repository-alpha",
-                    ReadinessCapabilityId = "capability-repository-alpha",
-                    ProviderResourceId = "repository-alpha",
-                    OperationAdmission = operationAdmission.Clone(),
+                    ToolName = "web_search",
                 },
             },
-            MayChangeExternalState = true,
-            ExternalEffect = NyxIdChatEffectEvidence.Confirmed,
+            MayChangeExternalState = false,
+            ExternalEffect = NyxIdChatEffectEvidence.NotApplied,
             Operation = new NyxIdChatOperationState
             {
                 Key = new NyxIdChatOperationKey
                 {
-                    ConversationActorId = "conversation-alpha",
-                    TurnId = "turn-effect-alpha",
+                    ConversationActorId = conversationActorId,
+                    TurnId = turnId,
                     TaskId = taskId,
-                    StepId = "step-completed-effect-alpha",
-                    OperationId = "operation-completed-effect-alpha",
+                    StepId = "step-uc2-search",
+                    OperationId = "operation-uc2-search",
                     OperationGeneration = 1,
                 },
                 Kind = NyxIdChatStepKind.Tool,
                 Phase = NyxIdChatOperationPhase.Succeeded,
-                MayChangeExternalState = true,
+                MayChangeExternalState = false,
                 Idempotent = true,
-                IdempotencyKey = "idempotency-completed-effect-alpha",
+                IdempotencyKey = "operation-uc2-search",
                 RequestedAt = completedAt.Clone(),
                 DispatchedAt = completedAt.Clone(),
                 CompletedAt = completedAt.Clone(),
@@ -6353,26 +6504,23 @@ public sealed partial class NyxIdChatConversationGAgentTests
                 LatestProgressSequence = 7,
                 LastProgressAt = completedAt.Clone(),
             },
-            ApprovalRequestId = "approval-completed-effect-alpha",
-            RetryToolInput = new NyxIdChatRetryToolInputState
-            {
-                CallId = "call-completed-effect-alpha",
-                ToolName = "repository_update",
-                Arguments = JsonParser.Default.Parse<Struct>(
-                    "{\"repositoryId\":\"repository-alpha\"}"),
-                OperationAdmission = operationAdmission.Clone(),
-            },
-            ApprovalObservation = new NyxIdChatPostReturnApprovalObservation
-            {
-                ApprovalRequestId = "approval-completed-effect-alpha",
-                DecisionMode = NyxIdApprovalDecisionMode.PerRequest,
-                ReceiptStatus = AgentToolReceiptStatus.Success,
-                ObservedAt = completedAt.Clone(),
-            },
             AddedBy = NyxIdChatStepAddedBy.Initial,
             AddedInPlanRevision = 1,
             UpdatedAt = completedAt.Clone(),
         };
+        step.Substeps.Add(new NyxIdChatSubstepState
+        {
+            SubstepId = "prepare-operation",
+            Title = "Build search query",
+            Status = NyxIdChatSubstepStatus.Done,
+        });
+        step.Substeps.Add(new NyxIdChatSubstepState
+        {
+            SubstepId = "execute-operation",
+            Title = "Search current web results",
+            Status = NyxIdChatSubstepStatus.Done,
+        });
+        return step;
     }
 
     private static void SetOwner(NyxIdChatStartTurnCommand command, string ownerSubject)

--- a/test/Aevatar.AI.Tests/NyxIdChatFixtureConvergenceTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatFixtureConvergenceTests.cs
@@ -114,6 +114,126 @@ public sealed class NyxIdChatFixtureConvergenceTests
             .Should().BeTrue("step.changed carries the same complete step shape");
     }
 
+    [Fact]
+    public void Uc2ResearchJourneyFixture_ShouldConvergeAcrossScopeSteerStopReloadAndRestart()
+    {
+        using var fixture = ReadFixture("uc2-research-journey.json");
+        var root = fixture.RootElement;
+        root.GetProperty("specRevision").GetString().Should()
+            .Be("f45febb057a7182dab2495d4c739d2bb8d7026f5");
+
+        var initial = root.GetProperty("initialInput").GetProperty("snapshot");
+        var initialTask = initial.GetProperty("activeTask");
+        var pending = initial.GetProperty("pendingInput");
+        initialTask.GetProperty("turnId").GetString().Should().Be("turn-uc2-1");
+        initialTask.GetProperty("taskId").GetString().Should().Be("task-uc2");
+        initialTask.GetProperty("planRevision").GetInt32().Should().Be(1);
+        initialTask.GetProperty("steps").EnumerateArray().Should().ContainSingle(step =>
+            step.GetProperty("kind").GetString() == "input");
+        pending.GetProperty("options").GetArrayLength().Should().Be(0);
+        pending.GetProperty("allowFreeText").GetBoolean().Should().BeTrue();
+        pending.GetProperty("prompt").GetString().Should().Contain("party size")
+            .And.Contain("dietary restrictions")
+            .And.Contain("budget cap")
+            .And.Contain("research-only shortlist");
+
+        var research = root.GetProperty("researchRunning").GetProperty("snapshot")
+            .GetProperty("activeTask");
+        research.GetProperty("planRevision").GetInt32().Should().Be(2);
+        research.GetProperty("gate").GetProperty("mode").GetString().Should().Be("auto");
+        var runningSearch = FindStep(research, "step-uc2-search");
+        runningSearch.GetProperty("source").GetProperty("tool").GetProperty("toolName")
+            .GetString().Should().Be("web_search");
+        runningSearch.GetProperty("externalEffect").GetString().Should().Be("not_started");
+        var runningOperation = runningSearch.GetProperty("operation");
+        runningOperation.GetProperty("phase").GetString().Should().Be("running");
+        runningOperation.GetProperty("key").GetProperty("operationId").GetString()
+            .Should().Be("operation-uc2-search");
+        runningOperation.GetProperty("idempotent").GetBoolean().Should().BeTrue();
+        runningSearch.GetProperty("substeps").EnumerateArray()
+            .Select(substep => (
+                substep.GetProperty("substepId").GetString(),
+                substep.GetProperty("title").GetString(),
+                substep.GetProperty("status").GetString()))
+            .Should().Equal(
+                ("prepare-operation", "Build search query", "done"),
+                ("execute-operation", "Search current web results", "running"));
+
+        var steeredSnapshot = root.GetProperty("steered").GetProperty("snapshot");
+        var steered = steeredSnapshot.GetProperty("activeTask");
+        steeredSnapshot.GetProperty("activeTurn").GetProperty("turnId").GetString()
+            .Should().Be("turn-uc2-2");
+        steered.GetProperty("taskId").GetString().Should().Be("task-uc2");
+        steered.GetProperty("planRevision").GetInt32().Should().Be(3);
+        var completedSearch = FindStep(steered, "step-uc2-search");
+        completedSearch.GetProperty("status").GetString().Should().Be("done");
+        completedSearch.GetProperty("externalEffect").GetString().Should().Be("not_applied");
+        completedSearch.GetProperty("operation").GetProperty("phase").GetString()
+            .Should().Be("succeeded");
+        completedSearch.GetProperty("substeps").EnumerateArray().Should().OnlyContain(substep =>
+            substep.GetProperty("status").GetString() == "done");
+        FindStep(steered, "step-uc2-compare").GetProperty("status").GetString()
+            .Should().Be("cancelled");
+        var replacement = FindStep(steered, "step-uc2-refine");
+        replacement.GetProperty("status").GetString().Should().Be("running");
+        replacement.GetProperty("addedBy").GetString().Should().Be("steering");
+        replacement.GetProperty("operation").GetProperty("phase").GetString()
+            .Should().Be("running");
+
+        var stoppedSnapshot = root.GetProperty("stopped").GetProperty("snapshot");
+        var stopped = stoppedSnapshot.GetProperty("activeTask");
+        stopped.GetProperty("status").GetString().Should().Be("stopped");
+        var fence = stoppedSnapshot.GetProperty("controlFence");
+        fence.GetProperty("requestId").GetString().Should().Be("stop-uc2-1");
+        fence.GetProperty("outcome").GetString().Should().Be("uncancellable");
+        fence.GetProperty("safeMessage").GetString().Should().Contain("Partial-work receipt")
+            .And.Contain("Retained: Answer logistics and agree to research-only scope")
+            .And.Contain("Fenced: Refine for 7 pm and a private room")
+            .And.Contain("No external effect was applied")
+            .And.Contain("Late evidence cannot advance this stopped task");
+        var stoppedSearch = FindStep(stopped, "step-uc2-search");
+        JsonNode.DeepEquals(
+                JsonNode.Parse(completedSearch.GetProperty("source").GetRawText()),
+                JsonNode.Parse(stoppedSearch.GetProperty("source").GetRawText()))
+            .Should().BeTrue("reload must preserve the exact Aevatar search executor identity");
+        JsonNode.DeepEquals(
+                JsonNode.Parse(completedSearch.GetProperty("substeps").GetRawText()),
+                JsonNode.Parse(stoppedSearch.GetProperty("substeps").GetRawText()))
+            .Should().BeTrue("reload must preserve completed search progress evidence");
+        JsonNode.DeepEquals(
+                JsonNode.Parse(completedSearch.GetProperty("operation").GetRawText()),
+                JsonNode.Parse(stoppedSearch.GetProperty("operation").GetRawText()))
+            .Should().BeTrue("reload must preserve the durable search operation reservation");
+        stopped.GetProperty("steps").EnumerateArray().Should().OnlyContain(step =>
+            step.GetProperty("externalEffect").GetString() == "not_started" ||
+            step.GetProperty("externalEffect").GetString() == "not_applied");
+
+        var restart = root.GetProperty("restart");
+        var restartedSnapshot = restart.GetProperty("snapshot");
+        var restarted = restartedSnapshot.GetProperty("activeTask");
+        restartedSnapshot.GetProperty("activeTurn").GetProperty("turnId").GetString()
+            .Should().Be("turn-uc2b-1");
+        restarted.GetProperty("taskId").GetString().Should().Be("task-uc2b")
+            .And.NotBe(stopped.GetProperty("taskId").GetString());
+        restarted.GetProperty("steps").EnumerateArray()
+            .Select(step => step.GetProperty("stepId").GetString())
+            .Intersect(stopped.GetProperty("steps").EnumerateArray()
+                .Select(step => step.GetProperty("stepId").GetString()))
+            .Should().BeEmpty();
+        var restartedSearch = FindStep(restarted, "step-uc2b-search");
+        restartedSearch.GetProperty("operation").GetProperty("key").GetProperty("taskId")
+            .GetString().Should().Be("task-uc2b");
+        restartedSearch.GetProperty("substeps").GetArrayLength().Should().Be(2);
+        var message = restart.GetProperty("assistantMessage");
+        message.GetProperty("turnId").GetString().Should().Be("turn-uc2b-1");
+        message.GetProperty("taskId").GetString().Should().Be("task-uc2b");
+        message.GetProperty("content").GetString().Should().Contain("Verified facts:")
+            .And.Contain("Cannot check right now:")
+            .And.EndWith("Research artifact only: no reservation was made.");
+
+        root.GetRawText().Should().NotContainAny("credential", "accessToken", "bearer");
+    }
+
     [Theory]
     [InlineData("input-request", "nyxid.input.request", "input", "pendingInput", null)]
     [InlineData("input-changed", "nyxid.input.changed", "none", null, "latestInputResolution")]
@@ -303,4 +423,8 @@ public sealed class NyxIdChatFixtureConvergenceTests
     private static JsonElement FindScenario(JsonElement root, string scenario) =>
         root.EnumerateArray().Single(item =>
             item.GetProperty("scenario").GetString() == scenario);
+
+    private static JsonElement FindStep(JsonElement task, string stepId) =>
+        task.GetProperty("steps").EnumerateArray().Single(step =>
+            step.GetProperty("stepId").GetString() == stepId);
 }

--- a/test/Aevatar.AI.Tests/NyxIdChatPlanGateDecisionsTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatPlanGateDecisionsTests.cs
@@ -88,6 +88,33 @@ public sealed class NyxIdChatPlanGateDecisionsTests
     }
 
     [Fact]
+    public void MountedWebSearch_ShouldAutoAdmitWithExactAevatarExecutorIdentity()
+    {
+        var planned = NyxIdChatTaskLifecycle.ApplyOperationResult(
+            ActiveLlmState(),
+            ToolPlan(
+                "{\"query\":\"Greek dinner northern Singapore Friday 7 pm\"}",
+                isReadOnly: true,
+                toolName: "web_search"),
+            Now);
+
+        planned.State.ActiveTask.Gate.Mode.Should().Be(NyxIdChatPlanGateMode.Auto);
+        planned.State.ActiveTask.Gate.Status.Should().Be(NyxIdChatPlanGateStatus.Satisfied);
+        var search = planned.State.ActiveTask.Steps.Single(step =>
+            step.Kind == NyxIdChatStepKind.Tool);
+        search.Source.Tool.ToolName.Should().Be("web_search");
+        search.MayChangeExternalState.Should().BeFalse();
+        search.Status.Should().Be(NyxIdChatStepStatus.Running);
+        search.AvailableActions.Stop.Should().BeTrue();
+        planned.NextCommand!.Tool.ToolName.Should().Be("web_search");
+        planned.NextCommand.Tool.MayChangeExternalState.Should().BeFalse();
+        planned.State.ActiveTask.Steps.Should().ContainSingle(step =>
+            step.Kind == NyxIdChatStepKind.Llm &&
+            step.Status == NyxIdChatStepStatus.Planned &&
+            step.DependsOn.Contains(search.StepId));
+    }
+
+    [Fact]
     public void EstimatedPlanAboveConfiguredThreshold_ShouldRequireConfirmation()
     {
         var state = ActiveLlmState();
@@ -586,7 +613,8 @@ public sealed class NyxIdChatPlanGateDecisionsTests
         string arguments,
         bool requiresApproval = false,
         bool isReadOnly = false,
-        AgentToolOperationAdmissionPayload? operationAdmission = null) => new()
+        AgentToolOperationAdmissionPayload? operationAdmission = null,
+        string toolName = "repository_update") => new()
         {
             Key = OperationKey("step-llm-alpha", "operation-llm-alpha"),
             Llm = new NyxIdChatLLMOperationResult
@@ -597,7 +625,7 @@ public sealed class NyxIdChatPlanGateDecisionsTests
                 new NyxIdChatToolCall
                 {
                     CallId = "call-alpha",
-                    ToolName = "repository_update",
+                    ToolName = toolName,
                     ArgumentsJson = arguments,
                     Safety = new NyxIdChatToolCallSafety
                     {

--- a/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatSystemPromptTests.cs
@@ -161,6 +161,21 @@ public class NyxIdChatSystemPromptTests
     }
 
     [Fact]
+    public void ComposedPrompt_ShouldKeepReadOnlyResearchFallbackAndArtifactHonest()
+    {
+        var prompt = ComposedAgentPrompt();
+
+        prompt.Should().Contain("include that scope change in the single composite `ask_user` question");
+        prompt.Should().Contain("require the user's free-text consent before any tool runs");
+        prompt.Should().Contain("name it as Aevatar `web_search`");
+        prompt.Should().Contain("actor-derived `auto` gate");
+        prompt.Should().Contain("separate facts supported by successful reads from facts that `cannot check right now`");
+        prompt.Should().Contain("no reservation, publication, or other external mutation occurred");
+        prompt.Should().Contain("partial-work receipt based on committed step evidence");
+        prompt.Should().Contain("late evidence cannot advance the stopped task");
+    }
+
+    [Fact]
     public void Value_ShouldKeepLocalHandoffsAndExcludedOperationsHonest()
     {
         var prompt = NyxIdChatSystemPrompt.Value.Content;

--- a/test/Aevatar.AI.Tests/NyxIdChatTurnGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatTurnGAgentTests.cs
@@ -2640,6 +2640,70 @@ public sealed partial class NyxIdChatTurnGAgentTests
     }
 
     [Fact]
+    public async Task OperationExecutor_WebSearch_ShouldPublishHonestResearchSubsteps()
+    {
+        var generationExecutor = new StreamingCapabilityReplyExecutor(toolName: "web_search");
+        var executor = new NyxIdChatTurnOperationExecutor(generationExecutor);
+        var session = new NyxIdChatTransientExecutionSession();
+        var progress = new List<NyxIdChatOperationProgressSignal>();
+        await executor.ExecuteAsync(
+            new NyxIdChatOperationDispatchCommand
+            {
+                Key = CreateKey(),
+                Llm = new NyxIdChatLLMOperationInput
+                {
+                    Request = new ChatRequestEvent
+                    {
+                        Prompt = "Research Greek dinner options in northern Singapore.",
+                        SessionId = "turn-uc2-1",
+                    },
+                },
+            },
+            session,
+            (signal, _) =>
+            {
+                progress.Add(signal.Clone());
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        var execution = await executor.ExecuteAsync(
+            new NyxIdChatOperationDispatchCommand
+            {
+                Key = CreateKey("step-uc2-search", "operation-uc2-search", 1),
+                Tool = new NyxIdChatToolOperationInput
+                {
+                    CallId = "call-alpha",
+                    ToolName = "web_search",
+                    ArgumentsJson = "{\"value\":1}",
+                    MayChangeExternalState = false,
+                },
+            },
+            session,
+            (signal, _) =>
+            {
+                progress.Add(signal.Clone());
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        generationExecutor.ToolExecutions.Should().Be(1);
+        execution.Result.Tool.Receipt.ToolName.Should().Be("web_search");
+        execution.Result.Tool.ExternalEffect.Should().Be(NyxIdChatEffectEvidence.NotApplied);
+        progress.Where(static signal =>
+                signal.ProgressCase == NyxIdChatOperationProgressSignal.ProgressOneofCase.Phase)
+            .Select(static signal => (
+                signal.Phase.SubstepId,
+                signal.Phase.Title,
+                signal.Phase.Status))
+            .Should().Equal(
+                ("prepare-operation", "Build search query", NyxIdChatSubstepStatus.Running),
+                ("prepare-operation", "Build search query", NyxIdChatSubstepStatus.Done),
+                ("execute-operation", "Search current web results", NyxIdChatSubstepStatus.Running),
+                ("execute-operation", "Search current web results", NyxIdChatSubstepStatus.Done));
+    }
+
+    [Fact]
     public async Task OperationExecutor_ExactPlanGateContinuation_ShouldUseTransientCallOnce()
     {
         var generationExecutor = new StreamingCapabilityReplyExecutor();
@@ -3777,13 +3841,14 @@ public sealed partial class NyxIdChatTurnGAgentTests
     }
 
     private sealed class StreamingCapabilityReplyExecutor(
-        AgentToolOperationAdmissionPayload? operationAdmission = null)
+        AgentToolOperationAdmissionPayload? operationAdmission = null,
+        string toolName = "tool-alpha")
         : IAgentRunReplyGenerationExecutorPort
     {
-        private static AgentRunToolCall AuthorizedToolCall { get; } = new()
+        private readonly AgentRunToolCall _authorizedToolCall = new()
         {
             Id = "call-alpha",
-            Name = "tool-alpha",
+            Name = toolName,
             ArgumentsJson = "{\"value\":1}",
         };
 
@@ -3857,14 +3922,16 @@ public sealed partial class NyxIdChatTurnGAgentTests
                 {
                     ToolCall = new ToolCall
                     {
-                        Id = AuthorizedToolCall.Id,
-                        Name = AuthorizedToolCall.Name,
-                        ArgumentsJson = AuthorizedToolCall.ArgumentsJson,
+                        Id = _authorizedToolCall.Id,
+                        Name = _authorizedToolCall.Name,
+                        ArgumentsJson = _authorizedToolCall.ArgumentsJson,
                     },
                     Presentation = new ToolPresentationDescriptor
                     {
-                        InvocationName = AuthorizedToolCall.Name,
-                        DisplayName = "Tool Alpha",
+                        InvocationName = _authorizedToolCall.Name,
+                        DisplayName = _authorizedToolCall.Name == "web_search"
+                            ? "Web search"
+                            : "Tool Alpha",
                         Kind = ToolPresentationKind.Generic,
                         Availability = ToolAvailability.Available,
                     },
@@ -3879,7 +3946,7 @@ public sealed partial class NyxIdChatTurnGAgentTests
                 FinishReason = "tool_calls",
                 HasStreamedTextContent = true,
             };
-            result.ToolCalls.Add(AuthorizedToolCall.Clone());
+            result.ToolCalls.Add(_authorizedToolCall.Clone());
             var continuation = new AgentRunNextLlmStepRequestedEvent
             {
                 RunId = request.RunId,
@@ -3895,7 +3962,7 @@ public sealed partial class NyxIdChatTurnGAgentTests
                 request.Request.CorrelationId,
                 request.Attempt,
                 continuation.StepIndex,
-                [AuthorizedToolCall],
+                [_authorizedToolCall],
                 _ =>
                 {
                     ToolExecutions++;
@@ -3907,7 +3974,7 @@ public sealed partial class NyxIdChatTurnGAgentTests
                             new AgentRunChatMessage
                             {
                                 Role = "tool",
-                                ToolCallId = AuthorizedToolCall.Id,
+                                ToolCallId = _authorizedToolCall.Id,
                                 Content = "{\"ok\":true}",
                             },
                         },
@@ -3915,8 +3982,8 @@ public sealed partial class NyxIdChatTurnGAgentTests
                         {
                             new AgentToolReceipt
                             {
-                                CallId = AuthorizedToolCall.Id,
-                                ToolName = AuthorizedToolCall.Name,
+                                CallId = _authorizedToolCall.Id,
+                                ToolName = _authorizedToolCall.Name,
                                 Status = AgentToolReceiptStatus.Success,
                                 ResultJson = "{\"ok\":true}",
                             },
@@ -3928,18 +3995,22 @@ public sealed partial class NyxIdChatTurnGAgentTests
                 capability,
                 [
                     new AgentRunAuthorizedToolCallSafety(
-                        AuthorizedToolCall.Id,
-                        AuthorizedToolCall.Name,
-                        AuthorizedToolCall.ArgumentsJson,
+                        _authorizedToolCall.Id,
+                        _authorizedToolCall.Name,
+                        _authorizedToolCall.ArgumentsJson,
                         new AgentToolCallSafety(
                             RequiresApproval: false,
-                            IsReadOnly: false,
+                            IsReadOnly: toolName == "web_search",
                             IsDestructive: false),
-                        SideEffectKind: "tool-alpha.update",
+                        SideEffectKind: toolName == "web_search"
+                            ? "web.search"
+                            : "tool-alpha.update",
                         Presentation: new ToolPresentationDescriptor
                         {
-                            InvocationName = AuthorizedToolCall.Name,
-                            DisplayName = "Tool Alpha",
+                            InvocationName = _authorizedToolCall.Name,
+                            DisplayName = _authorizedToolCall.Name == "web_search"
+                                ? "Web search"
+                                : "Tool Alpha",
                             Kind = ToolPresentationKind.NyxIdOperation,
                             Availability = ToolAvailability.Available,
                             NyxIdOperation = new NyxIdOperationRef

--- a/test/Aevatar.AI.Tests/WebSearchToolExecutionTests.cs
+++ b/test/Aevatar.AI.Tests/WebSearchToolExecutionTests.cs
@@ -85,6 +85,45 @@ public sealed class WebSearchToolExecutionTests
     }
 
     [Fact]
+    public async Task Uc2DinnerResearch_ShouldExecuteOneReadOnlySearchWithTypedEvidence()
+    {
+        var handler = new RecordingHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""
+                {
+                  "results": [
+                    {
+                      "title": "North Olive",
+                      "url": "https://example.test/north-olive",
+                      "snippet": "Greek menu, vegetarian choices, Friday dinner hours"
+                    }
+                  ]
+                }
+                """),
+        });
+        using var http = new HttpClient(handler);
+        var search = CreateTool(http);
+        using var _ = AgentToolContextScope.Push(WithNyxIdAccessToken("token-uc2"));
+
+        const string arguments =
+            "{\"query\":\"Greek dinner northern Singapore Friday 6 to 7 pm\",\"max_results\":5}";
+        var result = await search.ExecuteAsync(arguments);
+        var receipt = search.CreateResultReceipt("call-uc2-search", search.Name, arguments, result);
+
+        search.Name.Should().Be("web_search");
+        search.IsReadOnly.Should().BeTrue();
+        receipt.Should().NotBeNull();
+        receipt!.Status.Should().Be(AgentToolReceiptStatus.Success);
+        receipt.ToolName.Should().Be("web_search");
+        using var document = JsonDocument.Parse(receipt.ResultJson);
+        document.RootElement.GetProperty("results")[0].GetProperty("title").GetString()
+            .Should().Be("North Olive");
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.RequestUri!.AbsoluteUri.Should().Be(
+            "https://search.test/search?q=Greek%20dinner%20northern%20Singapore%20Friday%206%20to%207%20pm&limit=5");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_NonJsonStringPayload_ReturnsTypedErrorJson()
     {
         var handler = new RecordingHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConsoleStaticAssetEndpointTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowConsoleStaticAssetEndpointTests.cs
@@ -1069,6 +1069,167 @@ public sealed class WorkflowConsoleStaticAssetEndpointTests
     }
 
     [Fact]
+    public async Task WorkflowStudio_Uc2Projection_ShouldConvergeSteerStopReloadAndDistinctRestart()
+    {
+        var actorState = await GetStudioAssetAsync(WorkflowStudioEndpoints.GetAssistantActorState);
+        const string script = """
+            const assert = require('node:assert/strict');
+            const vm = require('node:vm');
+            const source = require('node:fs').readFileSync(0, 'utf8')
+              .replace(/^import[^;]+;\s*/m, '')
+              .replace(/^export /gm, '');
+            const context = { structuredClone, validateActionRequest:value => value };
+            vm.createContext(context);
+            vm.runInContext(source, context);
+
+            const completedSearch = {
+              stepId:'step-uc2-search',order:2,kind:'tool',status:'done',
+              description:'Aevatar web search - find Greek dinner candidates.',
+              source:{tool:{toolName:'web_search'}},externalEffect:'not_applied',
+              operation:{key:{conversationActorId:'conversation-uc2',turnId:'turn-uc2-1',
+                taskId:'task-uc2',stepId:'step-uc2-search',
+                operationId:'operation-uc2-search',operationGeneration:1},
+                kind:'tool',phase:'succeeded',mayChangeExternalState:false,
+                idempotent:true,idempotencyKey:'operation-uc2-search'},
+              addedBy:'replan',dependsOn:['step-uc2-gaps'],availableActions:{},
+              substeps:[
+                {substepId:'prepare-operation',title:'Build search query',status:'done'},
+                {substepId:'execute-operation',title:'Search current web results',status:'done'}
+              ]
+            };
+            const inputStep = {
+              stepId:'step-uc2-gaps',order:1,kind:'input',status:'done',
+              source:{input:{requestId:'input-uc2-gaps'}},externalEffect:'not_applied',
+              addedBy:'initial',availableActions:{}
+            };
+            let live = context.createActorProjection('conversation-uc2');
+            live = context.reduceActorEvent(live, {type:'task_snapshot',sequence:20,payload:{
+              schemaVersion:4,actorId:'conversation-uc2',turnId:'turn-uc2-1',
+              taskId:'task-uc2',planId:'plan-uc2',planRevision:2,
+              title:'Research a ready-to-book dinner shortlist',status:'active',
+              gate:{mode:'auto',reason:'Read and draft only.'},steps:[
+                inputStep,completedSearch,{
+                  stepId:'step-uc2-compare',order:3,kind:'llm',status:'running',
+                  source:{llm:{}},externalEffect:'not_started',addedBy:'replan',
+                  dependsOn:['step-uc2-search'],availableActions:{stop:true}
+                }
+              ]
+            }});
+            live = context.reduceActorEvent(live, {type:'task_snapshot',sequence:31,payload:{
+              schemaVersion:4,actorId:'conversation-uc2',turnId:'turn-uc2-2',
+              taskId:'task-uc2',planId:'plan-uc2',planRevision:3,
+              title:'Refine for 7 pm and a private room',status:'active',
+              gate:{mode:'auto',reason:'Read and draft only.'},steps:[
+                inputStep,completedSearch,{
+                  stepId:'step-uc2-compare',order:3,kind:'llm',status:'cancelled',
+                  source:{llm:{}},externalEffect:'not_started',addedBy:'replan',availableActions:{}
+                },{
+                  stepId:'step-uc2-refine',order:4,kind:'llm',status:'running',
+                  source:{llm:{}},externalEffect:'not_started',addedBy:'steering',
+                  operation:{key:{conversationActorId:'conversation-uc2',turnId:'turn-uc2-2',
+                    taskId:'task-uc2',stepId:'step-uc2-refine',
+                    operationId:'operation-uc2-refine',operationGeneration:1},
+                    kind:'llm',phase:'running',mayChangeExternalState:false,
+                    idempotent:true,idempotencyKey:'operation-uc2-refine'},
+                  dependsOn:['step-uc2-search'],availableActions:{stop:true}
+                }
+              ]
+            }});
+            assert.equal(live.task.taskId, 'task-uc2');
+            assert.equal(live.task.turnId, 'turn-uc2-2');
+            assert.equal(live.task.planRevision, 3);
+            assert.equal(live.steps.get('step-uc2-search').source.tool.toolName, 'web_search');
+            assert.equal(live.steps.get('step-uc2-search').substeps.length, 2);
+            assert.equal(live.steps.get('step-uc2-search').substeps[0].substepId, 'prepare-operation');
+            assert.equal(live.steps.get('step-uc2-search').operation.key.operationId, 'operation-uc2-search');
+            assert.equal(live.steps.get('step-uc2-compare').status, 'cancelled');
+            assert.equal(live.steps.get('step-uc2-refine').addedBy, 'steering');
+
+            const receipt = 'Stopped. Partial-work receipt: 2 completed steps were retained. ' +
+              'Retained: Answer logistics and agree to research-only scope; ' +
+              'Aevatar web search - find Greek dinner candidates. ' +
+              'Unfinished work was fenced; the in-flight operation could not be proven cancelled. ' +
+              'Fenced: Refine for 7 pm and a private room. No external effect was applied. ' +
+              'Late evidence cannot advance this stopped task.';
+            const stopped = context.applyCurrentStateResult(
+              context.createActorProjection('conversation-uc2'), {
+                status:'current',stateVersion:36,snapshot:{
+                  actorId:'conversation-uc2',scopeId:'scope-uc2',stateVersion:36,
+                  progressSequence:36,
+                  activeTurn:{turnId:'turn-uc2-2',taskId:'task-uc2',status:'stopped'},
+                  latestTurn:{turnId:'turn-uc2-2',taskId:'task-uc2',status:'stopped',safeMessage:receipt},
+                  recentTerminalTurns:[{turnId:'turn-uc2-2',taskId:'task-uc2',status:'stopped'}],
+                  activeTask:{schemaVersion:4,actorId:'conversation-uc2',turnId:'turn-uc2-2',
+                    taskId:'task-uc2',planId:'plan-uc2',planRevision:3,status:'stopped',
+                    safeMessage:receipt,gate:{mode:'auto',reason:'Read and draft only.'},steps:[
+                      inputStep,completedSearch,{
+                        stepId:'step-uc2-compare',order:3,kind:'llm',status:'cancelled',
+                        source:{llm:{}},externalEffect:'not_started',addedBy:'replan',availableActions:{}
+                      },{
+                        stepId:'step-uc2-refine',order:4,kind:'llm',status:'cancelled',
+                        source:{llm:{}},externalEffect:'not_applied',addedBy:'steering',
+                        operation:{key:{conversationActorId:'conversation-uc2',turnId:'turn-uc2-2',
+                          taskId:'task-uc2',stepId:'step-uc2-refine',
+                          operationId:'operation-uc2-refine',operationGeneration:1},
+                          kind:'llm',phase:'running',mayChangeExternalState:false,
+                          idempotent:true,idempotencyKey:'operation-uc2-refine'},availableActions:{}
+                      }
+                    ]},
+                  pendingInput:null,pendingApproval:null,latestInputResolution:null,
+                  latestApprovalResolution:null,taskStatus:'stopped',attentionKind:'none',
+                  activeStepSummary:null,pendingActions:[],
+                  controlFence:{kind:'stop',requestId:'stop-uc2-1',clientRequestId:'client-stop-uc2-1',
+                    turnId:'turn-uc2-2',taskId:'task-uc2',outcome:'uncancellable',safeMessage:receipt},
+                  latestControlResult:null,continuationAdmission:null
+                }
+              });
+            assert.equal(stopped.reloadWithoutCursor, false);
+            assert.equal(stopped.projection.task.status, 'stopped');
+            assert.equal(stopped.projection.controlFence.requestId, 'stop-uc2-1');
+            assert.equal(stopped.projection.controlFence.outcome, 'uncancellable');
+            assert.match(stopped.projection.controlFence.safeMessage, /No external effect was applied/);
+            assert.equal(stopped.projection.steps.get('step-uc2-search').substeps.length, 2);
+            assert.equal(stopped.projection.steps.get('step-uc2-search').operation.phase, 'succeeded');
+            assert.equal(stopped.projection.steps.get('step-uc2-refine').status, 'cancelled');
+
+            const restarted = context.applyCurrentStateResult(stopped.projection, {
+              status:'current',stateVersion:48,snapshot:{
+                actorId:'conversation-uc2',scopeId:'scope-uc2',stateVersion:48,progressSequence:48,
+                activeTurn:{turnId:'turn-uc2b-1',taskId:'task-uc2b',status:'active'},
+                latestTurn:{turnId:'turn-uc2b-1',taskId:'task-uc2b',status:'active'},
+                recentTerminalTurns:[{turnId:'turn-uc2-2',taskId:'task-uc2',status:'stopped'}],
+                activeTask:{schemaVersion:4,actorId:'conversation-uc2',turnId:'turn-uc2b-1',
+                  taskId:'task-uc2b',planId:'plan-uc2b',planRevision:1,status:'active',
+                  gate:{mode:'auto',reason:'Read and draft only.'},steps:[{
+                    stepId:'step-uc2b-search',order:1,kind:'tool',status:'running',
+                    source:{tool:{toolName:'web_search'}},externalEffect:'not_started',
+                    operation:{key:{conversationActorId:'conversation-uc2',turnId:'turn-uc2b-1',
+                      taskId:'task-uc2b',stepId:'step-uc2b-search',
+                      operationId:'operation-uc2b-search',operationGeneration:1},
+                      kind:'tool',phase:'running',mayChangeExternalState:false,
+                      idempotent:true,idempotencyKey:'operation-uc2b-search'},
+                    addedBy:'initial',availableActions:{stop:true}
+                  }]},
+                pendingInput:null,pendingApproval:null,latestInputResolution:null,
+                latestApprovalResolution:null,taskStatus:'active',attentionKind:'none',
+                activeStepSummary:null,pendingActions:[],controlFence:null,
+                latestControlResult:null,continuationAdmission:null
+              }
+            });
+            assert.equal(restarted.projection.task.taskId, 'task-uc2b');
+            assert.equal(restarted.projection.task.turnId, 'turn-uc2b-1');
+            assert.equal(restarted.projection.steps.has('step-uc2-refine'), false);
+            assert.equal(restarted.projection.steps.get('step-uc2b-search').source.tool.toolName, 'web_search');
+            assert.equal(restarted.projection.steps.get('step-uc2b-search').operation.key.taskId, 'task-uc2b');
+            assert.equal(restarted.projection.controlFence, null);
+            """;
+
+        var result = await RunNodeAsync(script, actorState);
+
+        result.ExitCode.Should().Be(0, result.Error + result.Output);
+    }
+
+    [Fact]
     public async Task WorkflowStudio_ConversationProtocol_ShouldPreserveAuthoritativeAttentionSummary()
     {
         var protocol = await GetStudioAssetAsync(WorkflowStudioEndpoints.GetAssistantProtocol);


### PR DESCRIPTION
## Problem and solution

The actor-owned control mechanics existed, but the UC2 product journey did not preserve completed research evidence through steering, return a durable partial-work receipt on stop, identify the exact read-only executor, or prove that later plain text creates a new task instead of resuming the stopped task.

This change adds the research-only planning semantics, named web-search substeps, durable stop receipt, committed fixture/reload convergence, and honest terminal artifact behavior with no implied reservation.

Refs #3375

## Impact

- NyxID Chat control and operation execution
- default system skill overlay
- UC2 deterministic fixture, actor tests, host projection test, and focused Chat route test
- no API identity conversions or provider-write paths change

## Verification

- focused Aevatar.AI UC2 tests - 9 passed
- focused Workflow Host projection test - 1 passed
- focused Chat route Jest test - 1 passed
- `pnpm --dir apps/aevatar-console-web tsc` - passed
- affected-file Biome and `git diff --check` - passed
- `bash tools/ci/test_stability_guards.sh` - passed
- `bash tools/ci/architecture_guards.sh` - passed

## Documentation

The stable user-facing research semantics are documented in the system skill overlay; the deterministic fixture README is updated for the new journey.
