### PR TITLE
Fix NyxID TaskPlan reload decoding

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanJsonFormatter.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTaskPlanJsonFormatter.cs
@@ -11,6 +11,7 @@ internal static class NyxIdChatTaskPlanJsonFormatter
     public static JsonNode FormatTaskPlan(IMessage payload)
     {
         var node = FormatProtobuf(payload);
+        IncludeDecoderRequiredStepBooleans(payload, node);
         NormalizeBrowserSafeIntegers(node);
         return node;
     }
@@ -23,6 +24,34 @@ internal static class NyxIdChatTaskPlanJsonFormatter
                        "Typed custom payload must serialize to JSON.");
         NormalizeNyxIdEnumValues(node);
         return node;
+    }
+
+    private static void IncludeDecoderRequiredStepBooleans(IMessage payload, JsonNode node)
+    {
+        switch (payload)
+        {
+            case NyxIdChatTaskPlan plan when node["steps"] is JsonArray steps:
+                if (steps.Count != plan.Steps.Count)
+                    throw new InvalidOperationException("TaskPlan step serialization is inconsistent.");
+
+                for (var index = 0; index < plan.Steps.Count; index++)
+                    IncludeDecoderRequiredStepBooleans(steps[index], plan.Steps[index]);
+                break;
+            case NyxIdChatTaskPlanStepChanged changed when changed.Step is not null:
+                IncludeDecoderRequiredStepBooleans(node["step"], changed.Step);
+                break;
+        }
+    }
+
+    private static void IncludeDecoderRequiredStepBooleans(
+        JsonNode? node,
+        NyxIdChatTaskPlanStep step)
+    {
+        if (node is not JsonObject stepNode)
+            throw new InvalidOperationException("TaskPlan step must serialize to a JSON object.");
+
+        stepNode["required"] = step.Required;
+        stepNode["mayChangeExternalState"] = step.MayChangeExternalState;
     }
 
     private static void NormalizeBrowserSafeIntegers(JsonNode node)

--- a/test/Aevatar.AI.Tests/NyxIdChatTaskContractTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatTaskContractTests.cs
@@ -328,6 +328,29 @@ public sealed class NyxIdChatTaskContractTests
     }
 
     [Fact]
+    public void FormatterOutput_ShouldIncludeDecoderRequiredStepBooleansWhenFalse()
+    {
+        var step = new NyxIdChatTaskPlanStep
+        {
+            StepId = "step-optional-read",
+            Required = false,
+            MayChangeExternalState = false,
+        };
+        var plan = new NyxIdChatTaskPlan();
+        plan.Steps.Add(step);
+
+        var planStep = NyxIdChatTaskPlanJsonFormatter
+            .FormatTaskPlan(plan)["steps"]![0]!;
+        planStep["required"]!.GetValue<bool>().Should().BeFalse();
+        planStep["mayChangeExternalState"]!.GetValue<bool>().Should().BeFalse();
+
+        var changedStep = NyxIdChatTaskPlanJsonFormatter
+            .FormatTaskPlan(new NyxIdChatTaskPlanStepChanged { Step = step })["step"]!;
+        changedStep["required"]!.GetValue<bool>().Should().BeFalse();
+        changedStep["mayChangeExternalState"]!.GetValue<bool>().Should().BeFalse();
+    }
+
+    [Fact]
     public async Task FormatterOutput_ShouldRoundTripThroughStudioProtocolWithRepeatedDefaults()
     {
         var plan = new NyxIdChatTaskPlan


### PR DESCRIPTION
## Problem

NyxID strictly requires `required` and `mayChangeExternalState` on every TaskPlan step. Default protobuf JSON omits both when false, so production `/state` hydration fails closed and the assistant cannot reload earlier messages.

## Solution

Preserve the decoder-required step booleans for both TaskPlan snapshots and step-change frames without changing generic protobuf formatting. Add regression coverage for false-valued fields.

## Impact

- NyxID assistant TaskPlan snapshots
- NyxID assistant step-change frames
- No generic protobuf wire change

Relates to #3366.

## Validation

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter FullyQualifiedName~NyxIdChatTaskContractTests` (10/10)
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --no-restore` (3052/3052)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`
- `git diff --check`

## Documentation

No documentation change. This restores the existing typed wire contract.