### PR TITLE
Preserve committed publication recovery failures

### DIFF
--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,15 +2,15 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "29bf4e60d25cb16138b98584c900debb5a5669a6",
-    "contract_files_sha256": "0bf6cd57359afd7c04374f4dd0f3d368664db5663b2d18b5e209471e4ec2246a",
+    "revision": "e8c9f3901a240a37d89eb78ee2108d7c9ecd1547",
+    "contract_files_sha256": "06979826bc53825a63e807e7253e1601956ba5aacfceb51ff309ad74f7101e68",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "ce28ba40efc8f863ae6cc42d35442d3c9cc30a4aa0be548394939a556497881e",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "1daa67dc2cad48249268990e525ada39b65a580d150a9ae8ed896d5392f6a130",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdChatBrowserActions.cs": "ed34d2ea4f13058f1a80b9809baf05a3ac4694606d89945cae15da57a13639e5",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationAguiFrameBuilder.cs": "24b36e1a4e43f611dbcec3c48415a184752886fed6d7369a58c006bed554a567",
       "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_recovery_secret.proto": "07dbc449a732df6c7a6d0a97054ddbe35a517f4af4c5670b05ed0bea0bf2011a",
-      "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto": "9711fc1712cb3d69facc69a5ee6c46b18e0cbd314b356d3c3538e7c20e8ca4aa",
+      "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto": "394847a6cc43f5876bc4823830252d9480e61a8e5434c94196b515db234cf45c",
       "docs/adr/0048-nyxid-assistant-operation-class-boundary.md": "30c9de6c6e77a7aee14f0eb4a2f74bd15b8874bcfed88ba957cdd8213b9114eb",
       "src/Aevatar.AI.Abstractions/ai_messages.proto": "06e24d63b85a38ad8d4e1dd9696577b3869cfc2ba39356b4b3e5d748ca425bd8",
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs": "20134044c6c3091e8c701100813cd7e058f51e19e301c5ed493e42e677170572",

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -520,7 +520,9 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
 
             await DispatchStepAsync(next, evt.Output ?? string.Empty, state.InputFileRefs, state, WorkflowStepDispatchKind.Forward, ctx, ct);
         }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
+        catch (Exception ex) when (
+            !ct.IsCancellationRequested &&
+            !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(ex))
         {
             ctx.Logger.LogError(
                 ex,
@@ -830,7 +832,9 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 preserveTerminalFacts,
                 preserveCurrentStepInputVariable);
         }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
+        catch (Exception ex) when (
+            !ct.IsCancellationRequested &&
+            !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(ex))
         {
             ctx.Logger.LogError(
                 ex,
@@ -1238,7 +1242,9 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
             state.CurrentStepDispatchPending = false;
             await SaveStateAsync(state, ctx, ct);
         }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
+        catch (Exception ex) when (
+            !ct.IsCancellationRequested &&
+            !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(ex))
         {
             if (timeoutLease != null)
             {
@@ -1252,7 +1258,8 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
                 {
                     await SaveStateAsync(state, ctx, CancellationToken.None);
                 }
-                catch (Exception saveEx)
+                catch (Exception saveEx) when (
+                    !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(saveEx))
                 {
                     ctx.Logger.LogError(
                         saveEx,
@@ -1292,7 +1299,9 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
         {
             await SaveStateAsync(state, ctx, ct);
         }
-        catch (Exception saveEx) when (!ct.IsCancellationRequested)
+        catch (Exception saveEx) when (
+            !ct.IsCancellationRequested &&
+            !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(saveEx))
         {
             ctx.Logger.LogError(
                 saveEx,

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRuntimeInfrastructureFailurePolicy.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRuntimeInfrastructureFailurePolicy.cs
@@ -1,0 +1,17 @@
+using Aevatar.Foundation.Core.EventSourcing;
+
+namespace Aevatar.Workflow.Core.Execution;
+
+internal static class WorkflowRuntimeInfrastructureFailurePolicy
+{
+    public static bool IsCommittedStatePublicationFailure(Exception exception) =>
+        exception switch
+        {
+            CommittedStatePublicationException => true,
+            AggregateException aggregate =>
+                aggregate.InnerExceptions.Any(IsCommittedStatePublicationFailure),
+            _ when exception.InnerException is not null =>
+                IsCommittedStatePublicationFailure(exception.InnerException),
+            _ => false,
+        };
+}

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -832,7 +832,9 @@ public sealed partial class WorkflowRunGAgent
         {
             await PublishAsync(start, TopologyAudience.Self);
         }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
+        catch (Exception ex) when (
+            !ct.IsCancellationRequested &&
+            !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(ex))
         {
             Logger.LogError(
                 ex,
@@ -850,7 +852,9 @@ public sealed partial class WorkflowRunGAgent
             {
                 await HandleWorkflowCompleted(terminal);
             }
-            catch (Exception terminalEx) when (!ct.IsCancellationRequested)
+            catch (Exception terminalEx) when (
+                !ct.IsCancellationRequested &&
+                !WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(terminalEx))
             {
                 Logger.LogError(
                     terminalEx,

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowRuntimeTerminalFailureBoundaryTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowRuntimeTerminalFailureBoundaryTests.cs
@@ -1,6 +1,8 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventSourcing;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core.Execution;
@@ -84,6 +86,33 @@ public sealed class WorkflowRuntimeTerminalFailureBoundaryTests
 
         message.Should().Be(
             "step_completion_handling_failed: step 'definition-step' (notify) failed during completion: boom");
+    }
+
+    [Fact]
+    public void InfrastructureFailurePolicy_ShouldRecognizeWrappedCommittedStatePublicationFailures()
+    {
+        var publicationFailure = new CommittedStatePublicationException(
+            "run-1",
+            new StateEvent
+            {
+                EventId = "event-7",
+                Version = 7,
+            },
+            CommittedStatePublicationFailureStage.AdapterAcceptance,
+            new InvalidOperationException("stream adapter unavailable"));
+
+        WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(
+                new InvalidOperationException("runtime wrapper", publicationFailure))
+            .Should()
+            .BeTrue();
+        WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(
+                new AggregateException(new InvalidOperationException("other"), publicationFailure))
+            .Should()
+            .BeTrue();
+        WorkflowRuntimeInfrastructureFailurePolicy.IsCommittedStatePublicationFailure(
+                new InvalidOperationException("ordinary workflow failure"))
+            .Should()
+            .BeFalse();
     }
 
     [Fact]
@@ -445,6 +474,69 @@ public sealed class WorkflowRuntimeTerminalFailureBoundaryTests
         completion.Success.Should().BeFalse();
         completion.Error.Should().StartWith("step_dispatch_failed: step 'step-1' (notify) failed during dispatch: ");
         completion.Error.Should().NotContain("super-secret-token");
+    }
+
+    [Fact]
+    public async Task Kernel_ShouldPropagateCommittedStatePublicationFailure_WithoutTerminalizingRun()
+    {
+        var workflow = new WorkflowDefinition
+        {
+            Name = "wf",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition { Id = "step-1", Type = "notify" },
+                new StepDefinition { Id = "step-2", Type = "notify" },
+            ],
+        };
+        var host = new RecordingStateHost { RunId = "run-1" };
+        var module = new WorkflowExecutionKernel(workflow, host);
+        var publicationFailure = new CommittedStatePublicationException(
+            "run-1",
+            new StateEvent
+            {
+                EventId = "event-7",
+                Version = 7,
+            },
+            CommittedStatePublicationFailureStage.AdapterAcceptance,
+            new InvalidOperationException("stream adapter unavailable"));
+        var stepRequestCount = 0;
+        var ctx = new RecordingEventHandlerContext
+        {
+            FailPublish = evt =>
+                evt is StepRequestEvent && ++stepRequestCount == 2
+                    ? throw publicationFailure
+                    : false,
+        };
+
+        await module.HandleAsync(
+            Envelope(new StartWorkflowEvent
+            {
+                RunId = "run-1",
+                WorkflowName = "wf",
+                Input = "hello",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var error = await FluentActions.Awaiting(() => module.HandleAsync(
+                Envelope(new StepCompletedEvent
+                {
+                    RunId = "run-1",
+                    StepId = "step-1",
+                    Success = true,
+                    Output = "done",
+                }),
+                ctx,
+                CancellationToken.None))
+            .Should()
+            .ThrowAsync<CommittedStatePublicationException>();
+
+        error.Which.Should().BeSameAs(publicationFailure);
+        ctx.Published
+            .Select(static published => published.Event)
+            .Should()
+            .NotContain(published => published.Is(WorkflowCompletedEvent.Descriptor));
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentForkOnFailureTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowRunGAgentForkOnFailureTests.cs
@@ -451,33 +451,27 @@ public sealed class WorkflowRunGAgentForkOnFailureTests
     }
 
     [Fact]
-    public async Task ChatRequest_WhenStartTerminalizationFails_ShouldPublishParentFailure()
+    public async Task ChatRequest_WhenStartTerminalizationPublicationFails_ShouldPropagateWithoutParentFailure()
     {
         var runId = "run-1917-" + Guid.NewGuid().ToString("N");
         var harness = await CreateRunAsync(runId, WorkflowYaml(onFailure: false));
         harness.Publisher.FailPublish = evt => evt is StartWorkflowEvent;
         harness.CommittedPublisher.FailBeforePublish = evt => evt is WorkflowCompletedEvent;
 
-        await harness.Agent.HandleEventAsync(EnvelopeFrom("api", new WorkflowChatRequestEvent
-        {
-            Prompt = "hello",
-            ScopeId = "scope-1",
-            SessionId = "session-1",
-        }));
-
-        var fallback = harness.Publisher.Published
-            .Where(x => x.Event is WorkflowLlmInvocationCompletedEvent)
-            .Select(x => (WorkflowLlmInvocationCompletedEvent)x.Event)
+        await FluentActions.Awaiting(() => harness.Agent.HandleEventAsync(
+                EnvelopeFrom("api", new WorkflowChatRequestEvent
+                {
+                    Prompt = "hello",
+                    ScopeId = "scope-1",
+                    SessionId = "session-1",
+                })))
             .Should()
-            .ContainSingle()
-            .Subject;
-        fallback.RunId.Should().Be(runId);
-        fallback.SessionId.Should().Be("session-1");
-        fallback.Success.Should().BeFalse();
-        fallback.Content.Should().Be("Workflow execution failed: start_dispatch_failed");
-        fallback.Error.Should().StartWith("start_dispatch_failed: failed during start_dispatch: ");
-        fallback.Error.Should().NotContain("super-secret-token");
-        fallback.Error.Should().NotContain("Bearer");
+            .ThrowAsync<CommittedStatePublicationException>();
+
+        harness.Publisher.Published
+            .Select(static published => published.Event)
+            .Should()
+            .NotContain(published => published is WorkflowLlmInvocationCompletedEvent);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem and solution

A workflow run can finish its steps successfully but fail while publishing the committed terminal state across a rollout. The recovery path treated that infrastructure failure as a completed run, which made committed Observatory state contradict the publication outcome.

This change preserves publication adapter failures as terminal infrastructure failures, makes the failure policy explicit, and covers both the execution boundary and fork-on-failure recovery behavior. It also refreshes the NyxID conformance source pin required by the current feature/integrate baseline.

## Impact paths

- Workflow execution terminal failure handling
- Workflow run recovery after committed publication failure
- NyxID assistant conformance source pin

## Verification

- Publication boundary tests: 18/18 passed
- Aevatar.Workflow.Core.Tests: 981/981 passed
- NyxID conformance guard: passed
- bash tools/ci/test_stability_guards.sh: passed
- bash tools/ci/architecture_guards.sh: passed
- git diff --check origin/feature/integrate...HEAD: passed

## Production acceptance

Production remains on image b58156d2, which does not contain the fix. Final acceptance requires deployment followed by a newer owner committed run; the existing HR-01 failure is intentionally not closed by this PR.