### PR TITLE
Fix workflow catalogue removal observation

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -544,6 +544,8 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.deleteFailed': "Draft couldn't be deleted",
   'workflowActivityVNext.workflows.deleteRefreshFailed':
     "Draft was deleted, but workflows couldn't refresh",
+  'workflowActivityVNext.workflows.deleteObservationDelayed':
+    'Draft was deleted, but the workflow catalogue has not confirmed its removal yet',
   'workflowActivityVNext.workflows.deleteRetry': 'Try again',
   'workflowActivityVNext.workflows.deleteTitle': 'Delete editable draft?',
   'workflowActivityVNext.workflows.empty': 'No workflows yet',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -504,6 +504,8 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.deleteFailed': '无法删除草稿',
     'workflowActivityVNext.workflows.deleteRefreshFailed':
       '草稿已删除，但工作流列表刷新失败',
+    'workflowActivityVNext.workflows.deleteObservationDelayed':
+      '草稿已删除，但工作流目录尚未确认其移除',
     'workflowActivityVNext.workflows.deleteRetry': '重试',
     'workflowActivityVNext.workflows.deleteTitle': '删除可编辑草稿？',
     'workflowActivityVNext.workflows.empty': '暂无工作流',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -1292,7 +1292,7 @@ describe('Workflow Activity vNext catalogue', () => {
       'wf-support',
       'scope-alpha',
     );
-    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(3);
   });
 
   it('archives by workflow identity and observes the exact row across catalogue pages', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -38,6 +38,7 @@ import {
   isWorkflowArchived,
   observeWorkflowArchival,
 } from './workflowArchival';
+import { observeWorkflowRemoval } from './workflowRemoval';
 
 type WorkflowRow = {
   readonly activeRevisionId: string;
@@ -448,6 +449,23 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
           removed = true;
           setDeleteSucceeded(true);
         }
+      }
+
+      const observation = await observeWorkflowRemoval({
+        readWorkflows: () =>
+          readWorkflowCatalogueMatch(scopeId, deleteTarget.workflowId),
+        workflowId: deleteTarget.workflowId,
+      });
+      if (observation.kind === 'delayed') {
+        toast.error(
+          t(
+            'workflowActivityVNext.workflows.deleteObservationDelayed',
+            'Draft was deleted, but the workflow catalogue has not confirmed its removal yet',
+          ),
+        );
+        setDeleteFailed(true);
+        setDeleteSucceeded(true);
+        return;
       }
 
       const refreshed = await catalogue.refetch();

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowRemoval.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowRemoval.test.ts
@@ -1,0 +1,50 @@
+import { observeWorkflowRemoval } from './workflowRemoval';
+
+describe('workflow removal observation', () => {
+  it('observes the exact workflow disappearing from the authoritative catalogue', async () => {
+    const readWorkflows = jest
+      .fn()
+      .mockResolvedValueOnce([{ workflowId: 'wf-alpha' }])
+      .mockResolvedValueOnce([]);
+
+    await expect(
+      observeWorkflowRemoval({
+        delaysMs: [0, 1],
+        readWorkflows,
+        wait: async () => undefined,
+        workflowId: 'wf-alpha',
+      }),
+    ).resolves.toEqual({ kind: 'observed' });
+    expect(readWorkflows).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not confuse another workflow disappearing with the target', async () => {
+    const readWorkflows = jest.fn(async () => [
+      { workflowId: 'wf-alpha' },
+      { workflowId: 'wf-beta' },
+    ]);
+
+    await expect(
+      observeWorkflowRemoval({
+        delaysMs: [0],
+        readWorkflows,
+        wait: async () => undefined,
+        workflowId: 'wf-alpha',
+      }),
+    ).resolves.toEqual({ kind: 'delayed' });
+  });
+
+  it('returns delayed after the bounded observation window', async () => {
+    const readWorkflows = jest.fn(async () => [{ workflowId: 'wf-alpha' }]);
+
+    await expect(
+      observeWorkflowRemoval({
+        delaysMs: [0, 0],
+        readWorkflows,
+        wait: async () => undefined,
+        workflowId: 'wf-alpha',
+      }),
+    ).resolves.toEqual({ kind: 'delayed' });
+    expect(readWorkflows).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowRemoval.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/workflowRemoval.ts
@@ -1,0 +1,32 @@
+export const WORKFLOW_REMOVAL_OBSERVATION_DELAYS_MS = [
+  0, 300, 700, 1200, 2000,
+] as const;
+
+export type WorkflowRemovalObservationResult =
+  | { readonly kind: 'observed' }
+  | { readonly kind: 'delayed' };
+
+function defaultWait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, delayMs));
+}
+
+export async function observeWorkflowRemoval(input: {
+  readonly delaysMs?: readonly number[];
+  readonly readWorkflows: () => Promise<readonly { workflowId: string }[]>;
+  readonly wait?: (delayMs: number) => Promise<void>;
+  readonly workflowId: string;
+}): Promise<WorkflowRemovalObservationResult> {
+  const delays = input.delaysMs ?? WORKFLOW_REMOVAL_OBSERVATION_DELAYS_MS;
+  const wait = input.wait ?? defaultWait;
+  const workflowId = input.workflowId.trim();
+
+  for (const delayMs of delays) {
+    if (delayMs > 0) await wait(delayMs);
+    const workflows = await input.readWorkflows();
+    if (!workflows.some((workflow) => workflow.workflowId === workflowId)) {
+      return { kind: 'observed' };
+    }
+  }
+
+  return { kind: 'delayed' };
+}


### PR DESCRIPTION
## Problem and solution
Issue #3403 was fixed in the backend by the workflow catalogue aggregate row readmodel. This frontend follow-up waits for the authoritative catalogue row to disappear after DeleteDraft instead of retaining stale projection state.

## Local verification
- Related tests: focused workflow removal and catalogue route tests passed (5 passed; 108 skipped by pattern)
- Changed-file static checks: Biome passed on all changed files
- Test stability guard: passed
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy