### PR TITLE
Preserve NyxID callback error details

### DIFF
--- a/apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
-import CallbackPage from './index';
 import { NyxIDAuthClient } from '@/shared/auth/client';
-import { CONSOLE_HOME_ROUTE } from '@/shared/navigation/consoleHome';
 import { persistAuthSession } from '@/shared/auth/session';
+import { CONSOLE_HOME_ROUTE } from '@/shared/navigation/consoleHome';
+import CallbackPage from './index';
 
 const replaceLocation = jest.fn();
 const handleRedirectCallback = jest.fn();
@@ -14,7 +14,9 @@ jest.mock('@/shared/auth/client', () => ({
   SERVICE_ACCESS_REVIEW_RETURN_TO: '/settings?section=account',
 }));
 
-function mockLocationReplace(path = '/auth/callback?code=auth-code&state=state-1') {
+function mockLocationReplace(
+  path = '/auth/callback?code=auth-code&state=state-1',
+) {
   const url = new URL(path, 'http://localhost:8000');
 
   Object.defineProperty(window, 'location', {
@@ -130,27 +132,29 @@ describe('NyxID callback page', () => {
 
   it('shows retryable service access review cancellation without replacing the session route', async () => {
     handleRedirectCallback.mockRejectedValue(
-      Object.assign(
-        new Error('OAuth error: access_denied'),
-        {
-          flow: 'serviceAccessReview',
-          reason: 'oauthDenied',
-          returnTo: '/settings?section=account',
-        },
-      ),
+      Object.assign(new Error('OAuth error: access_denied'), {
+        flow: 'serviceAccessReview',
+        reason: 'oauthDenied',
+        returnTo: '/settings?section=account',
+      }),
     );
 
-    const { findByRole, findByText } = render(React.createElement(CallbackPage));
+    const { findByRole, findByText } = render(
+      React.createElement(CallbackPage),
+    );
 
     expect(
       await findByText(
         'NyxID service access review was cancelled or denied. Your current Studio session is still active.',
       ),
     ).toBeTruthy();
-    const retryButton = await findByRole('button', { name: 'Retry service access review' });
+    const retryButton = await findByRole('button', {
+      name: 'Retry service access review',
+    });
     fireEvent.click(retryButton);
     expect(loginWithRedirect).toHaveBeenCalledWith({
-      flow: 'serviceAccessReview', returnTo: '/settings?section=account',
+      flow: 'serviceAccessReview',
+      returnTo: '/settings?section=account',
     });
     expect(
       await findByRole('link', { name: 'Back to Account settings' }),
@@ -159,14 +163,30 @@ describe('NyxID callback page', () => {
   });
 
   it.each([
-    ['requiredServiceAccessMissing', 'Required service access is still missing. Return to NyxID and keep every service marked as required by Aevatar selected.'],
-    ['issuedBindingInvalid', 'The new NyxID authorization expired before Aevatar could use it. Start the review again.'],
-    ['issuedBindingProbeFailed', 'NyxID could not verify the new service authorization. Try again in a moment.'],
-    ['bindingProbeFailed', 'NyxID could not verify the current service authorization. Try again in a moment.'],
+    [
+      'requiredServiceAccessMissing',
+      'Required service access is still missing. Return to NyxID and keep every service marked as required by Aevatar selected.',
+    ],
+    [
+      'issuedBindingInvalid',
+      'The new NyxID authorization expired before Aevatar could use it. Start the review again.',
+    ],
+    [
+      'issuedBindingProbeFailed',
+      'NyxID could not verify the new service authorization. Try again in a moment.',
+    ],
+    [
+      'bindingProbeFailed',
+      'NyxID could not verify the current service authorization. Try again in a moment.',
+    ],
   ])('shows localized review guidance for %s', async (reason, message) => {
-    handleRedirectCallback.mockRejectedValue(Object.assign(new Error('raw'), {
-      flow: 'serviceAccessReview', reason, returnTo: '/settings?section=account',
-    }));
+    handleRedirectCallback.mockRejectedValue(
+      Object.assign(new Error('raw'), {
+        flow: 'serviceAccessReview',
+        reason,
+        returnTo: '/settings?section=account',
+      }),
+    );
     const { findByRole } = render(React.createElement(CallbackPage));
     expect(await findByRole('alert')).toHaveTextContent(message);
   });
@@ -194,16 +214,47 @@ describe('NyxID callback page', () => {
     });
   });
 
+  it('preserves auth finalization network details for callback failures', async () => {
+    handleRedirectCallback.mockRejectedValue(
+      Object.assign(
+        new Error(
+          'Error occurred while trying to proxy: localhost:5174/api/auth/nyxid/finalize to https://aevatar-console-backend-api.aevatar.ai/ [ECONNRESET]',
+        ),
+        {
+          flow: 'signIn',
+          reason: 'signInFailed',
+          returnTo: '/login',
+        },
+      ),
+    );
+
+    const { findByRole } = render(React.createElement(CallbackPage));
+
+    const alert = await findByRole('alert');
+    expect(alert).toHaveTextContent('/api/auth/nyxid/finalize');
+    expect(alert).toHaveTextContent('ECONNRESET');
+    expect(alert).not.toHaveTextContent(
+      'The login status is temporarily unavailable, please refresh and try again.',
+    );
+  });
+
   it('keeps service access review retryable when authorization restart fails', async () => {
-    handleRedirectCallback.mockRejectedValue(Object.assign(new Error('raw'), {
-      flow: 'serviceAccessReview', reason: 'serviceAccessReviewUnavailable',
-      returnTo: '/settings?section=account',
-    }));
+    handleRedirectCallback.mockRejectedValue(
+      Object.assign(new Error('raw'), {
+        flow: 'serviceAccessReview',
+        reason: 'serviceAccessReviewUnavailable',
+        returnTo: '/settings?section=account',
+      }),
+    );
     loginWithRedirect.mockRejectedValueOnce(new Error('config unavailable'));
     const { findByRole } = render(React.createElement(CallbackPage));
-    const retryButton = await findByRole('button', { name: 'Retry service access review' });
+    const retryButton = await findByRole('button', {
+      name: 'Retry service access review',
+    });
     fireEvent.click(retryButton);
-    expect(await findByRole('alert')).toHaveTextContent('Could not restart service access review. Try again.');
+    expect(await findByRole('alert')).toHaveTextContent(
+      'Could not restart service access review. Try again.',
+    );
     await waitFor(() => expect(retryButton).not.toHaveClass('ant-btn-loading'));
   });
 

--- a/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
+++ b/apps/aevatar-console-web/src/pages/auth/callback/index.tsx
@@ -1,17 +1,17 @@
 import { Button, Result } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  NyxIDAuthClient,
-  SERVICE_ACCESS_REVIEW_RETURN_TO,
   type AuthFlow,
   type NyxIDAuthCallbackErrorReason,
+  NyxIDAuthClient,
+  SERVICE_ACCESS_REVIEW_RETURN_TO,
 } from '@/shared/auth/client';
 import { getNyxIDRuntimeConfig } from '@/shared/auth/config';
 import { loadStoredAuthSession } from '@/shared/auth/session';
+import { t } from '@/shared/i18n/messages';
 import { CONSOLE_HOME_ROUTE } from '@/shared/navigation/consoleHome';
 import { AevatarPageLoading } from '@/shared/ui/AevatarLoading';
 import { describeError } from '@/shared/ui/errorText';
-import { t } from "@/shared/i18n/messages";
 
 type CallbackErrorState = {
   readonly flow: AuthFlow;
@@ -21,49 +21,124 @@ type CallbackErrorState = {
 };
 
 const callbackErrorReasons = new Set<NyxIDAuthCallbackErrorReason>([
-  "oauthDenied", "requiredServiceAccessMissing", "issuedBindingInvalid",
-  "issuedBindingProbeFailed", "bindingProbeFailed",
-  "serviceAccessReviewRequired", "serviceAccessReviewUnavailable",
-  "serviceAccessReviewFailed", "signInFailed",
+  'oauthDenied',
+  'requiredServiceAccessMissing',
+  'issuedBindingInvalid',
+  'issuedBindingProbeFailed',
+  'bindingProbeFailed',
+  'serviceAccessReviewRequired',
+  'serviceAccessReviewUnavailable',
+  'serviceAccessReviewFailed',
+  'signInFailed',
 ]);
 
-function describeCallbackError(error: unknown, reason: NyxIDAuthCallbackErrorReason): string {
+function describeCallbackError(
+  error: unknown,
+  reason: NyxIDAuthCallbackErrorReason,
+): string {
   switch (reason) {
-    case "oauthDenied":
-      return t("pages.auth.callback.index.service.access.review.cancelled", "NyxID service access review was cancelled or denied. Your current Studio session is still active.");
-    case "requiredServiceAccessMissing":
-      return t("pages.auth.callback.index.required.service.access.missing", "Required service access is still missing. Return to NyxID and keep every service marked as required by Aevatar selected.");
-    case "issuedBindingInvalid":
-      return t("pages.auth.callback.index.issued.binding.invalid", "The new NyxID authorization expired before Aevatar could use it. Start the review again.");
-    case "issuedBindingProbeFailed":
-      return t("pages.auth.callback.index.issued.binding.probe.failed", "NyxID could not verify the new service authorization. Try again in a moment.");
-    case "bindingProbeFailed":
-      return t("pages.auth.callback.index.binding.probe.failed", "NyxID could not verify the current service authorization. Try again in a moment.");
-    case "serviceAccessReviewRequired":
-      return t("pages.auth.callback.index.service.access.review.required", "Service access review needs to be run again.");
-    case "serviceAccessReviewUnavailable":
-      return t("pages.auth.callback.index.service.access.review.unavailable", "Service access review is temporarily unavailable. Try again in a moment.");
-    case "serviceAccessReviewFailed":
-      return t("pages.auth.callback.index.service.access.review.failed", "Service access review failed. Try again.");
-    case "signInFailed":
-      return describeError(error);
+    case 'oauthDenied':
+      return t(
+        'pages.auth.callback.index.service.access.review.cancelled',
+        'NyxID service access review was cancelled or denied. Your current Studio session is still active.',
+      );
+    case 'requiredServiceAccessMissing':
+      return t(
+        'pages.auth.callback.index.required.service.access.missing',
+        'Required service access is still missing. Return to NyxID and keep every service marked as required by Aevatar selected.',
+      );
+    case 'issuedBindingInvalid':
+      return t(
+        'pages.auth.callback.index.issued.binding.invalid',
+        'The new NyxID authorization expired before Aevatar could use it. Start the review again.',
+      );
+    case 'issuedBindingProbeFailed':
+      return t(
+        'pages.auth.callback.index.issued.binding.probe.failed',
+        'NyxID could not verify the new service authorization. Try again in a moment.',
+      );
+    case 'bindingProbeFailed':
+      return t(
+        'pages.auth.callback.index.binding.probe.failed',
+        'NyxID could not verify the current service authorization. Try again in a moment.',
+      );
+    case 'serviceAccessReviewRequired':
+      return t(
+        'pages.auth.callback.index.service.access.review.required',
+        'Service access review needs to be run again.',
+      );
+    case 'serviceAccessReviewUnavailable':
+      return t(
+        'pages.auth.callback.index.service.access.review.unavailable',
+        'Service access review is temporarily unavailable. Try again in a moment.',
+      );
+    case 'serviceAccessReviewFailed':
+      return t(
+        'pages.auth.callback.index.service.access.review.failed',
+        'Service access review failed. Try again.',
+      );
+    case 'signInFailed':
+      return describeSignInCallbackError(error);
   }
+}
+
+function normalizeCallbackErrorMessage(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function readCallbackErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return normalizeCallbackErrorMessage(error.message || error.name || '');
+  }
+
+  if (error && typeof error === 'object' && !Array.isArray(error)) {
+    const record = error as { message?: unknown };
+    if (typeof record.message === 'string') {
+      return normalizeCallbackErrorMessage(record.message);
+    }
+  }
+
+  return normalizeCallbackErrorMessage(String(error ?? ''));
+}
+
+function isAuthFinalizationNetworkDetail(message: string): boolean {
+  const lower = message.toLowerCase();
+  const isNetworkOrProxyFailure =
+    lower.includes('error occurred while trying to proxy') ||
+    lower.includes('failed to fetch') ||
+    lower.includes('network error') ||
+    lower.includes('econnreset');
+
+  return isNetworkOrProxyFailure && lower.includes('/api/auth/nyxid/finalize');
+}
+
+function describeSignInCallbackError(error: unknown): string {
+  const message = readCallbackErrorMessage(error);
+  if (isAuthFinalizationNetworkDetail(message)) {
+    return message;
+  }
+
+  return describeError(error);
 }
 
 function readCallbackErrorState(error: unknown): CallbackErrorState {
   const record =
-    error && typeof error === "object" && !Array.isArray(error)
+    error && typeof error === 'object' && !Array.isArray(error)
       ? (error as { flow?: unknown; reason?: unknown; returnTo?: unknown })
       : null;
   const flow =
-    record?.flow === "serviceAccessReview" ? "serviceAccessReview" : "signIn";
-  const reason = callbackErrorReasons.has(record?.reason as NyxIDAuthCallbackErrorReason)
+    record?.flow === 'serviceAccessReview' ? 'serviceAccessReview' : 'signIn';
+  const reason = callbackErrorReasons.has(
+    record?.reason as NyxIDAuthCallbackErrorReason,
+  )
     ? (record?.reason as NyxIDAuthCallbackErrorReason)
-    : flow === "serviceAccessReview" ? "serviceAccessReviewFailed" : "signInFailed";
+    : flow === 'serviceAccessReview'
+      ? 'serviceAccessReviewFailed'
+      : 'signInFailed';
   const fallbackReturnTo =
-    flow === "serviceAccessReview" ? SERVICE_ACCESS_REVIEW_RETURN_TO : "/login";
+    flow === 'serviceAccessReview' ? SERVICE_ACCESS_REVIEW_RETURN_TO : '/login';
   const returnTo =
-    typeof record?.returnTo === "string" && record.returnTo.startsWith("/")
+    typeof record?.returnTo === 'string' && record.returnTo.startsWith('/')
       ? record.returnTo
       : fallbackReturnTo;
 
@@ -130,8 +205,8 @@ const CallbackPage: React.FC = () => {
       const client = new NyxIDAuthClient(config);
       await client.loginWithRedirect({
         flow: callbackError.flow,
-        ...(callbackError.reason === "requiredServiceAccessMissing"
-          ? { prompt: "consent" as const }
+        ...(callbackError.reason === 'requiredServiceAccessMissing'
+          ? { prompt: 'consent' as const }
           : {}),
         returnTo: callbackError.returnTo,
       });
@@ -139,15 +214,19 @@ const CallbackPage: React.FC = () => {
       setRetrying(false);
       setCallbackError({
         ...callbackError,
-        message: callbackError.flow === "serviceAccessReview"
-          ? t("pages.auth.callback.index.service.access.review.restart.failed", "Could not restart service access review. Try again.")
-          : describeError(error),
+        message:
+          callbackError.flow === 'serviceAccessReview'
+            ? t(
+                'pages.auth.callback.index.service.access.review.restart.failed',
+                'Could not restart service access review. Try again.',
+              )
+            : describeError(error),
       });
     }
   };
 
   if (callbackError) {
-    const isReviewFlow = callbackError.flow === "serviceAccessReview";
+    const isReviewFlow = callbackError.flow === 'serviceAccessReview';
     return (
       <Result
         extra={[
@@ -158,21 +237,37 @@ const CallbackPage: React.FC = () => {
             type="primary"
           >
             {isReviewFlow
-              ? t("pages.auth.callback.index.retry.service.access.review", "Retry service access review")
-              : t("pages.auth.callback.index.try.sign.in.again", "Try sign-in again")}
+              ? t(
+                  'pages.auth.callback.index.retry.service.access.review',
+                  'Retry service access review',
+                )
+              : t(
+                  'pages.auth.callback.index.try.sign.in.again',
+                  'Try sign-in again',
+                )}
           </Button>,
           <Button
-            href={isReviewFlow ? callbackError.returnTo : "/login"}
+            href={isReviewFlow ? callbackError.returnTo : '/login'}
             key="back"
           >
             {isReviewFlow
-              ? t("pages.auth.callback.index.back.to.account.settings", "Back to Account settings")
-              : t("pages.auth.callback.index.back.to.login", "Back to login")}
+              ? t(
+                  'pages.auth.callback.index.back.to.account.settings',
+                  'Back to Account settings',
+                )
+              : t('pages.auth.callback.index.back.to.login', 'Back to login')}
           </Button>,
         ]}
         status="error"
-        subTitle={<span aria-live="assertive" role="alert">{callbackError.message}</span>}
-        title={t("pages.auth.callback.index.nyxid.callback.failed", "NyxID callback failed")}
+        subTitle={
+          <span aria-live="assertive" role="alert">
+            {callbackError.message}
+          </span>
+        }
+        title={t(
+          'pages.auth.callback.index.nyxid.callback.failed',
+          'NyxID callback failed',
+        )}
       />
     );
   }
@@ -180,7 +275,10 @@ const CallbackPage: React.FC = () => {
   return (
     <AevatarPageLoading
       fullscreen
-      tip={t("pages.auth.callback.index.completing.nyxid.authorization", "Completing NyxID authorization...")}
+      tip={t(
+        'pages.auth.callback.index.completing.nyxid.authorization',
+        'Completing NyxID authorization...',
+      )}
     />
   );
 };


### PR DESCRIPTION
## Problem

NyxID callback failures could lose useful diagnostics because auth proxy/network errors were normalized into the generic login-status unavailable message. That made issues such as backend finalization connection resets look like an opaque frontend login state problem.

## Solution

- Keep the existing localized guidance for known service-access review callback reasons.
- For sign-in callback failures that specifically involve the auth finalization endpoint `/api/auth/nyxid/finalize` and network/proxy details, preserve the normalized raw error message so operators can see details such as the endpoint and `ECONNRESET`.
- Add a callback page regression test proving auth finalization network details are shown instead of the generic login-status fallback.

## Impact paths

- `apps/aevatar-console-web/src/pages/auth/callback/index.tsx`
- `apps/aevatar-console-web/src/pages/auth/callback/index.test.tsx`

## Local verification

- Related tests: `pnpm exec jest --findRelatedTests src/pages/auth/callback/index.tsx --runInBand` passed, 11 tests.
- Changed test file: `pnpm exec jest src/pages/auth/callback/index.test.tsx --runInBand` passed, 11 tests.
- Changed-file static checks: `pnpm exec biome check src/pages/auth/callback/index.test.tsx src/pages/auth/callback/index.tsx` passed.
- Test stability guard: `bash tools/ci/test_stability_guards.sh` passed.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.
