### PR TITLE
Clarify draft delete refresh toast

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -543,7 +543,7 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.deleteDraft': 'Delete draft',
   'workflowActivityVNext.workflows.deleteFailed': "Draft couldn't be deleted",
   'workflowActivityVNext.workflows.deleteRefreshFailed':
-    "Draft was deleted, but workflows couldn't refresh",
+    'Draft was deleted, but the workflow list could not refresh. Please try again.',
   'workflowActivityVNext.workflows.deleteObservationDelayed':
     'Draft was deleted, but the workflow catalogue has not confirmed its removal yet',
   'workflowActivityVNext.workflows.deleteRetry': 'Try again',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -503,7 +503,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.deleteDraft': '删除草稿',
     'workflowActivityVNext.workflows.deleteFailed': '无法删除草稿',
     'workflowActivityVNext.workflows.deleteRefreshFailed':
-      '草稿已删除，但工作流列表刷新失败',
+      '草稿已删除，但工作流列表无法刷新，请重试。',
     'workflowActivityVNext.workflows.deleteObservationDelayed':
       '草稿已删除，但工作流目录尚未确认其移除',
     'workflowActivityVNext.workflows.deleteRetry': '重试',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -625,6 +625,42 @@ describe('Workflow Activity vNext catalogue', () => {
     );
   });
 
+  it('reports only the specific delete refresh failure after the draft was removed', async () => {
+    mockScopesApi.queryWorkflowCatalogue
+      .mockResolvedValueOnce(
+        createCatalogueResponse([
+          createCatalogueRow({
+            workflowId: 'wf-draft-alpha',
+            name: 'Support triage',
+          }),
+        ]),
+      )
+      .mockRejectedValueOnce(new Error('refresh returned 503'));
+    mockStudioApi.deleteWorkflowDraft.mockResolvedValue(undefined);
+
+    renderWithQueryClient(<WorkflowActivityVNextPage />);
+
+    const draftName = await screen.findByText('Support triage');
+    fireEvent.click(
+      within(draftName.closest('tr') as HTMLElement).getByRole('button', {
+        name: 'More actions for Support triage in Workspace',
+      }),
+    );
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: 'Delete draft' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Delete draft' }));
+
+    await waitFor(() =>
+      expect(mockConsoleToast.error).toHaveBeenCalledWith(
+        'Draft was deleted, but the workflow list could not refresh. Please try again.',
+      ),
+    );
+    expect(mockConsoleToast.error).toHaveBeenCalledTimes(1);
+    expect(mockStudioApi.deleteWorkflowDraft).toHaveBeenCalledTimes(1);
+    expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
+  });
+
   it('maps unsupported legacy views to the backend all view', async () => {
     mockLocation =
       '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=archived';

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -477,7 +477,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
         removed
           ? t(
               'workflowActivityVNext.workflows.deleteRefreshFailed',
-              "Draft was deleted, but workflows couldn't refresh",
+              'Draft was deleted, but the workflow list could not refresh. Please try again.',
             )
           : t(
               'workflowActivityVNext.workflows.deleteFailed',


### PR DESCRIPTION
## Summary
- Clarify the draft-delete refresh failure toast so it now says the draft was deleted, but the workflow list could not refresh.
- Keep the change scoped to the workflow activity vNext page plus the related English and Chinese locale strings and test assertion.

## Impact
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/WorkflowsPage.tsx`
- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`
- `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`

## Local verification
- Related tests: `pnpm exec jest apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx --runInBand` (passed, 70 tests)
- Changed-file static checks: attempted scoped prettier/eslint checks in the worktree, but `pnpm exec` could not find those binaries there
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
