### PR TITLE
Respect auth-me profile authority in vNext

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts
@@ -39,7 +39,7 @@ function createBackendSession(
 }
 
 describe('resolveWorkflowActivityAccount', () => {
-  it('fills missing profile fields from a stored session with the same subject', () => {
+  it('keeps backend profile facts authoritative when local storage has the same subject', () => {
     const result = resolveWorkflowActivityAccount(
       createBackendSession({ subject: 'user-abigail', profile: null }),
       createStoredSession(),
@@ -47,18 +47,13 @@ describe('resolveWorkflowActivityAccount', () => {
 
     expect(result.principal).toEqual({
       authenticated: true,
-      displayName: 'Abigail Deng',
-      picture: 'https://example.test/abigail.png',
+      displayName: '',
+      picture: null,
     });
-    expect(result.auth?.profile).toEqual({
-      email: 'abigail@example.test',
-      emailVerified: true,
-      groups: ['platform'],
-      name: 'Abigail Deng',
-      picture: 'https://example.test/abigail.png',
-      roles: ['operator'],
-      subject: 'user-abigail',
-    });
+    expect(result.auth?.profile).toBeNull();
+    expect(result.auth?.name).toBeUndefined();
+    expect(result.auth?.email).toBeUndefined();
+    expect(result.auth?.picture).toBeUndefined();
   });
 
   it('does not reuse a stored profile for a different backend subject', () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts
@@ -1,4 +1,4 @@
-import type { NyxIDAuthSession, NyxIDUserInfo } from '@/shared/auth/session';
+import type { NyxIDAuthSession } from '@/shared/auth/session';
 import type {
   StudioAuthProfile,
   StudioAuthSession,
@@ -42,23 +42,21 @@ function storedPrincipal(
   };
 }
 
-function mergeProfile(
+function resolveBackendProfile(
   auth: StudioAuthSession,
   subject: string | undefined,
-  fallback: NyxIDUserInfo | undefined,
 ): StudioAuthProfile | null | undefined {
   const profile = auth.profile;
-  if (!profile && !fallback) return profile;
+  if (!profile) return profile;
 
   return {
     subject: subject || null,
-    name: firstValue(profile?.name, auth.name, fallback?.name) || null,
-    email: firstValue(profile?.email, auth.email, fallback?.email) || null,
-    emailVerified: profile?.emailVerified ?? fallback?.email_verified ?? null,
-    picture:
-      firstValue(profile?.picture, auth.picture, fallback?.picture) || null,
-    roles: profile?.roles ?? fallback?.roles ?? [],
-    groups: profile?.groups ?? fallback?.groups ?? [],
+    name: firstValue(profile.name, auth.name) || null,
+    email: firstValue(profile.email, auth.email) || null,
+    emailVerified: profile.emailVerified ?? null,
+    picture: firstValue(profile.picture, auth.picture) || null,
+    roles: profile.roles,
+    groups: profile.groups,
   };
 }
 
@@ -71,16 +69,13 @@ export function resolveWorkflowActivityAccount(
   }
 
   const subject = firstValue(auth.profile?.subject, auth.subject);
-  const storedSubject = normalize(storedSession?.user.sub);
-  const fallback =
-    subject && storedSubject === subject ? storedSession?.user : undefined;
-  const profile = mergeProfile(auth, subject, fallback);
+  const profile = resolveBackendProfile(auth, subject);
   const resolvedAuth: StudioAuthSession = {
     ...auth,
     subject: subject || null,
-    name: firstValue(profile?.name, auth.name, fallback?.name),
-    email: firstValue(profile?.email, auth.email, fallback?.email),
-    picture: firstValue(profile?.picture, auth.picture, fallback?.picture),
+    name: firstValue(profile?.name, auth.name),
+    email: firstValue(profile?.email, auth.email),
+    picture: firstValue(profile?.picture, auth.picture),
     profile,
   };
   const authenticated =


### PR DESCRIPTION
## Problem

Backend #3437 now resolves `/api/auth/me` profile fields from the provider and keeps scope identity separate from user identity. Workflow Activity vNext still merged local NyxID session profile fields into an authenticated backend account response whenever the subjects matched. That was useful while the backend profile contract was incomplete, but after #3437 it can hide the backend's honest missing-profile state and reintroduce stale browser identity as presentation truth.

## Solution

- Keep `/api/auth/me` profile/name/email/picture as the authoritative source whenever the backend account response is available.
- Preserve the local browser principal only for backend-unavailable and backend-unauthenticated recovery states.
- Update the resolver test to cover same-subject local storage data without allowing it to fill backend profile gaps.

## Impact

- Workflow Activity vNext account/header identity resolution.
- No backend endpoint or API shape changes.

## Local verification

- RED check: `pnpm --dir apps/aevatar-console-web exec jest src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts --runInBand` - failed before implementation on the same-subject local profile fallback assertion.
- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts --runInBand` - passed (5 suites, 147 tests).
- Changed test: `pnpm exec jest src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts --runInBand` - passed (1 suite, 4 tests).
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.ts src/pages/workflow-activity-vnext/account/resolveWorkflowActivityAccount.test.ts` - passed (2 files).
- Test guard: `bash tools/ci/test_stability_guards.sh` - passed.
- Diff check: `git diff --check` - passed.
- Affected typecheck: unavailable; full type verification delegated to GitHub CI.
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy.

Follow-up to #3410 and backend #3437.