### PR TITLE
Resolve workflow detail through catalogue service identity

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs
@@ -109,7 +109,9 @@ public sealed record ScopeWorkflowCatalogueCommittedFacts(
     string ActorId,
     string ActiveRevisionId,
     string DeploymentId,
-    string DeploymentStatus);
+    string DeploymentStatus,
+    string ServiceAppId,
+    string ServiceNamespace);
 
 public sealed record ScopeWorkflowCatalogueRowCapabilities(
     ScopeWorkflowCatalogueActionCapability Open,

--- a/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
@@ -64,6 +64,9 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IScopeWorkflowPublishedServiceDescriptorSource,
             StudioMemberScopeWorkflowDescriptorSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IScopeWorkflowPublishedServiceDescriptorSource,
+            CatalogueScopeWorkflowDescriptorSource>());
         services.TryAddSingleton<IStudioMemberWorkflowDurableAdmissionPort,
             StudioMemberWorkflowDurableAdmissionPort>();
         services.TryAddSingleton(new StudioMemberWorkflowSchedulePolicy());

--- a/src/Aevatar.Studio.Application/Studio/Services/CatalogueScopeWorkflowDescriptorSource.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/CatalogueScopeWorkflowDescriptorSource.cs
@@ -1,0 +1,85 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Services;
+
+public sealed class CatalogueScopeWorkflowDescriptorSource
+    : IScopeWorkflowPublishedServiceDescriptorSource
+{
+    private readonly IWorkflowCatalogueQueryPort _catalogueQueryPort;
+
+    public CatalogueScopeWorkflowDescriptorSource(IWorkflowCatalogueQueryPort catalogueQueryPort)
+    {
+        _catalogueQueryPort = catalogueQueryPort ?? throw new ArgumentNullException(nameof(catalogueQueryPort));
+    }
+
+    public async Task<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>> ListAsync(
+        string scopeId,
+        int take,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var queryTake = Math.Clamp(take, 1, 100);
+        var catalogue = await _catalogueQueryPort.QueryAsync(
+            new ScopeWorkflowCatalogueQuery(normalizedScopeId, Take: queryTake),
+            ct);
+
+        return catalogue.Items
+            .Select(Map)
+            .Where(static descriptor => descriptor != null)
+            .Select(static descriptor => descriptor!)
+            .Take(queryTake)
+            .ToArray();
+    }
+
+    public async Task<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>> FindByWorkflowIdAsync(
+        string scopeId,
+        string workflowId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var normalizedWorkflowId = NormalizeRequired(workflowId, nameof(workflowId));
+        var catalogue = await _catalogueQueryPort.QueryAsync(
+            new ScopeWorkflowCatalogueQuery(normalizedScopeId, Query: normalizedWorkflowId, Take: 100),
+            ct);
+
+        return catalogue.Items
+            .Where(row => string.Equals(row.WorkflowId, normalizedWorkflowId, StringComparison.Ordinal))
+            .Select(Map)
+            .Where(static descriptor => descriptor != null)
+            .Select(static descriptor => descriptor!)
+            .ToArray();
+    }
+
+    private static ScopeWorkflowPublishedServiceDescriptor? Map(ScopeWorkflowCatalogueRow row)
+    {
+        var committed = row.Committed;
+        if (!row.HasCommittedSource ||
+            committed == null ||
+            string.IsNullOrWhiteSpace(row.PublishedServiceId) ||
+            string.IsNullOrWhiteSpace(committed.ServiceAppId) ||
+            string.IsNullOrWhiteSpace(committed.ServiceNamespace))
+        {
+            return null;
+        }
+
+        return new ScopeWorkflowPublishedServiceDescriptor(
+            row.ScopeId,
+            row.WorkflowId,
+            committed.ServiceAppId.Trim(),
+            committed.ServiceNamespace.Trim(),
+            row.PublishedServiceId.Trim(),
+            string.IsNullOrWhiteSpace(row.Name) ? row.WorkflowId : row.Name.Trim(),
+            row.UpdatedAtUtc);
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+        return normalized;
+    }
+}

--- a/src/Aevatar.Studio.Application/Studio/Services/CatalogueScopeWorkflowDescriptorSource.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/CatalogueScopeWorkflowDescriptorSource.cs
@@ -22,16 +22,30 @@ public sealed class CatalogueScopeWorkflowDescriptorSource
     {
         var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
         var queryTake = Math.Clamp(take, 1, 100);
-        var catalogue = await _catalogueQueryPort.QueryAsync(
-            new ScopeWorkflowCatalogueQuery(normalizedScopeId, Take: queryTake),
-            ct);
+        var descriptors = new List<ScopeWorkflowPublishedServiceDescriptor>(queryTake);
+        string? cursor = null;
 
-        return catalogue.Items
-            .Select(Map)
-            .Where(static descriptor => descriptor != null)
-            .Select(static descriptor => descriptor!)
-            .Take(queryTake)
-            .ToArray();
+        do
+        {
+            var catalogue = await _catalogueQueryPort.QueryAsync(
+                new ScopeWorkflowCatalogueQuery(normalizedScopeId, Cursor: cursor, Take: queryTake),
+                ct);
+
+            foreach (var row in catalogue.Items)
+            {
+                var descriptor = Map(row);
+                if (descriptor == null)
+                    continue;
+
+                descriptors.Add(descriptor);
+                if (descriptors.Count == queryTake)
+                    return descriptors;
+            }
+
+            cursor = catalogue.NextPageToken;
+        } while (!string.IsNullOrWhiteSpace(cursor));
+
+        return descriptors;
     }
 
     public async Task<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>> FindByWorkflowIdAsync(
@@ -41,16 +55,24 @@ public sealed class CatalogueScopeWorkflowDescriptorSource
     {
         var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
         var normalizedWorkflowId = NormalizeRequired(workflowId, nameof(workflowId));
-        var catalogue = await _catalogueQueryPort.QueryAsync(
-            new ScopeWorkflowCatalogueQuery(normalizedScopeId, Query: normalizedWorkflowId, Take: 100),
-            ct);
+        string? cursor = null;
 
-        return catalogue.Items
-            .Where(row => string.Equals(row.WorkflowId, normalizedWorkflowId, StringComparison.Ordinal))
-            .Select(Map)
-            .Where(static descriptor => descriptor != null)
-            .Select(static descriptor => descriptor!)
-            .ToArray();
+        do
+        {
+            var catalogue = await _catalogueQueryPort.QueryAsync(
+                new ScopeWorkflowCatalogueQuery(normalizedScopeId, Query: normalizedWorkflowId, Cursor: cursor, Take: 100),
+                ct);
+
+            var exactRow = catalogue.Items.FirstOrDefault(row =>
+                string.Equals(row.WorkflowId, normalizedWorkflowId, StringComparison.Ordinal));
+            var descriptor = exactRow == null ? null : Map(exactRow);
+            if (descriptor != null)
+                return [descriptor];
+
+            cursor = catalogue.NextPageToken;
+        } while (!string.IsNullOrWhiteSpace(cursor));
+
+        return [];
     }
 
     private static ScopeWorkflowPublishedServiceDescriptor? Map(ScopeWorkflowCatalogueRow row)

--- a/src/Aevatar.Studio.Projection/Metadata/ScopeWorkflowCatalogueRowDocumentMetadataProvider.cs
+++ b/src/Aevatar.Studio.Projection/Metadata/ScopeWorkflowCatalogueRowDocumentMetadataProvider.cs
@@ -33,6 +33,8 @@ public sealed class ScopeWorkflowCatalogueRowDocumentMetadataProvider
                 ["active_revision_id"] = Keyword(),
                 ["deployment_id"] = Keyword(),
                 ["deployment_status"] = Keyword(),
+                ["service_app_id"] = Keyword(),
+                ["service_namespace"] = Keyword(),
                 ["published_service_id"] = Keyword(),
             },
         },

--- a/src/Aevatar.Studio.Projection/Projectors/ScopeWorkflowCatalogueRowMaterializer.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/ScopeWorkflowCatalogueRowMaterializer.cs
@@ -97,6 +97,8 @@ public sealed class ScopeWorkflowCatalogueRowMaterializer
             ActiveRevisionId = state.ServiceSource?.ActiveRevisionId ?? string.Empty,
             DeploymentId = state.ServiceSource?.DeploymentId ?? string.Empty,
             DeploymentStatus = state.ServiceSource?.DeploymentStatus ?? string.Empty,
+            ServiceAppId = state.ServiceSource?.ServiceAppId ?? string.Empty,
+            ServiceNamespace = state.ServiceSource?.ServiceNamespace ?? string.Empty,
             PublishedServiceId = state.ServiceSource?.PublishedServiceId ?? string.Empty,
         };
     }
@@ -132,6 +134,8 @@ public sealed class ScopeWorkflowCatalogueRowMaterializer
             DeploymentId = source.DeploymentId ?? string.Empty,
             DeploymentStatus = source.DeploymentStatus ?? string.Empty,
             PublishedServiceId = source.PublishedServiceId ?? string.Empty,
+            ServiceAppId = source.ServiceAppId ?? string.Empty,
+            ServiceNamespace = source.ServiceNamespace ?? string.Empty,
         };
     }
 

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionWorkflowCatalogueQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionWorkflowCatalogueQueryPort.cs
@@ -119,7 +119,9 @@ public sealed class ProjectionWorkflowCatalogueQueryPort : IWorkflowCatalogueQue
                     document.CommittedActorId,
                     document.ActiveRevisionId,
                     document.DeploymentId,
-                    document.DeploymentStatus)
+                    document.DeploymentStatus,
+                    document.ServiceAppId,
+                    document.ServiceNamespace)
                 : null,
             PublishedServiceId: ResolveOptional(document.PublishedServiceId));
     }

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -267,9 +267,9 @@ message ScopeWorkflowCatalogueRowDocument {
   string active_revision_id = 33;
   string deployment_id = 34;
   string deployment_status = 35;
-  string service_app_id = 36;
-  string service_namespace = 37;
-  string published_service_id = 38;
+  string published_service_id = 36;
+  string service_app_id = 37;
+  string service_namespace = 38;
 }
 
 // ─── UserConfig Current State ReadModel ───

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -267,7 +267,9 @@ message ScopeWorkflowCatalogueRowDocument {
   string active_revision_id = 33;
   string deployment_id = 34;
   string deployment_status = 35;
-  string published_service_id = 36;
+  string service_app_id = 36;
+  string service_namespace = 37;
+  string published_service_id = 38;
 }
 
 // ─── UserConfig Current State ReadModel ───

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/scope_workflow_catalogue.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/scope_workflow_catalogue.proto
@@ -21,6 +21,8 @@ message ScopeWorkflowCatalogueSourceSnapshot {
   string deployment_id = 14;
   string deployment_status = 15;
   string published_service_id = 16;
+  string service_app_id = 17;
+  string service_namespace = 18;
 }
 
 message ObserveScopeWorkflowCatalogueSourcesCommand {

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -328,8 +328,12 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
             ?? throw new InvalidOperationException("workflow authorization dependencies are required.");
         var capabilityAdmissionPlan = workflowSpec.CapabilityAdmissionPlan
             ?? throw new InvalidOperationException("workflow capability admission plan is required.");
+        var artifactRevisionSpec = revisionSpec.Clone();
+        artifactRevisionSpec.WorkflowSpec!.WorkflowId = string.IsNullOrWhiteSpace(workflowSpec.WorkflowId)
+            ? revisionSpec.RevisionId
+            : workflowSpec.WorkflowId;
         return WorkflowServiceRevisionArtifactBuilder.Build(
-            revisionSpec,
+            artifactRevisionSpec,
             resolvedWorkflowName,
             authorizationDependencies,
             capabilityAdmissionPlan);

--- a/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowQueryApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowQueryApplicationService.cs
@@ -152,14 +152,6 @@ public sealed class ScopeWorkflowQueryApplicationService : IScopeWorkflowQueryPo
         if (distinctDescriptors.Length == 1)
         {
             var explicitIdentity = BuildIdentity(distinctDescriptors[0]);
-            if (conventionalService != null && !HasSameIdentity(conventionalIdentity, explicitIdentity))
-            {
-                return new ScopeWorkflowLookupResult(
-                    ScopeWorkflowLookupStatus.Stale,
-                    Workflow: null,
-                    Reason: "published_service_descriptor_conflicts_with_conventional_identity");
-            }
-
             identity = explicitIdentity;
             serviceSnapshot = HasSameIdentity(conventionalIdentity, explicitIdentity)
                 ? conventionalService

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
@@ -76,9 +76,13 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
 
         var authorizationDependencies = parse.AuthorizationDependencies
             ?? throw new InvalidOperationException("workflow authorization dependencies are required.");
+        var artifactRevisionSpec = preparationSpec.Clone();
+        artifactRevisionSpec.WorkflowSpec!.WorkflowId = string.IsNullOrWhiteSpace(spec.WorkflowId)
+            ? request.Spec.RevisionId
+            : spec.WorkflowId;
 
         return WorkflowServiceRevisionArtifactBuilder.Build(
-            preparationSpec,
+            artifactRevisionSpec,
             resolvedWorkflowName,
             authorizationDependencies,
             capabilityAdmissionPlan);

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowWebhookBindingSecretCipher.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowWebhookBindingSecretCipher.cs
@@ -91,7 +91,15 @@ internal sealed class AesGcmWorkflowWebhookBindingSecretCipher : IWorkflowWebhoo
                 ? null
                 : $"aevatar:workflow-webhook-binding:v1:{activeKeyId}:{activeKey}";
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+        catch (JsonException)
         {
             return null;
         }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -559,6 +559,15 @@ public sealed class ScopeWorkflowEndpointsTests
                 ["child"] = "name: child\nsteps: []\n",
             },
             ExternalCapabilityExecutionMode.Durable);
+        var descriptorSource = new FakePublishedServiceDescriptorSource(
+            new ScopeWorkflowPublishedServiceDescriptor(
+                "user-1",
+                "approval",
+                "workflow-app",
+                "user:user-1-token",
+                "approval",
+                "Approval",
+                DateTimeOffset.UtcNow));
         var revisionCatalog = new FakeServiceRevisionCatalogQueryReader();
         await revisionCatalog.UpsertRevisionAsync(
             "tenant-a:workflow-app:user:token:approval",
@@ -582,7 +591,7 @@ public sealed class ScopeWorkflowEndpointsTests
             http,
             "user-1",
             "approval",
-            BuildQueryPort(queryPort: queryPort, bindingReader: bindingReader),
+            BuildQueryPort(queryPort: queryPort, bindingReader: bindingReader, descriptorSource: descriptorSource),
             bindingReader,
             revisionCatalog,
             Options.Create(new ScopeWorkflowCapabilityOptions()),
@@ -594,6 +603,9 @@ public sealed class ScopeWorkflowEndpointsTests
         http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         body.Should().Contain("\"available\":true");
         body.Should().Contain("\"workflowId\":\"approval\"");
+        body.Should().Contain("\"serviceAppId\":\"workflow-app\"");
+        body.Should().Contain("\"serviceNamespace\":\"user:user-1-token\"");
+        body.Should().Contain("\"publishedServiceId\":\"approval\"");
         body.Should().Contain("\"workflowYaml\":\"name: approval\\nsteps: []\\n\"");
         body.Should().Contain("\"inlineWorkflowYamls\":{\"child\":\"name: child\\nsteps: []\\n\"}");
     }
@@ -1521,12 +1533,14 @@ public sealed class ScopeWorkflowEndpointsTests
 
     private static IScopeWorkflowQueryPort BuildQueryPort(
         FakeServiceLifecycleQueryPort? queryPort = null,
-        FakeWorkflowActorBindingReader? bindingReader = null) =>
-        BuildQueryApplicationService(queryPort, bindingReader);
+        FakeWorkflowActorBindingReader? bindingReader = null,
+        IScopeWorkflowPublishedServiceDescriptorSource? descriptorSource = null) =>
+        BuildQueryApplicationService(queryPort, bindingReader, descriptorSource);
 
     private static ScopeWorkflowQueryApplicationService BuildQueryApplicationService(
         FakeServiceLifecycleQueryPort? queryPort = null,
-        FakeWorkflowActorBindingReader? bindingReader = null)
+        FakeWorkflowActorBindingReader? bindingReader = null,
+        IScopeWorkflowPublishedServiceDescriptorSource? descriptorSource = null)
     {
         return new ScopeWorkflowQueryApplicationService(
             queryPort ?? new FakeServiceLifecycleQueryPort(),
@@ -1536,7 +1550,8 @@ public sealed class ScopeWorkflowEndpointsTests
                 ServiceAppId = "default",
                 ServiceNamespace = "default",
                 DefinitionActorIdPrefix = "scope-workflow",
-            }));
+            }),
+            descriptorSource == null ? null : [descriptorSource]);
     }
 
     private static DefaultHttpContext CreateHttpContext(
@@ -1774,6 +1789,32 @@ public sealed class ScopeWorkflowEndpointsTests
                     string.Empty,
                     new Dictionary<string, string>(),
                     ExternalCapabilityExecutionMode.Durable));
+    }
+
+    private sealed class FakePublishedServiceDescriptorSource
+        : IScopeWorkflowPublishedServiceDescriptorSource
+    {
+        private readonly IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor> _descriptors;
+
+        public FakePublishedServiceDescriptorSource(params ScopeWorkflowPublishedServiceDescriptor[] descriptors)
+        {
+            _descriptors = descriptors;
+        }
+
+        public Task<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>> ListAsync(
+            string scopeId,
+            int take,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>>(
+                _descriptors.Where(descriptor => descriptor.ScopeId == scopeId).Take(take).ToArray());
+
+        public Task<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>> FindByWorkflowIdAsync(
+            string scopeId,
+            string workflowId,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ScopeWorkflowPublishedServiceDescriptor>>(
+                _descriptors.Where(descriptor =>
+                    descriptor.ScopeId == scopeId && descriptor.WorkflowId == workflowId).ToArray());
     }
 
     private sealed class FakeServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQueryReader

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -2249,6 +2249,8 @@ public sealed class ScopeBindingCommandApplicationServiceTests
             {
                 WorkflowPlan = new WorkflowServiceDeploymentPlan
                 {
+                    WorkflowId = revisionId,
+                    RevisionId = revisionId,
                     WorkflowName = workflowName,
                     WorkflowYaml = workflowYaml,
                     DefinitionActorId = DefaultOptions.BuildDefinitionActorIdPrefix(
@@ -2294,6 +2296,8 @@ public sealed class ScopeBindingCommandApplicationServiceTests
             {
                 WorkflowPlan = new WorkflowServiceDeploymentPlan
                 {
+                    WorkflowId = revisionId,
+                    RevisionId = revisionId,
                     WorkflowName = workflowName,
                     WorkflowYaml = workflowYaml,
                     ExecutionMode = workflowExecutionMode,

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowQueryApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeWorkflowQueryApplicationServiceTests.cs
@@ -236,16 +236,18 @@ public sealed class ScopeWorkflowQueryApplicationServiceTests
     }
 
     [Fact]
-    public async Task LookupByWorkflowIdAsync_ShouldRejectConventionalAndExplicitIdentityConflict()
+    public async Task LookupByWorkflowIdAsync_ShouldPreferExplicitPublishedServiceDescriptorOverConventionalIdentity()
     {
         const string workflowId = "wf-alpha";
         var directSnapshot = CreateServiceSnapshot(workflowId, "Direct Workflow");
         var studioSnapshot = CreateServiceSnapshot(
             "svc-alpha",
             "Studio Workflow",
+            primaryActorId: "actor-default",
             appId: "studio");
         var lifecyclePort = new FakeServiceLifecycleQueryPort(
-            listResult: [directSnapshot, studioSnapshot]);
+            listResult: [directSnapshot, studioSnapshot],
+            deploymentResult: CreateDeploymentCatalog(studioSnapshot));
         var descriptorSource = new FakePublishedServiceDescriptorSource(
             new ScopeWorkflowPublishedServiceDescriptor(
                 ScopeId,
@@ -257,14 +259,19 @@ public sealed class ScopeWorkflowQueryApplicationServiceTests
                 DateTimeOffset.UtcNow));
         var service = CreateService(
             lifecyclePort,
-            new FakeWorkflowActorBindingReader(),
+            new FakeWorkflowActorBindingReader(CreateBinding("actor-default", "Studio Workflow", workflowId)),
             descriptorSource);
 
         var result = await service.LookupByWorkflowIdAsync(ScopeId, workflowId);
 
-        result.Status.Should().Be(ScopeWorkflowLookupStatus.Stale);
-        result.Workflow.Should().BeNull();
-        result.Reason.Should().Be("published_service_descriptor_conflicts_with_conventional_identity");
+        result.Status.Should().Be(ScopeWorkflowLookupStatus.Runnable);
+        result.Workflow.Should().NotBeNull();
+        result.Workflow!.ServiceAppId.Should().Be("studio");
+        result.Workflow.ServiceNamespace.Should().Be(DefaultOptions.ServiceNamespace);
+        result.Workflow.PublishedServiceId.Should().Be("svc-alpha");
+        lifecyclePort.LastGetRequest.Should().NotBeNull();
+        lifecyclePort.LastGetRequest!.AppId.Should().Be("studio");
+        lifecyclePort.LastGetRequest.ServiceId.Should().Be("svc-alpha");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowCatalogueServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowCatalogueServiceTests.cs
@@ -55,6 +55,8 @@ public sealed class AppScopedWorkflowCatalogueServiceTests
         overlap.Committed.Should().NotBeNull();
         overlap.Committed!.ActorId.Should().Be("actor-wf-overlap");
         overlap.Committed.DeploymentId.Should().Be("dep-wf-overlap");
+        overlap.Committed.ServiceAppId.Should().Be("studio");
+        overlap.Committed.ServiceNamespace.Should().Be("default");
         overlap.PublishedServiceId.Should().Be("published-service-overlap");
         response.Freshness.RefreshWatermarkUtc.Should().Be(DateTimeOffset.Parse("2026-08-03T00:00:00Z"));
     }
@@ -216,6 +218,8 @@ public sealed class AppScopedWorkflowCatalogueServiceTests
             ActiveRevisionId = hasPublishedSource ? $"active-{workflowId}" : string.Empty,
             DeploymentId = hasPublishedSource ? $"dep-{workflowId}" : string.Empty,
             DeploymentStatus = hasPublishedSource ? "Active" : string.Empty,
+            ServiceAppId = hasPublishedSource ? "studio" : string.Empty,
+            ServiceNamespace = hasPublishedSource ? "default" : string.Empty,
             PublishedServiceId = hasPublishedSource ? publishedServiceId ?? workflowId : string.Empty,
         };
 

--- a/test/Aevatar.Studio.Tests/CatalogueScopeWorkflowDescriptorSourceTests.cs
+++ b/test/Aevatar.Studio.Tests/CatalogueScopeWorkflowDescriptorSourceTests.cs
@@ -11,32 +11,8 @@ public sealed class CatalogueScopeWorkflowDescriptorSourceTests
     public async Task FindByWorkflowIdAsync_ShouldMapCommittedCatalogueRowToPublishedServiceDescriptor()
     {
         var updatedAt = DateTimeOffset.Parse("2026-08-13T09:20:12Z");
-        var row = new ScopeWorkflowCatalogueRow(
-            "scope-1",
-            "wf-alpha",
-            "Alpha Workflow",
-            "",
-            HasDraftSource: false,
-            HasCommittedSource: true,
-            updatedAt,
-            "service",
-            new ScopeWorkflowCatalogueRowCapabilities(
-                new ScopeWorkflowCatalogueActionCapability(true),
-                new ScopeWorkflowCatalogueActionCapability(true),
-                new ScopeWorkflowCatalogueActionCapability(false),
-                new ScopeWorkflowCatalogueActionCapability(false)),
-            updatedAt,
-            new ScopeWorkflowCatalogueCommittedFacts(
-                "scope-1:studio:default:svc-alpha",
-                "Alpha Workflow",
-                "actor-alpha",
-                "rev-alpha",
-                "dep-alpha",
-                "Active",
-                "studio",
-                "default"),
-            "svc-alpha");
-        var source = new CatalogueScopeWorkflowDescriptorSource(new FixedWorkflowCatalogueQueryPort(row));
+        var row = CommittedRow("wf-alpha", "svc-alpha", "Alpha Workflow", updatedAt);
+        var source = new CatalogueScopeWorkflowDescriptorSource(new PagedWorkflowCatalogueQueryPort([row]));
 
         var result = await source.FindByWorkflowIdAsync("scope-1", "wf-alpha");
 
@@ -49,20 +25,107 @@ public sealed class CatalogueScopeWorkflowDescriptorSourceTests
         result[0].UpdatedAt.Should().Be(updatedAt);
     }
 
-    private sealed class FixedWorkflowCatalogueQueryPort(params ScopeWorkflowCatalogueRow[] rows) : IWorkflowCatalogueQueryPort
+    [Fact]
+    public async Task ListAsync_ShouldPageUntilEnoughCommittedDescriptorsAreFound()
+    {
+        var updatedAt = DateTimeOffset.Parse("2026-08-13T09:20:12Z");
+        var source = new CatalogueScopeWorkflowDescriptorSource(new PagedWorkflowCatalogueQueryPort(
+            [DraftRow("wf-draft-1"), DraftRow("wf-draft-2")],
+            [CommittedRow("wf-alpha", "svc-alpha", "Alpha Workflow", updatedAt),
+                CommittedRow("wf-beta", "svc-beta", "Beta Workflow", updatedAt)]));
+
+        var result = await source.ListAsync("scope-1", 2);
+
+        result.Should().HaveCount(2);
+        result.Select(descriptor => descriptor.WorkflowId).Should().Equal("wf-alpha", "wf-beta");
+    }
+
+    [Fact]
+    public async Task FindByWorkflowIdAsync_ShouldPageUntilExactWorkflowIdIsFound()
+    {
+        var updatedAt = DateTimeOffset.Parse("2026-08-13T09:20:12Z");
+        var source = new CatalogueScopeWorkflowDescriptorSource(new PagedWorkflowCatalogueQueryPort(
+            [CommittedRow("wf-alpha-copy-1", "svc-copy-1", "Copy 1", updatedAt)],
+            [CommittedRow("wf-alpha", "svc-alpha", "Alpha Workflow", updatedAt)]));
+
+        var result = await source.FindByWorkflowIdAsync("scope-1", "wf-alpha");
+
+        result.Should().ContainSingle();
+        result[0].WorkflowId.Should().Be("wf-alpha");
+        result[0].PublishedServiceId.Should().Be("svc-alpha");
+    }
+
+    private static ScopeWorkflowCatalogueRow CommittedRow(
+        string workflowId,
+        string serviceId,
+        string name,
+        DateTimeOffset updatedAt) =>
+        new(
+            "scope-1",
+            workflowId,
+            name,
+            "",
+            HasDraftSource: false,
+            HasCommittedSource: true,
+            updatedAt,
+            "service",
+            Capabilities(),
+            updatedAt,
+            new ScopeWorkflowCatalogueCommittedFacts(
+                $"scope-1:studio:default:{serviceId}",
+                name,
+                $"actor-{workflowId}",
+                $"rev-{workflowId}",
+                $"dep-{workflowId}",
+                "Active",
+                "studio",
+                "default"),
+            serviceId);
+
+    private static ScopeWorkflowCatalogueRow DraftRow(string workflowId) =>
+        new(
+            "scope-1",
+            workflowId,
+            workflowId,
+            "",
+            HasDraftSource: true,
+            HasCommittedSource: false,
+            DateTimeOffset.Parse("2026-08-13T09:20:12Z"),
+            "draft",
+            Capabilities(),
+            DateTimeOffset.Parse("2026-08-13T09:20:12Z"));
+
+    private static ScopeWorkflowCatalogueRowCapabilities Capabilities() =>
+        new(
+            new ScopeWorkflowCatalogueActionCapability(true),
+            new ScopeWorkflowCatalogueActionCapability(true),
+            new ScopeWorkflowCatalogueActionCapability(false),
+            new ScopeWorkflowCatalogueActionCapability(false));
+
+    private sealed class PagedWorkflowCatalogueQueryPort(params ScopeWorkflowCatalogueRow[][] pages) : IWorkflowCatalogueQueryPort
     {
         public Task<ScopeWorkflowCatalogueResponse> QueryAsync(
             ScopeWorkflowCatalogueQuery query,
             CancellationToken ct = default)
         {
-            var items = rows
-                .Where(row => string.Equals(row.ScopeId, query.ScopeId, StringComparison.Ordinal))
-                .ToArray();
+            var pageIndex = string.IsNullOrWhiteSpace(query.Cursor) ? 0 : int.Parse(query.Cursor);
+            var items = pageIndex < pages.Length
+                ? pages[pageIndex]
+                    .Where(row => string.Equals(row.ScopeId, query.ScopeId, StringComparison.Ordinal))
+                    .Where(row => MatchesQuery(row, query.Query))
+                    .ToArray()
+                : [];
+            var nextPageToken = pageIndex + 1 < pages.Length ? (pageIndex + 1).ToString() : null;
             return Task.FromResult(new ScopeWorkflowCatalogueResponse(
                 items,
-                null,
+                nextPageToken,
                 new ScopeWorkflowCatalogueFreshness(null, "test"),
                 new ScopeWorkflowCatalogueSearchContract([], "test", "FormKC", 128, "empty", "workflowId")));
         }
+
+        private static bool MatchesQuery(ScopeWorkflowCatalogueRow row, string? query) =>
+            string.IsNullOrWhiteSpace(query) ||
+            row.WorkflowId.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(row.WorkflowId, query, StringComparison.Ordinal);
     }
 }

--- a/test/Aevatar.Studio.Tests/CatalogueScopeWorkflowDescriptorSourceTests.cs
+++ b/test/Aevatar.Studio.Tests/CatalogueScopeWorkflowDescriptorSourceTests.cs
@@ -1,0 +1,68 @@
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class CatalogueScopeWorkflowDescriptorSourceTests
+{
+    [Fact]
+    public async Task FindByWorkflowIdAsync_ShouldMapCommittedCatalogueRowToPublishedServiceDescriptor()
+    {
+        var updatedAt = DateTimeOffset.Parse("2026-08-13T09:20:12Z");
+        var row = new ScopeWorkflowCatalogueRow(
+            "scope-1",
+            "wf-alpha",
+            "Alpha Workflow",
+            "",
+            HasDraftSource: false,
+            HasCommittedSource: true,
+            updatedAt,
+            "service",
+            new ScopeWorkflowCatalogueRowCapabilities(
+                new ScopeWorkflowCatalogueActionCapability(true),
+                new ScopeWorkflowCatalogueActionCapability(true),
+                new ScopeWorkflowCatalogueActionCapability(false),
+                new ScopeWorkflowCatalogueActionCapability(false)),
+            updatedAt,
+            new ScopeWorkflowCatalogueCommittedFacts(
+                "scope-1:studio:default:svc-alpha",
+                "Alpha Workflow",
+                "actor-alpha",
+                "rev-alpha",
+                "dep-alpha",
+                "Active",
+                "studio",
+                "default"),
+            "svc-alpha");
+        var source = new CatalogueScopeWorkflowDescriptorSource(new FixedWorkflowCatalogueQueryPort(row));
+
+        var result = await source.FindByWorkflowIdAsync("scope-1", "wf-alpha");
+
+        result.Should().ContainSingle();
+        result[0].WorkflowId.Should().Be("wf-alpha");
+        result[0].ServiceAppId.Should().Be("studio");
+        result[0].ServiceNamespace.Should().Be("default");
+        result[0].PublishedServiceId.Should().Be("svc-alpha");
+        result[0].DisplayName.Should().Be("Alpha Workflow");
+        result[0].UpdatedAt.Should().Be(updatedAt);
+    }
+
+    private sealed class FixedWorkflowCatalogueQueryPort(params ScopeWorkflowCatalogueRow[] rows) : IWorkflowCatalogueQueryPort
+    {
+        public Task<ScopeWorkflowCatalogueResponse> QueryAsync(
+            ScopeWorkflowCatalogueQuery query,
+            CancellationToken ct = default)
+        {
+            var items = rows
+                .Where(row => string.Equals(row.ScopeId, query.ScopeId, StringComparison.Ordinal))
+                .ToArray();
+            return Task.FromResult(new ScopeWorkflowCatalogueResponse(
+                items,
+                null,
+                new ScopeWorkflowCatalogueFreshness(null, "test"),
+                new ScopeWorkflowCatalogueSearchContract([], "test", "FormKC", 128, "empty", "workflowId")));
+        }
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioApplicationServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioApplicationServiceCollectionExtensionsTests.cs
@@ -88,6 +88,10 @@ public sealed class StudioApplicationServiceCollectionExtensionsTests
             x.ServiceType == typeof(IScopeWorkflowPublishedServiceDescriptorSource) &&
             x.ImplementationType == typeof(StudioMemberScopeWorkflowDescriptorSource) &&
             x.Lifetime == ServiceLifetime.Singleton);
+        services.Should().ContainSingle(x =>
+            x.ServiceType == typeof(IScopeWorkflowPublishedServiceDescriptorSource) &&
+            x.ImplementationType == typeof(CatalogueScopeWorkflowDescriptorSource) &&
+            x.Lifetime == ServiceLifetime.Singleton);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Use committed workflow catalogue rows as explicit workflow-to-published-service descriptors for detail lookup.
- Preserve service app and namespace through catalogue source snapshots, row documents, and catalogue response committed facts.
- Prefer the explicit published binding service identity over the conventional workflow-native identity when both exist.

## Test plan
- [x] dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter "FullyQualifiedName~CatalogueScopeWorkflowDescriptorSourceTests|FullyQualifiedName~AppScopedWorkflowCatalogueServiceTests|FullyQualifiedName~StudioApplicationServiceCollectionExtensionsTests"
- [x] dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter FullyQualifiedName~ScopeWorkflowQueryApplicationServiceTests
- [x] dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter FullyQualifiedName~ScopeWorkflowEndpointsTests
- [x] Local Mainnet Host save-and-bind flow: catalogue showed one committed binding-service row and detail returned 200 with serviceKey detail-fix-scope-173929:studio:default:svc-detail-fix-173929
- [ ] bash tools/ci/architecture_guards.sh (blocked locally by Python pyexpat/libexpat ImportError after earlier guard checks passed)
- [ ] bash tools/ci/test_stability_guards.sh (blocked locally by the same Python pyexpat/libexpat ImportError after earlier guard checks passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)