### PR TITLE
Align workflow catalogue service identity

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -6351,26 +6351,31 @@ describe('StudioPage', () => {
         updatedAtUtc: '2026-03-18T00:10:00Z',
       },
     ]);
-    mockScopeRuntimeApi.listServices
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
+    const draft2Service = {
+      serviceId: 'default',
+      displayName: 'draft2',
+      deploymentStatus: 'Active',
+      primaryActorId: 'actor-default',
+      endpoints: [
         {
-          serviceId: 'default',
-          displayName: 'draft2',
-          deploymentStatus: 'Active',
-          primaryActorId: 'actor-default',
-          endpoints: [
-            {
-              endpointId: 'chat',
-              displayName: 'Chat',
-              kind: 'chat',
-              description: 'Chat with the published workflow.',
-              requestTypeUrl: '',
-              responseTypeUrl: '',
-            },
-          ],
+          endpointId: 'chat',
+          displayName: 'Chat',
+          kind: 'chat',
+          description: 'Chat with the published workflow.',
+          requestTypeUrl: '',
+          responseTypeUrl: '',
         },
-      ]);
+      ],
+    };
+    let serviceCatalogVisible = false;
+    mockScopeRuntimeApi.listServices.mockImplementation(async () => {
+      if (!serviceCatalogVisible) {
+        serviceCatalogVisible = true;
+        return [];
+      }
+
+      return [draft2Service];
+    });
     (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
     (studioApi.getMemberBindingRun as jest.Mock).mockResolvedValueOnce({
       bindingRunId: 'bind-member-workflow-1',

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.test.ts
@@ -76,6 +76,7 @@ describe('scopesApi workflow catalogue', () => {
             hasCommittedSource: true,
             updatedAtUtc: '2026-08-04T10:00:00Z',
             updatedAtSource: 'committed',
+            publishedServiceId: 'svc-alpha',
             capabilities: {
               open: { available: true, unavailableReason: null },
               activity: { available: true, unavailableReason: null },
@@ -90,6 +91,8 @@ describe('scopesApi workflow catalogue', () => {
               activeRevisionId: 'rev-alpha',
               deploymentId: 'dep-alpha',
               deploymentStatus: 'Active',
+              serviceAppId: 'workflow-app',
+              serviceNamespace: 'workflow-namespace',
             },
           },
           {
@@ -154,6 +157,7 @@ describe('scopesApi workflow catalogue', () => {
     expect(response.nextPageToken).toBe('next token');
     expect(response.items[0]).toMatchObject({
       workflowId: 'wf-alpha',
+      publishedServiceId: 'svc-alpha',
       capabilities: {
         open: { available: true, unavailableReason: null },
         activity: { available: true, unavailableReason: null },
@@ -164,6 +168,8 @@ describe('scopesApi workflow catalogue', () => {
         serviceKey: 'scope-alpha:workflow:default:svc-alpha',
         actorId: 'actor-alpha',
         deploymentId: 'dep-alpha',
+        serviceAppId: 'workflow-app',
+        serviceNamespace: 'workflow-namespace',
       },
     });
     expect(response.items[1]?.committed).toBeNull();

--- a/apps/aevatar-console-web/src/shared/api/scopesApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopesApi.ts
@@ -106,6 +106,16 @@ function decodeScopeWorkflowCatalogueCommittedFacts(
       ['deploymentStatus', 'DeploymentStatus'],
       `${label}.deploymentStatus`,
     ),
+    serviceAppId: readString(
+      record,
+      ['serviceAppId', 'ServiceAppId'],
+      `${label}.serviceAppId`,
+    ),
+    serviceNamespace: readString(
+      record,
+      ['serviceNamespace', 'ServiceNamespace'],
+      `${label}.serviceNamespace`,
+    ),
   };
 }
 
@@ -159,6 +169,11 @@ function decodeScopeWorkflowCatalogueRow(
     committed: decodeScopeWorkflowCatalogueCommittedFacts(
       record.committed ?? record.Committed,
       `${label}.committed`,
+    ),
+    publishedServiceId: readNullableString(
+      record,
+      ['publishedServiceId', 'PublishedServiceId'],
+      `${label}.publishedServiceId`,
     ),
   };
 }

--- a/apps/aevatar-console-web/src/shared/models/scopes.ts
+++ b/apps/aevatar-console-web/src/shared/models/scopes.ts
@@ -19,6 +19,8 @@ export interface ScopeWorkflowCatalogueCommittedFacts {
   activeRevisionId: string;
   deploymentId: string;
   deploymentStatus: string;
+  serviceAppId: string;
+  serviceNamespace: string;
 }
 
 export interface ScopeWorkflowCatalogueRow {
@@ -33,6 +35,7 @@ export interface ScopeWorkflowCatalogueRow {
   capabilities: ScopeWorkflowCatalogueRowCapabilities;
   sourceWatermarkUtc: string;
   committed: ScopeWorkflowCatalogueCommittedFacts | null;
+  publishedServiceId: string | null;
 }
 
 export interface ScopeWorkflowCatalogueResponse {


### PR DESCRIPTION
## Summary
- Preserve the backend workflow catalogue row `publishedServiceId` introduced by the #3452 backend fix.
- Decode `committed.serviceAppId` and `committed.serviceNamespace` so the frontend contract matches the current catalogue response shape.
- Stabilize the Studio legacy `workflow:default` binding regression test by making the service catalog mock remain visible after its initial materialization gap.
- Keep Workflow Activity list rendering unchanged: published/draft status still follows backend `committed.activeRevisionId` and row capabilities.

## Analysis
- Issue #3440 was backend-owned: the frontend was faithfully rendering catalogue rows where committed/service facts were missing while workflow detail could still resolve the published service.
- The backend fix is in #3452 (`Resolve workflow detail through catalogue service identity`) after the catalogue row work in #3438.
- I checked current vNext frontend PRs; #3454 is Activity run detail layout work and does not adapt the catalogue API model/decoder. This PR is the small contract alignment for the frontend API layer.
- The console-web CI failure in `src/pages/studio/index.test.tsx` was test-order brittleness: the test used one-shot `listServices` results even though the Studio bind flow can refetch the service catalog more than once before the post-bind assertion.

## Impact
- `apps/aevatar-console-web/src/shared/models/scopes.ts`
- `apps/aevatar-console-web/src/shared/api/scopesApi.ts`
- `apps/aevatar-console-web/src/shared/api/scopesApi.test.ts`
- `apps/aevatar-console-web/src/pages/studio/index.test.tsx`

## Local verification
- Targeted CI failure: `pnpm exec jest --runTestsByPath src/pages/studio/index.test.tsx --runInBand -t "normalizes legacy workflow:default links"` (passed, 1 test)
- Changed Studio test file: `pnpm exec jest --runTestsByPath src/pages/studio/index.test.tsx --runInBand` (passed, 118 tests)
- Changed API test file: `pnpm exec jest src/shared/api/scopesApi.test.ts --runInBand` (passed, 4 tests)
- Related tests: `pnpm exec jest --findRelatedTests src/shared/api/scopesApi.ts src/shared/models/scopes.ts --runInBand` (passed, 29 suites / 745 tests)
- Changed-file static checks: `pnpm exec biome check src/pages/studio/index.test.tsx src/shared/api/scopesApi.test.ts src/shared/api/scopesApi.ts src/shared/models/scopes.ts` (passed)
- Typecheck: skipped; no reliable affected frontend typecheck target is available locally
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy

References #3440