### PR TITLE
Align workflow title before saving

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
@@ -450,6 +450,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
   }, [adoptReadableWorkflow, document, materialization.retry]);
 
   const save = React.useCallback(async () => {
+    const normalizedWorkflowTitle = workflowTitle.trim();
     const followsCanonicalRouteReplacement =
       pendingRouteWorkflowIdRef.current === workflow?.workflowId;
     if (
@@ -459,7 +460,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       savingRef.current ||
       receiptPending ||
       structuralMutationPendingRef.current ||
-      !workflowTitle.trim()
+      !normalizedWorkflowTitle
     )
       return false;
     savingRef.current = true;
@@ -470,7 +471,10 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       const parsedDocument = await parseCurrentYaml();
       if (!parsedDocument) return false;
       const serialized = await studioApi.serializeYaml({
-        document: parsedDocument,
+        document: {
+          ...parsedDocument,
+          name: normalizedWorkflowTitle,
+        },
       });
       setFindings(serialized.findings);
       if (hasBlockingFindings(serialized.document, serialized.findings))
@@ -489,10 +493,14 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
         directoryId,
         draftExists: workflow.draftExists,
         fileName: workflow.fileName,
-        layout: buildStudioWorkflowLayout(workflowTitle, graph.nodes, layout),
+        layout: buildStudioWorkflowLayout(
+          normalizedWorkflowTitle,
+          graph.nodes,
+          layout,
+        ),
         scopeId,
         workflowId: workflow.workflowId,
-        workflowName: workflowTitle,
+        workflowName: normalizedWorkflowTitle,
         yaml: serialized.yaml,
       });
       const submittedSnapshot: SubmittedSaveSnapshot = {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -19,6 +19,15 @@ import {
 } from '../../../tests/reactQueryTestUtils';
 import WorkflowActivityVNextPage from './index';
 
+type SerializableWorkflowDocument = {
+  readonly name?: string;
+};
+
+type SaveWorkflowRequestProbe = {
+  readonly workflowName: string;
+  readonly yaml: string;
+};
+
 let mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/workflows';
 let mockHistoryMutatesLocation = false;
 const mockLocationSubscribers = new Set<() => void>();
@@ -2140,28 +2149,34 @@ describe('Workflow Activity vNext editor', () => {
 
   it('enables Save workflow only while the loaded workflow has unsaved changes', async () => {
     mockStudioApi.serializeYaml.mockImplementationOnce(
-      async ({ document: nextDocument }) => ({
+      async ({
+        document: nextDocument,
+      }: {
+        document: SerializableWorkflowDocument;
+      }) => ({
         yaml: `name: ${nextDocument.name}\nroles: []\nsteps: []\n`,
         document: nextDocument,
         findings: [],
       }),
     );
-    mockStudioApi.saveWorkflow.mockImplementationOnce(async (input) => ({
-      kind: 'materialized',
-      workflow: {
-        workflowId: 'wf-draft-new',
-        name: input.workflowName,
-        fileName: 'committed-source.yaml',
-        filePath: '/workflows/committed-source.yaml',
-        directoryId: 'directory-alpha',
-        directoryLabel: 'Workflows',
-        yaml: input.yaml,
-        updatedAtUtc: '2026-08-04T10:01:00Z',
-        document: { name: input.workflowName, roles: [], steps: [] },
-        draftExists: true,
-        findings: [],
-      },
-    }));
+    mockStudioApi.saveWorkflow.mockImplementationOnce(
+      async (input: SaveWorkflowRequestProbe) => ({
+        kind: 'materialized',
+        workflow: {
+          workflowId: 'wf-draft-new',
+          name: input.workflowName,
+          fileName: 'committed-source.yaml',
+          filePath: '/workflows/committed-source.yaml',
+          directoryId: 'directory-alpha',
+          directoryLabel: 'Workflows',
+          yaml: input.yaml,
+          updatedAtUtc: '2026-08-04T10:01:00Z',
+          document: { name: input.workflowName, roles: [], steps: [] },
+          draftExists: true,
+          findings: [],
+        },
+      }),
+    );
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     const workflowName = await screen.findByRole('textbox', {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -2139,6 +2139,29 @@ describe('Workflow Activity vNext editor', () => {
   });
 
   it('enables Save workflow only while the loaded workflow has unsaved changes', async () => {
+    mockStudioApi.serializeYaml.mockImplementationOnce(
+      async ({ document: nextDocument }) => ({
+        yaml: `name: ${nextDocument.name}\nroles: []\nsteps: []\n`,
+        document: nextDocument,
+        findings: [],
+      }),
+    );
+    mockStudioApi.saveWorkflow.mockImplementationOnce(async (input) => ({
+      kind: 'materialized',
+      workflow: {
+        workflowId: 'wf-draft-new',
+        name: input.workflowName,
+        fileName: 'committed-source.yaml',
+        filePath: '/workflows/committed-source.yaml',
+        directoryId: 'directory-alpha',
+        directoryLabel: 'Workflows',
+        yaml: input.yaml,
+        updatedAtUtc: '2026-08-04T10:01:00Z',
+        document: { name: input.workflowName, roles: [], steps: [] },
+        draftExists: true,
+        findings: [],
+      },
+    }));
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     const workflowName = await screen.findByRole('textbox', {
@@ -2160,6 +2183,17 @@ describe('Workflow Activity vNext editor', () => {
 
     await waitFor(() =>
       expect(mockStudioApi.saveWorkflow).toHaveBeenCalledTimes(1),
+    );
+    expect(mockStudioApi.serializeYaml).toHaveBeenCalledWith({
+      document: expect.objectContaining({
+        name: 'Committed source updated',
+      }),
+    });
+    expect(mockStudioApi.saveWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowName: 'Committed source updated',
+        yaml: 'name: Committed source updated\nroles: []\nsteps: []\n',
+      }),
     );
     await waitFor(() => expect(saveWorkflowButton).toBeDisabled());
     expect(


### PR DESCRIPTION
## Summary

- Align the workflow document `name` to the inline editor title before serializing and saving.
- Keep `workflowName`, saved YAML, and layout title consistent when the user edits the workflow name in the editor header.
- Extend the editor save regression test so a title-only save must submit YAML with the updated name.
- Fix the PR unit test transform issue by keeping the typed Jest mock probes local to the test file instead of importing model types into inline mock annotations.

## Root cause

The editor already sent the updated title as `workflowName`, but it serialized the parsed YAML document without updating `document.name`. That created save requests where `workflowName` had the new title while `yaml` still contained the old workflow name. On the scoped backend path this was materialized back as the old YAML name.

The PR unit test follow-up was caused by the Jest/Babel transform failing on imported type bindings used in inline mock annotations. The test now uses local structural probe types, so runtime transform does not need to process those imported type symbols.

The backend should still defensively align scoped draft saves; that is tracked in #3449.

## Local verification

- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts --runInBand` - passed (`src/pages/workflow-activity-vnext/index.test.tsx`, 113 tests)
- Changed test file: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand --runTestsByPath` - passed (113 tests)
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts src/pages/workflow-activity-vnext/index.test.tsx` - passed
- Typecheck: skipped locally; no reliable affected frontend typecheck target is available
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
