### PR TITLE
Use explicit workflow names for scoped draft saves

### DIFF
--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -123,7 +123,10 @@ public sealed class AppScopedWorkflowService
         if (!parsed.Succeeded)
             throw new InvalidOperationException(parsed.Error);
 
-        var workflowName = NormalizeRequired(parsed.WorkflowName, nameof(request.WorkflowName));
+        var workflowName = string.IsNullOrWhiteSpace(request.WorkflowName)
+            ? NormalizeRequired(parsed.WorkflowName, nameof(request.WorkflowName))
+            : request.WorkflowName.Trim();
+        normalizedYaml = AlignWorkflowYamlName(normalizedYaml, workflowName);
         var workspaceQueryPort = _workspaceQueryPort
             ?? throw new InvalidOperationException("Scoped workflow workspace query port is not configured.");
         var workspaceCommandPort = _workspaceCommandPort
@@ -322,17 +325,35 @@ public sealed class AppScopedWorkflowService
             draft.UpdatedAtUtc);
     }
 
+    private string AlignWorkflowYamlName(string yaml, string workflowName)
+    {
+        if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
+            return yaml;
+
+        var parsed = _yamlDocumentService.Parse(yaml);
+        if (parsed.Document == null)
+            return yaml;
+
+        if (string.Equals(parsed.Document.Name?.Trim(), workflowName, StringComparison.Ordinal))
+            return yaml;
+
+        return _yamlDocumentService.Serialize(parsed.Document with
+        {
+            Name = workflowName,
+        });
+    }
+
     private static string ResolveDraftWorkflowName(
         StudioWorkflowDraftRecord draft,
         WorkflowParseResult parseResult)
     {
-        var parsedName = parseResult.Document?.Name?.Trim();
-        if (!string.IsNullOrWhiteSpace(parsedName))
-            return parsedName;
-
         var storedName = draft.Name?.Trim();
         if (!string.IsNullOrWhiteSpace(storedName))
             return storedName;
+
+        var parsedName = parseResult.Document?.Name?.Trim();
+        if (!string.IsNullOrWhiteSpace(parsedName))
+            return parsedName;
 
         return draft.WorkflowId;
     }

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -488,7 +488,7 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     }
 
     [Fact]
-    public async Task SaveDraftAsync_ShouldPreserveUnresolvedRuntimeYamlAndStableDraftIdentity()
+    public async Task SaveDraftAsync_ShouldUseExplicitWorkflowNameAndAlignYaml()
     {
         using var environment = new ScopedWorkflowEnvironment();
         var workspacePort = new RecordingStudioWorkspacePorts();
@@ -517,11 +517,16 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         var saved = workspacePort.SavedDrafts.Should().ContainSingle().Subject;
         saved.ScopeId.Should().Be("scope-alpha");
         saved.WorkflowId.Should().Be("wf-alpha");
-        saved.WorkflowName.Should().Be("x_digest");
-        saved.Yaml.Should().Be(yaml.Trim());
+        saved.WorkflowName.Should().Be("X Digest");
+        saved.Yaml.Should().Contain("name: X Digest");
         accepted.WorkflowId.Should().Be("wf-alpha");
         accepted.Accepted.Should().BeTrue();
         accepted.Readiness.Stage.Should().Be("projection_pending");
+
+        var reopened = await service.GetDraftAsync("scope-alpha", "wf-alpha");
+        reopened.Should().NotBeNull();
+        reopened!.Name.Should().Be("X Digest");
+        reopened.Yaml.Should().Contain("name: X Digest");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Make scoped draft saves treat `SaveWorkflowDraftRequest.WorkflowName` as the canonical draft name.
- Align the stored YAML `name` field to that explicit request name before persisting.
- Prefer the stored draft name when scoped read paths resolve titles.

## Test plan
- `dotnet test /Users/liyingpei/Desktop/Code/aevatar/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter "FullyQualifiedName~AppScopedWorkflowServiceDeleteDraftTests|FullyQualifiedName~WorkspaceControllerWorkflowDraftCreateTests"`
- `bash /Users/liyingpei/Desktop/Code/aevatar/tools/ci/test_stability_guards.sh`