### PR TITLE
Align workflow title before saving in vNext

### DIFF
--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts
@@ -450,6 +450,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
   }, [adoptReadableWorkflow, document, materialization.retry]);
 
   const save = React.useCallback(async () => {
+    const normalizedWorkflowTitle = workflowTitle.trim();
     const followsCanonicalRouteReplacement =
       pendingRouteWorkflowIdRef.current === workflow?.workflowId;
     if (
@@ -459,7 +460,7 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       savingRef.current ||
       receiptPending ||
       structuralMutationPendingRef.current ||
-      !workflowTitle.trim()
+      !normalizedWorkflowTitle
     )
       return false;
     savingRef.current = true;
@@ -470,7 +471,10 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
       const parsedDocument = await parseCurrentYaml();
       if (!parsedDocument) return false;
       const serialized = await studioApi.serializeYaml({
-        document: parsedDocument,
+        document: {
+          ...parsedDocument,
+          name: normalizedWorkflowTitle,
+        },
       });
       setFindings(serialized.findings);
       if (hasBlockingFindings(serialized.document, serialized.findings))
@@ -489,10 +493,14 @@ export function useWorkflowEditor(scopeId: string, routeWorkflowId: string) {
         directoryId,
         draftExists: workflow.draftExists,
         fileName: workflow.fileName,
-        layout: buildStudioWorkflowLayout(workflowTitle, graph.nodes, layout),
+        layout: buildStudioWorkflowLayout(
+          normalizedWorkflowTitle,
+          graph.nodes,
+          layout,
+        ),
         scopeId,
         workflowId: workflow.workflowId,
-        workflowName: workflowTitle,
+        workflowName: normalizedWorkflowTitle,
         yaml: serialized.yaml,
       });
       const submittedSnapshot: SubmittedSaveSnapshot = {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -19,6 +19,15 @@ import {
 } from '../../../tests/reactQueryTestUtils';
 import WorkflowActivityVNextPage from './index';
 
+type SerializableWorkflowDocument = {
+  readonly name?: string;
+};
+
+type SaveWorkflowRequestProbe = {
+  readonly workflowName: string;
+  readonly yaml: string;
+};
+
 let mockLocation = '/scopes/scope-alpha/workflow-activity-vnext/workflows';
 let mockHistoryMutatesLocation = false;
 const mockLocationSubscribers = new Set<() => void>();
@@ -2139,6 +2148,35 @@ describe('Workflow Activity vNext editor', () => {
   });
 
   it('enables Save workflow only while the loaded workflow has unsaved changes', async () => {
+    mockStudioApi.serializeYaml.mockImplementationOnce(
+      async ({
+        document: nextDocument,
+      }: {
+        document: SerializableWorkflowDocument;
+      }) => ({
+        yaml: `name: ${nextDocument.name}\nroles: []\nsteps: []\n`,
+        document: nextDocument,
+        findings: [],
+      }),
+    );
+    mockStudioApi.saveWorkflow.mockImplementationOnce(
+      async (input: SaveWorkflowRequestProbe) => ({
+        kind: 'materialized',
+        workflow: {
+          workflowId: 'wf-draft-new',
+          name: input.workflowName,
+          fileName: 'committed-source.yaml',
+          filePath: '/workflows/committed-source.yaml',
+          directoryId: 'directory-alpha',
+          directoryLabel: 'Workflows',
+          yaml: input.yaml,
+          updatedAtUtc: '2026-08-04T10:01:00Z',
+          document: { name: input.workflowName, roles: [], steps: [] },
+          draftExists: true,
+          findings: [],
+        },
+      }),
+    );
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     const workflowName = await screen.findByRole('textbox', {
@@ -2160,6 +2198,17 @@ describe('Workflow Activity vNext editor', () => {
 
     await waitFor(() =>
       expect(mockStudioApi.saveWorkflow).toHaveBeenCalledTimes(1),
+    );
+    expect(mockStudioApi.serializeYaml).toHaveBeenCalledWith({
+      document: expect.objectContaining({
+        name: 'Committed source updated',
+      }),
+    });
+    expect(mockStudioApi.saveWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowName: 'Committed source updated',
+        yaml: 'name: Committed source updated\nroles: []\nsteps: []\n',
+      }),
     );
     await waitFor(() => expect(saveWorkflowButton).toBeDisabled());
     expect(


### PR DESCRIPTION
## Problem

PR #3458 merged into the head branch of PR #3454 after #3454 had already merged into `feat/2026-08-04_workflow-activity-vnext`. As a result, the workflow-title save fix never reached vNext.

## Solution

- normalize the edited workflow title once before saving
- serialize the normalized title into the workflow YAML document
- use the same title for YAML, layout, and `workflowName`
- add regression coverage proving the request title and YAML `name` stay aligned

This PR carries only the two-file behavior from #3458. It does not include unrelated Run Detail changes from the old stacked branch.

Backend defensive handling remains tracked by #3449 and #3455.

## Impact

- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts`
- `apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx`

## Local verification

- TDD regression target: `pnpm --dir apps/aevatar-console-web exec jest --runInBand --runTestsByPath src/pages/workflow-activity-vnext/index.test.tsx --testNamePattern "enables Save workflow only while the loaded workflow has unsaved changes"` (expected RED reproduced, then 1 passed)
- Related tests: `pnpm exec jest --findRelatedTests src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts --runInBand` (113 passed)
- Changed test file: `pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand` (113 passed)
- Changed-file static checks: `pnpm exec biome check src/pages/workflow-activity-vnext/hooks/useWorkflowEditor.ts src/pages/workflow-activity-vnext/index.test.tsx` (passed)
- Test stability guard: `bash tools/ci/test_stability_guards.sh` (passed)
- Diff check: `git diff --check` (passed)
- A reliable repository-native affected typecheck target is unavailable, so local typecheck was skipped
- Full frontend suite, typecheck, and build: deferred to GitHub CI by personal local workflow policy
