### PR TITLE
Use explicit workflow names for scoped draft saves

### DIFF
--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "2bb1ed2fdffc1671a602a4c4166ce755fca06727",
-    "contract_files_sha256": "6a476ec8899fa0908ed279580cf6035939106dbab489cfe5a916dce5f238d693",
+    "revision": "bd7afd93f047de0f7d2cb6fa1c236efe0a370741",
+    "contract_files_sha256": "e0a3ac11bbad143ddad598dc5d1fae8da86c76aa415902106bb3e27a93caebdf",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "4dfe12f2699a1b193d80273d2ae6e4066e1a78b79325cf52c711af47b1b4ec46",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "1daa67dc2cad48249268990e525ada39b65a580d150a9ae8ed896d5392f6a130",
@@ -12,12 +12,12 @@
       "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_recovery_secret.proto": "07dbc449a732df6c7a6d0a97054ddbe35a517f4af4c5670b05ed0bea0bf2011a",
       "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto": "f1dd8f876c72af40c4e2e4158f1801cdf073ac345edc381c5c27bed88b7082f2",
       "docs/adr/0048-nyxid-assistant-operation-class-boundary.md": "30c9de6c6e77a7aee14f0eb4a2f74bd15b8874bcfed88ba957cdd8213b9114eb",
-      "src/Aevatar.AI.Abstractions/ai_messages.proto": "06e24d63b85a38ad8d4e1dd9696577b3869cfc2ba39356b4b3e5d748ca425bd8",
+      "src/Aevatar.AI.Abstractions/ai_messages.proto": "fceddf82a591ac839deb40e40a288b45b3b1be8f9fb964ab0b100894bc381f63",
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs": "5b438c99211a43f4f9233f67f9d00b8c0dbf1d1f36cda64c51b72bfe3792f56d",
-      "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "5dd5e5f062c6a3bc2109be12d2cbf66b8c5b67ace135f9c76d79fbcaa9c87a28",
+      "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1b033df9cb55c741e9b52054cbd4a91067f03c8c3797bd076a7e3d6133eb0fcb",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "2c4f2cda99154f2e667c6cfd291497e697ef11df17f081f96ec70070a8af8b8c",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyRotateTool.cs": "18212bb64644cfbca401065bccce439ea5fa00316deff57d730a0d9ac2650e53",
-      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "bbe2b3f041c1778310f51510dac8273dcafef5a6b8f9e4e834ec54a88ae835bd"
+      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "b2a88d5ff8b657614996f8e35ae547f3de1605378cdd00400d4e1c50ab738611"
     }
   },
   "nyxid": {

--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -22,8 +22,8 @@
   },
   "nyxid": {
     "repository": "https://github.com/ChronoAIProject/NyxID.git",
-    "revision": "17e2b5ff65cb4651eeaf7dad8e728c76250ca75d",
-    "tree": "a48e6d6ace55c636e62a62cb5488a0e0203e59d4",
+    "revision": "47f2e0086c6c2117f644f8559d871a01d2a61982",
+    "tree": "b26638257388b65d55c47a1fa57268436cdda8d5",
     "cli_source": "cli/src/cli.rs",
     "cli_source_sha256": "51dd82101d7671859351e9989e8d554b4aa1cb898a4e04d948df28aa37de0195",
     "cargo_lock_sha256": "a7f1bb375e4d5135b369caea4b803273956c96b63125d4221da70dd8115638b8"

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -325,22 +325,60 @@ public sealed class AppScopedWorkflowService
             draft.UpdatedAtUtc);
     }
 
-    private string AlignWorkflowYamlName(string yaml, string workflowName)
+    private static string AlignWorkflowYamlName(string yaml, string workflowName)
     {
         if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
             return yaml;
 
-        var parsed = _yamlDocumentService.Parse(yaml);
-        if (parsed.Document == null)
-            return yaml;
-
-        if (string.Equals(parsed.Document.Name?.Trim(), workflowName, StringComparison.Ordinal))
-            return yaml;
-
-        return _yamlDocumentService.Serialize(parsed.Document with
+        var alignedNameLine = $"name: {FormatWorkflowNameScalar(workflowName)}";
+        var lines = yaml.Split('\n');
+        for (var index = 0; index < lines.Length; index++)
         {
-            Name = workflowName,
-        });
+            var line = lines[index];
+            var withoutCarriageReturn = line.TrimEnd('\r');
+            if (!IsTopLevelNameLine(withoutCarriageReturn))
+                continue;
+
+            lines[index] = line.EndsWith('\r')
+                ? alignedNameLine + "\r"
+                : alignedNameLine;
+            return string.Join('\n', lines);
+        }
+
+        return alignedNameLine + "\n" + yaml;
+    }
+
+    private static bool IsTopLevelNameLine(string line)
+    {
+        if (!line.StartsWith("name", StringComparison.Ordinal))
+            return false;
+
+        for (var index = "name".Length; index < line.Length; index++)
+        {
+            var character = line[index];
+            if (character == ':')
+                return true;
+
+            if (character != ' ' && character != '\t')
+                return false;
+        }
+
+        return false;
+    }
+
+    private static string FormatWorkflowNameScalar(string workflowName)
+    {
+        if (workflowName.All(static character =>
+                char.IsLetterOrDigit(character) ||
+                character == ' ' ||
+                character == '_' ||
+                character == '-' ||
+                character == '.'))
+        {
+            return workflowName;
+        }
+
+        return "'" + workflowName.Replace("'", "''", StringComparison.Ordinal) + "'";
     }
 
     private static string ResolveDraftWorkflowName(

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -123,7 +123,10 @@ public sealed class AppScopedWorkflowService
         if (!parsed.Succeeded)
             throw new InvalidOperationException(parsed.Error);
 
-        var workflowName = NormalizeRequired(parsed.WorkflowName, nameof(request.WorkflowName));
+        var workflowName = string.IsNullOrWhiteSpace(request.WorkflowName)
+            ? NormalizeRequired(parsed.WorkflowName, nameof(request.WorkflowName))
+            : request.WorkflowName.Trim();
+        normalizedYaml = AlignWorkflowYamlName(normalizedYaml, workflowName);
         var workspaceQueryPort = _workspaceQueryPort
             ?? throw new InvalidOperationException("Scoped workflow workspace query port is not configured.");
         var workspaceCommandPort = _workspaceCommandPort
@@ -322,17 +325,35 @@ public sealed class AppScopedWorkflowService
             draft.UpdatedAtUtc);
     }
 
+    private string AlignWorkflowYamlName(string yaml, string workflowName)
+    {
+        if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
+            return yaml;
+
+        var parsed = _yamlDocumentService.Parse(yaml);
+        if (parsed.Document == null)
+            return yaml;
+
+        if (string.Equals(parsed.Document.Name?.Trim(), workflowName, StringComparison.Ordinal))
+            return yaml;
+
+        return _yamlDocumentService.Serialize(parsed.Document with
+        {
+            Name = workflowName,
+        });
+    }
+
     private static string ResolveDraftWorkflowName(
         StudioWorkflowDraftRecord draft,
         WorkflowParseResult parseResult)
     {
-        var parsedName = parseResult.Document?.Name?.Trim();
-        if (!string.IsNullOrWhiteSpace(parsedName))
-            return parsedName;
-
         var storedName = draft.Name?.Trim();
         if (!string.IsNullOrWhiteSpace(storedName))
             return storedName;
+
+        var parsedName = parseResult.Document?.Name?.Trim();
+        if (!string.IsNullOrWhiteSpace(parsedName))
+            return parsedName;
 
         return draft.WorkflowId;
     }

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -488,7 +488,7 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     }
 
     [Fact]
-    public async Task SaveDraftAsync_ShouldPreserveUnresolvedRuntimeYamlAndStableDraftIdentity()
+    public async Task SaveDraftAsync_ShouldUseExplicitWorkflowNameAndAlignYaml()
     {
         using var environment = new ScopedWorkflowEnvironment();
         var workspacePort = new RecordingStudioWorkspacePorts();
@@ -517,11 +517,16 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         var saved = workspacePort.SavedDrafts.Should().ContainSingle().Subject;
         saved.ScopeId.Should().Be("scope-alpha");
         saved.WorkflowId.Should().Be("wf-alpha");
-        saved.WorkflowName.Should().Be("x_digest");
-        saved.Yaml.Should().Be(yaml.Trim());
+        saved.WorkflowName.Should().Be("X Digest");
+        saved.Yaml.Should().Contain("name: X Digest");
         accepted.WorkflowId.Should().Be("wf-alpha");
         accepted.Accepted.Should().BeTrue();
         accepted.Readiness.Stage.Should().Be("projection_pending");
+
+        var reopened = await service.GetDraftAsync("scope-alpha", "wf-alpha");
+        reopened.Should().NotBeNull();
+        reopened!.Name.Should().Be("X Digest");
+        reopened.Yaml.Should().Contain("name: X Digest");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -497,6 +497,9 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             workspaceCommandPort: workspacePort);
         var yaml = """
             name: x_digest
+            when_to_use: Use when generating weekly reports.
+            on_failure:
+              mode: fail
             steps:
               - id: fetch
                 type: tool_call
@@ -519,6 +522,8 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         saved.WorkflowId.Should().Be("wf-alpha");
         saved.WorkflowName.Should().Be("X Digest");
         saved.Yaml.Should().Contain("name: X Digest");
+        saved.Yaml.Should().Contain("when_to_use: Use when generating weekly reports.");
+        saved.Yaml.Should().Contain("on_failure:");
         accepted.WorkflowId.Should().Be("wf-alpha");
         accepted.Accepted.Should().BeTrue();
         accepted.Readiness.Stage.Should().Be("projection_pending");


### PR DESCRIPTION
## Summary
- Make scoped draft saves treat `SaveWorkflowDraftRequest.WorkflowName` as the canonical draft name.
- Align the stored YAML `name` field to that explicit request name before persisting.
- Prefer the stored draft name when scoped read paths resolve titles.

Closes #3449

## Test plan
- `dotnet test /Users/liyingpei/Desktop/Code/aevatar/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter "FullyQualifiedName~AppScopedWorkflowServiceDeleteDraftTests|FullyQualifiedName~WorkspaceControllerWorkflowDraftCreateTests"`
- `bash /Users/liyingpei/Desktop/Code/aevatar/tools/ci/test_stability_guards.sh`