### PR TITLE
Preserve deactivated workflow sources in catalogue backfill

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueBackfillHostedService.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueBackfillHostedService.cs
@@ -106,7 +106,7 @@ internal sealed class ScopeWorkflowCatalogueBackfillHostedService : IHostedServi
             }
 
             if (!deploymentCatalogsByServiceKey.TryGetValue(serviceCatalog.Id, out var deploymentCatalog) ||
-                ResolveDeployment(deploymentCatalog) is not { } deployment ||
+                ResolveDeployment(serviceCatalog, deploymentCatalog) is not { } deployment ||
                 !revisionCatalogsByServiceKey.TryGetValue(serviceCatalog.Id, out var revisionCatalog) ||
                 !TryResolveWorkflowRevision(
                     revisionCatalog,
@@ -325,11 +325,48 @@ internal sealed class ScopeWorkflowCatalogueBackfillHostedService : IHostedServi
         }
     }
 
-    private static ServiceDeploymentReadModel? ResolveDeployment(ServiceDeploymentCatalogReadModel deploymentCatalog) =>
-        deploymentCatalog.Deployments
+    private static ServiceDeploymentReadModel? ResolveDeployment(
+        ServiceCatalogReadModel serviceCatalog,
+        ServiceDeploymentCatalogReadModel deploymentCatalog) =>
+        ResolveDefaultDeployment(deploymentCatalog.Deployments, serviceCatalog.DefaultServingRevisionId)
+        ?? ResolveActiveDeployment(deploymentCatalog.Deployments)
+        ?? ResolveFallbackDeployment(deploymentCatalog.Deployments);
+
+    private static ServiceDeploymentReadModel? ResolveDefaultDeployment(
+        IEnumerable<ServiceDeploymentReadModel> deployments,
+        string? defaultServingRevisionId)
+    {
+        if (string.IsNullOrWhiteSpace(defaultServingRevisionId))
+            return null;
+
+        return deployments
+            .Where(deployment => string.Equals(deployment.RevisionId, defaultServingRevisionId, StringComparison.Ordinal))
+            .OrderByDescending(static deployment => IsActiveDeployment(deployment))
+            .ThenByDescending(static deployment => ResolveDeploymentActivationTime(deployment))
+            .ThenByDescending(static deployment => deployment.UpdatedAt)
+            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
+            .FirstOrDefault();
+    }
+
+    private static ServiceDeploymentReadModel? ResolveActiveDeployment(IEnumerable<ServiceDeploymentReadModel> deployments) =>
+        deployments
+            .Where(static deployment => IsActiveDeployment(deployment))
+            .OrderByDescending(static deployment => ResolveDeploymentActivationTime(deployment))
+            .ThenByDescending(static deployment => deployment.UpdatedAt)
+            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+    private static ServiceDeploymentReadModel? ResolveFallbackDeployment(IEnumerable<ServiceDeploymentReadModel> deployments) =>
+        deployments
             .OrderByDescending(static deployment => deployment.UpdatedAt)
             .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
             .FirstOrDefault();
+
+    private static bool IsActiveDeployment(ServiceDeploymentReadModel deployment) =>
+        string.Equals(deployment.Status, ServiceDeploymentStatus.Active.ToString(), StringComparison.Ordinal);
+
+    private static DateTimeOffset ResolveDeploymentActivationTime(ServiceDeploymentReadModel deployment) =>
+        deployment.ActivatedAt ?? deployment.UpdatedAt;
 
     private static bool TryResolveWorkflowRevision(
         ServiceRevisionCatalogReadModel revisionCatalog,

--- a/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueBackfillHostedService.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueBackfillHostedService.cs
@@ -106,11 +106,11 @@ internal sealed class ScopeWorkflowCatalogueBackfillHostedService : IHostedServi
             }
 
             if (!deploymentCatalogsByServiceKey.TryGetValue(serviceCatalog.Id, out var deploymentCatalog) ||
-                ResolveActiveDeployment(deploymentCatalog) is not { } activeDeployment ||
+                ResolveDeployment(deploymentCatalog) is not { } deployment ||
                 !revisionCatalogsByServiceKey.TryGetValue(serviceCatalog.Id, out var revisionCatalog) ||
                 !TryResolveWorkflowRevision(
                     revisionCatalog,
-                    activeDeployment.RevisionId,
+                    deployment.RevisionId,
                     serviceCatalog.ServiceId,
                     out var revision,
                     out var workflowId))
@@ -118,7 +118,7 @@ internal sealed class ScopeWorkflowCatalogueBackfillHostedService : IHostedServi
                 continue;
             }
 
-            var serviceSource = ToServiceSource(serviceCatalog, deploymentCatalog, revision, activeDeployment, workflowId);
+            var serviceSource = ToServiceSource(serviceCatalog, deploymentCatalog, revision, deployment, workflowId);
             currentServiceSourceIds.Add(serviceSource.Id);
             await _catalogueWriteDispatcher.UpsertAsync(serviceSource, cancellationToken);
             await RefreshRowAsync(
@@ -325,9 +325,8 @@ internal sealed class ScopeWorkflowCatalogueBackfillHostedService : IHostedServi
         }
     }
 
-    private static ServiceDeploymentReadModel? ResolveActiveDeployment(ServiceDeploymentCatalogReadModel deploymentCatalog) =>
+    private static ServiceDeploymentReadModel? ResolveDeployment(ServiceDeploymentCatalogReadModel deploymentCatalog) =>
         deploymentCatalog.Deployments
-            .Where(static deployment => string.Equals(deployment.Status, ServiceDeploymentStatus.Active.ToString(), StringComparison.Ordinal))
             .OrderByDescending(static deployment => deployment.UpdatedAt)
             .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
             .FirstOrDefault();

--- a/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueServiceSourceProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueServiceSourceProjector.cs
@@ -63,8 +63,8 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
         }
 
         var revisionCatalog = await _revisionCatalogReader.GetAsync(serviceKey, ct);
-        var activeDeployment = ResolveActiveDeployment(state.Deployments.Values);
-        await MaterializeAsync(state.Identity, serviceKey, revisionCatalog, activeDeployment, eventId, observedAt, ct);
+        var deployment = ResolveDeployment(state.Deployments.Values);
+        await MaterializeAsync(state.Identity, serviceKey, revisionCatalog, deployment, eventId, observedAt, ct);
     }
 
     public async ValueTask ProjectRevisionCatalogAsync(
@@ -92,7 +92,7 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
             return;
 
         var deploymentCatalog = await _deploymentCatalogReader.GetAsync(serviceKey, ct);
-        var activeDeployment = ResolveActiveDeployment(deploymentCatalog?.Deployments);
+        var deployment = ResolveDeployment(deploymentCatalog?.Deployments);
         var observedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
         var revisionCatalog = ToRevisionCatalogReadModel(
             context,
@@ -105,7 +105,7 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
             state.Identity,
             serviceKey,
             revisionCatalog,
-            activeDeployment,
+            deployment,
             stateEvent.EventId ?? string.Empty,
             observedAt,
             ct);
@@ -171,16 +171,14 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
         return true;
     }
 
-    private static ServiceDeploymentRecord? ResolveActiveDeployment(IEnumerable<ServiceDeploymentRecord>? deployments) =>
+    private static ServiceDeploymentRecord? ResolveDeployment(IEnumerable<ServiceDeploymentRecord>? deployments) =>
         deployments?
-            .Where(static deployment => deployment.Status == ServiceDeploymentStatus.Active)
             .OrderByDescending(static deployment => deployment.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch)
             .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
             .FirstOrDefault();
 
-    private static ServiceDeploymentRecord? ResolveActiveDeployment(IEnumerable<ServiceDeploymentReadModel>? deployments) =>
+    private static ServiceDeploymentRecord? ResolveDeployment(IEnumerable<ServiceDeploymentReadModel>? deployments) =>
         deployments?
-            .Where(static deployment => string.Equals(deployment.Status, ServiceDeploymentStatus.Active.ToString(), StringComparison.Ordinal))
             .OrderByDescending(static deployment => deployment.UpdatedAt)
             .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
             .Select(static deployment => new ServiceDeploymentRecord
@@ -188,7 +186,9 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
                 DeploymentId = deployment.DeploymentId,
                 RevisionId = deployment.RevisionId,
                 PrimaryActorId = deployment.PrimaryActorId,
-                Status = ServiceDeploymentStatus.Active,
+                Status = global::System.Enum.TryParse<ServiceDeploymentStatus>(deployment.Status, ignoreCase: true, out var status)
+                    ? status
+                    : ServiceDeploymentStatus.Unspecified,
                 UpdatedAt = Timestamp.FromDateTimeOffset(deployment.UpdatedAt),
             })
             .FirstOrDefault();

--- a/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueServiceSourceProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Backfill/ScopeWorkflowCatalogueServiceSourceProjector.cs
@@ -16,6 +16,7 @@ namespace Aevatar.GAgentService.Hosting.Backfill;
 internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
     : IProjectionArtifactMaterializer<ServiceDeploymentCatalogProjectionContext>
 {
+    private readonly IProjectionDocumentReader<ServiceCatalogReadModel, string> _serviceCatalogReader;
     private readonly IProjectionDocumentReader<ServiceRevisionCatalogReadModel, string> _revisionCatalogReader;
     private readonly IProjectionDocumentReader<ServiceDeploymentCatalogReadModel, string> _deploymentCatalogReader;
     private readonly IProjectionWriteDispatcher<ScopeWorkflowCatalogueSourceDocument> _catalogueWriteDispatcher;
@@ -23,12 +24,14 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
     private readonly IProjectionClock _clock;
 
     public ScopeWorkflowCatalogueServiceSourceProjector(
+        IProjectionDocumentReader<ServiceCatalogReadModel, string> serviceCatalogReader,
         IProjectionDocumentReader<ServiceRevisionCatalogReadModel, string> revisionCatalogReader,
         IProjectionDocumentReader<ServiceDeploymentCatalogReadModel, string> deploymentCatalogReader,
         IProjectionWriteDispatcher<ScopeWorkflowCatalogueSourceDocument> catalogueWriteDispatcher,
         ScopeWorkflowCatalogueRowMaterializer catalogueRowMaterializer,
         IProjectionClock clock)
     {
+        _serviceCatalogReader = serviceCatalogReader ?? throw new ArgumentNullException(nameof(serviceCatalogReader));
         _revisionCatalogReader = revisionCatalogReader ?? throw new ArgumentNullException(nameof(revisionCatalogReader));
         _deploymentCatalogReader = deploymentCatalogReader ?? throw new ArgumentNullException(nameof(deploymentCatalogReader));
         _catalogueWriteDispatcher = catalogueWriteDispatcher ?? throw new ArgumentNullException(nameof(catalogueWriteDispatcher));
@@ -63,7 +66,8 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
         }
 
         var revisionCatalog = await _revisionCatalogReader.GetAsync(serviceKey, ct);
-        var deployment = ResolveDeployment(state.Deployments.Values);
+        var serviceCatalog = await _serviceCatalogReader.GetAsync(serviceKey, ct);
+        var deployment = ResolveDeployment(state.Deployments.Values, serviceCatalog?.DefaultServingRevisionId);
         await MaterializeAsync(state.Identity, serviceKey, revisionCatalog, deployment, eventId, observedAt, ct);
     }
 
@@ -91,8 +95,9 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
         if (string.IsNullOrWhiteSpace(serviceKey))
             return;
 
+        var serviceCatalog = await _serviceCatalogReader.GetAsync(serviceKey, ct);
         var deploymentCatalog = await _deploymentCatalogReader.GetAsync(serviceKey, ct);
-        var deployment = ResolveDeployment(deploymentCatalog?.Deployments);
+        var deployment = ResolveDeployment(deploymentCatalog?.Deployments, serviceCatalog?.DefaultServingRevisionId);
         var observedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
         var revisionCatalog = ToRevisionCatalogReadModel(
             context,
@@ -171,17 +176,24 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
         return true;
     }
 
-    private static ServiceDeploymentRecord? ResolveDeployment(IEnumerable<ServiceDeploymentRecord>? deployments) =>
-        deployments?
-            .OrderByDescending(static deployment => deployment.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch)
-            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
-            .FirstOrDefault();
+    private static ServiceDeploymentRecord? ResolveDeployment(
+        IEnumerable<ServiceDeploymentRecord>? deployments,
+        string? defaultServingRevisionId)
+    {
+        var deploymentList = deployments?.ToArray();
+        if (deploymentList == null || deploymentList.Length == 0)
+            return null;
 
-    private static ServiceDeploymentRecord? ResolveDeployment(IEnumerable<ServiceDeploymentReadModel>? deployments) =>
-        deployments?
-            .OrderByDescending(static deployment => deployment.UpdatedAt)
-            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
-            .Select(static deployment => new ServiceDeploymentRecord
+        return ResolveDefaultDeployment(deploymentList, defaultServingRevisionId)
+               ?? ResolveActiveDeployment(deploymentList)
+               ?? ResolveFallbackDeployment(deploymentList);
+    }
+
+    private static ServiceDeploymentRecord? ResolveDeployment(
+        IEnumerable<ServiceDeploymentReadModel>? deployments,
+        string? defaultServingRevisionId) =>
+        ResolveDeployment(
+            deployments?.Select(static deployment => new ServiceDeploymentRecord
             {
                 DeploymentId = deployment.DeploymentId,
                 RevisionId = deployment.RevisionId,
@@ -189,9 +201,47 @@ internal sealed class ScopeWorkflowCatalogueServiceSourceProjector
                 Status = global::System.Enum.TryParse<ServiceDeploymentStatus>(deployment.Status, ignoreCase: true, out var status)
                     ? status
                     : ServiceDeploymentStatus.Unspecified,
+                ActivatedAt = deployment.ActivatedAt == null
+                    ? null
+                    : Timestamp.FromDateTimeOffset(deployment.ActivatedAt.Value),
                 UpdatedAt = Timestamp.FromDateTimeOffset(deployment.UpdatedAt),
-            })
+            }),
+            defaultServingRevisionId);
+
+    private static ServiceDeploymentRecord? ResolveDefaultDeployment(
+        IEnumerable<ServiceDeploymentRecord> deployments,
+        string? defaultServingRevisionId)
+    {
+        if (string.IsNullOrWhiteSpace(defaultServingRevisionId))
+            return null;
+
+        return deployments
+            .Where(deployment => string.Equals(deployment.RevisionId, defaultServingRevisionId, StringComparison.Ordinal))
+            .OrderByDescending(static deployment => deployment.Status == ServiceDeploymentStatus.Active)
+            .ThenByDescending(static deployment => ResolveDeploymentActivationTime(deployment))
+            .ThenByDescending(static deployment => deployment.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch)
+            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
             .FirstOrDefault();
+    }
+
+    private static ServiceDeploymentRecord? ResolveActiveDeployment(IEnumerable<ServiceDeploymentRecord> deployments) =>
+        deployments
+            .Where(static deployment => deployment.Status == ServiceDeploymentStatus.Active)
+            .OrderByDescending(static deployment => ResolveDeploymentActivationTime(deployment))
+            .ThenByDescending(static deployment => deployment.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch)
+            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+    private static ServiceDeploymentRecord? ResolveFallbackDeployment(IEnumerable<ServiceDeploymentRecord> deployments) =>
+        deployments
+            .OrderByDescending(static deployment => deployment.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UnixEpoch)
+            .ThenBy(static deployment => deployment.DeploymentId, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+    private static DateTimeOffset ResolveDeploymentActivationTime(ServiceDeploymentRecord deployment) =>
+        deployment.ActivatedAt?.ToDateTimeOffset()
+        ?? deployment.UpdatedAt?.ToDateTimeOffset()
+        ?? DateTimeOffset.UnixEpoch;
 
     private static ServiceRevisionCatalogReadModel ToRevisionCatalogReadModel(
         ServiceRevisionCatalogProjectionContext context,

--- a/test/Aevatar.Studio.Tests/ScopeWorkflowCatalogueBackfillHostedServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ScopeWorkflowCatalogueBackfillHostedServiceTests.cs
@@ -291,6 +291,65 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_ShouldBackfillDeactivatedServiceSourcesFromWorkflowNativeCurrentStateReadModels()
+    {
+        var serviceCatalog = new ServiceCatalogReadModel
+        {
+            Id = "svc-key",
+            ActorId = "service-definition:scope-1:published-service-1",
+            StateVersion = 4,
+            LastEventId = "evt-service-catalog",
+            TenantId = "scope-1",
+            AppId = "workflow-app",
+            Namespace = "user",
+            ServiceId = "published-service-1",
+            DisplayName = "Published Service",
+            UpdatedAt = DateTimeOffset.Parse("2026-08-06T00:00:00Z"),
+        };
+        var deploymentCatalog = new ServiceDeploymentCatalogReadModel
+        {
+            Id = "svc-key",
+            ActorId = "service-deployment:scope-1:published-service-1",
+            StateVersion = 9,
+            LastEventId = "evt-deployment",
+            UpdatedAt = DateTimeOffset.Parse("2026-08-07T00:00:00Z"),
+            Deployments =
+            [
+                new ServiceDeploymentReadModel
+                {
+                    DeploymentId = "dep-1",
+                    RevisionId = "rev-live",
+                    PrimaryActorId = "workflow-actor-live",
+                    Status = ServiceDeploymentStatus.Deactivated.ToString(),
+                    UpdatedAt = DateTimeOffset.Parse("2026-08-07T01:00:00Z"),
+                },
+            ],
+        };
+        var revisionCatalog = WorkflowRevisionCatalog("svc-key", "rev-live", "wf-archived", "Archived Workflow");
+        var sourceWriter = new RecordingCatalogueSourceDispatcher();
+        var rowWriter = new RecordingCatalogueRowDispatcher();
+        var sourceReader = new RecordingCatalogueSourceReader([], sourceWriter);
+        var service = CreateService(
+            [serviceCatalog],
+            [deploymentCatalog],
+            [revisionCatalog],
+            [],
+            [],
+            sourceWriter,
+            rowWriter,
+            sourceReader);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var serviceSource = sourceWriter.Upserts.Should().ContainSingle().Subject;
+        serviceSource.WorkflowId.Should().Be("wf-archived");
+        serviceSource.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Deactivated.ToString());
+        rowWriter.Commands.Should().ContainSingle(command => command.WorkflowId == "wf-archived" &&
+                                                              command.ServiceSource != null &&
+                                                              command.ServiceSource.DeploymentStatus == ServiceDeploymentStatus.Deactivated.ToString());
+    }
+
+    [Fact]
     public async Task StartAsync_ShouldSkipMalformedWorkflowServiceRevisionWithoutFailingBackfill()
     {
         var sourceWriter = new RecordingCatalogueSourceDispatcher();
@@ -856,7 +915,8 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
     private static ScopeWorkflowCatalogueSourceDocument ExistingServiceSource(
         string scopeId,
         string workflowId,
-        string publishedServiceId) =>
+        string publishedServiceId,
+        string? deploymentStatus = null) =>
         new()
         {
             Id = $"{scopeId}:{workflowId}:service",
@@ -874,7 +934,7 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
             CommittedActorId = "workflow-actor-live",
             ActiveRevisionId = "rev-live",
             DeploymentId = "dep-1",
-            DeploymentStatus = ServiceDeploymentStatus.Active.ToString(),
+            DeploymentStatus = deploymentStatus ?? ServiceDeploymentStatus.Active.ToString(),
             PublishedServiceId = publishedServiceId,
         };
 

--- a/test/Aevatar.Studio.Tests/ScopeWorkflowCatalogueBackfillHostedServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ScopeWorkflowCatalogueBackfillHostedServiceTests.cs
@@ -291,6 +291,75 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_ShouldUseDefaultServingRevision_WhenOlderDeploymentWasDeactivatedLater()
+    {
+        var serviceCatalog = new ServiceCatalogReadModel
+        {
+            Id = "svc-key",
+            ActorId = "service-definition:scope-1:published-service-1",
+            StateVersion = 4,
+            LastEventId = "evt-service-catalog",
+            TenantId = "scope-1",
+            AppId = "workflow-app",
+            Namespace = "user",
+            ServiceId = "published-service-1",
+            DisplayName = "Published Service",
+            DefaultServingRevisionId = "rev-active",
+            UpdatedAt = DateTimeOffset.Parse("2026-08-06T00:00:00Z"),
+        };
+        var deploymentCatalog = new ServiceDeploymentCatalogReadModel
+        {
+            Id = "svc-key",
+            ActorId = "service-deployment:scope-1:published-service-1",
+            StateVersion = 9,
+            LastEventId = "evt-deployment",
+            UpdatedAt = DateTimeOffset.Parse("2026-08-07T00:00:00Z"),
+            Deployments =
+            [
+                new ServiceDeploymentReadModel
+                {
+                    DeploymentId = "dep-old",
+                    RevisionId = "rev-old",
+                    PrimaryActorId = "workflow-actor-old",
+                    Status = ServiceDeploymentStatus.Deactivated.ToString(),
+                    ActivatedAt = DateTimeOffset.Parse("2026-08-05T00:00:00Z"),
+                    UpdatedAt = DateTimeOffset.Parse("2026-08-07T01:00:00Z"),
+                },
+                new ServiceDeploymentReadModel
+                {
+                    DeploymentId = "dep-active",
+                    RevisionId = "rev-active",
+                    PrimaryActorId = "workflow-actor-active",
+                    Status = ServiceDeploymentStatus.Active.ToString(),
+                    ActivatedAt = DateTimeOffset.Parse("2026-08-06T00:00:00Z"),
+                    UpdatedAt = DateTimeOffset.Parse("2026-08-06T01:00:00Z"),
+                },
+            ],
+        };
+        var revisionCatalog = WorkflowRevisionCatalog("svc-key", "rev-active", "wf-active", "Active Workflow");
+        var sourceWriter = new RecordingCatalogueSourceDispatcher();
+        var rowWriter = new RecordingCatalogueRowDispatcher();
+        var sourceReader = new RecordingCatalogueSourceReader([], sourceWriter);
+        var service = CreateService(
+            [serviceCatalog],
+            [deploymentCatalog],
+            [revisionCatalog],
+            [],
+            [],
+            sourceWriter,
+            rowWriter,
+            sourceReader);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var serviceSource = sourceWriter.Upserts.Should().ContainSingle().Subject;
+        serviceSource.WorkflowId.Should().Be("wf-active");
+        serviceSource.ActiveRevisionId.Should().Be("rev-active");
+        serviceSource.DeploymentId.Should().Be("dep-active");
+        serviceSource.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
+    }
+
+    [Fact]
     public async Task StartAsync_ShouldBackfillDeactivatedServiceSourcesFromWorkflowNativeCurrentStateReadModels()
     {
         var serviceCatalog = new ServiceCatalogReadModel
@@ -467,6 +536,7 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
         var rowWriter = new RecordingCatalogueRowDispatcher();
         var sourceReader = new RecordingCatalogueSourceReader([], sourceWriter);
         var serviceProjector = new ScopeWorkflowCatalogueServiceSourceProjector(
+            new KeyedProjectionDocumentReader<ServiceCatalogReadModel>([]),
             new KeyedProjectionDocumentReader<ServiceRevisionCatalogReadModel>([]),
             new KeyedProjectionDocumentReader<ServiceDeploymentCatalogReadModel>([deploymentCatalog]),
             sourceWriter,
@@ -533,6 +603,7 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
         var rowWriter = new RecordingCatalogueRowDispatcher();
         var sourceReader = new RecordingCatalogueSourceReader([], sourceWriter);
         var projector = new ScopeWorkflowCatalogueServiceSourceProjector(
+            new KeyedProjectionDocumentReader<ServiceCatalogReadModel>([]),
             new KeyedProjectionDocumentReader<ServiceRevisionCatalogReadModel>([revisionCatalog]),
             new KeyedProjectionDocumentReader<ServiceDeploymentCatalogReadModel>([]),
             sourceWriter,
@@ -564,6 +635,88 @@ public sealed class ScopeWorkflowCatalogueBackfillHostedServiceTests
         command.WorkflowId.Should().Be("published-service-1");
         command.ServiceSource.Should().NotBeNull();
         command.ServiceSource!.PublishedServiceId.Should().Be("published-service-1");
+    }
+
+    [Fact]
+    public async Task ServiceSourceProjector_ShouldUseDefaultServingRevision_WhenOlderDeploymentWasDeactivatedLater()
+    {
+        var identity = ServiceIdentity("scope-1", "workflow-app", "user", "published-service-1");
+        var serviceKey = ServiceKeys.Build(identity);
+        var serviceCatalog = new ServiceCatalogReadModel
+        {
+            Id = serviceKey,
+            ActorId = "service-definition:scope-1:published-service-1",
+            StateVersion = 4,
+            LastEventId = "evt-service-catalog",
+            TenantId = identity.TenantId,
+            AppId = identity.AppId,
+            Namespace = identity.Namespace,
+            ServiceId = identity.ServiceId,
+            DisplayName = "Published Service",
+            DefaultServingRevisionId = "rev-active",
+            UpdatedAt = DateTimeOffset.Parse("2026-08-06T00:00:00Z"),
+        };
+        var revisionCatalog = WorkflowRevisionCatalog(serviceKey, "rev-active", "wf-active", "Active Workflow");
+        var deploymentState = new ServiceDeploymentState
+        {
+            Identity = identity.Clone(),
+        };
+        deploymentState.Deployments["dep-old"] = new ServiceDeploymentRecord
+        {
+            DeploymentId = "dep-old",
+            RevisionId = "rev-old",
+            PrimaryActorId = "workflow-actor-old",
+            Status = ServiceDeploymentStatus.Deactivated,
+            ActivatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-08-05T00:00:00Z")),
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-08-07T01:00:00Z")),
+        };
+        deploymentState.Deployments["dep-active"] = new ServiceDeploymentRecord
+        {
+            DeploymentId = "dep-active",
+            RevisionId = "rev-active",
+            PrimaryActorId = "workflow-actor-active",
+            Status = ServiceDeploymentStatus.Active,
+            ActivatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-08-06T00:00:00Z")),
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-08-06T01:00:00Z")),
+        };
+        var sourceWriter = new RecordingCatalogueSourceDispatcher();
+        var rowWriter = new RecordingCatalogueRowDispatcher();
+        var sourceReader = new RecordingCatalogueSourceReader([], sourceWriter);
+        var projector = new ScopeWorkflowCatalogueServiceSourceProjector(
+            new KeyedProjectionDocumentReader<ServiceCatalogReadModel>([serviceCatalog]),
+            new KeyedProjectionDocumentReader<ServiceRevisionCatalogReadModel>([revisionCatalog]),
+            new KeyedProjectionDocumentReader<ServiceDeploymentCatalogReadModel>([]),
+            sourceWriter,
+            new ScopeWorkflowCatalogueRowMaterializer(sourceReader, rowWriter),
+            new FixedProjectionClock(DateTimeOffset.Parse("2026-08-07T02:00:00Z")));
+
+        await projector.ProjectAsync(
+            new ServiceDeploymentCatalogProjectionContext
+            {
+                RootActorId = "service-deployment:svc-key",
+                ProjectionKind = "service-deployments",
+            },
+            BuildDeploymentEnvelope(
+                new ServiceDeploymentDeactivatedEvent
+                {
+                    Identity = identity.Clone(),
+                    RevisionId = "rev-old",
+                    DeploymentId = "dep-old",
+                    DeactivatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-08-07T01:00:00Z")),
+                },
+                deploymentState,
+                "evt-deployment"));
+
+        var source = sourceWriter.Upserts.Should().ContainSingle().Subject;
+        source.WorkflowId.Should().Be("wf-active");
+        source.ActiveRevisionId.Should().Be("rev-active");
+        source.DeploymentId.Should().Be("dep-active");
+        source.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
+
+        var command = rowWriter.Commands.Should().ContainSingle().Subject;
+        command.WorkflowId.Should().Be("wf-active");
+        command.ServiceSource.Should().NotBeNull();
+        command.ServiceSource!.DeploymentId.Should().Be("dep-active");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Keep workflow catalogue source materialization aligned with the latest deployment fact, even after deactivation.
- Preserve archived workflow visibility in the backfill path and cover the regression with a deactivated deployment test.

## Test plan
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`
- `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo`

Closes #3463

🤖 Generated with [Claude Code](https://claude.com/claude-code)