### PR TITLE
Show archived workflows explicitly in workflow activity

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -578,7 +578,7 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.workflows.archiveTitle': 'Archive this workflow?',
   'workflowActivityVNext.workflows.archiveTryAgain': 'Try again',
   'workflowActivityVNext.workflows.archivedStatus': 'Archived',
-  'workflowActivityVNext.workflows.archivedView': 'Archived',
+  'workflowActivityVNext.workflows.archivedView': 'Show archived workflows',
   'workflowActivityVNext.workflows.clearFilters': 'Clear filters',
   'workflowActivityVNext.workflows.columnActions': 'Actions',
   'workflowActivityVNext.workflows.columnStatus': 'Status',

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -536,7 +536,7 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.workflows.archiveTitle': '确认归档此工作流？',
     'workflowActivityVNext.workflows.archiveTryAgain': '重试',
     'workflowActivityVNext.workflows.archivedStatus': '已归档',
-    'workflowActivityVNext.workflows.archivedView': '已归档',
+    'workflowActivityVNext.workflows.archivedView': '显示已归档工作流',
     'workflowActivityVNext.workflows.clearFilters': '清除筛选',
     'workflowActivityVNext.workflows.columnActions': '操作',
     'workflowActivityVNext.workflows.columnStatus': '状态',

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx
@@ -565,11 +565,8 @@ describe('Workflow Activity vNext catalogue', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Drafts' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('option', { name: 'Active workflows' }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('option', { name: 'Archived' }),
-    ).not.toBeInTheDocument();
+      screen.getByRole('option', { name: 'Show archived workflows' }),
+    ).toBeInTheDocument();
   });
 
   it('refreshes the workflow catalogue when returning from the editor', async () => {
@@ -661,7 +658,7 @@ describe('Workflow Activity vNext catalogue', () => {
     expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledTimes(2);
   });
 
-  it('maps unsupported legacy views to the backend all view', async () => {
+  it('keeps the archived workflow view on the frontend and backend', async () => {
     mockLocation =
       '/scopes/scope-alpha/workflow-activity-vnext/workflows?view=archived';
     mockScopesApi.queryWorkflowCatalogue.mockResolvedValue(
@@ -684,14 +681,12 @@ describe('Workflow Activity vNext catalogue', () => {
     renderWithQueryClient(<WorkflowActivityVNextPage />);
 
     expect(await screen.findByText('Archived workflow')).toBeInTheDocument();
-    expect(screen.getByText('All workflows')).toBeInTheDocument();
+    expect(screen.getByText('Show archived workflows')).toBeInTheDocument();
     expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith(
-      expect.objectContaining({ view: 'all' }),
+      expect.objectContaining({ view: 'archived' }),
       expect.any(AbortSignal),
     );
-    expect(history.replace).toHaveBeenCalledWith(
-      '/scopes/scope-alpha/workflow-activity-vnext/workflows',
-    );
+    expect(history.replace).not.toHaveBeenCalled();
   });
 
   it('sends the drafts view and restored search to the backend', async () => {
@@ -1346,8 +1341,12 @@ describe('Workflow Activity vNext catalogue', () => {
     };
     let archived = false;
     mockScopesApi.queryWorkflowCatalogue.mockImplementation(
-      (input: { cursor?: string; query?: string }) => {
-        if (input.query === 'wf-alpha' && input.cursor !== 'archive-page-2') {
+      (input: { cursor?: string; query?: string; view?: string }) => {
+        if (
+          input.view === 'archived' &&
+          input.query === 'wf-alpha' &&
+          input.cursor !== 'archive-page-2'
+        ) {
           return Promise.resolve(
             createCatalogueResponse(
               [
@@ -1396,7 +1395,7 @@ describe('Workflow Activity vNext catalogue', () => {
     await waitFor(() =>
       expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith({
         scopeId: 'scope-alpha',
-        view: 'all',
+        view: 'archived',
         query: 'wf-alpha',
         cursor: undefined,
         take: 100,
@@ -1404,7 +1403,7 @@ describe('Workflow Activity vNext catalogue', () => {
     );
     expect(mockScopesApi.queryWorkflowCatalogue).toHaveBeenCalledWith({
       scopeId: 'scope-alpha',
-      view: 'all',
+      view: 'archived',
       query: 'wf-alpha',
       cursor: 'archive-page-2',
       take: 100,

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
@@ -73,6 +73,7 @@ function toWorkflowRow(item: ScopeWorkflowCatalogueRow): WorkflowRow {
 
 async function readWorkflowCatalogueMatch(
   scopeId: string,
+  view: ScopeWorkflowCatalogueView,
   workflowId: string,
 ): Promise<readonly WorkflowRow[]> {
   let cursor: string | undefined;
@@ -81,7 +82,7 @@ async function readWorkflowCatalogueMatch(
   do {
     const response = await scopesApi.queryWorkflowCatalogue({
       scopeId,
-      view: 'all',
+      view,
       query: workflowId,
       cursor,
       take: 100,
@@ -102,6 +103,7 @@ async function readWorkflowCatalogueMatch(
 
 function readWorkflowView(params: URLSearchParams): ScopeWorkflowCatalogueView {
   const view = params.get('view');
+  if (view === 'archived') return 'archived';
   return view === 'drafts' ? 'drafts' : 'all';
 }
 
@@ -391,7 +393,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
 
       const observation = await observeWorkflowArchival({
         readWorkflows: () =>
-          readWorkflowCatalogueMatch(scopeId, target.workflowId),
+          readWorkflowCatalogueMatch(scopeId, 'archived', target.workflowId),
         workflowId: target.workflowId,
       });
       if (observation.kind === 'delayed') {
@@ -453,7 +455,7 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
 
       const observation = await observeWorkflowRemoval({
         readWorkflows: () =>
-          readWorkflowCatalogueMatch(scopeId, deleteTarget.workflowId),
+          readWorkflowCatalogueMatch(scopeId, 'all', deleteTarget.workflowId),
         workflowId: deleteTarget.workflowId,
       });
       if (observation.kind === 'delayed') {
@@ -564,7 +566,15 @@ const WorkflowsPage: React.FC<{ readonly scopeId: string }> = ({ scopeId }) => {
                 ),
                 value: 'drafts',
               },
+              {
+                label: t(
+                  'workflowActivityVNext.workflows.archivedView',
+                  'Show archived workflows',
+                ),
+                value: 'archived',
+              },
             ]}
+            virtual={false}
             value={view}
           />
         </Space>

--- a/apps/aevatar-console-web/src/shared/models/scopes.ts
+++ b/apps/aevatar-console-web/src/shared/models/scopes.ts
@@ -1,4 +1,4 @@
-export type ScopeWorkflowCatalogueView = 'all' | 'drafts';
+export type ScopeWorkflowCatalogueView = 'all' | 'drafts' | 'archived';
 
 export interface ScopeWorkflowCatalogueActionCapability {
   available: boolean;


### PR DESCRIPTION
## Summary
- Add an explicit archived workflow view to the workflow activity vNext catalogue.
- Preserve ?view=archived in the route and route archive confirmation polling through the archived catalogue view.
- Update the workflow view selector copy to "Show archived workflows" / "显示已归档工作流".

## Impacted paths
- apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx
- apps/aevatar-console-web/src/shared/models/scopes.ts
- apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
- apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
- apps/aevatar-console-web/src/pages/workflow-activity-vnext/index.test.tsx

## Local verification
- Related tests: pnpm exec jest src/pages/workflow-activity-vnext/index.test.tsx --runInBand
- Related tests: pnpm exec jest --findRelatedTests src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx src/shared/models/scopes.ts --runInBand
- Changed-file static checks: pnpm exec biome check src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts src/pages/workflow-activity-vnext/index.test.tsx src/pages/workflow-activity-vnext/workflows/WorkflowsPage.tsx src/shared/models/scopes.ts
- Changed-file sanity: git diff --check
- Full frontend suite/build: deferred to GitHub CI by personal local workflow policy
