### PR TITLE
Keep AG-UI SSE response start state retryable

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Sse/AGUISseWriter.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Sse/AGUISseWriter.cs
@@ -93,13 +93,13 @@ public sealed class AGUISseWriter : IAsyncDisposable
             return;
 
         ThrowIfDisposed();
-        _started = true;
         _response.StatusCode = StatusCodes.Status200OK;
         _response.Headers.ContentType = "text/event-stream; charset=utf-8";
         _response.Headers.CacheControl = "no-store";
         _response.Headers.Pragma = "no-cache";
         _response.Headers["X-Accel-Buffering"] = "no";
         await _response.StartAsync(ct);
+        _started = true;
         StartHeartbeat();
     }
 

--- a/test/Aevatar.Workflow.Host.Api.Tests/AGUISseWriterTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/AGUISseWriterTests.cs
@@ -202,6 +202,29 @@ public sealed class AGUISseWriterTests
     }
 
     [Fact]
+    public async Task StartAsync_WhenFirstStartFails_ShouldRemainRetryable()
+    {
+        var bodyFeature = new RecordingResponseBodyFeature(
+            new MemoryStream(),
+            failFirstStart: true);
+        var http = new DefaultHttpContext();
+        http.Features.Set<IHttpResponseBodyFeature>(bodyFeature);
+
+        await using var writer = new AGUISseWriter(
+            http.Response,
+            heartbeatInterval: TimeSpan.FromMinutes(5));
+        var firstStart = async () => await writer.StartAsync();
+
+        await firstStart.Should().ThrowAsync<IOException>();
+        writer.ResponseStarted.Should().BeFalse();
+
+        await writer.StartAsync();
+
+        writer.ResponseStarted.Should().BeTrue();
+        bodyFeature.StartCount.Should().Be(2);
+    }
+
+    [Fact]
     public async Task DisposeAsync_DuringWrite_ShouldWaitForActiveFrame()
     {
         var body = new BlockingWriteStream();
@@ -386,7 +409,9 @@ public sealed class AGUISseWriterTests
         public override void SetLength(long value) => throw new NotSupportedException();
     }
 
-    private sealed class RecordingResponseBodyFeature(Stream stream) : IHttpResponseBodyFeature
+    private sealed class RecordingResponseBodyFeature(
+        Stream stream,
+        bool failFirstStart = false) : IHttpResponseBodyFeature
     {
         private readonly StreamResponseBodyFeature _inner = new(stream);
         private int _startCount;
@@ -397,7 +422,10 @@ public sealed class AGUISseWriterTests
 
         public Task StartAsync(CancellationToken cancellationToken = default)
         {
-            Interlocked.Increment(ref _startCount);
+            var startCount = Interlocked.Increment(ref _startCount);
+            if (failFirstStart && startCount == 1)
+                return Task.FromException(new IOException("Injected response start failure."));
+
             return _inner.StartAsync(cancellationToken);
         }
 


### PR DESCRIPTION
## Problem

AGUISseWriter marked ResponseStarted before HttpResponse.StartAsync completed. A cancelled or failed first start therefore left the writer permanently reporting success and skipped a later retry.

## Solution

Publish the started state only after the underlying response start succeeds. Add a regression test whose response feature fails once, verifies the state remains false, and then starts successfully on retry.

## Verification

- AGUISseWriterTests: 10/10 passed
- test_stability_guards.sh passed
- git diff --check passed