### PR TITLE
Fix workflow chat descriptor set ordering

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/WorkflowServiceRevisionArtifactBuilder.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/WorkflowServiceRevisionArtifactBuilder.cs
@@ -1,12 +1,17 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
 using Aevatar.Workflow.Abstractions;
+using Google.Protobuf;
 using Google.Protobuf.Reflection;
 
 namespace Aevatar.GAgentService.Abstractions.Services;
 
 public static class WorkflowServiceRevisionArtifactBuilder
 {
+    private static readonly ByteString ChatProtocolDescriptorSet = BuildProtocolDescriptorSet(
+        ChatRequestEvent.Descriptor,
+        ChatResponseEvent.Descriptor);
+
     public static PreparedServiceRevisionArtifact Build(
         ServiceRevisionSpec revisionSpec,
         string resolvedWorkflowName,
@@ -71,6 +76,7 @@ public static class WorkflowServiceRevisionArtifactBuilder
             Identity = identity.Clone(),
             RevisionId = revisionSpec.RevisionId,
             ImplementationKind = ServiceImplementationKind.Workflow,
+            ProtocolDescriptorSet = ChatProtocolDescriptorSet,
             Endpoints =
             {
                 new ServiceEndpointDescriptor
@@ -92,4 +98,30 @@ public static class WorkflowServiceRevisionArtifactBuilder
 
     private static string GetTypeUrl(MessageDescriptor descriptor) =>
         $"type.googleapis.com/{descriptor.FullName}";
+
+    private static ByteString BuildProtocolDescriptorSet(params MessageDescriptor[] descriptors)
+    {
+        var files = new List<FileDescriptorProto>();
+        var addedFiles = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var descriptor in descriptors)
+            AddFile(descriptor.File, addedFiles, files);
+
+        var descriptorSet = new FileDescriptorSet();
+        descriptorSet.File.Add(files);
+        return descriptorSet.ToByteString();
+    }
+
+    private static void AddFile(
+        FileDescriptor file,
+        ISet<string> addedFiles,
+        ICollection<FileDescriptorProto> files)
+    {
+        if (!addedFiles.Add(file.Name))
+            return;
+
+        foreach (var dependency in file.Dependencies)
+            AddFile(dependency, addedFiles, files);
+
+        files.Add(file.ToProto());
+    }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScheduledDispatchEndpointsTests.cs
@@ -15,6 +15,7 @@ using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Schedules;
 using Aevatar.GAgentService.Hosting.Endpoints.Schedules;
 using Aevatar.Studio.Application.Provisioning;
+using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.Reflection;
@@ -2846,7 +2847,7 @@ public sealed class ScheduledDispatchEndpointsTests
         host.RevisionCatalog.UpsertRevision(
             "tenant:app:default:workflow",
             "rev-active",
-            BuildPreparedArtifact(ChatRequestEvent.Descriptor));
+            BuildWorkflowPreparedArtifact("rev-active"));
 
         var response = await host.Client.PostAsJsonAsync("/api/schedules", new
         {
@@ -3272,6 +3273,43 @@ public sealed class ScheduledDispatchEndpointsTests
                 },
             },
         };
+
+    private static PreparedServiceRevisionArtifact BuildWorkflowPreparedArtifact(string revisionId)
+    {
+        const string workflowYaml = "name: workflow\nsteps: []";
+        var capabilityAdmissionPlan = WorkflowCapabilityAdmissionPlanIntegrity.Create(
+            workflowYaml,
+            inlineWorkflowYamls: null,
+            ExternalCapabilityExecutionMode.Interactive,
+            [],
+            []);
+        return WorkflowServiceRevisionArtifactBuilder.Build(
+            new ServiceRevisionSpec
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "tenant",
+                    AppId = "app",
+                    Namespace = "default",
+                    ServiceId = "workflow",
+                },
+                RevisionId = revisionId,
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                WorkflowSpec = new WorkflowServiceRevisionSpec
+                {
+                    WorkflowId = revisionId,
+                    WorkflowName = "workflow",
+                    WorkflowYaml = workflowYaml,
+                    ExpectedExecutionMode = ExternalCapabilityExecutionMode.Interactive,
+                },
+            },
+            "workflow",
+            new WorkflowAuthorizationDependencies
+            {
+                ServiceGrantPolicy = WorkflowServiceGrantPolicy.NotRequiredNoExternalService,
+            },
+            capabilityAdmissionPlan);
+    }
 
     private static ByteString BuildProtocolDescriptorSetFor(MessageDescriptor descriptor)
     {

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -2601,64 +2601,39 @@ public sealed class ScopeBindingCommandApplicationServiceTests
         WorkflowAuthorizationDependencies? dependencies = null,
         WorkflowCapabilityAdmissionPlan? capabilityAdmissionPlan = null)
     {
-        var admittedCapabilities = capabilityAdmissionPlan?.ExternalCapabilities
-            ?? dependencies?.ExternalCapabilities;
-        var serviceGrantRequirement = capabilityAdmissionPlan is not null
-            ? capabilityAdmissionPlan.ExternalCapabilities.Any(static capability =>
-                capability.CapabilityCase ==
-                ExternalWorkflowCapabilityRef.CapabilityOneofCase.NyxIdUserService)
-                ? Aevatar.GAgentService.Abstractions.Schedules.Authorization.AuthorizationGrantRequirement.Required
-                : Aevatar.GAgentService.Abstractions.Schedules.Authorization.AuthorizationGrantRequirement.NotRequired
-            : dependencies?.ServiceGrantPolicy switch
-            {
-                WorkflowServiceGrantPolicy.Required =>
-                    Aevatar.GAgentService.Abstractions.Schedules.Authorization.AuthorizationGrantRequirement.Required,
-                WorkflowServiceGrantPolicy.NotRequiredNoExternalService =>
-                    Aevatar.GAgentService.Abstractions.Schedules.Authorization.AuthorizationGrantRequirement.NotRequired,
-                _ => Aevatar.GAgentService.Abstractions.Schedules.Authorization.AuthorizationGrantRequirement.Unspecified,
-            };
-        var authorizationEvidence = new Aevatar.GAgentService.Abstractions.Schedules.Authorization.WorkflowRevisionAuthorizationEvidence
+        var effectiveWorkflowId = workflowId ?? revisionId;
+        var effectivePlan = capabilityAdmissionPlan ?? WorkflowCapabilityAdmissionPlanIntegrity.Create(
+            workflowYaml,
+            inlineWorkflowYamls: null,
+            ExternalCapabilityExecutionMode.Interactive,
+            [],
+            []);
+        var effectiveDependencies = dependencies ?? new WorkflowAuthorizationDependencies
         {
-            OwnerLlmRouteRequired = dependencies?.OwnerLlmRouteRequired ?? false,
-            ServiceGrantRequirement = serviceGrantRequirement,
+            ServiceGrantPolicy = WorkflowServiceGrantPolicy.NotRequiredNoExternalService,
         };
-        authorizationEvidence.ExternalCapabilities.Add(
-            (admittedCapabilities ?? []).Select(static capability => capability.Clone()));
-        var artifact = new PreparedServiceRevisionArtifact
-        {
-            Identity = DefaultServiceIdentity(serviceId),
-            RevisionId = revisionId,
-            ImplementationKind = ServiceImplementationKind.Workflow,
-            Endpoints =
+
+        var artifact = WorkflowServiceRevisionArtifactBuilder.Build(
+            new ServiceRevisionSpec
             {
-                new ServiceEndpointDescriptor
-                {
-                    EndpointId = "chat",
-                    DisplayName = "chat",
-                    Kind = ServiceEndpointKind.Chat,
-                    RequestTypeUrl = GetTypeUrl(ChatRequestEvent.Descriptor),
-                    ResponseTypeUrl = GetTypeUrl(ChatResponseEvent.Descriptor),
-                    Description = endpointDescription,
-                },
-            },
-            DeploymentPlan = new ServiceDeploymentPlan
-            {
-                WorkflowPlan = new WorkflowServiceDeploymentPlan
+                Identity = DefaultServiceIdentity(serviceId),
+                RevisionId = revisionId,
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                WorkflowSpec = new WorkflowServiceRevisionSpec
                 {
                     WorkflowName = workflowName,
                     WorkflowYaml = workflowYaml,
-                    WorkflowId = workflowId ?? revisionId,
-                    RevisionId = revisionId,
+                    WorkflowId = effectiveWorkflowId,
                     DefinitionActorId = DefaultOptions.BuildDefinitionActorIdPrefix(
                         ScopeId,
                         workflowId ?? DefaultOptions.DefaultServiceId),
-                    AuthorizationEvidence = authorizationEvidence,
-                    CapabilityAdmissionPlan = capabilityAdmissionPlan?.Clone(),
-                    ExecutionMode = capabilityAdmissionPlan?.ExecutionMode ??
-                                    ExternalCapabilityExecutionMode.Interactive,
+                    ExpectedExecutionMode = effectivePlan.ExecutionMode,
                 },
             },
-        };
+            workflowName,
+            effectiveDependencies,
+            effectivePlan);
+        artifact.Endpoints.Single().Description = endpointDescription;
         return new PreparedServiceRevisionArtifactAssembler().Assemble(artifact);
     }
 

--- a/test/Aevatar.GAgentService.Tests/Application/WorkflowServiceRevisionArtifactBuilderTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/WorkflowServiceRevisionArtifactBuilderTests.cs
@@ -1,14 +1,29 @@
+using Aevatar.AI.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Schedules.Authorization;
 using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Core.Assemblers;
 using Aevatar.Workflow.Abstractions;
 using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
 
 namespace Aevatar.GAgentService.Tests.Application;
 
 public sealed class WorkflowServiceRevisionArtifactBuilderTests
 {
+    [Fact]
+    public void Build_ShouldIncludeResolvableChatProtocolDescriptors()
+    {
+        var artifact = BuildArtifact();
+
+        artifact.ProtocolDescriptorSet.IsEmpty.Should().BeFalse();
+        ResolveDescriptor(artifact.ProtocolDescriptorSet, ChatRequestEvent.Descriptor.FullName)
+            .Should().NotBeNull();
+        ResolveDescriptor(artifact.ProtocolDescriptorSet, ChatResponseEvent.Descriptor.FullName)
+            .Should().NotBeNull();
+    }
+
     [Fact]
     public void Build_WithExplicitRequestCapability_ShouldRequireServiceGrant()
     {
@@ -256,4 +271,36 @@ public sealed class WorkflowServiceRevisionArtifactBuilderTests
                 },
             },
         };
+
+    private static MessageDescriptor? ResolveDescriptor(ByteString descriptorSet, string fullName)
+    {
+        var fileDescriptorSet = FileDescriptorSet.Parser.ParseFrom(descriptorSet);
+        var files = FileDescriptor.BuildFromByteStrings(
+            fileDescriptorSet.File.Select(static file => file.ToByteString()));
+        foreach (var file in files)
+        {
+            var descriptor = FindDescriptor(file.MessageTypes, fullName);
+            if (descriptor is not null)
+                return descriptor;
+        }
+
+        return null;
+    }
+
+    private static MessageDescriptor? FindDescriptor(
+        IList<MessageDescriptor> messageTypes,
+        string fullName)
+    {
+        foreach (var messageType in messageTypes)
+        {
+            if (string.Equals(messageType.FullName, fullName, StringComparison.Ordinal))
+                return messageType;
+
+            var nested = FindDescriptor(messageType.NestedTypes, fullName);
+            if (nested is not null)
+                return nested;
+        }
+
+        return null;
+    }
 }

--- a/test/Aevatar.GAgentService.Tests/Core/ServiceRevisionCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/ServiceRevisionCatalogGAgentTests.cs
@@ -581,11 +581,20 @@ public sealed class ServiceRevisionCatalogGAgentTests
         var identity = GAgentServiceTestKit.CreateIdentity("svc-padded-workflow-name");
         const string revisionId = "rev-padded-workflow-name";
         var actorId = ServiceActorIds.RevisionCatalog(identity);
+        var spec = CreateWorkflowRevisionSpec(identity, revisionId);
+        spec.WorkflowSpec!.WorkflowName = "  legacy-workflow  ";
+        var artifactSpec = spec.Clone();
+        artifactSpec.WorkflowSpec!.WorkflowId = revisionId;
         var artifact = new PreparedServiceRevisionArtifactAssembler().Assemble(
-            CreateWorkflowArtifact(
-                identity,
-                revisionId,
-                ExternalCapabilityExecutionMode.Interactive));
+            WorkflowServiceRevisionArtifactBuilder.Build(
+                artifactSpec,
+                "legacy-workflow",
+                new WorkflowAuthorizationDependencies
+                {
+                    ServiceGrantPolicy = WorkflowServiceGrantPolicy.NotRequiredNoExternalService,
+                },
+                artifactSpec.WorkflowSpec.CapabilityAdmissionPlan));
+        var expectedArtifactHash = artifact.ArtifactHash;
         var adapter = new RecordingAdapter(
             _ => Task.FromResult(artifact.Clone()),
             ServiceImplementationKind.Workflow);
@@ -593,8 +602,6 @@ public sealed class ServiceRevisionCatalogGAgentTests
             eventStore,
             adapter,
             actorId);
-        var spec = CreateWorkflowRevisionSpec(identity, revisionId);
-        spec.WorkflowSpec!.WorkflowName = "  legacy-workflow  ";
 
         await agent.HandleCreateRevisionAsync(new CreateServiceRevisionCommand
         {
@@ -615,12 +622,19 @@ public sealed class ServiceRevisionCatalogGAgentTests
             .Be(ServiceRevisionStatus.Published);
         agent.State.Revisions[revisionId].PreparedArtifact.DeploymentPlan.WorkflowPlan.WorkflowName
             .Should().Be("legacy-workflow");
+        agent.State.Revisions[revisionId].ArtifactHash.Should().Be(expectedArtifactHash);
+        agent.State.Revisions[revisionId].PreparedArtifact.ProtocolDescriptorSet.IsEmpty.Should().BeFalse();
         adapter.PrepareCalls.Should().Be(2);
 
         var replayed = CreateAgent(eventStore, adapter, actorId);
         await replayed.ActivateAsync();
         replayed.State.Revisions[revisionId].Status.Should()
             .Be(ServiceRevisionStatus.Published);
+        replayed.State.Revisions[revisionId].ArtifactHash.Should().Be(expectedArtifactHash);
+        replayed.State.Revisions[revisionId].PreparedArtifact.ProtocolDescriptorSet
+            .ToByteArray()
+            .Should()
+            .Equal(artifact.ProtocolDescriptorSet.ToByteArray());
         await replayed.HandlePrepareRevisionAsync(new PrepareServiceRevisionCommand
         {
             Identity = identity.Clone(),


### PR DESCRIPTION
## Summary
- Carry the workflow chat descriptor-set implementation onto the current `feature/integrate` base.
- Emit descriptor files in dependency-first topological order so `FileDescriptor.BuildFromByteStrings` can resolve well-known and custom imports.
- Keep workflow fixture coverage aligned with the canonical artifact builder.

## Verification
- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~WorkflowServiceRevisionArtifactBuilderTests` (11 passed)
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`

Supersedes #2383, whose original branch is stale/conflicting.