### PR TITLE
Fix cache child dispatch semantics

### DIFF
--- a/docs/canon/workflow-primitives.md
+++ b/docs/canon/workflow-primitives.md
@@ -277,7 +277,7 @@ steps:
 ### `cache`
 
 - 作用：按 key 缓存子步骤结果，命中直接返回，未命中执行子步骤。
-- 常用参数：`cache_key`、`ttl_seconds`、`child_step_type`、`child_target_role`。
+- 常用参数：`cache_key`、`ttl_seconds`、`child_step_type`、`child_target_role`，以及传给子步骤的 `sub_param_*`。
 
 ```yaml
 steps:
@@ -286,8 +286,9 @@ steps:
     parameters:
       cache_key: "$input"
       ttl_seconds: "600"
-      child_step_type: "llm_call"
-      child_target_role: "assistant"
+      child_step_type: "tool_call"
+      sub_param_tool: "summarize"
+      sub_param_arguments: '{"text":"${input}"}'
 ```
 
 ## 3. Control 原语

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionKernel.cs
@@ -3022,8 +3022,8 @@ internal sealed class WorkflowExecutionKernel : IEventModule<IEventHandlerContex
     }
 
     // The call-site identity a step carries at runtime must be the one admission committed, so both
-    // sides derive it from the compiler. Looping primitives receive their synthesized sub-step
-    // call site here and copy it onto every item/iteration they dispatch.
+    // sides derive it from the compiler. Composite primitives receive their synthesized sub-step
+    // call site here and copy it onto every child they dispatch.
     private void ApplyExternalInvocation(StepRequestEvent request, StepDefinition step)
     {
         var workflowName = _workflow?.Name ?? string.Empty;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/CacheModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/CacheModule.cs
@@ -110,7 +110,7 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
             state.ChildStepToCacheKey[BuildChildKey(runId, childStepId)] = cacheKey;
             await SaveStateAsync(state, ctx, ct);
 
-            await ctx.PublishAsync(new StepRequestEvent
+            var childRequest = new StepRequestEvent
             {
                 StepId = childStepId,
                 StepType = childType,
@@ -119,7 +119,15 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
                 TargetRole = childRole ?? "",
                 ExecutionId = childExecutionId,
                 InputValueId = request.InputValueId,
-            }, TopologyAudience.Self, ct);
+                ExternalInvocation = request.ExternalInvocation?.Clone(),
+            };
+            foreach (var (key, value) in request.Parameters)
+            {
+                if (key.StartsWith("sub_param_", StringComparison.OrdinalIgnoreCase))
+                    childRequest.Parameters[key["sub_param_".Length..]] = value;
+            }
+
+            await ctx.PublishAsync(childRequest, TopologyAudience.Self, ct);
         }
         else if (payload.Is(StepCompletedEvent.Descriptor))
         {
@@ -134,11 +142,27 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
             if (!state.ChildStepToCacheKey.TryGetValue(childKey, out var cacheKey))
                 return;
             if (!state.PendingByCacheKey.TryGetValue(cacheKey, out var pending))
+            {
+                ctx.Logger.LogWarning(
+                    "Cache child {ChildStepId} mapped to key={Key} but no pending call remains. run={RunId}",
+                    evt.StepId,
+                    ShortenKey(cacheKey),
+                    runId);
                 return;
+            }
             if (normalizedValues &&
                 (!string.Equals(pending.ChildStepId, evt.StepId, StringComparison.Ordinal) ||
                  !string.Equals(pending.ChildExecutionId, evt.ExecutionId, StringComparison.Ordinal)))
+            {
+                ctx.Logger.LogWarning(
+                    "Cache ignored stale child completion. run={RunId} child={ChildStepId} " +
+                    "expectedExecution={ExpectedExecutionId} actualExecution={ActualExecutionId}",
+                    runId,
+                    evt.StepId,
+                    pending.ChildExecutionId,
+                    evt.ExecutionId);
                 return;
+            }
 
             if (!normalizedValues)
             {
@@ -170,6 +194,12 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
                     completed.Annotations["cache.key"] = ShortenKey(cacheKey);
                     await ctx.PublishAsync(completed, TopologyAudience.Self, ct);
                 }
+                ctx.Logger.LogInformation(
+                    "Cache child {ChildStepId} completed key={Key}; released {WaiterCount} waiter(s). run={RunId}",
+                    evt.StepId,
+                    ShortenKey(cacheKey),
+                    pending.Waiters.Count,
+                    runId);
                 return;
             }
 
@@ -232,6 +262,12 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
             state.ChildStepToCacheKey.Remove(childKey);
             state.PendingByCacheKey.Remove(cacheKey);
             await SaveStateAsync(state, ctx, CancellationToken.None);
+            ctx.Logger.LogInformation(
+                "Cache child {ChildStepId} completed key={Key}; released {WaiterCount} waiter(s). run={RunId}",
+                evt.StepId,
+                ShortenKey(cacheKey),
+                pending.Waiters.Count,
+                runId);
         }
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowAuthorizationDependencyEvaluator.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowAuthorizationDependencyEvaluator.cs
@@ -85,7 +85,7 @@ public static class WorkflowAuthorizationDependencyEvaluator
     }
 
     /// <summary>
-    /// Compiles the external invocation for the sub-step a looping primitive synthesizes at runtime.
+    /// Compiles the external invocation for a sub-step a composite primitive synthesizes at runtime.
     /// The call-site identity is the owner step's, never the dynamic per-item or per-iteration id.
     /// </summary>
     public static ExternalToolInvocationSpec? TryCompileSynthesizedSubStepInvocation(
@@ -354,11 +354,16 @@ public static class WorkflowAuthorizationDependencyEvaluator
     private static StepDefinition? TryBuildSynthesizedSubStep(StepDefinition owner)
     {
         var ownerType = WorkflowPrimitiveCatalog.ToCanonicalType(owner.Type);
-        if (ownerType is not ("foreach" or "while"))
+        var (subStepTypeKey, defaultSubStepType, targetRoleKey) = ownerType switch
+        {
+            "foreach" => ("sub_step_type", "parallel", "sub_target_role"),
+            "while" => ("step", "llm_call", "sub_target_role"),
+            "cache" => ("child_step_type", "llm_call", "child_target_role"),
+            _ => (null, null, null),
+        };
+        if (subStepTypeKey is null)
             return null;
 
-        var subStepTypeKey = ownerType == "foreach" ? "sub_step_type" : "step";
-        var defaultSubStepType = ownerType == "foreach" ? "parallel" : "llm_call";
         var subStepType = owner.Parameters.GetValueOrDefault(subStepTypeKey, defaultSubStepType);
         var canonicalSubStepType = WorkflowPrimitiveCatalog.ToCanonicalType(subStepType);
         var subParameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -372,7 +377,7 @@ public static class WorkflowAuthorizationDependencyEvaluator
         {
             Id = $"{owner.Id}/sub-step",
             Type = canonicalSubStepType,
-            TargetRole = owner.Parameters.GetValueOrDefault("sub_target_role"),
+            TargetRole = owner.Parameters.GetValueOrDefault(targetRoleKey),
             Parameters = subParameters,
             Capability = owner.Capability?.Clone(),
             ResponseProjection = owner.ResponseProjection?.Clone(),

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModuleBehaviorTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModuleBehaviorTests.cs
@@ -777,6 +777,102 @@ public sealed class WorkflowCoreModuleBehaviorTests : WorkflowCoreModuleTestBase
         }
 
         [Fact]
+        public async Task CacheModule_OnMiss_ShouldForwardSynthesizedChildContract()
+        {
+            var module = new CacheModule();
+            var ctx = CreateContext();
+            var invocation = new ExternalToolInvocationSpec
+            {
+                CallSiteId = "cache-workflow/cached-tool/sub-step",
+                ToolName = "nyxid_proxy",
+            };
+
+            await module.HandleAsync(
+                Envelope(new StepRequestEvent
+                {
+                    StepId = "cached-tool",
+                    StepType = "cache",
+                    RunId = "run-cache-contract",
+                    ExecutionId = "exec-cache-parent",
+                    Input = "input-value",
+                    InputValueId = "value-cache-input",
+                    ExternalInvocation = invocation,
+                    Parameters =
+                    {
+                        ["cache_key"] = "cache-contract-key",
+                        ["child_step_type"] = "tool_call",
+                        ["child_target_role"] = "worker",
+                        ["sub_param_tool"] = "nyxid_proxy",
+                        ["sub_param_arguments"] = "{\"path_params\":{\"item_id\":\"input-value\"}}",
+                    },
+                }),
+                ctx,
+                CancellationToken.None);
+
+            var child = ctx.Published.Select(x => x.evt).OfType<StepRequestEvent>().Single();
+            child.StepType.Should().Be("tool_call");
+            child.TargetRole.Should().Be("worker");
+            child.ExecutionId.Should().NotBeNullOrWhiteSpace();
+            child.InputValueId.Should().Be("value-cache-input");
+            child.Parameters.Should().Contain("tool", "nyxid_proxy");
+            child.Parameters.Should().Contain(
+                "arguments",
+                "{\"path_params\":{\"item_id\":\"input-value\"}}");
+            child.Parameters.Should().NotContainKey("cache_key");
+            child.ExternalInvocation.Should().NotBeSameAs(invocation);
+            child.ExternalInvocation.Should().BeEquivalentTo(invocation);
+        }
+
+        [Fact]
+        public async Task CacheModule_ToolChild_ShouldExecuteForwardedParametersAndCompleteParent()
+        {
+            var cache = new CacheModule();
+            var tool = new CountingFakeAgentTool("cache_echo", static arguments => arguments);
+            var toolCall = CreateToolCallModule([new CountingToolSource([tool])]);
+            var ctx = CreateContext();
+
+            await cache.HandleAsync(
+                Envelope(new StepRequestEvent
+                {
+                    StepId = "cache-tool-parent",
+                    StepType = "cache",
+                    RunId = "run-cache-tool",
+                    ExecutionId = "exec-cache-tool-parent",
+                    Input = "ignored-input",
+                    Parameters =
+                    {
+                        ["cache_key"] = "cache-tool-key",
+                        ["child_step_type"] = "tool_call",
+                        ["sub_param_tool"] = "cache_echo",
+                        ["sub_param_arguments"] = "{\"value\":\"from-cache\"}",
+                    },
+                }),
+                ctx,
+                CancellationToken.None);
+
+            var child = ctx.Published.Select(x => x.evt).OfType<StepRequestEvent>().Single();
+            ctx.Published.Clear();
+
+            await ExecuteToolCallToCompletionAsync(toolCall, child, ctx);
+
+            tool.ExecuteCalls.Should().Be(1);
+            var childCompletion = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>()
+                .Single(x => x.StepId == child.StepId);
+            childCompletion.Success.Should().BeTrue();
+            childCompletion.Output.Should().Be("{\"value\":\"from-cache\"}");
+            ctx.Published.Clear();
+
+            await cache.HandleAsync(Envelope(childCompletion), ctx, CancellationToken.None);
+
+            var parentCompletion = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Single();
+            parentCompletion.StepId.Should().Be("cache-tool-parent");
+            parentCompletion.ExecutionId.Should().Be("exec-cache-tool-parent");
+            parentCompletion.Success.Should().BeTrue();
+            parentCompletion.Output.Should().Be("{\"value\":\"from-cache\"}");
+            parentCompletion.Annotations["cache.hit"].Should().Be("false");
+        }
+
+        [Fact]
         public async Task CacheModule_WhenSecondCallerJoinsPending_ShouldFanOutCompletionAndNotCacheFailures()
         {
             var module = new CacheModule();

--- a/test/Aevatar.Workflow.Core.Tests/Modules/NormalizedNestedModuleDataflowTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/NormalizedNestedModuleDataflowTests.cs
@@ -548,6 +548,51 @@ public sealed class NormalizedNestedModuleDataflowTests
     }
 
     [Fact]
+    public async Task Cache_ShouldCarryCompiledExternalInvocationToSynthesizedChild()
+    {
+        const string runId = "run-cache-external";
+        var workflow = new WorkflowDefinition
+        {
+            Name = "cache-external-workflow",
+            Roles = [],
+            Steps =
+            [
+                new StepDefinition
+                {
+                    Id = "cached_tool",
+                    Type = "cache",
+                    Parameters =
+                    {
+                        ["cache_key"] = "external-key",
+                        ["child_step_type"] = "tool_call",
+                        ["sub_param_tool"] = "nyxid_proxy",
+                        ["sub_param_arguments"] = "{\"path_params\":{\"item_id\":\"alpha\"}}",
+                    },
+                },
+            ],
+        };
+        var harness = NormalizedHarness.Create(workflow, runId, new CacheModule());
+
+        var parentRequest = await harness.StartAsync("seed-input");
+        parentRequest.ExternalInvocation.Should().NotBeNull();
+        parentRequest.ExternalInvocation!.CallSiteId.Should()
+            .Be("cache-external-workflow/cached_tool/sub-step");
+
+        var childRequest = (await harness.DispatchThroughBridgeAsync(parentRequest))
+            .Should().ContainSingle().Subject;
+
+        childRequest.StepType.Should().Be("tool_call");
+        childRequest.Parameters.Should().Contain("tool", "nyxid_proxy");
+        childRequest.Parameters.Should().Contain(
+            "arguments",
+            "{\"path_params\":{\"item_id\":\"alpha\"}}");
+        childRequest.ExternalInvocation.Should().NotBeNull();
+        childRequest.ExternalInvocation!.CallSiteId.Should()
+            .Be("cache-external-workflow/cached_tool/sub-step");
+        childRequest.ExternalInvocation.ToolName.Should().Be("nyxid_proxy");
+    }
+
+    [Fact]
     public async Task OnErrorSkip_ShouldCaptureDefaultOutputOnceAndForwardItWithoutDanglingReferences()
     {
         const string runId = "run-on-error-skip";

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowAuthorizationDependenciesTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowAuthorizationDependenciesTests.cs
@@ -537,6 +537,7 @@ public sealed class WorkflowAuthorizationDependenciesTests
     [InlineData("foreach_llm", "sub_step_type")]
     [InlineData("while", "step")]
     [InlineData("loop", "step")]
+    [InlineData("cache", "child_step_type")]
     public void EvaluateAuthorizationDependencies_IndirectNyxIdProxy_ShouldNeverBypassAdmission(
         string primitive,
         string subStepTypeKey)


### PR DESCRIPTION
## Problem

Cache miss children did not receive `sub_param_*` values or the compiled external invocation call site. A cached `tool_call`/`connector_call` could therefore execute with default parameters or fail admission, and the observability path did not identify orphaned/stale child completions. The original #3278 branch is stale and conflicting.

## Solution

- Forward cache `sub_param_*` values to the synthesized child.
- Compile cache sub-step external invocation metadata through the same authorization dependency evaluator used by runtime dispatch.
- Clone the compiled invocation onto the child request and preserve current execution fencing.
- Add safe diagnostics for missing pending calls and stale child completions.
- Document cache child parameters and cover both the dispatched contract and a real tool-child completion.

## Verification

- `dotnet test test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~CacheModule_` (8 passed)
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --no-build --no-restore --filter FullyQualifiedName~Cache_ShouldCarryCompiledExternalInvocationToSynthesizedChild|FullyQualifiedName~EvaluateAuthorizationDependencies_IndirectNyxIdProxy_ShouldNeverBypassAdmission` (7 passed)
- `bash tools/ci/architecture_guards.sh`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/docs/lint.sh`
- `git diff --check`

Supersedes #3278.