### PR TITLE
Keep public toolsets skill-first

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -287,7 +287,12 @@ public static class ServiceCollectionExtensions
 
     private static IEnumerable<IAgentToolSource> ResolveChannelToolSources(IServiceProvider serviceProvider)
     {
-        foreach (var source in serviceProvider.GetServices<IAgentToolSource>())
+        var workspace = serviceProvider.GetRequiredService<IToolSetRegistry>()
+            .Resolve(ToolSetNames.WorkspaceDefault);
+        var sources = workspace.IsSuccess
+            ? workspace.Sources
+            : serviceProvider.GetServices<IAgentToolSource>();
+        foreach (var source in sources)
             yield return source;
 
         var inventory = serviceProvider.GetService<ChannelNyxIdConnectedServiceInventoryToolSource>();

--- a/docs/canon/nyxid-responses-direct.md
+++ b/docs/canon/nyxid-responses-direct.md
@@ -145,7 +145,7 @@ Responses、Messages 和 Chat Completions 三条直连入口都把模型调用�
 
 ## 5. 直连工具行为
 
-`/v1/responses`、`/v1/messages`、`/v1/chat/completions` 使用同一套 `IResponsesDirectToolPlanService` + `IResponsesToolClassificationService` 抽象组装 tool sources 并做工具分类。三条 create 入口都会合并同一批全局 `IResponsesToolProvider`，并按 chat-route `ForwardToModel.ToolSetRef` 追加同一个 route tool set。Mainnet 的 direct LLM ingress 默认补 `workspace.default`；`lark.self_notify`、`voice.realtime` 也必须组合 `workspace.default`，所以 NyxID/Aevatar workspace tools 是默认可见能力，不依赖调用方显式配置 route tool set。最终工具分成三类：
+`/v1/responses`、`/v1/messages`、`/v1/chat/completions` 使用同一套 `IResponsesDirectToolPlanService` + `IResponsesToolClassificationService` 抽象组装 tool sources 并做工具分类。三条 create 入口都会合并同一批全局 `IResponsesToolProvider`，并按 chat-route `ForwardToModel.ToolSetRef` 追加同一个 route tool set。Mainnet 的 direct LLM ingress 默认补 `workspace.default`；`lark.self_notify`、`voice.realtime` 也必须组合 `workspace.default`，所以 NyxID/Aevatar workspace tools 是默认可见能力，不依赖调用方显式配置 route tool set。`workspace.default` 是 public/default surface，不包含 Studio provisioning、member、binding、schedule 或 query sources；这些能力只通过内置 Studio workflow 显式选择的 `studio.local` tool set 暴露。最终工具分成三类：
 
 - Aevatar substitute tools：由服务端接管执行并记录状态。
 - Aevatar additive tools：由服务端额外注入，供模型主动调用。

--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "418cab838565568cba5881ccf707d67c332f212d",
-    "contract_files_sha256": "d576998b4a6a015b9c8e12c4c00f05cb57526d224ead196414fb84625fbb42e9",
+    "revision": "3c3f4e605c670da5ff1b197c244f348c564b659b",
+    "contract_files_sha256": "cfe68b4349e4ac54260c352c4f6be1d55b9f0fcd5b1286ddd258599954e4322c",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "23fd2cf48541c4b8da3fa1ef07277a7700c8478f9c638be8221465bf877fbb31",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "99605fdacc1e15b369d53b8953620b122dbba19d8b386486fd1892a2537ff82b",
@@ -17,7 +17,7 @@
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1b033df9cb55c741e9b52054cbd4a91067f03c8c3797bd076a7e3d6133eb0fcb",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "2c4f2cda99154f2e667c6cfd291497e697ef11df17f081f96ec70070a8af8b8c",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyRotateTool.cs": "18212bb64644cfbca401065bccce439ea5fa00316deff57d730a0d9ac2650e53",
-      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "6281ec9394f937f55b1ff9dd800b92d9625f09219a33e31c87f8885430523f13"
+      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "6ea6525a7abe587f7e4303d7961a681cdd06cda6effe8d6d52f514ceb5a84f0c"
     }
   },
   "nyxid": {

--- a/docs/superpowers/specs/2026-07-23-chat-workflow-resource-semantics-design.md
+++ b/docs/superpowers/specs/2026-07-23-chat-workflow-resource-semantics-design.md
@@ -122,11 +122,20 @@ the resource boundary enforceable without relying on prompt compliance.
 
 ### Host Composition
 
-Register `StudioWorkflowQueryToolSource` through
-`AddStudioProvisioningTools()` and compose it into `workspace.default` alongside
-the existing Studio query sources. Keep `WorkflowCatalogAgentToolSource` in the
-same tool set because explicit template discovery remains supported under its
-new tool names.
+Compose `StudioWorkflowQueryToolSource` into the explicit `studio.local` tool
+set alongside the existing Studio provisioning, member, binding, schedule, and
+query sources. `workspace.default` remains the public/default surface and must
+not include Studio-local sources. Keep `WorkflowCatalogAgentToolSource` in
+`workspace.default` because explicit public template discovery remains
+supported under its template-oriented tool names.
+
+The built-in Studio workflow selects `studio.local` through its role-level
+`tool_sets` contract. Request-scoped toolset resolution adds those exact tools
+to that workflow turn without registering them as ambient `IAgentToolSource`
+instances or visibility-sensitive `IWorkflowToolSource` instances. This keeps
+`ToolCallModule` discovery cache stable and preserves the durable
+`AgentWorkflowToolSourceAdapter` execution/reconciliation contract for normal
+workflow tools.
 
 ## Error Semantics
 

--- a/src/Aevatar.AI.ToolProviders.ToolSetRegistry/ToolSetNames.cs
+++ b/src/Aevatar.AI.ToolProviders.ToolSetRegistry/ToolSetNames.cs
@@ -6,6 +6,12 @@ public static class ToolSetNames
     public const string LarkSelfNotify = "lark.self_notify";
 
     /// <summary>
+    /// Studio-owned provisioning, member, binding, schedule, and query tools. This set is
+    /// opt-in and must not be included by public/default route tool sets.
+    /// </summary>
+    public const string StudioLocal = "studio.local";
+
+    /// <summary>
     /// Opt-in tool set that exposes the caller's <c>x-aevatar-tool</c>-marked NyxID
     /// connected-service operations as individual tools. Kept out of
     /// <see cref="WorkspaceDefault"/> so connected services are only injected when a route

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -327,12 +327,6 @@ public static class MainnetHostBuilderExtensions
         builder.Services.AddChannelAdminTools();
         builder.Services.AddAgentCatalogTools();
         builder.Services.AddAevatarInvocationTools();
-        // Studio workflow scheduling tool (aevatar_provision_workflow_schedule): the channel-free,
-        // Observatory-delivered analogue of the Lark scheduled_agent_creator. Registered as an
-        // IAgentToolSource here; the studio workflow's allowed_tools allowlist (W2) scopes it to
-        // studio runs. The narrow IWorkflowScheduleProvisioningPort it depends on is registered by
-        // AddStudioApplication (via AddStudioCapability), composed in the same host container.
-        builder.Services.AddStudioProvisioningTools();
         builder.Services.Configure<DeviceEventOptions>(
             builder.Configuration.GetSection("Aevatar:DeviceEvents"));
         // Fail-fast: device HMAC verification must never be disabled in production.
@@ -508,16 +502,6 @@ public static class MainnetHostBuilderExtensions
                     CreateToolSource<ObserveRunToolSource>,
                     CreateToolSource<ReadWorkflowRunArtifactToolSource>,
                     CreateToolSource<WorkflowCatalogAgentToolSource>,
-                    CreateToolSource<ProvisionWorkflowScheduleToolSource>,
-                    CreateToolSource<CreateStudioTeamToolSource>,
-                    CreateToolSource<StudioTeamQueryToolSource>,
-                    CreateToolSource<CreateStudioMemberToolSource>,
-                    CreateToolSource<CreateStudioMemberWorkflowDraftToolSource>,
-                    CreateToolSource<StudioMemberQueryToolSource>,
-                    CreateToolSource<StudioScheduleQueryToolSource>,
-                    CreateToolSource<StudioWorkflowQueryToolSource>,
-                    CreateToolSource<BindStudioMemberWorkflowToolSource>,
-                    CreateToolSource<ScheduleStudioMemberWorkflowToolSource>,
                     CreateToolSource<ResponsesAevatarToolProvider>,
                     CreateToolSource<ChannelInteractiveReplyToolSource>,
                     CreateToolSource<ChannelRegistrationToolSource>,
@@ -536,6 +520,22 @@ public static class MainnetHostBuilderExtensions
                 [ToolSetNames.WorkspaceDefault],
                 [],
                 "Lark route tool composition with the default workspace tools.");
+            options.AddToolSet(
+                ToolSetNames.StudioLocal,
+                [
+                    CreateToolSource<ProvisionWorkflowScheduleToolSource>,
+                    CreateToolSource<CreateStudioTeamToolSource>,
+                    CreateToolSource<StudioTeamQueryToolSource>,
+                    CreateToolSource<CreateStudioMemberToolSource>,
+                    CreateToolSource<CreateStudioMemberWorkflowDraftToolSource>,
+                    CreateToolSource<StudioMemberQueryToolSource>,
+                    CreateToolSource<StudioMemberInvocationReadinessToolSource>,
+                    CreateToolSource<StudioWorkflowQueryToolSource>,
+                    CreateToolSource<StudioScheduleQueryToolSource>,
+                    CreateToolSource<BindStudioMemberWorkflowToolSource>,
+                    CreateToolSource<ScheduleStudioMemberWorkflowToolSource>,
+                ],
+                "Studio-owned local provisioning, member, binding, schedule, and query tools.");
             // Opt-in only: connected-service tools carry per-user NyxID surfaces, so this set
             // is referenced by route policy (not folded into workspace.default) to avoid
             // injecting every caller's connected services by default.

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -451,6 +451,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
               - ornn_search_skills
               - use_skill
             tool_sets:
+              - studio.local
               - nyxid.connected_services
         steps:
           - id: reply

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -74,6 +74,7 @@ using Aevatar.Studio.Hosting;
 using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Extensions.Hosting;
+using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Infrastructure.Runs;
 using Aevatar.Workflow.Integration.AI;
 using Aevatar.Workflow.Projection.ReadModels;
@@ -100,6 +101,39 @@ namespace Aevatar.Capabilities.Tests;
 [Collection(ProcessEnvSerialCollection.Name)]
 public sealed class MainnetHostCompositionTests
 {
+    private static readonly System.Type[] StudioLocalToolSourceTypes =
+    [
+        typeof(ProvisionWorkflowScheduleToolSource),
+        typeof(CreateStudioTeamToolSource),
+        typeof(StudioTeamQueryToolSource),
+        typeof(CreateStudioMemberToolSource),
+        typeof(CreateStudioMemberWorkflowDraftToolSource),
+        typeof(StudioMemberQueryToolSource),
+        typeof(StudioMemberInvocationReadinessToolSource),
+        typeof(StudioWorkflowQueryToolSource),
+        typeof(StudioScheduleQueryToolSource),
+        typeof(BindStudioMemberWorkflowToolSource),
+        typeof(ScheduleStudioMemberWorkflowToolSource),
+    ];
+
+    private static readonly string[] StudioLocalWorkflowToolNames =
+    [
+        "aevatar_provision_workflow_schedule",
+        "aevatar_create_team",
+        "aevatar_list_teams",
+        "aevatar_get_team",
+        "aevatar_create_member",
+        "aevatar_create_member_workflow_draft",
+        "aevatar_list_members",
+        "aevatar_get_member",
+        "aevatar_get_member_invocation_readiness",
+        "aevatar_list_workflows",
+        "aevatar_list_schedules",
+        "aevatar_get_schedule",
+        "aevatar_bind_member_workflow",
+        "aevatar_schedule_member_workflow",
+    ];
+
     [Fact]
     public void AddAevatarMainnetHost_ShouldExportProjectionAndKafkaTelemetry()
     {
@@ -414,6 +448,7 @@ public sealed class MainnetHostCompositionTests
         toolSources.Should().Contain(source => source is SkillsAgentToolSource);
         toolSources.Should().Contain(source => source is OrnnAgentToolSource);
         toolSources.Should().Contain(source => source is HumanInteractionChannelToolSource);
+        toolSources.Should().NotContain(source => StudioLocalToolSourceTypes.Contains(source.GetType()));
         app.Services.GetRequiredService<IHumanInteractionPort>()
             .Should()
             .BeOfType<SkillBackedHumanInteractionPort>();
@@ -716,6 +751,7 @@ public sealed class MainnetHostCompositionTests
             ToolSetNames.LarkSelfNotify,
             ToolSetNames.NyxIdAssistantAdmission,
             ToolSetNames.NyxIdConnectedServices,
+            ToolSetNames.StudioLocal,
             ToolSetNames.WorkspaceDefault);
 
         var workspace = registry.Resolve(ToolSetNames.WorkspaceDefault);
@@ -726,17 +762,8 @@ public sealed class MainnetHostCompositionTests
         workspace.Sources.Should().Contain(source => source is StartWorkflowToolSource);
         workspace.Sources.Should().Contain(source => source is ObserveRunToolSource);
         workspace.Sources.Should().Contain(source => source is ReadWorkflowRunArtifactToolSource);
-        workspace.Sources.Should().Contain(source => source is ProvisionWorkflowScheduleToolSource);
-        workspace.Sources.Should().Contain(source => source is CreateStudioTeamToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioTeamQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is CreateStudioMemberToolSource);
-        workspace.Sources.Should().Contain(source => source is CreateStudioMemberWorkflowDraftToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioMemberQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioScheduleQueryToolSource);
-        workspace.Sources.Should().Contain(source => source is StudioWorkflowQueryToolSource);
         workspace.Sources.Should().Contain(source => source is WorkflowCatalogAgentToolSource);
-        workspace.Sources.Should().Contain(source => source is BindStudioMemberWorkflowToolSource);
-        workspace.Sources.Should().Contain(source => source is ScheduleStudioMemberWorkflowToolSource);
+        workspace.Sources.Should().NotContain(source => StudioLocalToolSourceTypes.Contains(source.GetType()));
         workspace.Sources.Should().Contain(source => source.GetType().Name == "ResponsesAevatarToolProvider");
         workspace.Sources.Should().Contain(source => source is ChannelInteractiveReplyToolSource);
         workspace.Sources.Should().Contain(source => source is ChannelRegistrationToolSource);
@@ -753,6 +780,9 @@ public sealed class MainnetHostCompositionTests
             .Select(static source => source.GetType())
             .Should()
             .NotContain(typeof(NyxIdConnectedServiceInventoryToolSource));
+        app.Services.GetServices<IAgentToolSource>()
+            .Should()
+            .NotContain(source => StudioLocalToolSourceTypes.Contains(source.GetType()));
         app.Services.GetRequiredService<NyxIdConnectedServiceInventoryToolSource>()
             .Should()
             .NotBeNull();
@@ -772,6 +802,7 @@ public sealed class MainnetHostCompositionTests
                 source is ChannelNyxIdConnectedServiceInventoryToolSource)
             .Which.Should()
             .BeSameAs(channelInventorySource);
+        channelToolSources.Should().NotContain(source => StudioLocalToolSourceTypes.Contains(source.GetType()));
         var nyxIdChatToolSources = replyGenerator.GetType()
             .GetField("_nyxIdChatToolSources", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(replyGenerator)
@@ -794,6 +825,7 @@ public sealed class MainnetHostCompositionTests
             source is NyxIdConnectedServiceInventoryToolSource);
         nyxIdChatToolSources.Should().ContainSingle(source => source is WebSearchAgentToolSource);
         nyxIdChatToolSources.Should().NotContain(source => source is WebAgentToolSource);
+        nyxIdChatToolSources.Should().NotContain(source => StudioLocalToolSourceTypes.Contains(source.GetType()));
         var scheduleQueries = app.Services.GetRequiredService<IStudioMemberAutomationQueryPort>();
         var scheduleMutations = app.Services.GetRequiredService<IStudioMemberWorkflowSchedulePort>();
         scheduleQueries.Should().BeSameAs(scheduleMutations);
@@ -802,20 +834,59 @@ public sealed class MainnetHostCompositionTests
         app.Services.GetServices<Aevatar.Workflow.Application.Abstractions.Runs.IWorkflowConnectedServiceResourceFetchAdapter>()
             .Should()
             .ContainSingle(adapter => adapter.GetType().Name == "LarkMessageResourceFetchAdapter");
-        var workflowToolNames = new List<string>();
-        foreach (var source in app.Services.GetServices<Aevatar.Workflow.Core.Modules.IWorkflowToolSource>())
+        var workflowToolSources = app.Services.GetServices<IWorkflowToolSource>().ToArray();
+        var workflowTools = new List<IWorkflowTool>();
+        foreach (var source in workflowToolSources)
         {
             var tools = await source.GetToolsAsync();
-            workflowToolNames.AddRange(tools.Select(static tool => tool.Name));
+            workflowTools.AddRange(tools);
         }
+        var workflowToolNames = workflowTools.Select(static tool => tool.Name).ToArray();
         workflowToolNames.Should().ContainSingle(name => name == "workflow_connected_service_resource_fetch");
+        workflowToolNames.Should().NotContain(StudioLocalWorkflowToolNames);
+        var agentWorkflowSource = workflowToolSources
+            .Should()
+            .ContainSingle(source => source is AgentWorkflowToolSourceAdapter)
+            .Which;
+        (await agentWorkflowSource.GetToolsAsync()).Should()
+            .OnlyContain(tool => tool is IWorkflowDurableOperationTool);
+
+        using (AgentToolContextScope.Push(AgentToolExecutionContext.Empty with
+               {
+                   ToolVisibility = AgentToolVisibilityScope.FromAllowedToolNames(
+                       StudioLocalWorkflowToolNames),
+               }))
+        {
+            var ambientVisibleNames = new List<string>();
+            foreach (var source in workflowToolSources)
+            {
+                ambientVisibleNames.AddRange(
+                    (await source.GetToolsAsync()).Select(static tool => tool.Name));
+            }
+
+            ambientVisibleNames.Should().NotContain(StudioLocalWorkflowToolNames);
+        }
 
         var larkSelfNotify = registry.Resolve(ToolSetNames.LarkSelfNotify);
         larkSelfNotify.IsSuccess.Should().BeTrue(larkSelfNotify.Error?.Message);
         larkSelfNotify.Sources.Select(static source => source.GetType()).Should()
             .Equal(workspace.Sources.Select(static source => source.GetType()));
+        larkSelfNotify.Sources.Should().NotContain(source => StudioLocalToolSourceTypes.Contains(source.GetType()));
         larkSelfNotify.Sources.Should().Contain(source => source is LarkAgentToolSource);
         larkSelfNotify.Sources.Should().Contain(source => source is NyxIdAgentToolSource);
+
+        var studioLocal = registry.Resolve(ToolSetNames.StudioLocal);
+        studioLocal.IsSuccess.Should().BeTrue(studioLocal.Error?.Message);
+        studioLocal.Sources.Select(static source => source.GetType())
+            .Should()
+            .Equal(StudioLocalToolSourceTypes);
+        var studioLocalToolNames = new List<string>();
+        foreach (var source in studioLocal.Sources)
+        {
+            studioLocalToolNames.AddRange(
+                (await source.DiscoverToolsAsync()).Select(static tool => tool.Name));
+        }
+        studioLocalToolNames.Should().Contain(StudioLocalWorkflowToolNames);
 
         var nyxIdConnectedServices = registry.Resolve(ToolSetNames.NyxIdConnectedServices);
         nyxIdConnectedServices.IsSuccess.Should().BeTrue(nyxIdConnectedServices.Error?.Message);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -402,7 +402,9 @@ public class WorkflowDefinitionCatalogTests
         allowed.Should().Contain("nyxid_llm_status");
         allowed.Should().Contain("nyxid_services");
         allowed.Should().NotContain("nyxid_proxy");
-        role.AgentToolScope.ToolSetRefs.Should().Equal("nyxid.connected_services");
+        role.AgentToolScope.ToolSetRefs.Should().Equal(
+            "studio.local",
+            "nyxid.connected_services");
         allowed.Should().Contain("nyxid_require_service");
         allowed.Should().Contain("list_external_workflow_capabilities");
         allowed.Should().Contain("inspect_external_workflow_capability_readiness");


### PR DESCRIPTION
## Problem

Studio provisioning/member/query/binding/schedule sources were part of `workspace.default` and ambient `IAgentToolSource` discovery, leaking Studio-local capabilities into public default, direct LLM, Lark, channel, and workflow-wide catalogs. The earlier #2979 attempted to isolate them but left the built-in Studio workflow unable to reach those tools and introduced visibility-sensitive workflow discovery that could be frozen by `ToolCallModule` caching.

## Solution

- Move all 11 Studio source types into the opt-in `studio.local` tool set; keep `workspace.default` and inherited public surfaces Studio-free.
- Make the built-in Studio workflow explicitly select `studio.local` through role-level `tool_sets`, using the existing request-scoped `WorkflowRoleGAgent` catalog for execution, approval continuation, and recovery.
- Resolve channel defaults from `workspace.default` while retaining the existing global fallback for hosts without that registration.
- Preserve `AgentWorkflowToolSourceAdapter` durable operation semantics; do not add ambient visibility-dependent workflow sources.
- Update canonical/design documentation and add composition regressions covering global, workspace, Lark, channel, NyxID chat, workflow-wide, and Studio-local catalogs.

This replaces #2979, which now conflicts with `feature/integrate`.

## Impact

- Mainnet tool-set composition and channel default source resolution
- Built-in Studio workflow tool admission
- Tool-set boundary documentation and host composition tests

## Validation

- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --filter FullyQualifiedName~WorkflowDefinitionCatalogTests --nologo --verbosity minimal` (23 passed)
- `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --filter FullyQualifiedName~MainnetHostCompositionTests.AddAevatarMainnetHost_ShouldRegisterDefaultToolSets --nologo --verbosity minimal` (1 passed)
- `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --filter FullyQualifiedName~AgentWorkflowToolSourceAdapterTests --nologo --verbosity minimal` (39 passed)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/docs/lint.sh`
- `bash tools/ci/architecture_guards.sh`
- `git diff --check`

Fixes #2975