### PR TITLE
Preserve tool set scopes in Studio workflow documents

### DIFF
--- a/src/Aevatar.Studio.Domain/Studio/Compatibility/WorkflowCompatibilityProfile.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Compatibility/WorkflowCompatibilityProfile.cs
@@ -188,6 +188,7 @@ public sealed class WorkflowCompatibilityProfile
                 "max_tool_rounds",
                 "max_history_messages",
                 "allowed_tools",
+                "tool_sets",
                 "event_modules",
                 "event_routes",
                 "connectors",
@@ -195,7 +196,7 @@ public sealed class WorkflowCompatibilityProfile
             AllowedRoleExtensionFields = ImmutableHashSet.Create(comparer, "event_modules", "event_routes"),
             AllowedStepFields = ImmutableHashSet.Create(
                 comparer,
-                ["id", "type", "target_role", "role", "allowed_tools", "capability", "parameters", "next", "branches", "children", "retry", "on_error", "timeout_ms", .. rootParameterFields]),
+                ["id", "type", "target_role", "role", "allowed_tools", "tool_sets", "capability", "parameters", "next", "branches", "children", "retry", "on_error", "timeout_ms", .. rootParameterFields]),
             AllowedRetryFields = ImmutableHashSet.Create(comparer, "max_attempts", "backoff", "delay_ms"),
             AllowedOnErrorFields = ImmutableHashSet.Create(comparer, "strategy", "fallback_step", "default_output"),
             AllowedBranchListFields = ImmutableHashSet.Create(comparer, "condition", "when", "case", "label", "if", "next", "to", "target", "step"),

--- a/src/Aevatar.Studio.Domain/Studio/Models/RoleModel.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Models/RoleModel.cs
@@ -22,6 +22,8 @@ public sealed record RoleModel
 
     public List<string>? AllowedTools { get; init; }
 
+    public List<string>? ToolSets { get; init; }
+
     public string? EventModules { get; init; }
 
     public string? EventRoutes { get; init; }

--- a/src/Aevatar.Studio.Domain/Studio/Models/StepModel.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Models/StepModel.cs
@@ -14,6 +14,8 @@ public sealed record StepModel
 
     public List<string>? AllowedTools { get; init; }
 
+    public List<string>? ToolSets { get; init; }
+
     public StepCapability? Capability { get; init; }
 
     public StudioStepParameters Parameters { get; init; } = new();

--- a/src/Aevatar.Studio.Domain/Studio/Services/WorkflowDocumentNormalizer.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Services/WorkflowDocumentNormalizer.cs
@@ -37,7 +37,8 @@ public sealed class WorkflowDocumentNormalizer
             Model = NormalizeText(role.Model),
             EventModules = NormalizeText(role.EventModules),
             EventRoutes = NormalizeText(role.EventRoutes),
-            AllowedTools = NormalizeAllowedTools(role.AllowedTools),
+            AllowedTools = NormalizeOptionalStringList(role.AllowedTools),
+            ToolSets = NormalizeOptionalStringList(role.ToolSets),
             Connectors = role.Connectors
                 .SelectMany(SplitConnectorValue)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -80,7 +81,8 @@ public sealed class WorkflowDocumentNormalizer
             OriginalType = canonicalType,
             TargetRole = NormalizeText(step.TargetRole),
             UsedRoleAlias = false,
-            AllowedTools = NormalizeAllowedTools(step.AllowedTools),
+            AllowedTools = NormalizeOptionalStringList(step.AllowedTools),
+            ToolSets = NormalizeOptionalStringList(step.ToolSets),
             Capability = NormalizeCapability(step.Capability),
             Parameters = normalizedParameters,
             Next = NormalizeText(step.Next),
@@ -196,10 +198,10 @@ public sealed class WorkflowDocumentNormalizer
     private static string? NormalizeText(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
-    private static List<string>? NormalizeAllowedTools(IReadOnlyList<string>? allowedTools) =>
-        allowedTools is null
+    private static List<string>? NormalizeOptionalStringList(IReadOnlyList<string>? values) =>
+        values is null
             ? null
-            : allowedTools
+            : values
                 .Select(NormalizeText)
                 .Where(value => value is not null)
                 .Select(value => value!)

--- a/src/Aevatar.Studio.Infrastructure/Serialization/YamlWorkflowDocumentService.cs
+++ b/src/Aevatar.Studio.Infrastructure/Serialization/YamlWorkflowDocumentService.cs
@@ -188,7 +188,8 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
                 MaxTokens = ReadInteger(roleNode, "max_tokens", findings, path),
                 MaxToolRounds = ReadInteger(roleNode, "max_tool_rounds", findings, path),
                 MaxHistoryMessages = ReadInteger(roleNode, "max_history_messages", findings, path),
-                AllowedTools = ParseAllowedTools(roleNode, path, findings),
+                AllowedTools = ParseOptionalStringList(roleNode, "allowed_tools", path, findings),
+                ToolSets = ParseOptionalStringList(roleNode, "tool_sets", path, findings),
                 EventModules = eventModules,
                 EventRoutes = eventRoutes,
                 Connectors = ParseConnectors(roleNode, path, findings),
@@ -248,7 +249,8 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
             OriginalType = rawType,
             TargetRole = ReadScalar(stepNode, "target_role") ?? ReadScalar(stepNode, "role"),
             UsedRoleAlias = GetNode(stepNode, "target_role") is null && GetNode(stepNode, "role") is not null,
-            AllowedTools = ParseAllowedTools(stepNode, path, findings),
+            AllowedTools = ParseOptionalStringList(stepNode, "allowed_tools", path, findings),
+            ToolSets = ParseOptionalStringList(stepNode, "tool_sets", path, findings),
             Capability = ParseCapability(stepNode, path, findings),
             Parameters = parameters,
             Next = ReadScalar(stepNode, "next"),
@@ -554,47 +556,48 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
         return [];
     }
 
-    private static List<string>? ParseAllowedTools(
+    private static List<string>? ParseOptionalStringList(
         YamlMappingNode node,
+        string key,
         string path,
         ICollection<ValidationFinding> findings)
     {
-        var allowedToolsNode = GetNode(node, "allowed_tools");
-        if (allowedToolsNode is null)
+        var listNode = GetNode(node, key);
+        if (listNode is null)
         {
             return null;
         }
 
-        if (allowedToolsNode is YamlSequenceNode sequenceNode)
+        if (listNode is YamlSequenceNode sequenceNode)
         {
-            var tools = new List<string>();
+            var values = new List<string>();
             for (var index = 0; index < sequenceNode.Children.Count; index++)
             {
                 if (sequenceNode.Children[index] is not YamlScalarNode scalarNode)
                 {
                     findings.Add(ValidationFinding.Error(
-                        $"{path}/allowed_tools/{index}",
-                        "Each `allowed_tools` entry must be a string."));
+                        $"{path}/{key}/{index}",
+                        $"Each `{key}` entry must be a string."));
                     continue;
                 }
 
                 if (!string.IsNullOrWhiteSpace(scalarNode.Value))
                 {
-                    tools.Add(scalarNode.Value.Trim());
+                    values.Add(scalarNode.Value.Trim());
                 }
             }
 
-            return tools;
+            return values;
         }
 
-        if (allowedToolsNode is YamlScalarNode scalar)
+        if (listNode is YamlScalarNode scalar)
         {
             return (scalar.Value ?? string.Empty)
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToList();
         }
 
-        findings.Add(ValidationFinding.Error($"{path}/allowed_tools", "`allowed_tools` must be a list or comma-delimited string."));
+        findings.Add(ValidationFinding.Error($"{path}/{key}", $"`{key}` must be a list or comma-delimited string."));
         return [];
     }
 
@@ -625,6 +628,7 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
         AddIfNotNull(result, "max_tool_rounds", role.MaxToolRounds);
         AddIfNotNull(result, "max_history_messages", role.MaxHistoryMessages);
         AddIfPresent(result, "allowed_tools", role.AllowedTools);
+        AddIfPresent(result, "tool_sets", role.ToolSets);
         AddIfNotNull(result, "event_modules", role.EventModules);
         AddIfNotNull(result, "event_routes", role.EventRoutes);
 
@@ -650,6 +654,7 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
         }
 
         AddIfPresent(result, "allowed_tools", step.AllowedTools);
+        AddIfPresent(result, "tool_sets", step.ToolSets);
         AddIfNotNull(result, "capability", SerializeCapability(step.Capability));
 
         if (step.Parameters.Count > 0)

--- a/src/Aevatar.Studio.Infrastructure/Serialization/YamlWorkflowDocumentService.cs
+++ b/src/Aevatar.Studio.Infrastructure/Serialization/YamlWorkflowDocumentService.cs
@@ -581,6 +581,11 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
                     continue;
                 }
 
+                if (IsYamlNullScalar(scalarNode))
+                {
+                    continue;
+                }
+
                 if (!string.IsNullOrWhiteSpace(scalarNode.Value))
                 {
                     values.Add(scalarNode.Value.Trim());
@@ -592,6 +597,11 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
 
         if (listNode is YamlScalarNode scalar)
         {
+            if (IsYamlNullScalar(scalar))
+            {
+                return null;
+            }
+
             return (scalar.Value ?? string.Empty)
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToList();
@@ -599,6 +609,21 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
 
         findings.Add(ValidationFinding.Error($"{path}/{key}", $"`{key}` must be a list or comma-delimited string."));
         return [];
+    }
+
+    private static bool IsYamlNullScalar(YamlScalarNode scalar)
+    {
+        if (scalar.Tag == "tag:yaml.org,2002:null")
+        {
+            return true;
+        }
+
+        if (!scalar.Tag.IsEmpty || scalar.Style != ScalarStyle.Plain)
+        {
+            return false;
+        }
+
+        return scalar.Value is null or "" or "~" or "null" or "Null" or "NULL";
     }
 
     private Dictionary<string, object?> SerializeRole(RoleModel role)
@@ -744,9 +769,14 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
     {
         if (value is not null)
         {
-            dictionary[key] = value;
+            dictionary[key] = value.Select(ToYamlStringListItem).ToList();
         }
     }
+
+    private static object ToYamlStringListItem(string value) =>
+        value is "null" or "Null" or "NULL" or "~"
+            ? new YamlScalarNode(value) { Style = ScalarStyle.DoubleQuoted }
+            : value;
 
     private static void AddIfNotBlank(
         IDictionary<string, object?> dictionary,

--- a/test/Aevatar.Studio.Tests/EditorControllerSerializationTests.cs
+++ b/test/Aevatar.Studio.Tests/EditorControllerSerializationTests.cs
@@ -284,6 +284,57 @@ public sealed class EditorControllerSerializationTests
     }
 
     [Fact]
+    public async Task ParseAndSerializeYaml_ShouldPreserveToolSetsInDocumentJson()
+    {
+        using var host = await StartHostAsync();
+        var client = host.GetTestClient();
+
+        using var parseResponse = await client.PostAsJsonAsync("/api/editor/parse-yaml", new
+        {
+            yaml = """
+                   name: tool_set_scope
+                   roles:
+                     - id: planner
+                       tool_sets: [studio.local, nyxid.connected_services]
+                     - id: isolated
+                       tool_sets: []
+                   steps:
+                     - id: scoped
+                       type: llm_call
+                       target_role: planner
+                       tool_sets: [nyxid.connected_services]
+                     - id: no_tool_sets
+                       type: llm_call
+                       target_role: isolated
+                       tool_sets: []
+                   """,
+            availableStepTypes = new[] { "llm_call" },
+        });
+
+        var parseBody = await parseResponse.Content.ReadAsStringAsync();
+        parseResponse.StatusCode.Should().Be(HttpStatusCode.OK, parseBody);
+        parseBody.Should().NotContain("\"code\":\"unknown_field\"");
+        parseBody.Should().Contain("\"toolSets\":[\"studio.local\",\"nyxid.connected_services\"]");
+        parseBody.Should().Contain("\"toolSets\":[\"nyxid.connected_services\"]");
+        parseBody.Should().Contain("\"toolSets\":[]");
+
+        using var parsedJson = JsonDocument.Parse(parseBody);
+        var document = parsedJson.RootElement.GetProperty("document").Clone();
+        using var serializeResponse = await client.PostAsJsonAsync("/api/editor/serialize-yaml", new
+        {
+            document,
+            availableStepTypes = new[] { "llm_call" },
+        });
+
+        var serializeBody = await serializeResponse.Content.ReadAsStringAsync();
+        serializeResponse.StatusCode.Should().Be(HttpStatusCode.OK, serializeBody);
+        serializeBody.Should().Contain("tool_sets:");
+        serializeBody.Should().Contain("- studio.local");
+        serializeBody.Should().Contain("- nyxid.connected_services");
+        serializeBody.Should().Contain("tool_sets: []");
+    }
+
+    [Fact]
     public async Task ParseAndSerializeYaml_ShouldPreserveTypedNyxIdCapabilitiesRecursively()
     {
         using var host = await StartHostAsync();

--- a/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
@@ -254,6 +254,86 @@ public sealed class WorkflowCompatibilityProfileTests
         runtimeRoundTrip.Steps[2].AgentToolScope.Should().BeNull();
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("null")]
+    [InlineData("Null")]
+    [InlineData("NULL")]
+    [InlineData("~")]
+    public void Parse_WhenRoleAndStepToolSetsUseYamlNullScalars_ShouldPreserveInheritedScopeThroughRoundTrips(
+        string nullMarker)
+    {
+        var service = new YamlWorkflowDocumentService(_profile);
+        var scalarSuffix = string.IsNullOrEmpty(nullMarker) ? string.Empty : $" {nullMarker}";
+        var yaml = $"""
+            name: inherited_tool_set_scope
+            roles:
+              - id: inherited
+                tool_sets:{scalarSuffix}
+            steps:
+              - id: inherited_step
+                type: llm_call
+                target_role: inherited
+                tool_sets:{scalarSuffix}
+            """;
+
+        var studioParse = service.Parse(yaml);
+
+        studioParse.Document.Should().NotBeNull();
+        studioParse.Document!.Roles[0].ToolSets.Should().BeNull();
+        studioParse.Document.Steps[0].ToolSets.Should().BeNull();
+        var runtimeParse = new WorkflowParser().Parse(yaml);
+        runtimeParse.Roles[0].AgentToolScope.Should().BeNull();
+        runtimeParse.Steps[0].AgentToolScope.Should().BeNull();
+
+        var serialized = service.Serialize(studioParse.Document);
+        serialized.Should().NotContain("tool_sets:");
+        var studioRoundTrip = service.Parse(serialized);
+        studioRoundTrip.Document!.Roles[0].ToolSets.Should().BeNull();
+        studioRoundTrip.Document.Steps[0].ToolSets.Should().BeNull();
+        var runtimeRoundTrip = new WorkflowParser().Parse(serialized);
+        runtimeRoundTrip.Roles[0].AgentToolScope.Should().BeNull();
+        runtimeRoundTrip.Steps[0].AgentToolScope.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("~")]
+    public void Parse_WhenRoleAndStepToolSetsUseQuotedNullLikeStrings_ShouldPreserveLiteralScopeThroughRoundTrips(
+        string literal)
+    {
+        var service = new YamlWorkflowDocumentService(_profile);
+        var yaml = $$"""
+            name: literal_tool_set_scope
+            roles:
+              - id: literal_role
+                tool_sets: "{{literal}}"
+            steps:
+              - id: literal_step
+                type: llm_call
+                target_role: literal_role
+                tool_sets: [{{literal}}, "{{literal}}"]
+            """;
+
+        var studioParse = service.Parse(yaml);
+
+        studioParse.Document.Should().NotBeNull();
+        studioParse.Document!.Roles[0].ToolSets.Should().Equal(literal);
+        studioParse.Document.Steps[0].ToolSets.Should().Equal(literal);
+        var runtimeParse = new WorkflowParser().Parse(yaml);
+        runtimeParse.Roles[0].AgentToolScope!.ToolSetRefs.Should().Equal(literal);
+        runtimeParse.Steps[0].AgentToolScope!.ToolSetRefs.Should().Equal(literal);
+
+        var serialized = service.Serialize(studioParse.Document);
+        serialized.Should().Contain($"\"{literal}\"");
+        var studioRoundTrip = service.Parse(serialized);
+        studioRoundTrip.Document!.Roles[0].ToolSets.Should().Equal(literal);
+        studioRoundTrip.Document.Steps[0].ToolSets.Should().Equal(literal);
+        var runtimeRoundTrip = new WorkflowParser().Parse(serialized);
+        runtimeRoundTrip.Roles[0].AgentToolScope!.ToolSetRefs.Should().Equal(literal);
+        runtimeRoundTrip.Steps[0].AgentToolScope!.ToolSetRefs.Should().Equal(literal);
+    }
+
     [Fact]
     public void Parse_WhenAllowedToolsScalarContainsNonRuntimeDelimiters_ShouldPreserveRuntimeTokenization()
     {

--- a/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
@@ -197,6 +197,64 @@ public sealed class WorkflowCompatibilityProfileTests
     }
 
     [Fact]
+    public void Parse_WhenRuntimeToolSetsFieldsDeclared_ShouldAcceptTypedFieldsAndRoundTripToRuntime()
+    {
+        var service = new YamlWorkflowDocumentService(_profile);
+        var yaml = """
+            name: tool_set_scope
+            roles:
+              - id: planner
+                tool_sets: [studio.local, nyxid.connected_services]
+              - id: isolated
+                tool_sets: []
+              - id: inherited
+            steps:
+              - id: scoped
+                type: llm_call
+                target_role: planner
+                tool_sets: [nyxid.connected_services]
+              - id: no_tool_sets
+                type: llm_call
+                target_role: isolated
+                tool_sets: []
+              - id: inherited_tool_sets
+                type: llm_call
+                target_role: inherited
+            """;
+
+        var studioParse = service.Parse(yaml);
+
+        studioParse.Findings.Should().NotContain(finding =>
+            string.Equals(finding.Code, "unknown_field", StringComparison.OrdinalIgnoreCase));
+        studioParse.Document.Should().NotBeNull();
+
+        var serialized = service.Serialize(studioParse.Document!);
+        serialized.Should().Contain("tool_sets:");
+        serialized.Should().Contain("tool_sets: []");
+
+        var runtimeRoundTrip = new WorkflowParser().Parse(serialized);
+        var plannerScope = runtimeRoundTrip.Roles[0].AgentToolScope;
+        var isolatedRoleScope = runtimeRoundTrip.Roles[1].AgentToolScope;
+        var scopedStepScope = runtimeRoundTrip.Steps[0].AgentToolScope;
+        var isolatedStepScope = runtimeRoundTrip.Steps[1].AgentToolScope;
+        plannerScope.Should().NotBeNull();
+        isolatedRoleScope.Should().NotBeNull();
+        scopedStepScope.Should().NotBeNull();
+        isolatedStepScope.Should().NotBeNull();
+        plannerScope!.ToolSetRefs.Should()
+            .Equal("studio.local", "nyxid.connected_services");
+        plannerScope.RestrictToolSets.Should().BeTrue();
+        isolatedRoleScope!.ToolSetRefs.Should().BeEmpty();
+        isolatedRoleScope.RestrictToolSets.Should().BeTrue();
+        runtimeRoundTrip.Roles[2].AgentToolScope.Should().BeNull();
+        scopedStepScope!.ToolSetRefs.Should().Equal("nyxid.connected_services");
+        scopedStepScope.RestrictToolSets.Should().BeTrue();
+        isolatedStepScope!.ToolSetRefs.Should().BeEmpty();
+        isolatedStepScope.RestrictToolSets.Should().BeTrue();
+        runtimeRoundTrip.Steps[2].AgentToolScope.Should().BeNull();
+    }
+
+    [Fact]
     public void Parse_WhenAllowedToolsScalarContainsNonRuntimeDelimiters_ShouldPreserveRuntimeTokenization()
     {
         var service = new YamlWorkflowDocumentService(_profile);

--- a/test/Aevatar.Studio.Tests/WorkflowDocumentNormalizerTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowDocumentNormalizerTests.cs
@@ -75,6 +75,36 @@ public sealed class WorkflowDocumentNormalizerTests
     }
 
     [Fact]
+    public void NormalizeForExport_ShouldNormalizeToolSetsWithoutCollapsingPresence()
+    {
+        var doc = new WorkflowDocument
+        {
+            Name = "wf",
+            Roles =
+            [
+                new RoleModel { Id = "r1", ToolSets = [" studio.local ", " ", "nyxid.connected_services"] },
+                new RoleModel { Id = "r2", ToolSets = [] },
+                new RoleModel { Id = "r3" },
+            ],
+            Steps =
+            [
+                new StepModel { Id = "s1", Type = "llm_call", ToolSets = [" nyxid.connected_services ", ""] },
+                new StepModel { Id = "s2", Type = "llm_call", ToolSets = [] },
+                new StepModel { Id = "s3", Type = "llm_call" },
+            ],
+        };
+
+        var result = _normalizer.NormalizeForExport(doc);
+
+        result.Roles[0].ToolSets.Should().Equal("studio.local", "nyxid.connected_services");
+        result.Roles[1].ToolSets.Should().BeEmpty();
+        result.Roles[2].ToolSets.Should().BeNull();
+        result.Steps[0].ToolSets.Should().Equal("nyxid.connected_services");
+        result.Steps[1].ToolSets.Should().BeEmpty();
+        result.Steps[2].ToolSets.Should().BeNull();
+    }
+
+    [Fact]
     public void NormalizeForExport_ShouldCanonicalizeStepType()
     {
         var doc = new WorkflowDocument


### PR DESCRIPTION
## Problem
Template instantiation stores runtime-supported tool_sets in the Studio draft YAML, but Studio rejected the field as unknown during the next parse and could not save the workflow.

## Solution
- Add typed ToolSets fields to Studio role and step documents.
- Accept, parse, normalize, and serialize tool_sets independently from allowed_tools.
- Preserve absent, empty, and populated lists so runtime tool-set restriction semantics remain unchanged.

## Verification
- /Users/abigaildeng/.dotnet/dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~WorkflowCompatibilityProfileTests|FullyQualifiedName~EditorControllerSerializationTests|FullyQualifiedName~WorkflowDocumentNormalizerTests" (119 passed)
- PATH with temporary Python 3.12 python3 entrypoint bash tools/ci/test_stability_guards.sh (passed)
- git diff --check (passed)