### PR TITLE
Unify workflow template tooltips

### DIFF
--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -379,8 +379,14 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.new.templateBrowser.none': 'None',
   'workflowActivityVNext.new.templateBrowser.llmProvider': 'LLM provider',
   'workflowActivityVNext.new.templateBrowser.runsSteps': 'Runs {count} {unit}',
-  'workflowActivityVNext.new.templateBrowser.runsStepsTooltip':
-    'This template contains {count} configured workflow {unit}.',
+  'workflowActivityVNext.new.templateBrowser.stepsTooltipTitle':
+    'Workflow steps ({count})',
+  'workflowActivityVNext.new.templateBrowser.stepsTooltipLoading':
+    'Loading step details…',
+  'workflowActivityVNext.new.templateBrowser.stepsTooltipUnavailable':
+    'Step details are unavailable. Open View to inspect this template.',
+  'workflowActivityVNext.new.templateBrowser.stepsTooltipEmpty':
+    'No workflow steps are exposed for this template.',
   'workflowActivityVNext.new.templateBrowser.step': 'step',
   'workflowActivityVNext.new.templateBrowser.steps': 'steps',
   'workflowActivityVNext.new.templateBrowser.fallbackDescription':

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts
@@ -372,15 +372,15 @@ const workflowActivityVNextMessages = {
   'workflowActivityVNext.new.templateBrowser.catalogue':
     'Workflow template catalogue',
   'workflowActivityVNext.new.templateBrowser.template': 'Template',
-  'workflowActivityVNext.new.templateBrowser.reads': 'Reads',
   'workflowActivityVNext.new.templateBrowser.connection': 'Connection',
   'workflowActivityVNext.new.templateBrowser.does': 'Does',
   'workflowActivityVNext.new.templateBrowser.updatedColumn': 'Updated',
   'workflowActivityVNext.new.templateBrowser.actions': 'Actions',
-  'workflowActivityVNext.new.templateBrowser.workflowInputs': 'Workflow inputs',
   'workflowActivityVNext.new.templateBrowser.none': 'None',
   'workflowActivityVNext.new.templateBrowser.llmProvider': 'LLM provider',
   'workflowActivityVNext.new.templateBrowser.runsSteps': 'Runs {count} {unit}',
+  'workflowActivityVNext.new.templateBrowser.runsStepsTooltip':
+    'This template contains {count} configured workflow {unit}.',
   'workflowActivityVNext.new.templateBrowser.step': 'step',
   'workflowActivityVNext.new.templateBrowser.steps': 'steps',
   'workflowActivityVNext.new.templateBrowser.fallbackDescription':

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -357,8 +357,14 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.new.templateBrowser.llmProvider': 'LLM Provider',
     'workflowActivityVNext.new.templateBrowser.runsSteps':
       '运行 {count} 个{unit}',
-    'workflowActivityVNext.new.templateBrowser.runsStepsTooltip':
-      '此模板包含 {count} 个已配置的工作流{unit}。',
+    'workflowActivityVNext.new.templateBrowser.stepsTooltipTitle':
+      '工作流步骤（{count}）',
+    'workflowActivityVNext.new.templateBrowser.stepsTooltipLoading':
+      '正在加载步骤详情…',
+    'workflowActivityVNext.new.templateBrowser.stepsTooltipUnavailable':
+      '暂时无法加载步骤详情，请点击“查看”查看完整工作流。',
+    'workflowActivityVNext.new.templateBrowser.stepsTooltipEmpty':
+      '该模板未提供可展示的工作流步骤。',
     'workflowActivityVNext.new.templateBrowser.step': '步骤',
     'workflowActivityVNext.new.templateBrowser.steps': '步骤',
     'workflowActivityVNext.new.templateBrowser.fallbackDescription':

--- a/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts
@@ -349,16 +349,16 @@ const workflowActivityVNextMessages: Record<keyof typeof enUSMessages, string> =
     'workflowActivityVNext.new.templateBrowser.useNamed': '使用模板 {name}',
     'workflowActivityVNext.new.templateBrowser.catalogue': '工作流模板目录',
     'workflowActivityVNext.new.templateBrowser.template': '模板',
-    'workflowActivityVNext.new.templateBrowser.reads': '读取',
     'workflowActivityVNext.new.templateBrowser.connection': '连接',
     'workflowActivityVNext.new.templateBrowser.does': '执行',
     'workflowActivityVNext.new.templateBrowser.updatedColumn': '更新时间',
     'workflowActivityVNext.new.templateBrowser.actions': '操作',
-    'workflowActivityVNext.new.templateBrowser.workflowInputs': '工作流输入',
     'workflowActivityVNext.new.templateBrowser.none': '无',
     'workflowActivityVNext.new.templateBrowser.llmProvider': 'LLM Provider',
     'workflowActivityVNext.new.templateBrowser.runsSteps':
       '运行 {count} 个{unit}',
+    'workflowActivityVNext.new.templateBrowser.runsStepsTooltip':
+      '此模板包含 {count} 个已配置的工作流{unit}。',
     'workflowActivityVNext.new.templateBrowser.step': '步骤',
     'workflowActivityVNext.new.templateBrowser.steps': '步骤',
     'workflowActivityVNext.new.templateBrowser.fallbackDescription':

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -19,12 +19,12 @@ import {
   Table,
   Tabs,
   Tag,
-  Tooltip,
   Typography,
   theme,
 } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import {
   readServiceQueryDraft,
   trimServiceQuery,
@@ -714,7 +714,7 @@ const DeploymentsScopeCard: React.FC<{
         >
           {t("pages.deployments.index.team.application.namespace.2", "team/Application/Namespace")}</span>
       </Space>
-      <Tooltip title={scopeLabel}>
+      <AevatarTooltip title={scopeLabel}>
         <div
           style={{
             alignItems: 'center',
@@ -736,7 +736,7 @@ const DeploymentsScopeCard: React.FC<{
         >
           {scopeLabel}
         </div>
-      </Tooltip>
+      </AevatarTooltip>
     </div>
 
     <div
@@ -2328,7 +2328,7 @@ const DeploymentsPage: React.FC = () => {
                           </div>
                         </td>
                         <td style={tableCellStyle}>
-                          <Tooltip
+                          <AevatarTooltip
                             title={`${service.tenantId}/${service.appId}/${service.namespace}`}
                           >
                             <Typography.Text
@@ -2343,7 +2343,7 @@ const DeploymentsPage: React.FC = () => {
                                 service.namespace,
                               )}
                             </Typography.Text>
-                          </Tooltip>
+                          </AevatarTooltip>
                         </td>
                         <td style={tableCellStyle}>
                           {service.activeServingRevisionId ||
@@ -2428,7 +2428,7 @@ const DeploymentsPage: React.FC = () => {
                 type="primary"
               >
                 {t("pages.deployments.index.deploy.release.candidate.3", "Deploy a release candidate")}</Button>
-              <Tooltip title={servingEntryAvailability.reason}>
+              <AevatarTooltip title={servingEntryAvailability.reason}>
                 <span>
                   <Button
                     disabled={!servingEntryAvailability.enabled}
@@ -2440,8 +2440,8 @@ const DeploymentsPage: React.FC = () => {
                       : t("pages.deployments.index.view.traffic.status", "View traffic status")}
                   </Button>
                 </span>
-              </Tooltip>
-              <Tooltip title={rolloutControlEntryAvailability.reason}>
+              </AevatarTooltip>
+              <AevatarTooltip title={rolloutControlEntryAvailability.reason}>
                 <span>
                   <Button
                     disabled={!rolloutControlEntryAvailability.enabled}
@@ -2453,7 +2453,7 @@ const DeploymentsPage: React.FC = () => {
                       : t("pages.deployments.index.no.activity.control", "No activity control")}
                   </Button>
                 </span>
-              </Tooltip>
+              </AevatarTooltip>
             </Space>
           ) : null
         }
@@ -2629,7 +2629,7 @@ const DeploymentsPage: React.FC = () => {
                                 {t("pages.deployments.index.rollout.active", "Rollout active")}
                               </Tag>
                             ) : null}
-                            <Tooltip title={servingEntryAvailability.reason}>
+                            <AevatarTooltip title={servingEntryAvailability.reason}>
                               <span>
                                 <Button
                                   disabled={!servingEntryAvailability.enabled}
@@ -2641,7 +2641,7 @@ const DeploymentsPage: React.FC = () => {
                                     : t("pages.deployments.index.view.traffic.status.2", "View traffic status")}
                                 </Button>
                               </span>
-                            </Tooltip>
+                            </AevatarTooltip>
                           </Space>
                         }
                       >
@@ -2682,7 +2682,7 @@ const DeploymentsPage: React.FC = () => {
                             <Tag>
                               {t("pages.deployments.index.generation.4", "Generation")}{trafficQuery.data?.generation ?? 0}
                             </Tag>
-                            <Tooltip title={servingEntryAvailability.reason}>
+                            <AevatarTooltip title={servingEntryAvailability.reason}>
                               <span>
                                 <Button
                                   disabled={!servingEntryAvailability.enabled}
@@ -2694,7 +2694,7 @@ const DeploymentsPage: React.FC = () => {
                                     : t("pages.deployments.index.view.traffic.status.3", "View traffic status")}
                                 </Button>
                               </span>
-                            </Tooltip>
+                            </AevatarTooltip>
                           </Space>
                         }
                       >
@@ -3061,7 +3061,7 @@ const DeploymentsPage: React.FC = () => {
                         servingTargetPlanStatus.enabled ? 'info' : 'warning'
                       }
                     />
-                    <Tooltip title={servingTargetPlanStatus.reason}>
+                    <AevatarTooltip title={servingTargetPlanStatus.reason}>
                       <span
                         style={{ display: 'inline-flex', width: 'fit-content' }}
                       >
@@ -3074,7 +3074,7 @@ const DeploymentsPage: React.FC = () => {
                         >
                           {t("pages.deployments.index.apply.weights.2", "Apply weights")}</Button>
                       </span>
-                    </Tooltip>
+                    </AevatarTooltip>
                   </div>
                 ),
                 key: 'weights',
@@ -3124,7 +3124,7 @@ const DeploymentsPage: React.FC = () => {
                           rolloutActionAvailability[definition.action];
 
                         return (
-                          <Tooltip
+                          <AevatarTooltip
                             key={definition.action}
                             title={availability.reason}
                           >
@@ -3144,7 +3144,7 @@ const DeploymentsPage: React.FC = () => {
                                 {formatConsoleMessage(definition.label)}
                               </Button>
                             </span>
-                          </Tooltip>
+                          </AevatarTooltip>
                         );
                       })}
                     </Space>
@@ -3372,7 +3372,7 @@ const DeploymentsPage: React.FC = () => {
                       }}
                     >
                       {t("pages.deployments.index.adjust.flow.10", "Adjust flow")}</Button>
-                    <Tooltip title={deploymentDeactivateAvailability.reason}>
+                    <AevatarTooltip title={deploymentDeactivateAvailability.reason}>
                       <span>
                         <Button
                           danger
@@ -3394,7 +3394,7 @@ const DeploymentsPage: React.FC = () => {
                             : t("pages.deployments.index.cannot.be.deactivated", "Cannot be deactivated")}
                         </Button>
                       </span>
-                    </Tooltip>
+                    </AevatarTooltip>
                   </Space>
                 </DrawerSection>
               </div>

--- a/apps/aevatar-console-web/src/pages/MissionControl/TopologyCanvas.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/TopologyCanvas.tsx
@@ -15,8 +15,9 @@ import {
   type NodeProps,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { Tag, Tooltip, Typography, theme } from 'antd';
+import { Tag, Typography, theme } from 'antd';
 import React, { useMemo } from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import type {
   MissionControlSnapshot,
   MissionObservationStatus,
@@ -154,7 +155,7 @@ function TopologyNodeCard({
         }}
         type="target"
       />
-      <Tooltip
+      <AevatarTooltip
         title={`Observation: ${formatMissionLabel(node.observationStatus)} · freshness ${node.freshnessLabel}`}
       >
         <div
@@ -173,7 +174,7 @@ function TopologyNodeCard({
             width: 10,
           }}
         />
-      </Tooltip>
+      </AevatarTooltip>
       <div
         style={{
           alignItems: 'flex-start',
@@ -234,7 +235,7 @@ function TopologyNodeCard({
       >
         {node.summary}
       </Typography.Paragraph>
-      <Tooltip title={node.handoff.nextStep}>
+      <AevatarTooltip title={node.handoff.nextStep}>
         <div
           aria-label={t("pages.missioncontrol.topologycanvas.mission.control.node.handoff", "Mission Control node handoff")}
           style={{
@@ -266,7 +267,7 @@ function TopologyNodeCard({
             {node.handoff.evidence}
           </Typography.Text>
         </div>
-      </Tooltip>
+      </AevatarTooltip>
       <div
         style={{
           borderTop: `1px solid ${token.colorBorderSecondary}`,

--- a/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
@@ -12,7 +12,6 @@ import {
   Segmented,
   Space,
   Tag,
-  Tooltip,
   Typography,
   theme,
 } from 'antd';
@@ -24,6 +23,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { history } from '@/shared/navigation/history';
 import { buildRuntimeRunsHref } from '@/shared/navigation/runtimeRoutes';
 import { buildTeamDetailHref } from '@/shared/navigation/teamRoutes';
@@ -735,20 +735,20 @@ function MissionDock({
         }}
       >
         <Space wrap size={[8, 8]}>
-          <Tooltip title={t("pages.missioncontrol.index.key.events.2", "Key events")}>
+          <AevatarTooltip title={t("pages.missioncontrol.index.key.events.2", "Key events")}>
             <Button
               icon={<ClockCircleOutlined />}
               onClick={() => onTabChange('timeline')}
               type={activeTab === 'timeline' ? 'primary' : 'default'}
             />
-          </Tooltip>
-          <Tooltip title={t("pages.missioncontrol.index.raw.logs.2", "Raw logs")}>
+          </AevatarTooltip>
+          <AevatarTooltip title={t("pages.missioncontrol.index.raw.logs.2", "Raw logs")}>
             <Button
               icon={<BorderBottomOutlined />}
               onClick={() => onTabChange('logs')}
               type={activeTab === 'logs' ? 'primary' : 'default'}
             />
-          </Tooltip>
+          </AevatarTooltip>
           <Typography.Text style={{ color: token.colorTextHeading }}>
             {t("pages.missioncontrol.index.event.dock.2", "Event Dock")}</Typography.Text>
         </Space>

--- a/apps/aevatar-console-web/src/pages/chat/index.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.tsx
@@ -16,7 +16,6 @@ import {
   Space,
   Spin,
   Tag,
-  Tooltip,
   Typography,
   theme,
 } from "antd";
@@ -28,6 +27,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { studioApi } from "@/shared/studio/api";
 import { AevatarPageShell } from "@/shared/ui/aevatarPageShells";
 import { useConsoleToast } from "@/shared/ui/ConsoleToast";
@@ -1886,7 +1886,7 @@ const ChatPage: React.FC = () => {
                   </button>
                   {conversation.historyReconciliation?.status === "failed" &&
                   conversation.historyReconciliation.retryable ? (
-                    <Tooltip
+                    <AevatarTooltip
                       title={t(
                         "pages.chat.index.retryHistorySave",
                         "Retry saving {title}",
@@ -1907,9 +1907,9 @@ const ChatPage: React.FC = () => {
                         style={{ minHeight: 40, minWidth: 40 }}
                         type="text"
                       />
-                    </Tooltip>
+                    </AevatarTooltip>
                   ) : null}
-                  <Tooltip
+                  <AevatarTooltip
                     title={t("pages.chat.index.deleteChat", "Delete {title}", {
                       title: conversation.title,
                     })}
@@ -1927,7 +1927,7 @@ const ChatPage: React.FC = () => {
                       style={{ minHeight: 40, minWidth: 40 }}
                       type="text"
                     />
-                  </Tooltip>
+                  </AevatarTooltip>
                 </div>
               );
             })}
@@ -1991,7 +1991,7 @@ const ChatPage: React.FC = () => {
               padding: "10px 14px",
             }}
           >
-            <Tooltip
+            <AevatarTooltip
               title={t("pages.chat.index.openHistory", "Open chat history")}
             >
               <Button
@@ -2002,7 +2002,7 @@ const ChatPage: React.FC = () => {
                 style={{ minHeight: 44, minWidth: 44 }}
                 type="text"
               />
-            </Tooltip>
+            </AevatarTooltip>
             <div style={{ flex: 1, minWidth: 0 }}>
               <Typography.Text
                 strong

--- a/apps/aevatar-console-web/src/pages/primitives/index.tsx
+++ b/apps/aevatar-console-web/src/pages/primitives/index.tsx
@@ -16,6 +16,7 @@ import {
   AevatarWorkbenchLayout,
 } from "@/shared/ui/aevatarPageShells";
 import AevatarContentSkeleton from "@/shared/ui/AevatarContentSkeleton";
+import AevatarTooltip from "@/shared/ui/AevatarTooltip";
 import {
   cardListActionStyle,
   cardListStyle,
@@ -132,15 +133,17 @@ const PrimitiveCatalogCard: React.FC<{
         <Typography.Text strong style={{ fontSize: 16, lineHeight: 1.4 }}>
           {primitive.name}
         </Typography.Text>
-        <Typography.Paragraph
-          ellipsis={{ rows: 2, tooltip: summary }}
-          style={{
-            color: "var(--ant-color-text-secondary)",
-            margin: 0,
-          }}
-        >
-          {summary}
-        </Typography.Paragraph>
+        <AevatarTooltip title={summary}>
+          <Typography.Paragraph
+            ellipsis={{ rows: 2 }}
+            style={{
+              color: "var(--ant-color-text-secondary)",
+              margin: 0,
+            }}
+          >
+            {summary}
+          </Typography.Paragraph>
+        </AevatarTooltip>
       </div>
 
       <div

--- a/apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx
+++ b/apps/aevatar-console-web/src/pages/runtime-published-runs/MemberPublishedRunsReplay.tsx
@@ -18,10 +18,10 @@ import {
   Space,
   Tabs,
   Tag,
-  Tooltip,
   Typography,
 } from "antd";
 import React from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
 import { studioApi } from "@/shared/studio/api";
 import { formatDateTime } from "@/shared/datetime/dateTime";
@@ -1349,7 +1349,7 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
             )}
             className="member-published-runs-replay__navigation"
           >
-            <Tooltip title={backToTeamMembersLabel}>
+            <AevatarTooltip title={backToTeamMembersLabel}>
               <Button
                 aria-label={backToTeamMembersLabel}
                 className="member-published-runs-replay__back-button"
@@ -1358,7 +1358,7 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
                 shape="circle"
                 size="small"
               />
-            </Tooltip>
+            </AevatarTooltip>
             <div className="member-published-runs-replay__breadcrumbs">
               <a
                 className="member-published-runs-replay__breadcrumb-link"
@@ -1396,7 +1396,7 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
                 </Typography.Text>
               </div>
             </div>
-            <Tooltip title={t("pages.runs.memberPublishedRuns.refresh", "Refresh")}>
+            <AevatarTooltip title={t("pages.runs.memberPublishedRuns.refresh", "Refresh")}>
               <Button
                 aria-label={t("pages.runs.memberPublishedRuns.refresh", "Refresh")}
                 icon={<ReloadOutlined />}
@@ -1405,7 +1405,7 @@ const MemberPublishedRunsReplay: React.FC<MemberPublishedRunsReplayProps> = ({
                 shape="circle"
                 size="small"
               />
-            </Tooltip>
+            </AevatarTooltip>
           </div>
           {normalizedScheduleId ? (
             <div

--- a/apps/aevatar-console-web/src/pages/settings/index.tsx
+++ b/apps/aevatar-console-web/src/pages/settings/index.tsx
@@ -14,12 +14,12 @@ import {
   Input,
   Select,
   Space,
-  Tooltip,
   Typography,
   theme,
 } from "antd";
 import type { CollapseProps, SelectProps } from "antd";
 import React from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import {
   LLM_MODEL_HEADER_KEY,
   LLM_ROUTE_HEADER_KEY,
@@ -411,7 +411,7 @@ const ConnectedProviderChip: React.FC<{
   const dotColor = ready ? token.colorSuccess : token.colorTextQuaternary;
 
   return (
-    <Tooltip
+    <AevatarTooltip
       mouseEnterDelay={0.15}
       placement="top"
       title={accessibleLabel}
@@ -445,7 +445,7 @@ const ConnectedProviderChip: React.FC<{
         />
         <span>{label}</span>
       </div>
-    </Tooltip>
+    </AevatarTooltip>
   );
 };
 
@@ -1574,7 +1574,7 @@ const SettingsPage: React.FC = () => {
                       <SummaryField
                         label={t("pages.settings.index.runtime.url", "Runtime URL")}
                         value={
-                          <Tooltip
+                          <AevatarTooltip
                             mouseEnterDelay={0.15}
                             placement="topLeft"
                             title={displayedRuntimeBaseUrl}
@@ -1582,7 +1582,7 @@ const SettingsPage: React.FC = () => {
                             <Typography.Text style={previewValueStyle}>
                               {truncateMiddle(displayedRuntimeBaseUrl, 18, 14)}
                             </Typography.Text>
-                          </Tooltip>
+                          </AevatarTooltip>
                         }
                       />
                     </div>
@@ -1627,7 +1627,7 @@ const SettingsPage: React.FC = () => {
                           <Typography.Text style={previewKeyStyle}>
                             {row.keyLabel}
                           </Typography.Text>
-                          <Tooltip
+                          <AevatarTooltip
                             mouseEnterDelay={0.15}
                             placement="topLeft"
                             title={
@@ -1644,7 +1644,7 @@ const SettingsPage: React.FC = () => {
                             <Typography.Text style={previewValueStyle}>
                               {truncateMiddle(row.value, 14, 12)}
                             </Typography.Text>
-                          </Tooltip>
+                          </AevatarTooltip>
                         </div>
                       ))}
                     </div>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
@@ -1,5 +1,5 @@
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { Alert, Button, Tooltip } from 'antd';
+import { Alert, Button } from 'antd';
 import React, {
   useCallback,
   useEffect,
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import {
   applyRuntimeEvent,
   createRuntimeEventAccumulator,
@@ -225,11 +226,11 @@ function renderTargetMetaItem(item: TargetMetaItem): React.ReactNode {
   const content = item.label ? `${item.label}: ${item.value}` : item.value;
 
   return (
-    <Tooltip key={item.key} placement="topLeft" title={content}>
+    <AevatarTooltip key={item.key} placement="topLeft" title={content}>
       <span style={targetMetaItemWrapStyle}>
         <span style={targetMetaItemStyle}>{content}</span>
       </span>
-    </Tooltip>
+    </AevatarTooltip>
   );
 }
 
@@ -2012,7 +2013,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
                   : targetTitleWrapStyle
               }
             >
-              <Tooltip placement="topLeft" title={currentMemberLabel}>
+              <AevatarTooltip placement="topLeft" title={currentMemberLabel}>
                 <div
                   style={
                     isMemberRunSurface
@@ -2022,7 +2023,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
                 >
                   {currentMemberLabel}
                 </div>
-              </Tooltip>
+              </AevatarTooltip>
               <div
                 style={
                   isMemberRunSurface
@@ -2034,11 +2035,11 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
                 {invokeBlockedReason ? (
                   <>
                     <span>·</span>
-                    <Tooltip placement="topLeft" title={invokeBlockedReason}>
+                    <AevatarTooltip placement="topLeft" title={invokeBlockedReason}>
                       <span style={targetMetaItemStyle}>
                         {invokeBlockedReason}
                       </span>
-                    </Tooltip>
+                    </AevatarTooltip>
                   </>
                 ) : null}
               </div>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
@@ -7,8 +7,9 @@ import {
   PlayCircleOutlined,
   StopOutlined,
 } from '@ant-design/icons';
-import { Button, Input, Tooltip, Typography } from 'antd';
+import { Button, Input, Typography } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { AevatarPanel } from '@/shared/ui/aevatarPageShells';
 import type { InvokeResultState } from './StudioMemberInvokePanel.currentRun';
 import {
@@ -403,7 +404,7 @@ export const StudioMemberInvokeComposerPanel: React.FC<
             event.currentTarget.value = '';
           }}
         />
-        <Tooltip
+        <AevatarTooltip
           title={t(
             "pages.studio.studiomemberinvokesetuppanels.attach.files",
             "Attach files",
@@ -418,7 +419,7 @@ export const StudioMemberInvokeComposerPanel: React.FC<
             icon={<PaperClipOutlined />}
             onClick={() => fileInputRef.current?.click()}
           />
-        </Tooltip>
+        </AevatarTooltip>
         <div style={attachmentListStyle}>
           {attachments.length === 0 ? (
             <span style={attachmentEmptyStyle}>
@@ -435,9 +436,9 @@ export const StudioMemberInvokeComposerPanel: React.FC<
                 style={attachmentChipStyle}
               >
                 {getFileIcon(file)}
-                <Tooltip title={`${file.name} · ${file.type || 'file'} · ${formatFileSize(file.size)}`}>
+                <AevatarTooltip title={`${file.name} · ${file.type || 'file'} · ${formatFileSize(file.size)}`}>
                   <span style={attachmentNameStyle}>{file.name}</span>
-                </Tooltip>
+                </AevatarTooltip>
                 <span style={attachmentMetaStyle}>{formatFileSize(file.size)}</span>
                 <Button
                   aria-label={t(

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -46,6 +46,7 @@ import {
 } from '@/shared/ui/proComponents';
 import { AevatarPanel, AevatarStatusTag } from '@/shared/ui/aevatarPageShells';
 import ConsoleOperationNotice from '@/shared/ui/ConsoleOperationNotice';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { describeError } from '@/shared/ui/errorText';
 import {
   AEVATAR_INTERACTIVE_BUTTON_CLASS,
@@ -1893,12 +1894,14 @@ export const StudioExecutionPage: React.FC<StudioExecutionPageProps> = ({
                 }}
               >
                 <Typography.Text type="secondary">{row.label}</Typography.Text>
-                <Typography.Text ellipsis={{ tooltip: row.current }}>
-                  {row.current}
-                </Typography.Text>
-                <Typography.Text type="secondary" ellipsis={{ tooltip: row.baseline }}>
-                  {row.baseline}
-                </Typography.Text>
+                <AevatarTooltip title={row.current}>
+                  <Typography.Text ellipsis>{row.current}</Typography.Text>
+                </AevatarTooltip>
+                <AevatarTooltip title={row.baseline}>
+                  <Typography.Text ellipsis type="secondary">
+                    {row.baseline}
+                  </Typography.Text>
+                </AevatarTooltip>
                 <AevatarStatusTag
                   domain="observation"
                   label="delta"

--- a/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
+++ b/apps/aevatar-console-web/src/pages/team-member-workflow-studio/components/WorkflowStudioHeader.tsx
@@ -13,8 +13,9 @@ import {
   SaveOutlined,
 } from '@ant-design/icons';
 import type { InputRef, MenuProps } from 'antd';
-import { Button, Dropdown, Input, Tag, Tooltip } from 'antd';
+import { Button, Dropdown, Input, Tag } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { t } from '@/shared/i18n/messages';
 
 type WorkflowHeaderMenuItem = NonNullable<MenuProps['items']>[number];
@@ -548,7 +549,7 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
         value={workflowTitle}
         variant="borderless"
       />
-      <Tooltip
+      <AevatarTooltip
         title={t(
           'teamMemberWorkflowStudio.header.editWorkflowName',
           'Edit workflow name',
@@ -565,7 +566,7 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
           size="small"
           type="text"
         />
-      </Tooltip>
+      </AevatarTooltip>
     </div>
   );
 
@@ -578,7 +579,7 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
       className="workflow-studio-header__identity"
       data-testid="workflow-header-identity"
     >
-      <Tooltip title={t('teamMemberWorkflowStudio.header.back', 'Back')}>
+      <AevatarTooltip title={t('teamMemberWorkflowStudio.header.back', 'Back')}>
         <Button
           aria-label={t('teamMemberWorkflowStudio.header.back', 'Back')}
           className="workflow-studio-header__back-button"
@@ -588,7 +589,7 @@ const HeaderIdentity: React.FC<HeaderIdentityProps> = ({
           size="small"
           type="text"
         />
-      </Tooltip>
+      </AevatarTooltip>
       <div className="workflow-studio-header__title-zone">
         <HeaderBreadcrumb
           onNavigateToTeam={onNavigateToTeam}

--- a/apps/aevatar-console-web/src/pages/teams/components/TeamDetailPrimitives.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamDetailPrimitives.tsx
@@ -1,5 +1,6 @@
-import { Space, Tooltip, Typography, theme } from "antd";
+import { Space, Typography, theme } from "antd";
 import React from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import {
   AevatarCompactText,
   aevatarMonoFontFamily,
@@ -48,7 +49,7 @@ export const SignalCard: React.FC<{
         {value}
       </Typography.Title>
       {typeof caption === "string" ? (
-        <Tooltip
+        <AevatarTooltip
           placement="topLeft"
           title={typeof captionTooltip === "string" ? captionTooltip : caption}
         >
@@ -64,7 +65,7 @@ export const SignalCard: React.FC<{
           >
             {caption}
           </Typography.Text>
-        </Tooltip>
+        </AevatarTooltip>
       ) : caption ? (
         <Typography.Text style={{ fontSize: 13 }} type="secondary">
           {caption}
@@ -111,7 +112,7 @@ export const FactLine: React.FC<{
   const normalized = text || "--";
 
   return (
-    <Tooltip placement="topLeft" title={tooltipText || normalized}>
+    <AevatarTooltip placement="topLeft" title={tooltipText || normalized}>
       <Typography.Text
         strong={!secondary}
         style={{
@@ -129,7 +130,7 @@ export const FactLine: React.FC<{
       >
         {normalized}
       </Typography.Text>
-    </Tooltip>
+    </AevatarTooltip>
   );
 };
 

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -11,11 +11,11 @@ import {
   Empty,
   Skeleton,
   Space,
-  Tooltip,
   Typography,
   theme,
 } from "antd";
 import React from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
 import { loadRestorableAuthSession } from "@/shared/auth/session";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
@@ -441,7 +441,7 @@ const TeamFact: React.FC<{
       }}
     >
       {typeof value === "string" && (tooltip || value) ? (
-        <Tooltip title={tooltip || value}>{renderedValue}</Tooltip>
+        <AevatarTooltip title={tooltip || value}>{renderedValue}</AevatarTooltip>
       ) : (
         renderedValue
       )}
@@ -987,17 +987,19 @@ const TeamRosterCard: React.FC<{
           <div style={{ fontSize: 22 }}>
             <TeamTitle level={3} title={preview.title} />
           </div>
-          <Typography.Paragraph
-            ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
-            style={{
-              color: token.colorTextSecondary,
-              fontSize: 14,
-              marginBottom: 0,
-              marginTop: 6,
-            }}
-          >
-            {preview.attentionDetail}
-          </Typography.Paragraph>
+          <AevatarTooltip title={preview.attentionDetail}>
+            <Typography.Paragraph
+              ellipsis={{ rows: 1 }}
+              style={{
+                color: token.colorTextSecondary,
+                fontSize: 14,
+                marginBottom: 0,
+                marginTop: 6,
+              }}
+            >
+              {preview.attentionDetail}
+            </Typography.Paragraph>
+          </AevatarTooltip>
         </div>
         <span
           style={{
@@ -1112,17 +1114,19 @@ const TeamRosterRow: React.FC<{
               {formatAttentionLabel(preview.attention)}
             </span>
           </Space>
-          <Typography.Paragraph
-            ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
-            style={{
-              color: token.colorTextSecondary,
-              fontSize: 13,
-              marginBottom: 0,
-              marginTop: 0,
-            }}
-          >
-            {preview.attentionDetail}
-          </Typography.Paragraph>
+          <AevatarTooltip title={preview.attentionDetail}>
+            <Typography.Paragraph
+              ellipsis={{ rows: 1 }}
+              style={{
+                color: token.colorTextSecondary,
+                fontSize: 13,
+                marginBottom: 0,
+                marginTop: 0,
+              }}
+            >
+              {preview.attentionDetail}
+            </Typography.Paragraph>
+          </AevatarTooltip>
         </div>
 
         <div className="teams-home-roster-row-actions">
@@ -1540,7 +1544,7 @@ const TeamsHomePage: React.FC = () => {
                   </div>
                   {visibleTeamCount > 1 ? (
                     <Space.Compact>
-                      <Tooltip title={t("pages.teams.home.copy.56", "Card view")}>
+                      <AevatarTooltip title={t("pages.teams.home.copy.56", "Card view")}>
                         <Button
                           aria-label={t("pages.teams.home.copy.57", "Switch to card view")}
                           icon={<AppstoreOutlined />}
@@ -1548,8 +1552,8 @@ const TeamsHomePage: React.FC = () => {
                           style={{ height: 44, width: 44 }}
                           type={resolvedRosterView === "cards" ? "primary" : "default"}
                         />
-                      </Tooltip>
-                      <Tooltip title={t("pages.teams.home.copy.58", "List view")}>
+                      </AevatarTooltip>
+                      <AevatarTooltip title={t("pages.teams.home.copy.58", "List view")}>
                         <Button
                           aria-label={t("pages.teams.home.copy.59", "Switch to list view")}
                           icon={<BarsOutlined />}
@@ -1557,7 +1561,7 @@ const TeamsHomePage: React.FC = () => {
                           style={{ height: 44, width: 44 }}
                           type={resolvedRosterView === "list" ? "primary" : "default"}
                         />
-                      </Tooltip>
+                      </AevatarTooltip>
                     </Space.Compact>
                   ) : null}
                 </div>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAutomationsTab.tsx
@@ -25,11 +25,11 @@ import {
   Space,
   Spin,
   Switch,
-  Tooltip,
   Typography,
   theme,
 } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { previewScheduledDispatch } from '@/shared/api/scheduledDispatchApi';
 import {
   createTeamAutomationOperationIdentity,
@@ -1492,7 +1492,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
     readonly onClick: () => void;
     readonly primary?: boolean;
   }) => (
-    <Tooltip title={label}>
+    <AevatarTooltip title={label}>
       <Button
         aria-label={label}
         className="team-automation-action-button"
@@ -1505,7 +1505,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
           danger ? 'danger' : primary ? 'primary' : 'default',
         )}
       />
-    </Tooltip>
+    </AevatarTooltip>
   );
 
   const renderActions = (view: TeamAutomationView) => {
@@ -1661,7 +1661,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
             )}
           />
           {view.lastAuthorizationErrorCode ? (
-            <Tooltip
+            <AevatarTooltip
               placement="topLeft"
               title={view.lastAuthorizationErrorCode}
             >
@@ -1675,7 +1675,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
               >
                 {view.lastAuthorizationErrorCode}
               </Typography.Text>
-            </Tooltip>
+            </AevatarTooltip>
           ) : null}
           {view.revocationPending ? (
             <Space size={8} wrap>
@@ -1957,7 +1957,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
               </Typography.Text>
             </div>
             <Space>
-              <Tooltip
+              <AevatarTooltip
                 title={copy('teams.automations.actions.refresh', 'Refresh')}
               >
                 <Button
@@ -1969,7 +1969,7 @@ const TeamAutomationsTab: React.FC<Props> = ({
                   loading={automationsQuery.isFetching}
                   onClick={() => void automationsQuery.refetch()}
                 />
-              </Tooltip>
+              </AevatarTooltip>
               <Button
                 className="team-automations-create-button"
                 disabled={eligibleMembers.length === 0}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -8,9 +8,10 @@ import {
   StopOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
-import { Button, Skeleton, Tooltip, Typography, theme } from "antd";
+import { Button, Skeleton, Typography, theme } from "antd";
 import { useIntl } from "@umijs/max";
 import React from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import {
   AevatarInspectorEmpty,
   AevatarPanel,
@@ -247,7 +248,7 @@ const EllipsisText: React.FC<{
   readonly style?: React.CSSProperties;
   readonly type?: "secondary";
 }> = ({ children, strong = false, style, type }) => (
-  <Tooltip placement="topLeft" title={children}>
+  <AevatarTooltip placement="topLeft" title={children}>
     <Typography.Text
       strong={strong}
       style={{
@@ -258,7 +259,7 @@ const EllipsisText: React.FC<{
     >
       {children}
     </Typography.Text>
-  </Tooltip>
+  </AevatarTooltip>
 );
 
 const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
@@ -653,7 +654,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                             border: `1px solid ${token.colorBorderSecondary}`,
                           }}
                         >
-                          <Tooltip
+                          <AevatarTooltip
                             title={
                               row.canInvokeMember
                                 ? invokeActionLabel
@@ -677,8 +678,8 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                               )}
                               type="default"
                             />
-                          </Tooltip>
-                          <Tooltip
+                          </AevatarTooltip>
+                          <AevatarTooltip
                             title={
                               row.canOpenPublishedRuns
                                 ? publishedRunsActionLabel
@@ -704,8 +705,8 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                               style={buildMemberActionButtonStyle()}
                               type="default"
                             />
-                          </Tooltip>
-                          <Tooltip
+                          </AevatarTooltip>
+                          <AevatarTooltip
                             title={
                               row.canAutomateMember
                                 ? automateActionLabel
@@ -731,8 +732,8 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                               style={buildMemberActionButtonStyle()}
                               type="default"
                             />
-                          </Tooltip>
-                          <Tooltip
+                          </AevatarTooltip>
+                          <AevatarTooltip
                             title={
                               row.workflowSupported
                                 ? studioActionLabel
@@ -756,9 +757,9 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                               style={buildMemberActionButtonStyle()}
                               type="default"
                             />
-                          </Tooltip>
+                          </AevatarTooltip>
                           {row.isEntryMember ? (
-                            <Tooltip title={entryActionLabel}>
+                            <AevatarTooltip title={entryActionLabel}>
                               <Button
                                 aria-label={entryActionLabel}
                                 icon={entryActionIcon}
@@ -775,9 +776,9 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                                 style={buildMemberActionButtonStyle("primary")}
                                 type="default"
                               />
-                            </Tooltip>
+                            </AevatarTooltip>
                           ) : row.canSetAsEntry && onSetEntry ? (
-                            <Tooltip title={entryActionLabel}>
+                            <AevatarTooltip title={entryActionLabel}>
                               <Button
                                 aria-label={entryActionLabel}
                                 className="team-members-table-action-button team-members-table-entry-action"
@@ -794,10 +795,10 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                                 style={buildMemberActionButtonStyle()}
                                 type="default"
                               />
-                            </Tooltip>
+                            </AevatarTooltip>
                           ) : null}
                           {onDeleteMember ? (
-                            <Tooltip title={deleteActionLabel}>
+                            <AevatarTooltip title={deleteActionLabel}>
                               <Button
                                 aria-label={deleteActionLabel}
                                 className="team-members-table-action-button team-members-table-delete-action"
@@ -820,7 +821,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                                 style={buildMemberActionButtonStyle("danger")}
                                 type="default"
                               />
-                            </Tooltip>
+                            </AevatarTooltip>
                           ) : null}
                         </div>
                       </div>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -6,9 +6,10 @@ import {
   PlayCircleOutlined,
   ToolOutlined,
 } from "@ant-design/icons";
-import { Button, Space, Tooltip, Typography, theme } from "antd";
+import { Button, Space, Typography, theme } from "antd";
 import { useIntl } from "@umijs/max";
 import React from "react";
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { AevatarInspectorEmpty } from "@/shared/ui/aevatarPageShells";
 import {
   DetailPill,
@@ -232,7 +233,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               <DetailPill compact style={currentRunPillStyle} text={currentRunPillText} />
             </Space>
           </div>
-          <Tooltip title={teamRunDisabled ? teamRunDisabledReason : undefined}>
+          <AevatarTooltip title={teamRunDisabled ? teamRunDisabledReason : undefined}>
             <Button
               disabled={teamRunDisabled}
               icon={<PlayCircleOutlined />}
@@ -243,7 +244,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                 id: "teams.detail.overview.quickRun.runTeam",
               })}
             </Button>
-          </Tooltip>
+          </AevatarTooltip>
         </div>
         <div
           style={{
@@ -271,11 +272,11 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               <Typography.Text style={{ fontSize: 12 }} type="secondary">
                 {item.label}
               </Typography.Text>
-              <Tooltip title={item.tooltip}>
+              <AevatarTooltip title={item.tooltip}>
                 <Typography.Text strong ellipsis>
                   {item.value}
                 </Typography.Text>
-              </Tooltip>
+              </AevatarTooltip>
             </div>
           ))}
         </div>
@@ -347,11 +348,11 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                 <Typography.Text style={{ fontSize: 12 }} type="secondary">
                   {row.label}
                 </Typography.Text>
-                <Tooltip title={row.noteTooltip || row.note}>
+                <AevatarTooltip title={row.noteTooltip || row.note}>
                   <Typography.Text strong ellipsis>
                     {row.value}
                   </Typography.Text>
-                </Tooltip>
+                </AevatarTooltip>
               </div>
             ))}
           </div>
@@ -418,7 +419,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                   </Space>
                 </div>
                 <Space.Compact>
-                  <Tooltip
+                  <AevatarTooltip
                     title={
                       row.canRun
                         ? runMemberLabel
@@ -438,9 +439,9 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                       size="small"
                       type={row.canRun ? "primary" : "default"}
                     />
-                  </Tooltip>
+                  </AevatarTooltip>
                   {row.configureLabel ? (
-                    <Tooltip
+                    <AevatarTooltip
                       title={
                         row.canConfigure
                           ? row.configureLabel
@@ -460,7 +461,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                         size="small"
                         type={row.canConfigure ? "default" : "dashed"}
                       />
-                    </Tooltip>
+                    </AevatarTooltip>
                   ) : null}
                 </Space.Compact>
               </div>
@@ -527,7 +528,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                     <Typography.Text style={{ fontSize: 12 }} type="secondary">
                       <ClockCircleOutlined /> {run.updatedLabel}
                     </Typography.Text>
-                    <Tooltip
+                    <AevatarTooltip
                       title={
                         <div style={{ display: "grid", gap: 4 }}>
                           {run.detailItems.map((item) => (
@@ -546,7 +547,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                       >
                         <InfoCircleOutlined />
                       </span>
-                    </Tooltip>
+                    </AevatarTooltip>
                   </Space>
                   <Typography.Text strong>{run.memberLabel}</Typography.Text>
                   <Typography.Text style={{ fontSize: 12 }} type="secondary">
@@ -555,7 +556,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                   <FactLine rows={2} secondary text={run.outputPreview} />
                 </div>
                 {run.detailsHref ? (
-                  <Tooltip
+                  <AevatarTooltip
                     title={intl.formatMessage({
                       id: "teams.detail.overview.history.actions.view",
                     })}
@@ -569,7 +570,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                       onClick={handleNavigate(run.detailsHref)}
                       size="small"
                     />
-                  </Tooltip>
+                  </AevatarTooltip>
                 ) : null}
               </div>
             ))}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -233,31 +233,26 @@ export const workflowActivityVNextCss = `
 .wa-vnext__template-sort-label { color: var(--wa-muted); font-size: 12px; font-weight: 600; white-space: nowrap; }
 .wa-vnext__template-sort .ant-select { min-width: 224px; }
 .wa-vnext__table-wrap.wa-vnext__template-table-region { border: 0; border-radius: 0; max-height: none; overflow-y: hidden; overscroll-behavior-y: auto; scrollbar-gutter: auto; }
-.wa-vnext__template-table { min-width: 1160px; }
+.wa-vnext__template-table { min-width: 1040px; }
 .wa-vnext__template-table th { background: #f4f6fa; border-bottom: 0; height: 52px; padding-inline: 14px; position: static; }
 .wa-vnext__template-table th:first-child { border-radius: 8px 0 0 8px; }
 .wa-vnext__template-table th:last-child { border-radius: 0 8px 8px 0; }
-.wa-vnext__template-column--identity { width: 35%; }
-.wa-vnext__template-column--reads { width: 12%; }
-.wa-vnext__template-column--connection { width: 15%; }
-.wa-vnext__template-column--does { width: 12%; }
+.wa-vnext__template-column--identity { width: 43%; }
+.wa-vnext__template-column--connection { width: 17%; }
+.wa-vnext__template-column--does { width: 14%; }
 .wa-vnext__template-column--updated { width: 110px; }
 .wa-vnext__template-column--actions { width: 210px; }
 .wa-vnext__template-header-label { align-items: center; display: inline-flex; gap: 10px; white-space: nowrap; }
 .wa-vnext__template-header-label .anticon { color: #667085; font-size: 15px; }
 .wa-vnext__template-table td { height: 106px; padding: 18px 14px; }
-.wa-vnext__template-identity { align-items: center; display: grid; gap: 14px; grid-template-columns: 48px minmax(0, 1fr); min-width: 0; }
-.wa-vnext__template-marker { align-items: center; border-radius: 8px; display: inline-flex; font-size: 24px; height: 48px; justify-content: center; width: 48px; }
-.wa-vnext__template-marker--violet { background: #eee8ff; color: #6938ef; }
-.wa-vnext__template-marker--teal { background: #dcf7f4; color: #0e9384; }
-.wa-vnext__template-marker--green { background: #e3f8e7; color: #16a34a; }
-.wa-vnext__template-marker--amber { background: #fff3d6; color: #d49400; }
-.wa-vnext__template-marker--coral { background: #ffe4e1; color: #f04438; }
+.wa-vnext__template-identity { min-width: 0; }
 .wa-vnext__template-copy { min-width: 0; }
 .wa-vnext__template-identity h2 { font-size: 15px; line-height: 20px; margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .wa-vnext__template-identity p { -webkit-box-orient: vertical; -webkit-line-clamp: 2; color: var(--wa-muted); display: -webkit-box; line-height: 18px; margin: 5px 0 0; max-height: 36px; overflow: hidden; overflow-wrap: anywhere; }
 .wa-vnext__template-fact { min-width: 0; }
 .wa-vnext__template-fact strong { font-size: 12px; font-weight: 600; line-height: 17px; overflow-wrap: anywhere; }
+.wa-vnext__template-step-summary { background: none; border: 0; border-radius: 4px; color: inherit; cursor: help; display: inline-block; font: inherit; font-size: 12px; font-weight: 600; line-height: 17px; margin: 0; padding: 0; text-align: left; }
+.wa-vnext__template-step-summary:focus-visible { outline: 2px solid var(--wa-blue); outline-offset: 2px; }
 .wa-vnext__template-updated { color: var(--wa-muted); white-space: nowrap; }
 .wa-vnext__template-actions-cell { text-align: right; }
 .wa-vnext__template-actions { align-items: center; display: inline-flex; gap: 8px; justify-content: flex-end; white-space: nowrap; }

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts
@@ -235,6 +235,8 @@ export const workflowActivityVNextCss = `
 .wa-vnext__table-wrap.wa-vnext__template-table-region { border: 0; border-radius: 0; max-height: none; overflow-y: hidden; overscroll-behavior-y: auto; scrollbar-gutter: auto; }
 .wa-vnext__template-table { min-width: 1040px; }
 .wa-vnext__template-table th { background: #f4f6fa; border-bottom: 0; height: 52px; padding-inline: 14px; position: static; }
+.wa-vnext__template-table .wa-vnext__template-cell--left { text-align: left; }
+.wa-vnext__template-table .wa-vnext__template-cell--right { text-align: right; }
 .wa-vnext__template-table th:first-child { border-radius: 8px 0 0 8px; }
 .wa-vnext__template-table th:last-child { border-radius: 0 8px 8px 0; }
 .wa-vnext__template-column--identity { width: 43%; }
@@ -253,6 +255,13 @@ export const workflowActivityVNextCss = `
 .wa-vnext__template-fact strong { font-size: 12px; font-weight: 600; line-height: 17px; overflow-wrap: anywhere; }
 .wa-vnext__template-step-summary { background: none; border: 0; border-radius: 4px; color: inherit; cursor: help; display: inline-block; font: inherit; font-size: 12px; font-weight: 600; line-height: 17px; margin: 0; padding: 0; text-align: left; }
 .wa-vnext__template-step-summary:focus-visible { outline: 2px solid var(--wa-blue); outline-offset: 2px; }
+.wa-vnext__template-step-tooltip { display: grid; gap: 8px; max-width: 320px; min-width: 220px; }
+.wa-vnext__template-step-tooltip > strong { font-size: 12px; line-height: 17px; }
+.wa-vnext__template-step-tooltip > span { line-height: 18px; }
+.wa-vnext__template-step-tooltip ol { display: grid; gap: 5px; margin: 0; max-height: 220px; overflow-y: auto; padding: 0 4px 0 20px; }
+.wa-vnext__template-step-tooltip li { line-height: 17px; padding-left: 2px; }
+.wa-vnext__template-step-tooltip li > span { display: block; overflow-wrap: anywhere; }
+.wa-vnext__template-step-tooltip li > small { color: rgba(255, 255, 255, 0.72); display: block; font-size: 11px; line-height: 15px; }
 .wa-vnext__template-updated { color: var(--wa-muted); white-space: nowrap; }
 .wa-vnext__template-actions-cell { text-align: right; }
 .wa-vnext__template-actions { align-items: center; display: inline-flex; gap: 8px; justify-content: flex-end; white-space: nowrap; }

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
@@ -469,6 +469,57 @@ describe('New workflow save-target recovery', () => {
 
   it('renders only decision-useful template facts with step help', async () => {
     mockStudioApi.getWorkspaceSettings.mockResolvedValue(readyWorkspace);
+    mockRuntimeCatalogApi.getWorkflowTemplate.mockResolvedValue({
+      template: {
+        templateId: 'template-incident-triage',
+        displayName: 'Incident triage',
+        description: 'Classify an incident.',
+        defaultDraftName: 'Incident triage',
+        authorityStateVersion: 7,
+        stepCount: 2,
+        requiredConnections: ['pagerduty'],
+        requiresLlmProvider: true,
+        freshness: {
+          projectionWatermark: '2026-08-18T00:00:00Z',
+          lastEventId: 'event-template-7',
+          versionSemantics: 'workflow-catalog-authority-state-version',
+        },
+      },
+      yaml: 'name: incident_triage\nsteps: []\n',
+      definition: {
+        name: 'incident_triage',
+        description: 'Classify an incident.',
+        closedWorldMode: true,
+        roles: [],
+        steps: [
+          {
+            id: 'classify',
+            type: 'llm_call',
+            targetRole: '',
+            parameters: {},
+            next: 'notify',
+            branches: {},
+            children: [],
+          },
+          {
+            id: 'notify',
+            type: 'connector_call',
+            targetRole: '',
+            parameters: {},
+            next: '',
+            branches: {},
+            children: [],
+          },
+        ],
+      },
+      edges: [],
+      authorityStateVersion: 7,
+      freshness: {
+        projectionWatermark: '2026-08-18T00:00:00Z',
+        lastEventId: 'event-template-7',
+        versionSemantics: 'workflow-catalog-authority-state-version',
+      },
+    });
 
     renderWithQueryClient(<WorkflowTemplatesPage scopeId="scope-alpha" />);
 
@@ -488,6 +539,11 @@ describe('New workflow save-target recovery', () => {
         within(table).getByRole('columnheader', { name }),
       ),
     ).toEqual(headers);
+    expect(headers[0]).toHaveClass('wa-vnext__template-cell--left');
+    expect(headers[1]).toHaveClass('wa-vnext__template-cell--left');
+    expect(headers[2]).toHaveClass('wa-vnext__template-cell--left');
+    expect(headers[3]).toHaveClass('wa-vnext__template-cell--right');
+    expect(headers[4]).toHaveClass('wa-vnext__template-cell--right');
     expect(cells).toHaveLength(5);
     expect(screen.queryByText('Reads')).not.toBeInTheDocument();
     expect(screen.queryByText('Workflow inputs')).not.toBeInTheDocument();
@@ -500,13 +556,27 @@ describe('New workflow save-target recovery', () => {
     expect(
       within(cells[1]).getByText('LLM provider, pagerduty'),
     ).toBeInTheDocument();
+    expect(cells[0]).toHaveClass('wa-vnext__template-cell--left');
+    expect(cells[1]).toHaveClass('wa-vnext__template-cell--left');
+    expect(cells[2]).toHaveClass('wa-vnext__template-cell--left');
+    expect(cells[3]).toHaveClass('wa-vnext__template-cell--right');
+    expect(cells[4]).toHaveClass('wa-vnext__template-cell--right');
     const stepSummary = within(cells[2]).getByRole('button', {
       name: 'Runs 2 steps',
     });
+    expect(mockRuntimeCatalogApi.getWorkflowTemplate).not.toHaveBeenCalled();
     fireEvent.mouseEnter(stepSummary);
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(
-      'This template contains 2 configured workflow steps.',
-    );
+    await waitFor(() => {
+      expect(mockRuntimeCatalogApi.getWorkflowTemplate).toHaveBeenCalledWith(
+        'template-incident-triage',
+      );
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toHaveTextContent('Workflow steps (2)');
+      expect(tooltip).toHaveTextContent('classify');
+      expect(tooltip).toHaveTextContent('LLM call');
+      expect(tooltip).toHaveTextContent('notify');
+      expect(tooltip).toHaveTextContent('Connector call');
+    });
     expect(within(cells[3]).getByText('2026/08/18')).toBeInTheDocument();
     expect(
       within(cells[4]).getByRole('button', {
@@ -518,6 +588,28 @@ describe('New workflow save-target recovery', () => {
         name: 'Use template Incident triage',
       }),
     ).toBeInTheDocument();
+  });
+
+  it('shows an actionable tooltip state when step details are unavailable', async () => {
+    mockStudioApi.getWorkspaceSettings.mockResolvedValue(readyWorkspace);
+    mockRuntimeCatalogApi.getWorkflowTemplate.mockRejectedValue(
+      new Error('Template details unavailable'),
+    );
+
+    renderWithQueryClient(<WorkflowTemplatesPage scopeId="scope-alpha" />);
+
+    const stepSummary = await screen.findByRole('button', {
+      name: 'Runs 2 steps',
+    });
+    fireEvent.mouseEnter(stepSummary);
+
+    await waitFor(() => {
+      const tooltip = screen.getByRole('tooltip');
+      expect(tooltip).toHaveTextContent(
+        'Step details are unavailable. Open View to inspect this template.',
+      );
+      expect(tooltip).not.toHaveTextContent('Loading step details');
+    });
   });
 
   it('lets vertical wheel input over the template table reach the page scroller', async () => {

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx
@@ -467,7 +467,7 @@ describe('New workflow save-target recovery', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders template facts in aligned table columns', async () => {
+  it('renders only decision-useful template facts with step help', async () => {
     mockStudioApi.getWorkspaceSettings.mockResolvedValue(readyWorkspace);
 
     renderWithQueryClient(<WorkflowTemplatesPage scopeId="scope-alpha" />);
@@ -482,30 +482,39 @@ describe('New workflow save-target recovery', () => {
     const row = within(table).getByRole('row', { name: /Incident triage/ });
     const cells = within(row).getAllByRole('cell');
 
-    expect(headers).toHaveLength(6);
+    expect(headers).toHaveLength(5);
     expect(
-      ['Template', 'Reads', 'Connection', 'Does', 'Updated', 'Actions'].map(
-        (name) => within(table).getByRole('columnheader', { name }),
+      ['Template', 'Connection', 'Does', 'Updated', 'Actions'].map((name) =>
+        within(table).getByRole('columnheader', { name }),
       ),
     ).toEqual(headers);
-    expect(cells).toHaveLength(6);
-    expect(screen.getAllByText('Reads')).toHaveLength(1);
+    expect(cells).toHaveLength(5);
+    expect(screen.queryByText('Reads')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workflow inputs')).not.toBeInTheDocument();
     expect(screen.getAllByText('Connection')).toHaveLength(1);
     expect(screen.getAllByText('Does')).toHaveLength(1);
     expect(within(cells[0]).getByText('Incident triage')).toBeInTheDocument();
-    expect(within(cells[1]).getByText('Workflow inputs')).toBeInTheDocument();
     expect(
-      within(cells[2]).getByText('LLM provider, pagerduty'),
+      cells[0].querySelector('.wa-vnext__template-marker'),
+    ).not.toBeInTheDocument();
+    expect(
+      within(cells[1]).getByText('LLM provider, pagerduty'),
     ).toBeInTheDocument();
-    expect(within(cells[3]).getByText('Runs 2 steps')).toBeInTheDocument();
-    expect(within(cells[4]).getByText('2026/08/18')).toBeInTheDocument();
+    const stepSummary = within(cells[2]).getByRole('button', {
+      name: 'Runs 2 steps',
+    });
+    fireEvent.mouseEnter(stepSummary);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'This template contains 2 configured workflow steps.',
+    );
+    expect(within(cells[3]).getByText('2026/08/18')).toBeInTheDocument();
     expect(
-      within(cells[5]).getByRole('button', {
+      within(cells[4]).getByRole('button', {
         name: 'View Incident triage',
       }),
     ).toBeInTheDocument();
     expect(
-      within(cells[5]).getByRole('button', {
+      within(cells[4]).getByRole('button', {
         name: 'Use template Incident triage',
       }),
     ).toBeInTheDocument();

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowEditorPage.tsx
@@ -9,8 +9,9 @@ import {
   UpOutlined,
 } from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
-import { Alert, Button, Input, Modal, Segmented, Space, Tooltip } from 'antd';
+import { Alert, Button, Input, Modal, Segmented, Space } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import WorkflowStudioEditorSurface from '@/pages/team-member-workflow-studio/components/WorkflowStudioEditorSurface';
 import { scopesApi } from '@/shared/api/scopesApi';
 import { formatUtcDateTime } from '@/shared/datetime/dateTime';
@@ -1008,7 +1009,7 @@ const WorkflowEditorPage: React.FC<{
           </Button>
           {!publicationCurrent &&
             (publishReadinessIssues.length > 0 ? (
-              <Tooltip
+              <AevatarTooltip
                 placement="bottomRight"
                 title={
                   <div className="wa-vnext__publish-readiness">
@@ -1022,7 +1023,7 @@ const WorkflowEditorPage: React.FC<{
                 trigger={['hover', 'focus']}
               >
                 {publishButton}
-              </Tooltip>
+              </AevatarTooltip>
             ) : (
               publishButton
             ))}

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowNodeInspector.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowNodeInspector.tsx
@@ -7,10 +7,10 @@ import {
   Modal,
   Select,
   Switch,
-  Tooltip,
   Typography,
 } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { formatConsoleMessage, t } from '@/shared/i18n/messages';
 import {
   parseInspectorParameters,
@@ -486,7 +486,7 @@ const WorkflowNodeInspector = React.forwardRef<
                 {stepDraft.id}
               </Typography.Text>
             </div>
-            <Tooltip
+            <AevatarTooltip
               title={t(
                 'workflowActivityVNext.nodeInspector.close',
                 'Close configuration',
@@ -502,7 +502,7 @@ const WorkflowNodeInspector = React.forwardRef<
                 onClick={requestClose}
                 type="text"
               />
-            </Tooltip>
+            </AevatarTooltip>
           </header>
           <div className="wa-vnext__node-inspector-body">
             <section aria-labelledby="wa-vnext-node-configuration-title">

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowTemplateBrowser.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowTemplateBrowser.tsx
@@ -30,6 +30,7 @@ import { history } from '@/shared/navigation/history';
 import { isStudioApiErrorCode, studioApi } from '@/shared/studio/api';
 import {
   buildStudioGraphElements,
+  formatStudioStepTypeLabel,
   type StudioGraphElements,
 } from '@/shared/studio/graph';
 import AevatarTooltip from '@/shared/ui/AevatarTooltip';
@@ -104,6 +105,65 @@ function formatUpdatedAt(template: WorkflowTemplateSummary): string {
   return `${date.getUTCFullYear()}/${month}/${day}`;
 }
 
+function TemplateStepTooltip({
+  detail,
+  hasRequestedDetails,
+  isError,
+  isLoading,
+  stepCount,
+}: {
+  readonly detail?: WorkflowTemplateDetail;
+  readonly hasRequestedDetails: boolean;
+  readonly isError: boolean;
+  readonly isLoading: boolean;
+  readonly stepCount: number;
+}) {
+  const steps = detail?.definition.steps ?? [];
+
+  return (
+    <div className="wa-vnext__template-step-tooltip">
+      <strong>
+        {t(
+          'workflowActivityVNext.new.templateBrowser.stepsTooltipTitle',
+          'Workflow steps ({count})',
+          { count: detail?.definition.steps.length ?? stepCount },
+        )}
+      </strong>
+      {!hasRequestedDetails || isLoading ? (
+        <span>
+          {t(
+            'workflowActivityVNext.new.templateBrowser.stepsTooltipLoading',
+            'Loading step details…',
+          )}
+        </span>
+      ) : isError ? (
+        <span>
+          {t(
+            'workflowActivityVNext.new.templateBrowser.stepsTooltipUnavailable',
+            'Step details are unavailable. Open View to inspect this template.',
+          )}
+        </span>
+      ) : steps.length === 0 ? (
+        <span>
+          {t(
+            'workflowActivityVNext.new.templateBrowser.stepsTooltipEmpty',
+            'No workflow steps are exposed for this template.',
+          )}
+        </span>
+      ) : (
+        <ol>
+          {steps.map((step) => (
+            <li key={step.id}>
+              <span>{step.id}</span>
+              <small>{formatStudioStepTypeLabel(step.type)}</small>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
 function TemplateRow({
   creating,
   disabled,
@@ -117,6 +177,17 @@ function TemplateRow({
   readonly onView: (templateId: string) => void;
   readonly template: WorkflowTemplateSummary;
 }) {
+  const [stepTooltipOpen, setStepTooltipOpen] = React.useState(false);
+  const stepDetailQuery = useQuery({
+    enabled: stepTooltipOpen,
+    queryKey: [
+      'workflow-activity-vnext',
+      'workflow-template',
+      template.templateId,
+    ],
+    queryFn: () => runtimeCatalogApi.getWorkflowTemplate(template.templateId),
+    retry: false,
+  });
   const templateLabel = t(
     'workflowActivityVNext.new.templateBrowser.template',
     'Template',
@@ -145,15 +216,9 @@ function TemplateRow({
     'Runs {count} {unit}',
     { count: template.stepCount, unit: stepUnit },
   );
-  const stepHelp = t(
-    'workflowActivityVNext.new.templateBrowser.runsStepsTooltip',
-    'This template contains {count} configured workflow {unit}.',
-    { count: template.stepCount, unit: stepUnit },
-  );
-
   return (
     <tr className="wa-vnext__template-row">
-      <td data-label={templateLabel}>
+      <td className="wa-vnext__template-cell--left" data-label={templateLabel}>
         <div className="wa-vnext__template-identity">
           <div className="wa-vnext__template-copy">
             <AevatarTooltip title={template.displayName}>
@@ -171,20 +236,44 @@ function TemplateRow({
           </div>
         </div>
       </td>
-      <td className="wa-vnext__template-fact" data-label={connectionLabel}>
+      <td
+        className="wa-vnext__template-cell--left wa-vnext__template-fact"
+        data-label={connectionLabel}
+      >
         <strong>{formatConnections(template)}</strong>
       </td>
-      <td className="wa-vnext__template-fact" data-label={doesLabel}>
-        <AevatarTooltip title={stepHelp} trigger={['hover', 'focus', 'click']}>
+      <td
+        className="wa-vnext__template-cell--left wa-vnext__template-fact"
+        data-label={doesLabel}
+      >
+        <AevatarTooltip
+          onOpenChange={setStepTooltipOpen}
+          title={
+            <TemplateStepTooltip
+              detail={stepDetailQuery.data}
+              hasRequestedDetails={stepTooltipOpen}
+              isError={stepDetailQuery.isError}
+              isLoading={stepDetailQuery.isLoading}
+              stepCount={template.stepCount}
+            />
+          }
+          trigger={['hover', 'focus', 'click']}
+        >
           <button className="wa-vnext__template-step-summary" type="button">
             {stepSummary}
           </button>
         </AevatarTooltip>
       </td>
-      <td className="wa-vnext__template-updated" data-label={updatedLabel}>
+      <td
+        className="wa-vnext__template-cell--right wa-vnext__template-updated"
+        data-label={updatedLabel}
+      >
         {formatUpdatedAt(template)}
       </td>
-      <td className="wa-vnext__template-actions-cell" data-label={actionsLabel}>
+      <td
+        className="wa-vnext__template-cell--right wa-vnext__template-actions-cell"
+        data-label={actionsLabel}
+      >
         <div className="wa-vnext__template-actions">
           <Button
             aria-label={t(
@@ -893,7 +982,7 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
               </colgroup>
               <thead>
                 <tr>
-                  <th scope="col">
+                  <th className="wa-vnext__template-cell--left" scope="col">
                     <span className="wa-vnext__template-header-label">
                       <ProfileOutlined aria-hidden="true" />
                       {t(
@@ -902,7 +991,7 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
                       )}
                     </span>
                   </th>
-                  <th scope="col">
+                  <th className="wa-vnext__template-cell--left" scope="col">
                     <span className="wa-vnext__template-header-label">
                       <LinkOutlined aria-hidden="true" />
                       {t(
@@ -911,7 +1000,7 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
                       )}
                     </span>
                   </th>
-                  <th scope="col">
+                  <th className="wa-vnext__template-cell--left" scope="col">
                     <span className="wa-vnext__template-header-label">
                       <PlayCircleOutlined aria-hidden="true" />
                       {t(
@@ -920,7 +1009,7 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
                       )}
                     </span>
                   </th>
-                  <th scope="col">
+                  <th className="wa-vnext__template-cell--right" scope="col">
                     <span className="wa-vnext__template-header-label">
                       <CalendarOutlined aria-hidden="true" />
                       {t(
@@ -934,6 +1023,7 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
                       'workflowActivityVNext.new.templateBrowser.actions',
                       'Actions',
                     )}
+                    className="wa-vnext__template-cell--right"
                     scope="col"
                   />
                 </tr>

--- a/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowTemplateBrowser.tsx
+++ b/apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowTemplateBrowser.tsx
@@ -1,14 +1,8 @@
 import {
-  ApartmentOutlined,
-  ApiOutlined,
   CalendarOutlined,
-  CodeOutlined,
-  EyeOutlined,
   LinkOutlined,
-  MessageOutlined,
   PlayCircleOutlined,
   ProfileOutlined,
-  ThunderboltOutlined,
 } from '@ant-design/icons';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { MarkerType } from '@xyflow/react';
@@ -38,6 +32,7 @@ import {
   buildStudioGraphElements,
   type StudioGraphElements,
 } from '@/shared/studio/graph';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { useConsoleToast } from '@/shared/ui/ConsoleToast';
 import { useDraftMaterialization } from '../hooks/useDraftMaterialization';
 import { buildWorkflowActivityEditorHref } from '../navigation';
@@ -109,37 +104,6 @@ function formatUpdatedAt(template: WorkflowTemplateSummary): string {
   return `${date.getUTCFullYear()}/${month}/${day}`;
 }
 
-function templateMarker(template: WorkflowTemplateSummary) {
-  if (template.requiredConnections.length > 0) {
-    return {
-      icon: <ApiOutlined />,
-      tone: 'teal',
-    } as const;
-  }
-  if (template.requiresLlmProvider && template.stepCount > 4) {
-    return {
-      icon: <MessageOutlined />,
-      tone: 'coral',
-    } as const;
-  }
-  if (template.stepCount > 1) {
-    return {
-      icon: <ApartmentOutlined />,
-      tone: 'violet',
-    } as const;
-  }
-  if (template.requiresLlmProvider) {
-    return {
-      icon: <ThunderboltOutlined />,
-      tone: 'amber',
-    } as const;
-  }
-  return {
-    icon: <CodeOutlined />,
-    tone: 'green',
-  } as const;
-}
-
 function TemplateRow({
   creating,
   disabled,
@@ -153,14 +117,9 @@ function TemplateRow({
   readonly onView: (templateId: string) => void;
   readonly template: WorkflowTemplateSummary;
 }) {
-  const marker = templateMarker(template);
   const templateLabel = t(
     'workflowActivityVNext.new.templateBrowser.template',
     'Template',
-  );
-  const readsLabel = t(
-    'workflowActivityVNext.new.templateBrowser.reads',
-    'Reads',
   );
   const connectionLabel = t(
     'workflowActivityVNext.new.templateBrowser.connection',
@@ -175,21 +134,33 @@ function TemplateRow({
     'workflowActivityVNext.new.templateBrowser.actions',
     'Actions',
   );
+  const stepUnit = t(
+    template.stepCount === 1
+      ? 'workflowActivityVNext.new.templateBrowser.step'
+      : 'workflowActivityVNext.new.templateBrowser.steps',
+    template.stepCount === 1 ? 'step' : 'steps',
+  );
+  const stepSummary = t(
+    'workflowActivityVNext.new.templateBrowser.runsSteps',
+    'Runs {count} {unit}',
+    { count: template.stepCount, unit: stepUnit },
+  );
+  const stepHelp = t(
+    'workflowActivityVNext.new.templateBrowser.runsStepsTooltip',
+    'This template contains {count} configured workflow {unit}.',
+    { count: template.stepCount, unit: stepUnit },
+  );
 
   return (
     <tr className="wa-vnext__template-row">
       <td data-label={templateLabel}>
         <div className="wa-vnext__template-identity">
-          <span
-            aria-hidden="true"
-            className={`wa-vnext__template-marker wa-vnext__template-marker--${marker.tone}`}
-          >
-            {marker.icon}
-          </span>
           <div className="wa-vnext__template-copy">
-            <Typography.Title level={2} title={template.displayName}>
-              {template.displayName}
-            </Typography.Title>
+            <AevatarTooltip title={template.displayName}>
+              <Typography.Title level={2}>
+                {template.displayName}
+              </Typography.Title>
+            </AevatarTooltip>
             <p>
               {template.description ||
                 t(
@@ -200,33 +171,15 @@ function TemplateRow({
           </div>
         </div>
       </td>
-      <td className="wa-vnext__template-fact" data-label={readsLabel}>
-        <strong>
-          {t(
-            'workflowActivityVNext.new.templateBrowser.workflowInputs',
-            'Workflow inputs',
-          )}
-        </strong>
-      </td>
       <td className="wa-vnext__template-fact" data-label={connectionLabel}>
         <strong>{formatConnections(template)}</strong>
       </td>
       <td className="wa-vnext__template-fact" data-label={doesLabel}>
-        <strong>
-          {t(
-            'workflowActivityVNext.new.templateBrowser.runsSteps',
-            'Runs {count} {unit}',
-            {
-              count: template.stepCount,
-              unit: t(
-                template.stepCount === 1
-                  ? 'workflowActivityVNext.new.templateBrowser.step'
-                  : 'workflowActivityVNext.new.templateBrowser.steps',
-                template.stepCount === 1 ? 'step' : 'steps',
-              ),
-            },
-          )}
-        </strong>
+        <AevatarTooltip title={stepHelp} trigger={['hover', 'focus', 'click']}>
+          <button className="wa-vnext__template-step-summary" type="button">
+            {stepSummary}
+          </button>
+        </AevatarTooltip>
       </td>
       <td className="wa-vnext__template-updated" data-label={updatedLabel}>
         {formatUpdatedAt(template)}
@@ -933,7 +886,6 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
             >
               <colgroup>
                 <col className="wa-vnext__template-column--identity" />
-                <col className="wa-vnext__template-column--reads" />
                 <col className="wa-vnext__template-column--connection" />
                 <col className="wa-vnext__template-column--does" />
                 <col className="wa-vnext__template-column--updated" />
@@ -947,15 +899,6 @@ const WorkflowTemplateBrowser: React.FC<WorkflowTemplateBrowserProps> = ({
                       {t(
                         'workflowActivityVNext.new.templateBrowser.template',
                         'Template',
-                      )}
-                    </span>
-                  </th>
-                  <th scope="col">
-                    <span className="wa-vnext__template-header-label">
-                      <EyeOutlined aria-hidden="true" />
-                      {t(
-                        'workflowActivityVNext.new.templateBrowser.reads',
-                        'Reads',
                       )}
                     </span>
                   </th>

--- a/apps/aevatar-console-web/src/pages/workflows/index.tsx
+++ b/apps/aevatar-console-web/src/pages/workflows/index.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/shared/ui/aevatarPageShells";
 import { AevatarCompactText } from "@/shared/ui/compactText";
 import AevatarContentSkeleton from "@/shared/ui/AevatarContentSkeleton";
+import AevatarTooltip from "@/shared/ui/AevatarTooltip";
 import {
   codeBlockStyle,
   summaryFieldLabelStyle,
@@ -286,15 +287,17 @@ const WorkflowsPage: React.FC = () => {
               <Typography.Text strong style={{ fontSize: 15 }}>
                 {workflow.name}
               </Typography.Text>
-              <Typography.Paragraph
-                ellipsis={{ rows: 2, tooltip: summary }}
-                style={{
-                  color: "var(--ant-color-text-secondary)",
-                  margin: 0,
-                }}
-              >
-                {summary}
-              </Typography.Paragraph>
+              <AevatarTooltip title={summary}>
+                <Typography.Paragraph
+                  ellipsis={{ rows: 2 }}
+                  style={{
+                    color: "var(--ant-color-text-secondary)",
+                    margin: 0,
+                  }}
+                >
+                  {summary}
+                </Typography.Paragraph>
+              </AevatarTooltip>
             </div>
           );
         },

--- a/apps/aevatar-console-web/src/shared/ui/AevatarTooltip.test.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarTooltip.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+function loadTooltip(): React.ComponentType<{
+  children: React.ReactElement;
+  placement?: 'topLeft';
+  title: React.ReactNode;
+}> {
+  return require('./AevatarTooltip').default;
+}
+
+afterEach(() => cleanup());
+
+describe('AevatarTooltip', () => {
+  it('shows its help on hover', async () => {
+    const AevatarTooltip = loadTooltip();
+    render(
+      <AevatarTooltip title="Configured workflow step count">
+        <button type="button">Runs 3 steps</button>
+      </AevatarTooltip>,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Runs 3 steps' }));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Configured workflow step count',
+    );
+  });
+
+  it('shows its help on keyboard focus and preserves placement overrides', async () => {
+    const AevatarTooltip = loadTooltip();
+    render(
+      <AevatarTooltip placement="topLeft" title="Placement help">
+        <button type="button">Inspect placement</button>
+      </AevatarTooltip>,
+    );
+
+    fireEvent.focus(screen.getByRole('button', { name: 'Inspect placement' }));
+
+    expect(
+      (await screen.findByRole('tooltip')).closest('.ant-tooltip'),
+    ).toHaveClass('ant-tooltip-placement-topLeft');
+  });
+});

--- a/apps/aevatar-console-web/src/shared/ui/AevatarTooltip.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarTooltip.tsx
@@ -1,0 +1,38 @@
+import { Tooltip, type TooltipProps } from 'antd';
+import React from 'react';
+
+const DEFAULT_TOOLTIP_CONTAINER_STYLE: React.CSSProperties = {
+  lineHeight: 1.5,
+  maxWidth: 320,
+  overflowWrap: 'anywhere',
+};
+
+const DEFAULT_TOOLTIP_TRIGGER: TooltipProps['trigger'] = ['hover', 'focus'];
+
+const AevatarTooltip: React.FC<TooltipProps> = ({
+  mouseEnterDelay = 0.2,
+  placement = 'top',
+  styles,
+  trigger = DEFAULT_TOOLTIP_TRIGGER,
+  ...props
+}) => (
+  <Tooltip
+    {...props}
+    mouseEnterDelay={mouseEnterDelay}
+    placement={placement}
+    styles={(info) => {
+      const resolvedStyles =
+        typeof styles === 'function' ? styles(info) : styles;
+      return {
+        ...resolvedStyles,
+        container: {
+          ...DEFAULT_TOOLTIP_CONTAINER_STYLE,
+          ...resolvedStyles?.container,
+        },
+      };
+    }}
+    trigger={trigger}
+  />
+);
+
+export default AevatarTooltip;

--- a/apps/aevatar-console-web/src/shared/ui/AevatarTooltipImportGuard.test.ts
+++ b/apps/aevatar-console-web/src/shared/ui/AevatarTooltipImportGuard.test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const SOURCE_ROOT = path.resolve(__dirname, '..', '..');
+const TOOLTIP_ADAPTER = path.join(__dirname, 'AevatarTooltip.tsx');
+
+function listTypeScriptFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listTypeScriptFiles(entryPath);
+    if (
+      !entry.isFile() ||
+      !/\.tsx?$/.test(entry.name) ||
+      entry.name.endsWith('.d.ts')
+    ) {
+      return [];
+    }
+    return [entryPath];
+  });
+}
+
+function directlyImportsAntTooltip(filePath: string): boolean {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    fs.readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  return sourceFile.statements.some((statement) => {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== 'antd'
+    ) {
+      return false;
+    }
+    const bindings = statement.importClause?.namedBindings;
+    return (
+      bindings !== undefined &&
+      ts.isNamedImports(bindings) &&
+      bindings.elements.some(
+        (element) => (element.propertyName ?? element.name).text === 'Tooltip',
+      )
+    );
+  });
+}
+
+function usesTypographyEllipsisTooltip(filePath: string): boolean {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    fs.readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  let found = false;
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isJsxAttribute(node) &&
+      node.name.getText(sourceFile) === 'ellipsis' &&
+      node.initializer &&
+      ts.isJsxExpression(node.initializer) &&
+      node.initializer.expression
+    ) {
+      const inspectEllipsisValue = (value: ts.Node): void => {
+        if (
+          ts.isPropertyAssignment(value) &&
+          value.name.getText(sourceFile) === 'tooltip'
+        ) {
+          found = true;
+          return;
+        }
+        ts.forEachChild(value, inspectEllipsisValue);
+      };
+
+      inspectEllipsisValue(node.initializer.expression);
+    }
+
+    if (!found) ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+describe('AevatarTooltip import boundary', () => {
+  it('keeps the Ant Tooltip dependency inside the shared adapter', () => {
+    const directConsumers = listTypeScriptFiles(SOURCE_ROOT)
+      .filter((filePath) => filePath !== TOOLTIP_ADAPTER)
+      .filter(directlyImportsAntTooltip)
+      .map((filePath) => path.relative(SOURCE_ROOT, filePath))
+      .sort();
+
+    expect(directConsumers).toEqual([]);
+  });
+
+  it('keeps Typography ellipsis tooltips behind the shared adapter', () => {
+    const bypasses = listTypeScriptFiles(SOURCE_ROOT)
+      .filter(usesTypographyEllipsisTooltip)
+      .map((filePath) => path.relative(SOURCE_ROOT, filePath))
+      .sort();
+
+    expect(bypasses).toEqual([]);
+  });
+});

--- a/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/ConsoleHeaderActions.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/shared/auth/session';
 import { normalizeConsoleLocale } from '@/shared/i18n/localeProvider';
 import { history } from '@/shared/navigation/history';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 
 type ConsoleLocaleOption = {
   readonly key: 'zh-CN' | 'en-US';
@@ -206,24 +207,25 @@ export const ConsoleAuthActions: React.FC<ConsoleAuthActionsProps> = ({
           maxWidth: 220,
           padding: '0 10px 0 6px',
         }}
-        title={displayName}
       >
         <Avatar icon={<UserOutlined />} size={24} src={picture} />
-        <Typography.Text
-          className="console-header-actions__user-name"
-          style={{
-            flex: 1,
-            color: 'var(--ant-color-text)',
-            lineHeight: '20px',
-            marginBottom: 0,
-            maxWidth: 160,
-            minWidth: 0,
-            whiteSpace: 'nowrap',
-          }}
-          ellipsis={{ tooltip: displayName }}
-        >
-          {displayName}
-        </Typography.Text>
+        <AevatarTooltip title={displayName}>
+          <Typography.Text
+            className="console-header-actions__user-name"
+            ellipsis
+            style={{
+              flex: 1,
+              color: 'var(--ant-color-text)',
+              lineHeight: '20px',
+              marginBottom: 0,
+              maxWidth: 160,
+              minWidth: 0,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {displayName}
+          </Typography.Text>
+        </AevatarTooltip>
         <DownOutlined
           className="console-header-actions__user-caret"
           style={{

--- a/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
@@ -7,11 +7,11 @@ import {
   Grid,
   Space,
   Tag,
-  Tooltip,
   Typography,
   theme,
 } from 'antd';
 import React from 'react';
+import AevatarTooltip from './AevatarTooltip';
 import {
   AEVATAR_GLOBAL_UI_SPEC,
   aevatarDrawerBodyStyle,
@@ -416,7 +416,7 @@ export const AevatarBackButton: React.FC<AevatarBackButtonProps> = ({
   const label = ariaLabel ?? t("shared.ui.aevatarpageshells.back", "Back");
 
   return (
-    <Tooltip title={title ?? label}>
+    <AevatarTooltip title={title ?? label}>
       <Button
         aria-label={label}
         className={className}
@@ -427,7 +427,7 @@ export const AevatarBackButton: React.FC<AevatarBackButtonProps> = ({
         style={{ ...backButtonStyle, ...style }}
         type="text"
       />
-    </Tooltip>
+    </AevatarTooltip>
   );
 };
 
@@ -472,7 +472,7 @@ export const AevatarHelpTooltip: React.FC<{
   const { token } = theme.useToken();
 
   return (
-    <Tooltip
+    <AevatarTooltip
       placement="topLeft"
       styles={{ container: helpTooltipContentStyle }}
       title={<div>{content}</div>}
@@ -485,7 +485,7 @@ export const AevatarHelpTooltip: React.FC<{
       >
         <InfoCircleOutlined />
       </button>
-    </Tooltip>
+    </AevatarTooltip>
   );
 };
 

--- a/apps/aevatar-console-web/src/shared/ui/compactText.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/compactText.tsx
@@ -1,5 +1,6 @@
-import { Tag, Tooltip, Typography } from "antd";
+import { Tag, Typography } from "antd";
 import React from "react";
+import AevatarTooltip from './AevatarTooltip';
 import { isMachineIdentifierValue } from "./userFacingIdentifiers";
 
 export const aevatarMonoFontFamily = '"IBM Plex Mono", "SF Mono", monospace';
@@ -79,7 +80,7 @@ export const AevatarCompactText: React.FC<AevatarCompactTextProps> = ({
     </Typography.Text>
   );
 
-  return displayValue !== value ? <Tooltip title={value}>{content}</Tooltip> : content;
+  return displayValue !== value ? <AevatarTooltip title={value}>{content}</AevatarTooltip> : content;
 };
 
 type AevatarCompactTagProps = {
@@ -131,5 +132,5 @@ export const AevatarCompactTag: React.FC<AevatarCompactTagProps> = ({
     </Tag>
   );
 
-  return displayValue !== value ? <Tooltip title={value}>{tag}</Tooltip> : tag;
+  return displayValue !== value ? <AevatarTooltip title={value}>{tag}</AevatarTooltip> : tag;
 };

--- a/apps/aevatar-console-web/src/shared/workflows/WorkflowExecutionLogsPanel.tsx
+++ b/apps/aevatar-console-web/src/shared/workflows/WorkflowExecutionLogsPanel.tsx
@@ -8,8 +8,9 @@ import {
   LoadingOutlined,
   PauseCircleOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Segmented, Tag, Tooltip, Typography } from 'antd';
+import { Alert, Button, Segmented, Tag, Typography } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { t } from '@/shared/i18n/messages';
 import {
   type ExecutionLogItem,
@@ -1141,7 +1142,7 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                       tokenUsage.totalTokens,
                     )
                   : null}
-                <Tooltip
+                <AevatarTooltip
                   title={t(
                     'teamMemberWorkflowStudio.executionPanel.copyAll',
                     'Copy all logs',
@@ -1170,9 +1171,9 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                     size="small"
                     type="text"
                   />
-                </Tooltip>
+                </AevatarTooltip>
                 {onCollapse ? (
-                  <Tooltip
+                  <AevatarTooltip
                     title={t(
                       'shared.workflowExecutionLogs.collapse',
                       'Collapse workflow logs',
@@ -1191,9 +1192,9 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                       size="small"
                       type="text"
                     />
-                  </Tooltip>
+                  </AevatarTooltip>
                 ) : null}
-                <Tooltip
+                <AevatarTooltip
                   title={t(
                     'teamMemberWorkflowStudio.executionPanel.clear',
                     'Clear logs',
@@ -1209,7 +1210,7 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                     size="small"
                     type="text"
                   />
-                </Tooltip>
+                </AevatarTooltip>
               </div>
               {error ? (
                 <div style={{ flexBasis: '100%' }}>
@@ -1466,7 +1467,7 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                         </div>
                       ) : null}
                       {overviewMode === 'events' && selectedEntry ? (
-                        <Tooltip
+                        <AevatarTooltip
                           title={t(
                             'teamMemberWorkflowStudio.executionPanel.copySelected',
                             'Copy selected log',
@@ -1495,7 +1496,7 @@ const WorkflowExecutionLogsPanel: React.FC<WorkflowExecutionLogsPanelProps> = ({
                             size="small"
                             type="text"
                           />
-                        </Tooltip>
+                        </AevatarTooltip>
                       ) : null}
                     </div>
                   </div>

--- a/apps/aevatar-console-web/src/shared/workflows/WorkflowRunInputPanel.tsx
+++ b/apps/aevatar-console-web/src/shared/workflows/WorkflowRunInputPanel.tsx
@@ -5,8 +5,9 @@ import {
   PaperClipOutlined,
   PlayCircleOutlined,
 } from '@ant-design/icons';
-import { Button, Input, Tooltip, Typography } from 'antd';
+import { Button, Input, Typography } from 'antd';
 import React from 'react';
+import AevatarTooltip from '@/shared/ui/AevatarTooltip';
 import { t } from '@/shared/i18n/messages';
 import WorkflowSidePanel from './WorkflowSidePanel';
 
@@ -351,7 +352,7 @@ const WorkflowRunInputPanel: React.FC<WorkflowRunInputPanelProps> = ({
             style={fileDropZoneStyle}
           >
             <div style={attachmentToolbarStyle}>
-              <Tooltip
+              <AevatarTooltip
                 title={t(
                   'teamMemberWorkflowStudio.draftRunPanel.attachFiles',
                   'Attach files',
@@ -371,7 +372,7 @@ const WorkflowRunInputPanel: React.FC<WorkflowRunInputPanelProps> = ({
                     'Add files',
                   )}
                 </Button>
-              </Tooltip>
+              </AevatarTooltip>
               <Typography.Text style={{ color: '#64748b', fontSize: 12 }}>
                 {t(
                   'teamMemberWorkflowStudio.draftRunPanel.dropFiles',
@@ -395,11 +396,11 @@ const WorkflowRunInputPanel: React.FC<WorkflowRunInputPanelProps> = ({
                     style={attachmentChipStyle}
                   >
                     {getFileIcon(file)}
-                    <Tooltip
+                    <AevatarTooltip
                       title={`${file.name} · ${file.type || 'file'} · ${formatFileSize(file.size)}`}
                     >
                       <span style={attachmentNameStyle}>{file.name}</span>
-                    </Tooltip>
+                    </AevatarTooltip>
                     <span style={attachmentMetaStyle}>
                       {formatFileSize(file.size)}
                     </span>

--- a/docs/superpowers/plans/2026-08-21-workflow-template-tooltips.md
+++ b/docs/superpowers/plans/2026-08-21-workflow-template-tooltips.md
@@ -1,0 +1,110 @@
+# Workflow Template Tooltips Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove non-informative template catalogue content and establish one accessible tooltip component across console-web.
+
+**Architecture:** Add `AevatarTooltip` under shared UI as the sole Ant Tooltip adapter, migrate all business consumers without changing their existing content or placement overrides, and enforce that boundary with a TypeScript-AST test. Simplify the template table to its distinguishing facts and use the shared adapter for the step-count explanation.
+
+**Tech Stack:** React 19, TypeScript, Ant Design 6, Jest, Testing Library, Biome.
+
+---
+
+### Task 1: Add The Shared Tooltip Adapter
+
+**Files:**
+- Create: `apps/aevatar-console-web/src/shared/ui/AevatarTooltip.tsx`
+- Create: `apps/aevatar-console-web/src/shared/ui/AevatarTooltip.test.tsx`
+
+- [ ] **Step 1: Write the failing component tests**
+
+Test that hover and focus display the supplied content and that an explicit placement override remains accepted.
+
+- [ ] **Step 2: Run the component test and verify RED**
+
+Run: `pnpm exec jest src/shared/ui/AevatarTooltip.test.tsx --runInBand --runTestsByPath`
+
+Expected: FAIL because `AevatarTooltip` does not exist.
+
+- [ ] **Step 3: Implement the minimal adapter**
+
+Wrap Ant Design `Tooltip`, preserve `TooltipProps`, and default `trigger` to `['hover', 'focus']`, `placement` to `top`, `mouseEnterDelay` to `0.2`, and the content container to a readable maximum width while merging consumer styles.
+
+- [ ] **Step 4: Run the component test and verify GREEN**
+
+Run the Task 1 Jest command and expect all tests to pass.
+
+### Task 2: Migrate Existing Tooltip Consumers
+
+**Files:**
+- Create: `apps/aevatar-console-web/src/shared/ui/AevatarTooltipImportGuard.test.ts`
+- Modify: every console-web source file that directly imports `Tooltip` from `antd`
+
+- [ ] **Step 1: Write the failing import-boundary test**
+
+Parse TypeScript and TSX source imports with the TypeScript compiler API and fail when any file except `AevatarTooltip.tsx` imports the named `Tooltip` export from `antd`.
+
+- [ ] **Step 2: Run the guard and verify RED**
+
+Run: `pnpm exec jest src/shared/ui/AevatarTooltipImportGuard.test.ts --runInBand --runTestsByPath`
+
+Expected: FAIL and list the current direct-import files.
+
+- [ ] **Step 3: Mechanically migrate consumers**
+
+Replace JSX `Tooltip` elements with `AevatarTooltip`, remove `Tooltip` from Ant imports, add the shared adapter import, and update `AevatarHelpTooltip` to compose the adapter.
+
+- [ ] **Step 4: Run the guard and direct shared tests**
+
+Run both shared tooltip test files by path and expect them to pass.
+
+### Task 3: Simplify The Template Catalogue And Add Step Help
+
+**Files:**
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/WorkflowTemplateBrowser.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx`
+- Modify: `apps/aevatar-console-web/src/pages/workflow-activity-vnext/styles.ts`
+- Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.en-US.ts`
+- Modify: `apps/aevatar-console-web/src/locales/workflowActivityVNextMessages.zh-CN.ts`
+
+- [ ] **Step 1: Update the page regression and verify RED**
+
+Require five table columns, no `Reads` or `Workflow inputs`, no decorative marker, and a step-count tooltip that opens on hover and focus.
+
+- [ ] **Step 2: Run the focused page test and verify RED**
+
+Run: `pnpm exec jest src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx --runInBand --runTestsByPath -t "renders only decision-useful template facts with step help"`
+
+Expected: FAIL against the six-column marker implementation.
+
+- [ ] **Step 3: Implement the table and copy change**
+
+Delete marker selection and icon imports, remove the reads header/cell/column, change the identity layout to text-only, rebalance the five columns, and wrap the step summary in `AevatarTooltip` with localized explanatory content.
+
+- [ ] **Step 4: Run the complete changed page test**
+
+Run the complete `NewWorkflowPage.test.tsx` by path and expect all tests to pass.
+
+### Task 4: Focused Verification And Delivery
+
+**Files:** all changed task files only.
+
+- [ ] **Step 1: Analyze affected frontend scope**
+
+Run the `frontend_change_scope.py` analyzer against `feat/2026-08-18_workflow-template-browser`.
+
+- [ ] **Step 2: Run dependency-related and directly changed tests**
+
+Use Jest `--findRelatedTests` for changed source files and run every changed/new test file explicitly.
+
+- [ ] **Step 3: Run changed-file static checks and repository test guard**
+
+Run Biome only on analyzer `staticCheckFiles`, `bash tools/ci/test_stability_guards.sh`, and `git diff --check`.
+
+- [ ] **Step 4: Verify in the existing Chrome tab**
+
+Reuse the user's existing browser tab, verify desktop and 390px layouts, removed content, hover/focus tooltip, scrolling, and absence of document-level horizontal overflow.
+
+- [ ] **Step 5: Commit, push, and create the pull request**
+
+Stage only task files, commit with an imperative message, push `fix/2026-08-21_workflow-template-tooltips`, create a stacked PR against `feat/2026-08-18_workflow-template-browser`, and record exact focused verification while delegating the full frontend suite/build to GitHub CI.

--- a/docs/superpowers/specs/2026-08-21-workflow-template-tooltips-design.md
+++ b/docs/superpowers/specs/2026-08-21-workflow-template-tooltips-design.md
@@ -1,0 +1,23 @@
+# Workflow Template Tooltip Design
+
+## Product Decision
+
+The template catalogue should show only facts that distinguish one template from another. The decorative template marker and the repeated `Workflow inputs` fact do not add decision value, so the catalogue removes both. The execution summary remains visible as `Runs N step(s)` and gains an explanatory tooltip for users who need context.
+
+## Shared Tooltip Contract
+
+`AevatarTooltip` becomes the only direct adapter around Ant Design `Tooltip` in console-web source. It accepts the Ant tooltip contract so existing placements and rich content remain compatible, while supplying consistent defaults for hover and keyboard-focus triggers, top placement, a short reveal delay, and a bounded readable content width.
+
+All existing direct Ant Tooltip usages migrate to this adapter. `AevatarHelpTooltip` remains a specialized help-button composition, but uses `AevatarTooltip` internally. A static source test rejects future direct `Tooltip` imports from `antd` outside the adapter.
+
+## Catalogue Layout
+
+The semantic table keeps five columns: Template, Connection, Does, Updated, and the unlabeled action column. Template rows contain name and description without a decorative icon track. The execution summary is focusable as well as hoverable and explains that the count is the number of configured workflow steps the template runs.
+
+## Accessibility And Localization
+
+Tooltips open on hover and focus. The step-count trigger remains ordinary text visually and receives a focus ring only during keyboard navigation. Tooltip copy is localized in the existing vNext English and Chinese catalogues and preserves singular/plural step wording.
+
+## Verification
+
+Component tests cover default and overridden tooltip behavior. A static import guard covers the repository-wide migration. The template browser regression asserts the removed content, five-column table, and hover/focus tooltip. Focused dependency tests, changed-file static checks, test-stability guards, and existing-browser desktop/mobile inspection complete delivery; full frontend validation remains delegated to GitHub CI.


### PR DESCRIPTION
## Summary

- Removed decorative template marker icons from the workflow template catalogue.
- Removed the non-actionable Reads / Workflow inputs column and reduced the table to five aligned columns.
- Added a shared AevatarTooltip for consistent hover, focus, and click behavior across the console.
- Updated the template step summary Tooltip to lazily fetch template details on first open, then show the ordered step IDs and readable step types.
- Added explicit loading, unavailable, and empty states so a failed detail request cannot leave the Tooltip stuck in loading.
- Aligned each table header with its body cells: Template, Connection, and Does are left-aligned; Updated and Actions are right-aligned.
- Added focused tests for lazy detail loading, concrete step content, actionable failure copy, and header/body alignment.

## Scope

This PR targets `feat/2026-08-04_workflow-activity-vnext`; the prerequisite template browser implementation from #3495 is already merged into this base.

## Local verification

- `pnpm exec jest src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx --runInBand --runTestsByPath` -> 1 suite, 23 tests passed.
- `pnpm exec jest src/shared/ui/AevatarTooltip.test.tsx src/shared/ui/AevatarTooltipImportGuard.test.ts --runInBand --runTestsByPath` -> 2 suites, 4 tests passed.
- `pnpm exec biome check src/pages/workflow-activity-vnext/workflows/WorkflowTemplateBrowser.tsx src/pages/workflow-activity-vnext/styles.ts src/pages/workflow-activity-vnext/workflows/NewWorkflowPage.test.tsx src/locales/workflowActivityVNextMessages.en-US.ts src/locales/workflowActivityVNextMessages.zh-CN.ts` -> 5 files clean.
- `bash tools/ci/test_stability_guards.sh` -> passed.
- `git diff --check` -> passed.
- Frontend scope analyzer: affected Jest test files were the three files covered above.

Existing browser QA was performed on the shared `http://127.0.0.1:5173` session against the remote backend; no local backend or mock configuration was added.

Full frontend suite/typecheck/build deferred to GitHub CI by personal local workflow policy.
