### PR TITLE
Align Studio workflow tool set schema

### DIFF
--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "1d8a531ced051675400ea891e0c3ddccc299f68f",
+    "revision": "411b7aabd91c720bc9130ebd42348ff92f1ff878",
     "contract_files_sha256": "92f31b6fe6531ea2807421e7dac56e5bfb6fe740dfdf12aed9e21c3156d1bc75",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "23fd2cf48541c4b8da3fa1ef07277a7700c8478f9c638be8221465bf877fbb31",

--- a/src/Aevatar.Studio.Application/Studio/Authoring/WorkflowAuthoringPreviewGenerator.cs
+++ b/src/Aevatar.Studio.Application/Studio/Authoring/WorkflowAuthoringPreviewGenerator.cs
@@ -19,7 +19,7 @@ internal sealed class WorkflowAuthoringPreviewGenerator
     private static readonly string[] BaseAuthoringSchemaRules =
     [
         "Use canonical step types only. For a simple assistant/chat workflow, the step type must be llm_call (not llm, chat, or task).",
-        "Use only these step-level fields: id, type, target_role (or role), parameters, next, branches, children, retry, on_error, timeout_ms.",
+        "Use only these step-level fields: id, type, target_role (or role), allowed_tools, tool_sets, parameters, next, branches, children, retry, on_error, timeout_ms.",
         "Do not put model, provider, temperature, max_tokens, max_history_messages, connectors, or system_prompt on steps. Those belong under roles[*].",
         "Do not use steps[*].messages.",
         "Do not use steps[*].params. Put step options under steps[*].parameters.",

--- a/src/Aevatar.Studio.Domain/Studio/Compatibility/WorkflowCompatibilityProfile.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Compatibility/WorkflowCompatibilityProfile.cs
@@ -188,6 +188,7 @@ public sealed class WorkflowCompatibilityProfile
                 "max_tool_rounds",
                 "max_history_messages",
                 "allowed_tools",
+                "tool_sets",
                 "event_modules",
                 "event_routes",
                 "connectors",
@@ -195,7 +196,7 @@ public sealed class WorkflowCompatibilityProfile
             AllowedRoleExtensionFields = ImmutableHashSet.Create(comparer, "event_modules", "event_routes"),
             AllowedStepFields = ImmutableHashSet.Create(
                 comparer,
-                ["id", "type", "target_role", "role", "allowed_tools", "capability", "parameters", "next", "branches", "children", "retry", "on_error", "timeout_ms", .. rootParameterFields]),
+                ["id", "type", "target_role", "role", "allowed_tools", "tool_sets", "capability", "parameters", "next", "branches", "children", "retry", "on_error", "timeout_ms", .. rootParameterFields]),
             AllowedRetryFields = ImmutableHashSet.Create(comparer, "max_attempts", "backoff", "delay_ms"),
             AllowedOnErrorFields = ImmutableHashSet.Create(comparer, "strategy", "fallback_step", "default_output"),
             AllowedBranchListFields = ImmutableHashSet.Create(comparer, "condition", "when", "case", "label", "if", "next", "to", "target", "step"),

--- a/src/Aevatar.Studio.Domain/Studio/Models/RoleModel.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Models/RoleModel.cs
@@ -22,6 +22,8 @@ public sealed record RoleModel
 
     public List<string>? AllowedTools { get; init; }
 
+    public List<string>? ToolSets { get; init; }
+
     public string? EventModules { get; init; }
 
     public string? EventRoutes { get; init; }

--- a/src/Aevatar.Studio.Domain/Studio/Models/StepModel.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Models/StepModel.cs
@@ -14,6 +14,8 @@ public sealed record StepModel
 
     public List<string>? AllowedTools { get; init; }
 
+    public List<string>? ToolSets { get; init; }
+
     public StepCapability? Capability { get; init; }
 
     public StudioStepParameters Parameters { get; init; } = new();

--- a/src/Aevatar.Studio.Domain/Studio/Services/WorkflowDocumentNormalizer.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Services/WorkflowDocumentNormalizer.cs
@@ -38,6 +38,7 @@ public sealed class WorkflowDocumentNormalizer
             EventModules = NormalizeText(role.EventModules),
             EventRoutes = NormalizeText(role.EventRoutes),
             AllowedTools = NormalizeAllowedTools(role.AllowedTools),
+            ToolSets = NormalizeAllowedTools(role.ToolSets),
             Connectors = role.Connectors
                 .SelectMany(SplitConnectorValue)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -81,6 +82,7 @@ public sealed class WorkflowDocumentNormalizer
             TargetRole = NormalizeText(step.TargetRole),
             UsedRoleAlias = false,
             AllowedTools = NormalizeAllowedTools(step.AllowedTools),
+            ToolSets = NormalizeAllowedTools(step.ToolSets),
             Capability = NormalizeCapability(step.Capability),
             Parameters = normalizedParameters,
             Next = NormalizeText(step.Next),

--- a/src/Aevatar.Studio.Infrastructure/Serialization/YamlWorkflowDocumentService.cs
+++ b/src/Aevatar.Studio.Infrastructure/Serialization/YamlWorkflowDocumentService.cs
@@ -189,6 +189,7 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
                 MaxToolRounds = ReadInteger(roleNode, "max_tool_rounds", findings, path),
                 MaxHistoryMessages = ReadInteger(roleNode, "max_history_messages", findings, path),
                 AllowedTools = ParseAllowedTools(roleNode, path, findings),
+                ToolSets = ParseToolSets(roleNode, path, findings),
                 EventModules = eventModules,
                 EventRoutes = eventRoutes,
                 Connectors = ParseConnectors(roleNode, path, findings),
@@ -249,6 +250,7 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
             TargetRole = ReadScalar(stepNode, "target_role") ?? ReadScalar(stepNode, "role"),
             UsedRoleAlias = GetNode(stepNode, "target_role") is null && GetNode(stepNode, "role") is not null,
             AllowedTools = ParseAllowedTools(stepNode, path, findings),
+            ToolSets = ParseToolSets(stepNode, path, findings),
             Capability = ParseCapability(stepNode, path, findings),
             Parameters = parameters,
             Next = ReadScalar(stepNode, "next"),
@@ -557,44 +559,57 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
     private static List<string>? ParseAllowedTools(
         YamlMappingNode node,
         string path,
+        ICollection<ValidationFinding> findings) =>
+        ParseDelimitedStringList(node, "allowed_tools", path, findings);
+
+    private static List<string>? ParseToolSets(
+        YamlMappingNode node,
+        string path,
+        ICollection<ValidationFinding> findings) =>
+        ParseDelimitedStringList(node, "tool_sets", path, findings);
+
+    private static List<string>? ParseDelimitedStringList(
+        YamlMappingNode node,
+        string fieldName,
+        string path,
         ICollection<ValidationFinding> findings)
     {
-        var allowedToolsNode = GetNode(node, "allowed_tools");
-        if (allowedToolsNode is null)
+        var nodeValue = GetNode(node, fieldName);
+        if (nodeValue is null)
         {
             return null;
         }
 
-        if (allowedToolsNode is YamlSequenceNode sequenceNode)
+        if (nodeValue is YamlSequenceNode sequenceNode)
         {
-            var tools = new List<string>();
+            var items = new List<string>();
             for (var index = 0; index < sequenceNode.Children.Count; index++)
             {
                 if (sequenceNode.Children[index] is not YamlScalarNode scalarNode)
                 {
                     findings.Add(ValidationFinding.Error(
-                        $"{path}/allowed_tools/{index}",
-                        "Each `allowed_tools` entry must be a string."));
+                        $"{path}/{fieldName}/{index}",
+                        $"Each `{fieldName}` entry must be a string."));
                     continue;
                 }
 
                 if (!string.IsNullOrWhiteSpace(scalarNode.Value))
                 {
-                    tools.Add(scalarNode.Value.Trim());
+                    items.Add(scalarNode.Value.Trim());
                 }
             }
 
-            return tools;
+            return items;
         }
 
-        if (allowedToolsNode is YamlScalarNode scalar)
+        if (nodeValue is YamlScalarNode scalar)
         {
             return (scalar.Value ?? string.Empty)
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .ToList();
         }
 
-        findings.Add(ValidationFinding.Error($"{path}/allowed_tools", "`allowed_tools` must be a list or comma-delimited string."));
+        findings.Add(ValidationFinding.Error($"{path}/{fieldName}", $"`{fieldName}` must be a list or comma-delimited string."));
         return [];
     }
 
@@ -625,6 +640,7 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
         AddIfNotNull(result, "max_tool_rounds", role.MaxToolRounds);
         AddIfNotNull(result, "max_history_messages", role.MaxHistoryMessages);
         AddIfPresent(result, "allowed_tools", role.AllowedTools);
+        AddIfPresent(result, "tool_sets", role.ToolSets);
         AddIfNotNull(result, "event_modules", role.EventModules);
         AddIfNotNull(result, "event_routes", role.EventRoutes);
 
@@ -650,6 +666,7 @@ public sealed class YamlWorkflowDocumentService : IWorkflowYamlDocumentService
         }
 
         AddIfPresent(result, "allowed_tools", step.AllowedTools);
+        AddIfPresent(result, "tool_sets", step.ToolSets);
         AddIfNotNull(result, "capability", SerializeCapability(step.Capability));
 
         if (step.Parameters.Count > 0)

--- a/test/Aevatar.Studio.Tests/EditorControllerSerializationTests.cs
+++ b/test/Aevatar.Studio.Tests/EditorControllerSerializationTests.cs
@@ -245,6 +245,7 @@ public sealed class EditorControllerSerializationTests
                    roles:
                      - id: planner
                        allowed_tools: [search, calendar]
+                       tool_sets: [nyxid.connected_services]
                      - id: isolated
                        allowed_tools: []
                    steps:
@@ -252,10 +253,12 @@ public sealed class EditorControllerSerializationTests
                        type: llm_call
                        target_role: planner
                        allowed_tools: [calendar]
+                       tool_sets: [nyxid.connected_services]
                      - id: no_tools
                        type: llm_call
                        target_role: isolated
                        allowed_tools: []
+                       tool_sets: []
                    """,
             availableStepTypes = new[] { "llm_call" },
         });
@@ -264,7 +267,9 @@ public sealed class EditorControllerSerializationTests
         parseResponse.StatusCode.Should().Be(HttpStatusCode.OK, parseBody);
         parseBody.Should().NotContain("\"code\":\"unknown_field\"");
         parseBody.Should().Contain("\"allowedTools\":[\"search\",\"calendar\"]");
+        parseBody.Should().Contain("\"toolSets\":[\"nyxid.connected_services\"]");
         parseBody.Should().Contain("\"allowedTools\":[\"calendar\"]");
+        parseBody.Should().Contain("\"toolSets\":[]");
         parseBody.Should().Contain("\"allowedTools\":[]");
 
         using var parsedJson = JsonDocument.Parse(parseBody);
@@ -278,9 +283,11 @@ public sealed class EditorControllerSerializationTests
         var serializeBody = await serializeResponse.Content.ReadAsStringAsync();
         serializeResponse.StatusCode.Should().Be(HttpStatusCode.OK, serializeBody);
         serializeBody.Should().Contain("allowed_tools:");
+        serializeBody.Should().Contain("tool_sets:");
         serializeBody.Should().Contain("- search");
         serializeBody.Should().Contain("- calendar");
         serializeBody.Should().Contain("allowed_tools: []");
+        serializeBody.Should().Contain("tool_sets: []");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
@@ -144,6 +144,7 @@ public sealed class WorkflowCompatibilityProfileTests
             roles:
               - id: planner
                 allowed_tools: [search, calendar]
+                tool_sets: [nyxid.connected_services]
               - id: isolated
                 allowed_tools: []
               - id: inherited
@@ -152,12 +153,14 @@ public sealed class WorkflowCompatibilityProfileTests
                 type: llm_call
                 target_role: planner
                 allowed_tools: [calendar]
+                tool_sets: [nyxid.connected_services]
                 parameters:
                   prompt_prefix: "Use scoped tool"
               - id: no_tools
                 type: llm_call
                 target_role: isolated
                 allowed_tools: []
+                tool_sets: []
               - id: inherited_tools
                 type: llm_call
                 target_role: inherited
@@ -170,10 +173,13 @@ public sealed class WorkflowCompatibilityProfileTests
         studioParse.Document.Should().NotBeNull();
         var document = studioParse.Document!;
         document.Roles[0].AllowedTools.Should().Equal("search", "calendar");
+        document.Roles[0].ToolSets.Should().Equal("nyxid.connected_services");
         document.Roles[1].AllowedTools.Should().BeEmpty();
         document.Roles[2].AllowedTools.Should().BeNull();
         document.Steps[0].AllowedTools.Should().Equal("calendar");
+        document.Steps[0].ToolSets.Should().Equal("nyxid.connected_services");
         document.Steps[1].AllowedTools.Should().BeEmpty();
+        document.Steps[1].ToolSets.Should().BeEmpty();
         document.Steps[2].AllowedTools.Should().BeNull();
 
         var serialized = service.Serialize(document);
@@ -181,18 +187,24 @@ public sealed class WorkflowCompatibilityProfileTests
         studioRoundTrip.Findings.Should().NotContain(finding =>
             string.Equals(finding.Code, "unknown_field", StringComparison.OrdinalIgnoreCase));
         studioRoundTrip.Document!.Roles[0].AllowedTools.Should().Equal("search", "calendar");
+        studioRoundTrip.Document.Roles[0].ToolSets.Should().Equal("nyxid.connected_services");
         studioRoundTrip.Document.Roles[1].AllowedTools.Should().BeEmpty();
         studioRoundTrip.Document.Roles[2].AllowedTools.Should().BeNull();
         studioRoundTrip.Document.Steps[0].AllowedTools.Should().Equal("calendar");
+        studioRoundTrip.Document.Steps[0].ToolSets.Should().Equal("nyxid.connected_services");
         studioRoundTrip.Document.Steps[1].AllowedTools.Should().BeEmpty();
+        studioRoundTrip.Document.Steps[1].ToolSets.Should().BeEmpty();
         studioRoundTrip.Document.Steps[2].AllowedTools.Should().BeNull();
 
         var runtimeRoundTrip = new WorkflowParser().Parse(serialized);
         runtimeRoundTrip.Roles[0].AgentToolScope!.AllowedToolNames.Should().Equal("search", "calendar");
+        runtimeRoundTrip.Roles[0].AgentToolScope!.ToolSetRefs.Should().Equal("nyxid.connected_services");
         runtimeRoundTrip.Roles[1].AgentToolScope!.AllowedToolNames.Should().BeEmpty();
         runtimeRoundTrip.Roles[2].AgentToolScope.Should().BeNull();
         runtimeRoundTrip.Steps[0].AgentToolScope!.AllowedToolNames.Should().Equal("calendar");
+        runtimeRoundTrip.Steps[0].AgentToolScope!.ToolSetRefs.Should().Equal("nyxid.connected_services");
         runtimeRoundTrip.Steps[1].AgentToolScope!.AllowedToolNames.Should().BeEmpty();
+        runtimeRoundTrip.Steps[1].AgentToolScope!.ToolSetRefs.Should().BeEmpty();
         runtimeRoundTrip.Steps[2].AgentToolScope.Should().BeNull();
     }
 

--- a/test/Aevatar.Studio.Tests/WorkflowDocumentNormalizerTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowDocumentNormalizerTests.cs
@@ -39,6 +39,22 @@ public sealed class WorkflowDocumentNormalizerTests
     }
 
     [Fact]
+    public void NormalizeForExport_ShouldTrimToolSets()
+    {
+        var doc = new WorkflowDocument
+        {
+            Name = "wf",
+            Roles = [new RoleModel { Id = "r1", ToolSets = [" route.a ", "route.b "] }],
+            Steps = [new StepModel { Id = "s1", Type = "llm_call", ToolSets = [" step.scope "] }],
+        };
+
+        var result = _normalizer.NormalizeForExport(doc);
+
+        result.Roles[0].ToolSets.Should().Equal("route.a", "route.b");
+        result.Steps[0].ToolSets.Should().Equal("step.scope");
+    }
+
+    [Fact]
     public void NormalizeForExport_ShouldUseIdAsNameWhenNameIsBlank()
     {
         var doc = new WorkflowDocument


### PR DESCRIPTION
## Summary
- Fixes a Studio/runtime schema drift where `tool_sets` was valid for runtime workflow YAML but rejected by Studio editor parsing.
- Adds typed Studio document support for role and step `tool_sets`, preserving it through parse, normalize, serialize, and authoring schema hints.
- Extends Studio tests to verify editor JSON/YAML round trips and runtime parser `ToolSetRefs` compatibility.

Fixes aevatarAI/aevatar#3510

## Test plan
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo`
- [x] `bash tools/ci/test_stability_guards.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)