### PR TITLE
Fix HR-01 code execution route admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,9 +386,10 @@ jobs:
       (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
       needs.changes.outputs.docs_only == 'false'
     runs-on: ubuntu-latest
-    # Full coverage recently passed at 34-35 minutes, then timed out during the
-    # 121 MB artifact upload. Keep the fail-fast guard while allowing cleanup.
-    timeout-minutes: 45
+    # Full coverage takes 34-35 minutes after a roughly 10-minute restore/build,
+    # then still needs time to upload the report. Keep the fail-fast guard while
+    # leaving enough headroom for runner variance and cleanup.
+    timeout-minutes: 55
     services:
       agent-tool-admission-redis:
         image: redis:7.2.3

--- a/apps/aevatar-console-web/src/locales/en-US.ts
+++ b/apps/aevatar-console-web/src/locales/en-US.ts
@@ -1437,6 +1437,8 @@ const enUSMessages = {
   'pages.studio.studiomemberinvokeinspector.service.target': 'Service target',
   'pages.studio.studiomemberinvokeinspector.title': 'Details',
   'pages.studio.studiomemberinvokepanel.endpoint': 'Endpoint',
+  'pages.studio.studiomemberinvokepanel.endpoint.contract.changed':
+    'The selected member endpoint is unavailable or no longer matches this published service.',
   'pages.studio.studiomemberinvokepanel.inspector': 'Details',
   'pages.actors.index.actor': 'Actor',
   'pages.actors.index.command.recorded': 'Command recorded',

--- a/apps/aevatar-console-web/src/locales/zh-CN.ts
+++ b/apps/aevatar-console-web/src/locales/zh-CN.ts
@@ -1020,7 +1020,7 @@ const zhCNMessages = {
   'pages.teammemberinvoke.endpoint.notReady.description':
     '端点契约有效，但运行时尚未准备好接收调用。',
   'pages.teammemberinvoke.endpoint.versionPending.description':
-    '已提交的服务和修订版本尚未在读模型中可见。',
+    '已提交的服务和修订尚未在读模型中可见。',
   'pages.teammemberinvoke.fact.member': '成员',
   'pages.teammemberinvoke.fact.revision': '服务状态',
   'pages.teammemberinvoke.fact.service': '服务',
@@ -1357,6 +1357,8 @@ const zhCNMessages = {
   'pages.studio.studiomemberinvokeinspector.service.target': '服务目标',
   'pages.studio.studiomemberinvokeinspector.title': '详情',
   'pages.studio.studiomemberinvokepanel.endpoint': '端点',
+  'pages.studio.studiomemberinvokepanel.endpoint.contract.changed':
+    '所选成员端点不可用，或已不再匹配该发布服务。',
   'pages.studio.studiomemberinvokepanel.inspector': '详情',
   'pages.actors.index.actor': 'Actor',
   'pages.actors.index.command.recorded': 'Command recorded',

--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "600d19ee680ffe1a903e72c787a47366465bcda4",
-    "contract_files_sha256": "be5ff6dc0bbdaf42ef53a7a20f8e0bf852561b425f585f931e881ea4385f9c80",
+    "revision": "1c8ba2928b67fc31177b8f289595f023c338e072",
+    "contract_files_sha256": "02b7dbaa107046f9af851a0363b99f935c3e15d32542ec8c5065faccb321c9c8",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "23fd2cf48541c4b8da3fa1ef07277a7700c8478f9c638be8221465bf877fbb31",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "99605fdacc1e15b369d53b8953620b122dbba19d8b386486fd1892a2537ff82b",
@@ -13,7 +13,7 @@
       "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto": "523b8182bdd0a30224e001a7257ad42450226f42a84542a363e97816e34f23d9",
       "docs/adr/0048-nyxid-assistant-operation-class-boundary.md": "884aca09774e773e68154c923fec8078610b2cf8e97f581fedc36e10451ccec3",
       "src/Aevatar.AI.Abstractions/ai_messages.proto": "7ca08d69adbd97d82b89fc041d8d0eebd81e3ca125e2c4798bf012f1c29dc26d",
-      "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs": "9aaf3d1e8f071bdf2bc81e3a82f861440dade2a02d040c906477065cc147082e",
+      "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs": "2c679f03818997d1759b5bc60560b37119214bd6d5ee64f41578e02fa44cc9ee",
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1b033df9cb55c741e9b52054cbd4a91067f03c8c3797bd076a7e3d6133eb0fcb",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "2c4f2cda99154f2e667c6cfd291497e697ef11df17f081f96ec70070a8af8b8c",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyRotateTool.cs": "18212bb64644cfbca401065bccce439ea5fa00316deff57d730a0d9ac2650e53",

--- a/src/Aevatar.AI.Abstractions/CodeExecution/ICodeExecutionPort.cs
+++ b/src/Aevatar.AI.Abstractions/CodeExecution/ICodeExecutionPort.cs
@@ -37,12 +37,20 @@ public interface IDurableCodeExecutionPort
 public static class CodeExecutionContract
 {
     public const string ServiceSlug = "chrono-sandbox";
+    public const string PersonalServiceSlug = "chrono-sandbox-aevatar";
     public const int MinimumTimeoutSeconds = 1;
     public const int DefaultTimeoutSeconds = 180;
     public const int MaximumTimeoutSeconds = 600;
 
     public static bool IsValidTimeoutSeconds(int timeoutSeconds) =>
         timeoutSeconds is >= MinimumTimeoutSeconds and <= MaximumTimeoutSeconds;
+
+    public static bool IsValidServiceSlug(string? serviceSlug) =>
+        Aevatar.AI.Abstractions.LLMProviders.NyxIdServiceSlugPolicy.IsCanonical(serviceSlug);
+
+    public static bool IsSupportedServiceSlug(string? serviceSlug) =>
+        string.Equals(serviceSlug, ServiceSlug, StringComparison.Ordinal) ||
+        string.Equals(serviceSlug, PersonalServiceSlug, StringComparison.Ordinal);
 }
 
 public sealed record CodeExecutionRequest(

--- a/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.Durable.cs
+++ b/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.Durable.cs
@@ -308,13 +308,10 @@ internal sealed partial class NyxIdCodeExecutionPort
         string localDiagnosticId,
         CancellationToken ct)
     {
-        if (TryResolveExactAdmittedRoute(request.Route, out var admittedUserServiceId))
+        if (TryResolveExactAdmittedRoute(request.Route, out _))
         {
             return new DurableRouteResolution(
-                new CodeExecutionRouteIdentity(
-                    RequiredServiceSlug,
-                    admittedUserServiceId,
-                    CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission),
+                request.Route,
                 null);
         }
 
@@ -808,16 +805,16 @@ internal sealed partial class NyxIdCodeExecutionPort
         CodeExecutionContract.IsValidTimeoutSeconds(request.TimeoutSeconds) &&
         request.Route is not null &&
         IsValidExecutionCredentialKind(request.Caller?.ExecutionCredentialKind) &&
-        string.Equals(request.Route.ServiceSlug, RequiredServiceSlug, StringComparison.Ordinal);
+        IsValidRequestedRoute(request.Route);
 
     private static bool IsValidResolvedRoute(CodeExecutionRouteIdentity? route) =>
         route is not null &&
-        string.Equals(route.ServiceSlug, RequiredServiceSlug, StringComparison.Ordinal) &&
+        CodeExecutionContract.IsSupportedServiceSlug(route.ServiceSlug) &&
         !string.IsNullOrWhiteSpace(route.UserServiceId) &&
         string.Equals(route.UserServiceId, route.UserServiceId.Trim(), StringComparison.Ordinal) &&
         !route.UserServiceId.Any(char.IsControl) &&
-        (route.Source is CodeExecutionRouteIdentitySource.NyxIdUserServiceCatalog or
-            CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission);
+        route.Source is CodeExecutionRouteIdentitySource.NyxIdUserServiceCatalog or
+            CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission;
 
     private static bool IsValidIdempotencyKey(string? value) =>
         value is { Length: > 0 and <= 128 } &&

--- a/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.cs
+++ b/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.cs
@@ -47,7 +47,7 @@ internal sealed partial class NyxIdCodeExecutionPort(
             !CodeExecutionContract.IsValidTimeoutSeconds(request.TimeoutSeconds) ||
             request.Route is null ||
             !IsValidExecutionCredentialKind(request.Caller?.ExecutionCredentialKind) ||
-            !string.Equals(request.Route.ServiceSlug, RequiredServiceSlug, StringComparison.Ordinal))
+            !IsValidRequestedRoute(request.Route))
         {
             return Failed(
                 CodeExecutionFailureKind.AdmissionDenied,
@@ -70,7 +70,7 @@ internal sealed partial class NyxIdCodeExecutionPort(
         CodeExecutionRouteIdentity route;
         if (sourceReadableBearerToken is null)
         {
-            if (!TryResolveExactAdmittedRoute(request.Route, out var admittedUserServiceId))
+            if (!TryResolveExactAdmittedRoute(request.Route, out _))
             {
                 return Failed(
                     CodeExecutionFailureKind.AdmissionDenied,
@@ -79,10 +79,7 @@ internal sealed partial class NyxIdCodeExecutionPort(
                     localDiagnosticId);
             }
 
-            route = new CodeExecutionRouteIdentity(
-                RequiredServiceSlug,
-                admittedUserServiceId,
-                CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission);
+            route = request.Route;
         }
         else
         {
@@ -116,15 +113,12 @@ internal sealed partial class NyxIdCodeExecutionPort(
             if (!resolution.IsReady)
             {
                 if (resolution.SourceFailure?.Kind == NyxIdApiAccessFailureKind.Unauthorized &&
-                    TryResolveExactAdmittedRoute(request.Route, out var admittedUserServiceId))
+                    TryResolveExactAdmittedRoute(request.Route, out _))
                 {
                     _logger.LogWarning(
                         "Code execution source revalidation was unauthorized; using the exact workflow admission and deferring final access control to NyxID. diagnosticId={DiagnosticId} failureKind=source_unauthorized_exact_admission",
                         localDiagnosticId);
-                    route = new CodeExecutionRouteIdentity(
-                        RequiredServiceSlug,
-                        admittedUserServiceId,
-                        CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission);
+                    route = request.Route;
                 }
                 else
                 {
@@ -212,6 +206,32 @@ internal sealed partial class NyxIdCodeExecutionPort(
                !string.IsNullOrWhiteSpace(userServiceId) &&
                string.Equals(userServiceId, userServiceId.Trim(), StringComparison.Ordinal);
     }
+
+    private static bool IsValidRequestedRoute(CodeExecutionRouteIdentity route) =>
+        CodeExecutionContract.IsValidServiceSlug(route.ServiceSlug) &&
+        route.Source switch
+        {
+            CodeExecutionRouteIdentitySource.CodeExecutionContract =>
+                string.Equals(
+                    route.ServiceSlug,
+                    RequiredServiceSlug,
+                    StringComparison.Ordinal) &&
+                IsValidOptionalUserServiceId(route.UserServiceId),
+            CodeExecutionRouteIdentitySource.NyxIdUserServiceCatalog =>
+                IsValidExactUserServiceId(route.UserServiceId),
+            CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission =>
+                CodeExecutionContract.IsSupportedServiceSlug(route.ServiceSlug) &&
+                IsValidExactUserServiceId(route.UserServiceId),
+            _ => false,
+        };
+
+    private static bool IsValidOptionalUserServiceId(string? userServiceId) =>
+        userServiceId is null || IsValidExactUserServiceId(userServiceId);
+
+    private static bool IsValidExactUserServiceId(string? userServiceId) =>
+        !string.IsNullOrWhiteSpace(userServiceId) &&
+        string.Equals(userServiceId, userServiceId.Trim(), StringComparison.Ordinal) &&
+        !userServiceId.Any(char.IsControl);
 
     private static string? NormalizeCredential(string? token)
     {

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs
@@ -71,7 +71,8 @@ public sealed record NyxIdUserService(
     string? CatalogServiceId = null,
     bool? ForwardAccessToken = null,
     bool? InjectDelegationToken = null,
-    string? DelegationTokenScope = null);
+    string? DelegationTokenScope = null,
+    bool AutoConnected = false);
 
 public sealed record NyxIdUserServices(IReadOnlyList<NyxIdUserService> Services);
 
@@ -388,7 +389,9 @@ public static class NyxIdApiAccessResponseParser
                     : null,
                 includeCodeExecutionRouteFields
                     ? ReadOptionalNormalizedString(serviceElement, "delegation_token_scope")
-                    : null));
+                    : null,
+                includeCodeExecutionRouteFields &&
+                ReadOptionalBoolean(serviceElement, "auto_connected") == true));
         }
 
         return new NyxIdUserServices(services);

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRoutePolicyReconciler.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRoutePolicyReconciler.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.CodeExecution;
+
 namespace Aevatar.AI.ToolProviders.NyxId;
 
 public enum NyxIdCodeExecutionRouteRepairFailureKind
@@ -25,11 +28,13 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
         NyxIdUserServiceBooleanRequirement.Enabled,
         ["proxy:*", "sandbox:execute"]);
 
+    private readonly INyxIdApiClientFactory _clientFactory;
     private readonly NyxIdUserServiceRouteConverger _converger;
 
     public NyxIdCodeExecutionRoutePolicyReconciler(INyxIdApiClientFactory clientFactory)
     {
-        _converger = new NyxIdUserServiceRouteConverger(clientFactory);
+        _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
+        _converger = new NyxIdUserServiceRouteConverger(_clientFactory);
     }
 
     public async Task<NyxIdCodeExecutionRouteReconciliation> ReconcileAsync(
@@ -50,35 +55,43 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
         }
 
         var route = SelectRepairCandidate(before, exactUserServiceId);
-        if (route is null)
+        if (route is not null)
+        {
+            var convergence = await _converger.ConvergeAsync(
+                    mutationAuthority,
+                    route.Id,
+                    RouteContract,
+                    before,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            var verified = NyxIdCodeExecutionRouteResolver.Resolve(
+                convergence.Snapshot,
+                route.Id);
+            var postconditionSatisfied = convergence.Verified && verified.IsReady;
+            return new NyxIdCodeExecutionRouteReconciliation(
+                verified,
+                Attempted: convergence.Attempted,
+                Verified: postconditionSatisfied,
+                FailureKind: postconditionSatisfied
+                    ? NyxIdCodeExecutionRouteRepairFailureKind.None
+                    : convergence.FailureKind ==
+                      NyxIdUserServiceRouteConvergenceFailureKind.UpdateException
+                        ? NyxIdCodeExecutionRouteRepairFailureKind.UpdateException
+                        : NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch);
+        }
+
+        if (!CanCreatePersonalRoute(before, resolution, exactUserServiceId))
         {
             return new NyxIdCodeExecutionRouteReconciliation(
                 resolution,
                 Attempted: false,
-                Verified: resolution.IsReady);
+                Verified: false);
         }
 
-        var convergence = await _converger.ConvergeAsync(
+        return await CreateAndVerifyPersonalRouteAsync(
                 mutationAuthority,
-                route.Id,
-                RouteContract,
-                before,
                 cancellationToken)
             .ConfigureAwait(false);
-        var verified = NyxIdCodeExecutionRouteResolver.Resolve(
-            convergence.Snapshot,
-            route.Id);
-        var postconditionSatisfied = convergence.Verified && verified.IsReady;
-        return new NyxIdCodeExecutionRouteReconciliation(
-            verified,
-            Attempted: convergence.Attempted,
-            Verified: postconditionSatisfied,
-            FailureKind: postconditionSatisfied
-                ? NyxIdCodeExecutionRouteRepairFailureKind.None
-                : convergence.FailureKind ==
-                  NyxIdUserServiceRouteConvergenceFailureKind.UpdateException
-                    ? NyxIdCodeExecutionRouteRepairFailureKind.UpdateException
-                    : NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch);
     }
 
     private static NyxIdUserService? SelectRepairCandidate(
@@ -93,10 +106,7 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
             : exactUserServiceId.Trim();
         var repairCandidates = snapshot.Routes.Value!.Services
             .Where(service =>
-                string.Equals(
-                    service.Slug,
-                    Aevatar.AI.Abstractions.CodeExecution.CodeExecutionContract.ServiceSlug,
-                    StringComparison.Ordinal) &&
+                CodeExecutionContract.IsSupportedServiceSlug(service.Slug) &&
                 !string.IsNullOrWhiteSpace(service.CatalogServiceId) &&
                 service.IsActive &&
                 (requestedId is null ||
@@ -105,9 +115,114 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
                 authority is { CanManageRoute: true } &&
                 string.Equals(
                     authority.Execution.CatalogServiceSlug,
-                    Aevatar.AI.Abstractions.CodeExecution.CodeExecutionContract.ServiceSlug,
+                    CodeExecutionContract.ServiceSlug,
                     StringComparison.Ordinal))
             .ToArray();
         return repairCandidates.Length == 1 ? repairCandidates[0] : null;
+    }
+
+    private static bool CanCreatePersonalRoute(
+        NyxIdUserServiceAuthoritySnapshot snapshot,
+        NyxIdCodeExecutionRouteResolution resolution,
+        string? exactUserServiceId)
+    {
+        if (!snapshot.Succeeded ||
+            !string.IsNullOrWhiteSpace(exactUserServiceId) ||
+            resolution.Kind != NyxIdCodeExecutionRouteResolutionKind.PolicyMismatch)
+        {
+            return false;
+        }
+
+        var canonical = snapshot.Routes.Value!.Services
+            .Where(service =>
+                CodeExecutionContract.IsSupportedServiceSlug(service.Slug) &&
+                snapshot.TryGetExact(service.Id, out var authority) &&
+                authority is { IsExecutionReady: true } &&
+                string.Equals(
+                    authority.Execution.CatalogServiceSlug,
+                    CodeExecutionContract.ServiceSlug,
+                    StringComparison.Ordinal))
+            .ToArray();
+        return canonical.Length == 1 &&
+               canonical[0].AutoConnected &&
+               string.Equals(
+                   canonical[0].Slug,
+                   CodeExecutionContract.ServiceSlug,
+                   StringComparison.Ordinal) &&
+               !RouteContract.IsSatisfiedBy(canonical[0]);
+    }
+
+    private async Task<NyxIdCodeExecutionRouteReconciliation> CreateAndVerifyPersonalRouteAsync(
+        NyxIdUserServiceRouteMutationAuthority mutationAuthority,
+        CancellationToken cancellationToken)
+    {
+        var createFailed = false;
+        try
+        {
+            var body = JsonSerializer.Serialize(new
+            {
+                service_slug = CodeExecutionContract.ServiceSlug,
+                slug = CodeExecutionContract.PersonalServiceSlug,
+                forward_access_token = true,
+                inject_delegation_token = true,
+                delegation_token_scope = "proxy:* sandbox:execute",
+            });
+            _ = await _clientFactory.CreateClient()
+                .CreateServiceAsync(
+                    mutationAuthority.BearerToken,
+                    body,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            createFailed = true;
+        }
+
+        var after = await _converger.ReadAsync(mutationAuthority, cancellationToken)
+            .ConfigureAwait(false);
+        var personalRoute = SelectVerifiedPersonalRoute(after);
+        var verifiedResolution = personalRoute is null
+            ? NyxIdCodeExecutionRouteResolver.Resolve(after)
+            : NyxIdCodeExecutionRouteResolver.Resolve(after, personalRoute.Id);
+        var verified = personalRoute is not null && verifiedResolution.IsReady;
+        return new NyxIdCodeExecutionRouteReconciliation(
+            verifiedResolution,
+            Attempted: true,
+            Verified: verified,
+            FailureKind: verified
+                ? NyxIdCodeExecutionRouteRepairFailureKind.None
+                : createFailed
+                    ? NyxIdCodeExecutionRouteRepairFailureKind.UpdateException
+                    : NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch);
+    }
+
+    private static NyxIdUserService? SelectVerifiedPersonalRoute(
+        NyxIdUserServiceAuthoritySnapshot snapshot)
+    {
+        if (!snapshot.Succeeded)
+            return null;
+
+        var candidates = snapshot.Routes.Value!.Services
+            .Where(service =>
+                string.Equals(
+                    service.Slug,
+                    CodeExecutionContract.PersonalServiceSlug,
+                    StringComparison.Ordinal) &&
+                !service.AutoConnected &&
+                service.CredentialSource.Kind == NyxIdUserServiceCredentialSourceKind.Personal &&
+                snapshot.TryGetExact(service.Id, out var authority) &&
+                authority is { IsExecutionReady: true } &&
+                string.Equals(
+                    authority.Execution.CatalogServiceSlug,
+                    CodeExecutionContract.ServiceSlug,
+                    StringComparison.Ordinal) &&
+                RouteContract.IsSatisfiedBy(service))
+            .ToArray();
+        return candidates.Length == 1 ? candidates[0] : null;
     }
 }

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRouteResolver.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRouteResolver.cs
@@ -86,12 +86,28 @@ public static class NyxIdCodeExecutionRouteResolver
                 inventory.Failure);
         }
 
+        if (executionInventory is not null && !executionInventory.Succeeded)
+        {
+            var denied = executionInventory.Failure?.Kind is
+                NyxIdApiAccessFailureKind.Unauthorized or NyxIdApiAccessFailureKind.Forbidden;
+            return new NyxIdCodeExecutionRouteResolution(
+                denied
+                    ? NyxIdCodeExecutionRouteResolutionKind.AccessDenied
+                    : NyxIdCodeExecutionRouteResolutionKind.SourceUnavailable,
+                null,
+                0,
+                0,
+                0,
+                0,
+                executionInventory.Failure);
+        }
+
         var requestedId = NormalizeOptional(exactUserServiceId);
         var canonical = inventory.Value!.Services
             .Where(service =>
-                string.Equals(service.Slug, CodeExecutionContract.ServiceSlug, StringComparison.Ordinal) &&
                 !string.IsNullOrWhiteSpace(service.CatalogServiceId) &&
-                (requestedId is null || string.Equals(service.Id, requestedId, StringComparison.Ordinal)))
+                (requestedId is null || string.Equals(service.Id, requestedId, StringComparison.Ordinal)) &&
+                IsCanonicalCodeExecutionRoute(inventory, executionInventory, service))
             .ToArray();
         if (canonical.Length == 0)
             return Result(NyxIdCodeExecutionRouteResolutionKind.Missing, canonical, [], [], []);
@@ -113,22 +129,6 @@ public static class NyxIdCodeExecutionRouteResolver
                 accessible,
                 active,
                 []);
-
-        if (executionInventory is not null && !executionInventory.Succeeded)
-        {
-            var denied = executionInventory.Failure?.Kind is
-                NyxIdApiAccessFailureKind.Unauthorized or NyxIdApiAccessFailureKind.Forbidden;
-            return new NyxIdCodeExecutionRouteResolution(
-                denied
-                    ? NyxIdCodeExecutionRouteResolutionKind.AccessDenied
-                    : NyxIdCodeExecutionRouteResolutionKind.SourceUnavailable,
-                null,
-                canonical.Length,
-                accessible.Length,
-                active.Length,
-                0,
-                executionInventory.Failure);
-        }
 
         var executionReady = executionInventory is null
             ? active
@@ -232,6 +232,33 @@ public static class NyxIdCodeExecutionRouteResolver
         out NyxIdUserServiceAuthority? authority) =>
         new NyxIdUserServiceAuthoritySnapshot(routes, executionInventory)
             .TryGetExact(userServiceId, out authority);
+
+    private static bool IsCanonicalCodeExecutionRoute(
+        NyxIdApiAccessResult<NyxIdUserServices> routes,
+        NyxIdApiAccessResult<NyxIdUserServiceKeys>? executionInventory,
+        NyxIdUserService service)
+    {
+        if (executionInventory is null)
+        {
+            return string.Equals(
+                service.Slug,
+                CodeExecutionContract.ServiceSlug,
+                StringComparison.Ordinal);
+        }
+
+        return executionInventory.Succeeded &&
+               CodeExecutionContract.IsSupportedServiceSlug(service.Slug) &&
+               TryResolveExecutionAuthority(
+                   routes,
+                   executionInventory,
+                   service.Id,
+                   out var authority) &&
+               authority is not null &&
+               string.Equals(
+                   authority.Execution.CatalogServiceSlug,
+                   CodeExecutionContract.ServiceSlug,
+                   StringComparison.Ordinal);
+    }
 
     private static NyxIdCodeExecutionRouteResolution Result(
         NyxIdCodeExecutionRouteResolutionKind kind,

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionWorkflowCapabilitySource.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionWorkflowCapabilitySource.cs
@@ -168,6 +168,7 @@ public sealed class NyxIdCodeExecutionWorkflowCapabilitySource(
                 service.ForwardAccessToken?.ToString(CultureInfo.InvariantCulture),
                 service.InjectDelegationToken?.ToString(CultureInfo.InvariantCulture),
                 service.DelegationTokenScope,
+                service.AutoConnected.ToString(CultureInfo.InvariantCulture),
             });
         var executionComponents = authority.ExecutionInventory.Value!.Services
             .OrderBy(static service => service.Id, StringComparer.Ordinal)

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdUserServiceRouteConverger.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdUserServiceRouteConverger.cs
@@ -216,7 +216,7 @@ public sealed record NyxIdUserServiceAuthority(
             : Execution.NodeStatus == NyxIdUserServiceNodeStatus.Online);
 
     public bool CanManageRoute =>
-        IsExecutionReady && Route.CredentialSource.Kind switch
+        !Route.AutoConnected && IsExecutionReady && Route.CredentialSource.Kind switch
         {
             NyxIdUserServiceCredentialSourceKind.Personal => true,
             NyxIdUserServiceCredentialSourceKind.Organization =>
@@ -240,6 +240,7 @@ public sealed record NyxIdUserServiceAuthority(
             Execution.CatalogServiceSlug,
             other.Execution.CatalogServiceSlug,
             StringComparison.Ordinal) &&
+        Route.AutoConnected == other.Route.AutoConnected &&
         SameAuthority(Execution.CredentialSource, other.Execution.CredentialSource);
 
     private static bool SameAuthority(

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdCodeExecuteTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdCodeExecuteTool.cs
@@ -855,7 +855,7 @@ public sealed class NyxIdCodeExecuteTool(
                     "A typed NyxID execution credential is required for code execution."));
         }
 
-        if (!TryResolveAdmittedRoute(out var admittedUserServiceId))
+        if (!TryResolveAdmittedRoute(out var admittedServiceSlug, out var admittedUserServiceId))
         {
             return CodeExecutionPreparation.Failed(new CodeExecutionFailure(
                     CodeExecutionFailureKind.AdmissionDenied,
@@ -877,7 +877,7 @@ public sealed class NyxIdCodeExecuteTool(
             source,
             timeoutSeconds,
             new CodeExecutionRouteIdentity(
-                CodeExecutionContract.ServiceSlug,
+                admittedServiceSlug,
                 admittedUserServiceId,
                 admittedUserServiceId is null
                     ? CodeExecutionRouteIdentitySource.CodeExecutionContract
@@ -1009,10 +1009,7 @@ public sealed class NyxIdCodeExecuteTool(
             pending.ServiceSlug,
             pending.UserServiceId,
             pending.RouteIdentitySource);
-        if (!string.Equals(
-                route.ServiceSlug,
-                CodeExecutionContract.ServiceSlug,
-                StringComparison.Ordinal) ||
+        if (!CodeExecutionContract.IsValidServiceSlug(route.ServiceSlug) ||
             route.Source == CodeExecutionRouteIdentitySource.Unspecified ||
             !Enum.IsDefined(route.Source))
         {
@@ -1020,7 +1017,20 @@ public sealed class NyxIdCodeExecuteTool(
         }
 
         if (route.UserServiceId is null)
-            return route.Source == CodeExecutionRouteIdentitySource.CodeExecutionContract;
+        {
+            return route.Source == CodeExecutionRouteIdentitySource.CodeExecutionContract &&
+                   string.Equals(
+                       route.ServiceSlug,
+                       CodeExecutionContract.ServiceSlug,
+                       StringComparison.Ordinal);
+        }
+
+        if ((route.Source is CodeExecutionRouteIdentitySource.NyxIdUserServiceCatalog or
+                CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission) &&
+            !CodeExecutionContract.IsSupportedServiceSlug(route.ServiceSlug))
+        {
+            return false;
+        }
 
         return !string.IsNullOrWhiteSpace(route.UserServiceId) &&
                string.Equals(route.UserServiceId, route.UserServiceId.Trim(), StringComparison.Ordinal);
@@ -1039,10 +1049,7 @@ public sealed class NyxIdCodeExecuteTool(
                preparedRoute.UserServiceId is null &&
                pendingRoute.Source == CodeExecutionRouteIdentitySource.NyxIdUserServiceCatalog &&
                !string.IsNullOrWhiteSpace(pendingRoute.UserServiceId) &&
-               string.Equals(
-                   pendingRoute.ServiceSlug,
-                   preparedRoute.ServiceSlug,
-                   StringComparison.Ordinal);
+               CodeExecutionContract.IsSupportedServiceSlug(pendingRoute.ServiceSlug);
     }
 
     private static long RetryAfterMilliseconds(TimeSpan? value, TimeSpan fallback)
@@ -1108,8 +1115,11 @@ public sealed class NyxIdCodeExecuteTool(
             failure.DiagnosticId,
             failure.ProviderPhase);
 
-    private static bool TryResolveAdmittedRoute(out string? userServiceId)
+    private static bool TryResolveAdmittedRoute(
+        out string serviceSlug,
+        out string? userServiceId)
     {
+        serviceSlug = CodeExecutionContract.ServiceSlug;
         userServiceId = null;
         var admission = AgentToolRequestContext.Current?.OperationAdmission;
         if (admission is null)
@@ -1120,10 +1130,7 @@ public sealed class NyxIdCodeExecuteTool(
                 admission.ServiceInstanceId,
                 admission.ServiceInstanceId.Trim(),
                 StringComparison.Ordinal) ||
-            !string.Equals(
-                admission.ServiceSlug,
-                CodeExecutionContract.ServiceSlug,
-                StringComparison.Ordinal) ||
+            !CodeExecutionContract.IsSupportedServiceSlug(admission.ServiceSlug) ||
             admission.Identity is not AgentToolOperationIdentity.PlatformBuiltIn
             {
                 CapabilityId: "code_execute",
@@ -1136,6 +1143,7 @@ public sealed class NyxIdCodeExecuteTool(
             return false;
         }
 
+        serviceSlug = admission.ServiceSlug;
         userServiceId = admission.ServiceInstanceId;
         return true;
     }

--- a/src/Aevatar.CQRS.Projection.Providers.Neo4j/Stores/Neo4jProjectionGraphStore.Versioned.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Neo4j/Stores/Neo4jProjectionGraphStore.Versioned.cs
@@ -598,15 +598,38 @@ public sealed partial class Neo4jProjectionGraphStore
         if (promotableNodeIds.Length > 0 || promotableEdgeIds.Length > 0)
         {
             parameters.Remove("edges");
-            parameters["promotableNodeIds"] = promotableNodeIds;
-            parameters["promotableEdgeIds"] = promotableEdgeIds;
-            var promotableRows = await RunRowsAsync(
-                transaction,
-                Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesCypher(
-                    _versionedEdgeIdentityLabel),
-                parameters,
-                ct);
+            var promotableRows = new List<IReadOnlyDictionary<string, object>>();
+            if (promotableEdgeIds.Length > 0)
+            {
+                parameters["promotableEdgeIds"] = promotableEdgeIds;
+                promotableRows.AddRange(await RunRowsAsync(
+                    transaction,
+                    Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesByIdCypher(
+                        _versionedEdgeIdentityLabel),
+                    parameters,
+                    ct));
+            }
+
+            if (promotableNodeIds.Length > 0)
+            {
+                parameters["promotableNodeIds"] = promotableNodeIds;
+                promotableRows.AddRange(await RunRowsAsync(
+                    transaction,
+                    Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesByFromNodeCypher(
+                        _versionedEdgeIdentityLabel),
+                    parameters,
+                    ct));
+                promotableRows.AddRange(await RunRowsAsync(
+                    transaction,
+                    Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesByToNodeCypher(
+                        _versionedEdgeIdentityLabel),
+                    parameters,
+                    ct));
+            }
+
             var promotable = promotableRows
+                .GroupBy(row => ReadString(row, "edgeId"), StringComparer.Ordinal)
+                .Select(static group => group.First())
                 .Select(row => new Dictionary<string, object?>
                 {
                     ["edgeId"] = ReadString(row, "edgeId"),

--- a/src/Aevatar.CQRS.Projection.Providers.Neo4j/Stores/Neo4jProjectionGraphStoreVersionedCypherSupport.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Neo4j/Stores/Neo4jProjectionGraphStoreVersionedCypherSupport.cs
@@ -175,18 +175,25 @@ internal static class Neo4jProjectionGraphStoreVersionedCypherSupport
         "edge.projectionOwnerId = $ownerId, edge.projectionGraphVersion = item.projectionGraphVersion " +
         "RETURN count(edge) AS appliedCount";
 
-    // Promotion is two statements. The disjunctive selection of promotable pending identities is a
-    // read on its own; the endpoint match + relationship MERGE then runs per selected identity via
-    // UNWIND (the same shape as live-edge creation). Planning the disjunction together with the
-    // MERGE in one query graph trips a Neo4j 5 planner assertion ("Expected:
-    // RegularSinglePlannerQuery") on the production database, and a plain WITH does not create a
-    // planner boundary.
-    internal static string BuildSelectPromotablePendingEdgesCypher(string edgeIdentityLabel) =>
+    // Promotion remains a separate read followed by a write. Each selection query is UNWIND-driven
+    // and uses one exact indexed identity path; a single OR query over large node-id batches can
+    // exhaust the Neo4j planner/runtime heap before the relationship MERGE even starts.
+    internal static string BuildSelectPromotablePendingEdgesByIdCypher(string edgeIdentityLabel) =>
+        "UNWIND $promotableEdgeIds AS edgeId " +
+        $"MATCH (identity:{edgeIdentityLabel} {{physicalNamespace: $physicalNamespace, edgeId: edgeId}}) " +
+        "WHERE identity.projectionOwnerId = $ownerId AND identity.status = 'pending' " +
+        "RETURN identity.edgeId AS edgeId, identity.fromNodeId AS fromNodeId, identity.toNodeId AS toNodeId";
+
+    internal static string BuildSelectPromotablePendingEdgesByFromNodeCypher(string edgeIdentityLabel) =>
+        "UNWIND $promotableNodeIds AS nodeId " +
         $"MATCH (identity:{edgeIdentityLabel} {{physicalNamespace: $physicalNamespace, " +
-        "projectionOwnerId: $ownerId, status: 'pending'}) " +
-        "WHERE identity.edgeId IN $promotableEdgeIds " +
-        "OR identity.fromNodeId IN $promotableNodeIds " +
-        "OR identity.toNodeId IN $promotableNodeIds " +
+        "projectionOwnerId: $ownerId, status: 'pending', fromNodeId: nodeId}) " +
+        "RETURN identity.edgeId AS edgeId, identity.fromNodeId AS fromNodeId, identity.toNodeId AS toNodeId";
+
+    internal static string BuildSelectPromotablePendingEdgesByToNodeCypher(string edgeIdentityLabel) =>
+        "UNWIND $promotableNodeIds AS nodeId " +
+        $"MATCH (identity:{edgeIdentityLabel} {{physicalNamespace: $physicalNamespace, " +
+        "projectionOwnerId: $ownerId, status: 'pending', toNodeId: nodeId}) " +
         "RETURN identity.edgeId AS edgeId, identity.fromNodeId AS fromNodeId, identity.toNodeId AS toNodeId";
 
     internal static string BuildPromotePendingEdgesCypher(

--- a/src/workflow/Aevatar.Workflow.Abstractions/WorkflowCapabilityAdmissionPlanIntegrity.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/WorkflowCapabilityAdmissionPlanIntegrity.cs
@@ -770,7 +770,7 @@ public static class WorkflowCapabilityAdmissionPlanIntegrity
 
         var proof = admission.Capability.CodeExecution;
         if (!IsCanonicalIdentity(proof.UserServiceId) ||
-            !string.Equals(proof.ServiceSlugSnapshot, "chrono-sandbox", StringComparison.Ordinal) ||
+            !IsSupportedCodeExecutionServiceSlug(proof.ServiceSlugSnapshot) ||
             !IsCanonicalIdentity(proof.CatalogServiceId) ||
             !FixedTimeEquals(
                 proof.ContractDigest,
@@ -1139,6 +1139,10 @@ public static class WorkflowCapabilityAdmissionPlanIntegrity
     private static bool IsCanonicalIdentity(string? value) =>
         !string.IsNullOrWhiteSpace(value) &&
         string.Equals(value, value.Trim(), StringComparison.Ordinal);
+
+    private static bool IsSupportedCodeExecutionServiceSlug(string? value) =>
+        string.Equals(value, "chrono-sandbox", StringComparison.Ordinal) ||
+        string.Equals(value, "chrono-sandbox-aevatar", StringComparison.Ordinal);
 
     private static string SourceKey(ExternalCapabilitySourceStamp source) =>
         string.Join(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -2474,7 +2474,7 @@ public sealed partial class ToolCallModule :
         string.IsNullOrWhiteSpace(pending.UserServiceId) &&
         pending.RouteIdentitySource == WorkflowToolPendingOperationRouteIdentitySource.CodeExecutionContract &&
         HasProviderReceipt(operation) &&
-        string.Equals(operation.ServiceSlug, CodeExecutionContract.ServiceSlug, StringComparison.Ordinal) &&
+        CodeExecutionContract.IsSupportedServiceSlug(operation.ServiceSlug) &&
         operation.RouteIdentitySource == WorkflowToolPendingOperationRouteIdentitySource.NyxIdUserServiceCatalog &&
         !string.IsNullOrWhiteSpace(operation.UserServiceId);
 

--- a/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdCodeExecutionPortTests.cs
+++ b/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdCodeExecutionPortTests.cs
@@ -110,6 +110,42 @@ public sealed class NyxIdCodeExecutionPortTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ScheduledPersonalRouteUsesItsAdmittedSlug()
+    {
+        var handler = new SequenceHandler(JsonResponse(
+            """
+            {
+              "success": true,
+              "output": {
+                "stdout": "scheduled-ok",
+                "stderr": "",
+                "exit_code": 0
+              }
+            }
+            """));
+        var port = CreatePort(handler);
+        var request = Request(
+            "us-code-aevatar",
+            executionCredential: "scheduled-agent-key",
+            sourceReadableBearerToken: null,
+            executionCredentialKind: CodeExecutionNyxIdCredentialKind.AgentKey) with
+        {
+            Route = new CodeExecutionRouteIdentity(
+                "chrono-sandbox-aevatar",
+                "us-code-aevatar",
+                CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission),
+        };
+
+        var outcome = await port.ExecuteAsync(request);
+
+        outcome.Failure.Should().BeNull();
+        outcome.ResolvedRoute.Should().Be(request.Route);
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].PathAndQuery.Should().Be(
+            "/api/v1/proxy/s/chrono-sandbox-aevatar/execute?_nyxid_via=us-code-aevatar");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenUserServicesSourceCredentialExpiresAfterExactAdmission_UsesAdmittedRoute()
     {
         var handler = new SequenceHandler(

--- a/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdDurableCodeExecutionPortTests.cs
+++ b/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdDurableCodeExecutionPortTests.cs
@@ -97,6 +97,37 @@ public sealed class NyxIdDurableCodeExecutionPortTests
     }
 
     [Fact]
+    public async Task SubmitAsync_PersonalExecutionRouteUsesItsAdmittedSlug()
+    {
+        var handler = new SequenceHandler(_ => Response(
+            HttpStatusCode.Accepted,
+            $$"""
+              {
+                "operation_id":"{{OperationId}}",
+                "status":"queued",
+                "created_at":"2026-08-14T10:00:00Z",
+                "expires_at":"2026-08-15T10:00:00Z"
+              }
+              """));
+        var port = CreatePort(handler);
+        var route = new CodeExecutionRouteIdentity(
+            "chrono-sandbox-aevatar",
+            "us-code-aevatar",
+            CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission);
+        var execution = ExecutionRequest() with { Route = route };
+
+        var outcome = await port.SubmitAsync(new DurableCodeExecutionSubmitRequest(
+            execution,
+            IdempotencyKey));
+
+        outcome.Failure.Should().BeNull();
+        outcome.Receipt!.ResolvedRoute.Should().Be(route);
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].Uri.Should().Be(
+            "https://nyx-public.example/api/v1/proxy/s/chrono-sandbox-aevatar/executions?_nyxid_via=us-code-aevatar");
+    }
+
+    [Fact]
     public async Task GetStatusAsync_NotModifiedPreservesEtagAndRetryAfter()
     {
         var handler = new SequenceHandler(_ => Response(

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecuteToolTests.cs
@@ -1247,6 +1247,34 @@ public sealed class NyxIdCodeExecuteToolTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteWithOutcomeAsync_WorkflowAdmissionPreservesPersonalExecutionRouteSlug()
+    {
+        var port = new StubCodeExecutionPort(CodeExecutionOutcome.Succeeded(
+            new CodeExecutionResult("ok", string.Empty, 0),
+            ResolvedRoute));
+        var tool = new NyxIdCodeExecuteTool(port);
+        SetAgentKey("scheduled-agent-key");
+        AgentToolRequestContext.Current = AgentToolRequestContext.Current! with
+        {
+            OperationAdmission = CodeExecutionAdmission("us-code-aevatar") with
+            {
+                ServiceSlug = "chrono-sandbox-aevatar",
+            },
+        };
+
+        await tool.ExecuteWithOutcomeAsync(
+            "call-managed-admitted",
+            tool.Name,
+            """{"language":"javascript","code":"console.log('ok')"}""");
+
+        port.Request.Should().NotBeNull();
+        port.Request!.Route.Should().Be(new CodeExecutionRouteIdentity(
+            "chrono-sandbox-aevatar",
+            "us-code-aevatar",
+            CodeExecutionRouteIdentitySource.WorkflowCapabilityAdmission));
+    }
+
+    [Fact]
     public async Task ExecuteWithOutcomeAsync_AgentKeyUsesExactAdmissionWithoutSourceReadableCredential()
     {
         var port = new StubCodeExecutionPort(CodeExecutionOutcome.Succeeded(

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecutionRouteAdmissionPreparerTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecutionRouteAdmissionPreparerTests.cs
@@ -14,6 +14,83 @@ namespace Aevatar.AI.Tests;
 public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
 {
     [Fact]
+    public async Task AdmitAsync_AutoConnectedPlatformRoute_CreatesPersonalRouteAndCommitsItsExactProof()
+    {
+        const string yaml = "name: code-workflow\nsteps: []\n";
+        var handler = new SequenceHandler(
+            AutoConnectedInventory(),
+            AutoConnectedKeysInventory(),
+            AutoConnectedInventory(),
+            AutoConnectedKeysInventory(),
+            """{"error":true,"status":409,"body":"concurrent create"}""",
+            PersonalExecutionInventory(),
+            PersonalExecutionKeysInventory(),
+            PersonalExecutionInventory(),
+            PersonalExecutionKeysInventory());
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyx.example" };
+        var client = new NyxIdApiClient(options, new HttpClient(handler));
+        var factory = new TestClientFactory(client);
+        var source = new NyxIdCodeExecutionWorkflowCapabilitySource(
+            factory,
+            options,
+            logger: NullLogger<NyxIdCodeExecutionWorkflowCapabilitySource>.Instance);
+        var preparer = new NyxIdCodeExecutionRouteAdmissionPreparer(
+            new NyxIdCodeExecutionRoutePolicyReconciler(factory),
+            options,
+            NullLogger<NyxIdCodeExecutionRouteAdmissionPreparer>.Instance);
+        var dependencies = new WorkflowAuthorizationDependencies
+        {
+            ServiceGrantPolicy = WorkflowServiceGrantPolicy.Required,
+        };
+        dependencies.ExternalInvocations.Add(new ExternalToolInvocationSpec
+        {
+            CallSiteId = "code-workflow/run-code",
+            ToolName = "code_execute",
+            Selector = Selector(),
+        });
+        var admission = new WorkflowExternalCapabilityAdmissionService(
+            new StaticParser(WorkflowYamlParseResult.Success("code-workflow", dependencies)),
+            new ExternalWorkflowCapabilityReadinessService([source]),
+            preparers: [preparer]);
+
+        var plan = await admission.AdmitAsync(new WorkflowExternalCapabilityAdmissionRequest(
+            Access(),
+            yaml,
+            new Dictionary<string, string>(),
+            "test",
+            ExternalCapabilityExecutionMode.Interactive,
+            workflowId: "wf-alpha",
+            revisionId: "rev-alpha"));
+
+        handler.Requests.Select(static request => request.Method)
+            .Should().Equal(
+                HttpMethod.Get,
+                HttpMethod.Get,
+                HttpMethod.Get,
+                HttpMethod.Get,
+                HttpMethod.Post,
+                HttpMethod.Get,
+                HttpMethod.Get,
+                HttpMethod.Get,
+                HttpMethod.Get);
+        handler.Requests.Should().NotContain(static request => request.Method == HttpMethod.Put);
+        handler.Requests[4].Uri.Should().Be("https://nyx.example/api/v1/keys");
+        using (var body = JsonDocument.Parse(handler.Requests[4].Body!))
+        {
+            body.RootElement.GetProperty("service_slug").GetString().Should().Be("chrono-sandbox");
+            body.RootElement.GetProperty("slug").GetString().Should().Be("chrono-sandbox-aevatar");
+            body.RootElement.GetProperty("forward_access_token").GetBoolean().Should().BeTrue();
+            body.RootElement.GetProperty("inject_delegation_token").GetBoolean().Should().BeTrue();
+            body.RootElement.GetProperty("delegation_token_scope").GetString().Should()
+                .Be("proxy:* sandbox:execute");
+        }
+        var proof = plan.InvocationAdmissions.Should().ContainSingle().Which.Capability.CodeExecution;
+        proof.UserServiceId.Should().Be("us-code-aevatar");
+        proof.ServiceSlugSnapshot.Should().Be("chrono-sandbox-aevatar");
+        proof.CatalogServiceId.Should().Be("catalog-chrono-sandbox");
+    }
+
+    [Fact]
     public async Task AdmitAsync_LegacyPersonalRoute_RepairsThenCommitsVerifiedExactProof()
     {
         const string yaml = "name: code-workflow\nsteps: []\n";
@@ -581,6 +658,107 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
             },
         });
     }
+
+    private static string AutoConnectedInventory() =>
+        JsonSerializer.Serialize(new
+        {
+            services = new[]
+            {
+                new
+                {
+                    id = "us-code-platform",
+                    slug = "chrono-sandbox",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    is_active = true,
+                    auto_connected = true,
+                    forward_access_token = true,
+                    inject_delegation_token = true,
+                    delegation_token_scope = "proxy:*",
+                    credential_source = new { type = "personal" },
+                },
+            },
+        });
+
+    private static string AutoConnectedKeysInventory() =>
+        JsonSerializer.Serialize(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    id = "us-code-platform",
+                    slug = "chrono-sandbox",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    catalog_service_slug = "chrono-sandbox",
+                    is_active = true,
+                    status = "active",
+                    connected = true,
+                    credential_source = new { type = "personal" },
+                },
+            },
+        });
+
+    private static string PersonalExecutionInventory() =>
+        JsonSerializer.Serialize(new
+        {
+            services = new object[]
+            {
+                new
+                {
+                    id = "us-code-platform",
+                    slug = "chrono-sandbox",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    is_active = true,
+                    auto_connected = true,
+                    forward_access_token = true,
+                    inject_delegation_token = true,
+                    delegation_token_scope = "proxy:*",
+                    credential_source = new { type = "personal" },
+                },
+                new
+                {
+                    id = "us-code-aevatar",
+                    slug = "chrono-sandbox-aevatar",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    is_active = true,
+                    auto_connected = false,
+                    forward_access_token = true,
+                    inject_delegation_token = true,
+                    delegation_token_scope = "proxy:* sandbox:execute",
+                    credential_source = new { type = "personal" },
+                },
+            },
+        });
+
+    private static string PersonalExecutionKeysInventory() =>
+        JsonSerializer.Serialize(new
+        {
+            keys = new object[]
+            {
+                new
+                {
+                    id = "us-code-platform",
+                    slug = "chrono-sandbox",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    catalog_service_slug = "chrono-sandbox",
+                    is_active = true,
+                    status = "active",
+                    connected = true,
+                    credential_source = new { type = "personal" },
+                },
+                new
+                {
+                    id = "us-code-aevatar",
+                    slug = "chrono-sandbox-aevatar",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    catalog_service_slug = "chrono-sandbox",
+                    is_active = true,
+                    status = "active",
+                    connected = true,
+                    credential_source = new { type = "personal" },
+                },
+            },
+        });
 
     private static string MixedInventory(
         string personalScope,

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecutionWorkflowCapabilitySourceTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecutionWorkflowCapabilitySourceTests.cs
@@ -265,9 +265,46 @@ public sealed class NyxIdCodeExecutionWorkflowCapabilitySourceTests
             ExternalCapabilityExecutionMode.Interactive);
 
         readiness.Status.Should().Be(
-            ExternalCapabilityReadinessStatus.CredentialConnectionRequired);
+            ExternalCapabilityReadinessStatus.ServiceRegistrationRequired);
         readiness.Blockers.Should().ContainSingle().Which.Code.Should()
-            .Be("CODE_EXECUTION_ROUTE_NOT_READY");
+            .Be("CODE_EXECUTION_ROUTE_MISSING");
+    }
+
+    [Fact]
+    public async Task InspectAsync_UnsupportedAliasForSandboxCatalogCannotBecomePlatformRoute()
+    {
+        var routeInventory = Inventory(Service(
+            "us-code-alias",
+            "personal",
+            allowed: true,
+            slug: "arbitrary-shadow"));
+        var handler = new InventoryHandler(
+            routeInventory,
+            """
+            {
+              "keys": [{
+                "id": "us-code-alias",
+                "slug": "arbitrary-shadow",
+                "catalog_service_id": "catalog-chrono-sandbox",
+                "catalog_service_slug": "chrono-sandbox",
+                "is_active": true,
+                "status": "active",
+                "connected": true,
+                "credential_source": { "type": "personal" }
+              }]
+            }
+            """);
+        var source = CreateSource(handler);
+
+        var readiness = await source.InspectAsync(
+            Access(),
+            Selector(),
+            ExternalCapabilityExecutionMode.Interactive);
+
+        readiness.Status.Should().Be(
+            ExternalCapabilityReadinessStatus.ServiceRegistrationRequired);
+        readiness.Blockers.Should().ContainSingle().Which.Code.Should()
+            .Be("CODE_EXECUTION_ROUTE_MISSING");
     }
 
     [Fact]
@@ -322,7 +359,8 @@ public sealed class NyxIdCodeExecutionWorkflowCapabilitySourceTests
         bool injectDelegationToken = true,
         string scope = "proxy:* sandbox:execute",
         bool isActive = true,
-        bool forwardAccessToken = true)
+        bool forwardAccessToken = true,
+        string slug = "chrono-sandbox")
     {
         var credentialSource = credentialSourceType == "personal"
             ? (object)new { type = "personal" }
@@ -337,7 +375,7 @@ public sealed class NyxIdCodeExecutionWorkflowCapabilitySourceTests
         return new
         {
             id,
-            slug = "chrono-sandbox",
+            slug,
             catalog_service_id = catalogServiceId,
             is_active = isActive,
             forward_access_token = forwardAccessToken,

--- a/test/Aevatar.CQRS.Projection.Core.Tests/Neo4jVersionedProjectionGraphCypherTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/Neo4jVersionedProjectionGraphCypherTests.cs
@@ -75,7 +75,9 @@ public sealed class Neo4jVersionedProjectionGraphCypherTests
             ["upsert-edge-identities"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildUpsertEdgeIdentitiesCypher("EdgeIdentity"),
             ["delete-rewire"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildDeleteRelationshipsForRewireCypher("REL"),
             ["create-live-edges"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildCreateLiveEdgesCypher("Node", "REL"),
-            ["select-promotable"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesCypher("EdgeIdentity"),
+            ["select-promotable-by-id"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesByIdCypher("EdgeIdentity"),
+            ["select-promotable-by-from"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesByFromNodeCypher("EdgeIdentity"),
+            ["select-promotable-by-to"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildSelectPromotablePendingEdgesByToNodeCypher("EdgeIdentity"),
             ["promote-pending"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildPromotePendingEdgesCypher("Node", "REL", "EdgeIdentity"),
             ["commit-watermark"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildCommitWatermarkCypher("OwnerState", "OwnerEvent"),
             ["read-snapshot"] = Neo4jProjectionGraphStoreVersionedCypherSupport.BuildReadOwnerSnapshotCypher("OwnerState", "Node", "REL", "EdgeIdentity"),
@@ -133,15 +135,23 @@ public sealed class Neo4jVersionedProjectionGraphCypherTests
         edgeIdentities.Should().Contain("identity.status = item.status");
         edgeIdentities.Should().Contain("identity.mutationPayload = item.mutationPayload");
         edgeIdentities.Should().Contain("identity.projectionGraphVersion = item.projectionGraphVersion");
-        var select = Neo4jProjectionGraphStoreVersionedCypherSupport
-            .BuildSelectPromotablePendingEdgesCypher("EdgeIdentity");
-        select.Should().Contain("status: 'pending'");
-        select.Should().Contain("identity.edgeId IN $promotableEdgeIds");
-        select.Should().Contain("identity.fromNodeId IN $promotableNodeIds");
-        select.Should().Contain("identity.toNodeId IN $promotableNodeIds");
-        select.Should().NotContain("MERGE");
-        // The MERGE statement is UNWIND-driven and carries no disjunction: the selection above is
-        // the only place the OR predicate lives, so the planner never sees it next to the MERGE.
+        var selectById = Neo4jProjectionGraphStoreVersionedCypherSupport
+            .BuildSelectPromotablePendingEdgesByIdCypher("EdgeIdentity");
+        var selectByFrom = Neo4jProjectionGraphStoreVersionedCypherSupport
+            .BuildSelectPromotablePendingEdgesByFromNodeCypher("EdgeIdentity");
+        var selectByTo = Neo4jProjectionGraphStoreVersionedCypherSupport
+            .BuildSelectPromotablePendingEdgesByToNodeCypher("EdgeIdentity");
+        selectById.Should().StartWith("UNWIND $promotableEdgeIds AS edgeId ");
+        selectById.Should().Contain("edgeId: edgeId");
+        selectByFrom.Should().StartWith("UNWIND $promotableNodeIds AS nodeId ");
+        selectByFrom.Should().Contain("status: 'pending', fromNodeId: nodeId");
+        selectByTo.Should().StartWith("UNWIND $promotableNodeIds AS nodeId ");
+        selectByTo.Should().Contain("status: 'pending', toNodeId: nodeId");
+        new[] { selectById, selectByFrom, selectByTo }.Should().OnlyContain(
+            statement => !statement.Contains(" OR ", StringComparison.Ordinal) &&
+                         !statement.Contains("MERGE", StringComparison.Ordinal));
+        // Selection and MERGE stay in separate statements, and every statement is UNWIND-driven
+        // with no disjunction for the Neo4j planner to expand across a large id batch.
         promote.Should().StartWith("UNWIND $promotable AS item ");
         promote.Should().NotContain(" OR ");
         promote.Should().Contain("identity.status = 'pending'");

--- a/test/Aevatar.Capabilities.Tests/VoiceRealtimeOAuthStaticAssetTests.cs
+++ b/test/Aevatar.Capabilities.Tests/VoiceRealtimeOAuthStaticAssetTests.cs
@@ -18,7 +18,8 @@ public sealed class VoiceRealtimeOAuthStaticAssetTests
         await using var app = await CreateAppAsync();
         var html = await app.GetTestClient().GetStringAsync("/admin");
 
-        html.Should().Contain("beginLogin(msg.resources,msg.tokenPurpose,msg.authFlow)");
+        html.Should().Contain(
+            "beginLogin(msg.resources,msg.tokenPurpose,msg.authFlow,msg.popupName,msg.authRequestId,ev.source)");
         html.Should().Contain(":voice-realtime:token",
             "global logout must clear the feature-scoped Voice token too");
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityOrleansDispatchProjectionTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityOrleansDispatchProjectionTests.cs
@@ -172,14 +172,15 @@ public sealed class ChannelIdentityOrleansDispatchProjectionTests
 
         await observer.WaitForDeleteAsync(actorId, TestTimeout);
 
-        observer.Snapshot(actorId)
+        var observations = observer.Snapshot(actorId);
+        observations
+            .Where(static observation => observation.Operation == nameof(BindingWriteObservation.Upsert))
             .Should()
-            .Equal(
-            [
-                BindingWriteObservation.Upsert(actorId, "bnd-issue1355-first", 1),
-                BindingWriteObservation.Delete(actorId)
-            ],
-                "the revoke delete is an ordered barrier after the duplicate commit turn");
+            .OnlyContain(
+                observation => observation == BindingWriteObservation.Upsert(actorId, "bnd-issue1355-first", 1),
+                "at-least-once projection replay may repeat the first write but must never project the duplicate binding");
+        observations.Should().Contain(BindingWriteObservation.Upsert(actorId, "bnd-issue1355-first", 1));
+        observations.Should().Contain(BindingWriteObservation.Delete(actorId));
 
         var queryPort = host.Services.GetRequiredService<IExternalIdentityBindingQueryPort>();
         var resolved = await queryPort.ResolveAsync(subject);

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -2910,14 +2910,14 @@ public sealed class ToolCallModuleContextTests
     }
 
     [Fact]
-    public async Task ToolCallModule_WhenV4SubmissionUncertainRecoversCatalogRoute_ShouldRefinePendingReceipt()
+    public async Task ToolCallModule_WhenV4SubmissionUncertainRecoversPersonalCatalogRoute_ShouldRefinePendingReceipt()
     {
         var now = new DateTimeOffset(2026, 8, 17, 0, 0, 0, TimeSpan.Zero);
         var providerReceipt = DurableOperation(
             status: WorkflowToolPendingOperationStatus.Running,
             etag: "etag-catalog") with
         {
-            ServiceSlug = CodeExecutionContract.ServiceSlug,
+            ServiceSlug = "chrono-sandbox-aevatar",
             UserServiceId = "catalog-service",
             RouteIdentitySource = WorkflowToolPendingOperationRouteIdentitySource.NyxIdUserServiceCatalog,
             ExpiresAtUnixMs = now.AddMinutes(10).ToUnixTimeMilliseconds(),
@@ -2930,6 +2930,7 @@ public sealed class ToolCallModuleContextTests
             CancelPath = string.Empty,
             Status = WorkflowToolPendingOperationStatus.SubmissionUncertain,
             ETag = null,
+            ServiceSlug = CodeExecutionContract.ServiceSlug,
             UserServiceId = null,
             RouteIdentitySource = WorkflowToolPendingOperationRouteIdentitySource.CodeExecutionContract,
             ExpiresAtUnixMs = now.AddMinutes(12).ToUnixTimeMilliseconds(),
@@ -2964,7 +2965,7 @@ public sealed class ToolCallModuleContextTests
         var pending = ctx.LoadState<ToolCallModuleState>(ToolCallModule.ModuleStateKey)
             .PendingOperations.Should().ContainSingle().Subject.Value;
         pending.ProviderOperationId.Should().Be(providerReceipt.ProviderOperationId);
-        pending.ServiceSlug.Should().Be(CodeExecutionContract.ServiceSlug);
+        pending.ServiceSlug.Should().Be("chrono-sandbox-aevatar");
         pending.UserServiceId.Should().Be("catalog-service");
         pending.RouteIdentitySource.Should()
             .Be(WorkflowToolPendingOperationRouteIdentitySource.NyxIdUserServiceCatalog);


### PR DESCRIPTION
## Problem

HR-01 managed code execution treated NyxID auto-connected platform routes as writable. The attempted policy update was correctly rejected with HTTP 403, preventing the workflow from obtaining a `sandbox:execute` route.

After the target branch advanced, its graph replacement conformance case also exposed an existing Neo4j query-shape defect: pending-edge selection expanded one disjunction across a 10,000-node batch and exhausted the CI container's 256 MB heap.

## Solution

- Parse and honor NyxID `auto_connected` route ownership.
- Keep platform-managed routes read-only.
- Create and re-read a constrained personal `chrono-sandbox-aevatar` route when the platform route lacks `sandbox:execute`.
- Admit only an exact route/catalog join with the required delegation and forwarding policy.
- Preserve the selected personal route slug through proof, tool, synchronous, durable, and pending-receipt paths.
- Restrict proof-bound slugs to the platform and Aevatar-owned route names.
- Refresh the pinned NyxID conformance source digest.
- Split pending-edge promotion selection into exact, index-friendly `UNWIND` reads by edge ID, from-node ID, and to-node ID, then deduplicate before the separate relationship write.

## Impact

The HR-01 change affects the managed Chrono Sandbox route-resolution and workflow-admission path. It does not mutate NyxID, loosen route policy, or alter production deployment configuration. The Neo4j adjustment preserves pending-edge promotion semantics while bounding planner/runtime memory for large graph replacements.

## Verification

- AI route, tool, and proof suites: 184/184 passed.
- Chrono Sandbox synchronous and durable suites: 75/75 passed.
- Workflow actor and mapping suites: 40/40 passed.
- Projection Cypher and shared semantics focused tests: 9/9 passed.
- Projection core non-provider suite: 855/855 passed.
- CI projection provider E2E with 256 MB Neo4j heap: core 7/7, scripting 3/3, workflow 1/1 passed.
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`
- NyxID conformance guard and source refresh.
- `git diff origin/feature/integrate...HEAD --check`

## Documentation

No user-facing documentation change. The existing managed-code-execution and graph-store contracts remain unchanged; this fixes their implementations.
