### PR TITLE
Fix durable workflow execution tool discovery

### DIFF
--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "1c8ba2928b67fc31177b8f289595f023c338e072",
-    "contract_files_sha256": "02b7dbaa107046f9af851a0363b99f935c3e15d32542ec8c5065faccb321c9c8",
+    "revision": "533ba4db0050b6b9675806c041259b380938ad05",
+    "contract_files_sha256": "72cbba3befa317b98febd922eef6d385078391eabc935bc0ae2237bad6e7ca49",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "23fd2cf48541c4b8da3fa1ef07277a7700c8478f9c638be8221465bf877fbb31",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "99605fdacc1e15b369d53b8953620b122dbba19d8b386486fd1892a2537ff82b",
@@ -17,7 +17,7 @@
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1b033df9cb55c741e9b52054cbd4a91067f03c8c3797bd076a7e3d6133eb0fcb",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "2c4f2cda99154f2e667c6cfd291497e697ef11df17f081f96ec70070a8af8b8c",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyRotateTool.cs": "18212bb64644cfbca401065bccce439ea5fa00316deff57d730a0d9ac2650e53",
-      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "0e9771d063dfd41645655e16c0b7ae0da1e75dfc8fdc08671116ace22552b82a"
+      "src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs": "b81324e247f19d5148e2cc5f4f26b2afa419c42c9c21d04a1f14b79fde72d20b"
     }
   },
   "nyxid": {

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -77,6 +77,7 @@ using Aevatar.Mainnet.Host.Api.WorkflowAdmission;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Hosting;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Extensions.Hosting;
 using Aevatar.Workflow.Infrastructure.Workflows;
 using Aevatar.Workflow.Integration.AI;
@@ -86,6 +87,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Google.Protobuf.WellKnownTypes;
 
@@ -453,6 +455,7 @@ public static class MainnetHostBuilderExtensions
                 "Aevatar:NyxId:ManagedWorkflowAdmissionMode",
                 o.ManagedWorkflowAdmissionMode);
         });
+        ReplaceMainnetWorkflowAgentToolSourceAdapter(builder.Services);
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostedService, NyxIdWorkflowAdmissionEnforcementStartupGuard>());
         builder.Services.Replace(ServiceDescriptor.Singleton<
@@ -647,6 +650,27 @@ public static class MainnetHostBuilderExtensions
         builder.Services.Replace(
             ServiceDescriptor.Singleton<INyxIdChatAgentProfileResolver,
                 MainnetNyxIdChatAgentProfileResolver>());
+    }
+
+    private static void ReplaceMainnetWorkflowAgentToolSourceAdapter(IServiceCollection services)
+    {
+        var defaultAdapter = services.SingleOrDefault(static descriptor =>
+            descriptor.ServiceType == typeof(IWorkflowToolSource) &&
+            descriptor.ImplementationType == typeof(AgentWorkflowToolSourceAdapter));
+        if (defaultAdapter is null)
+        {
+            throw new InvalidOperationException(
+                "The default workflow agent tool source adapter registration is missing.");
+        }
+
+        services.Remove(defaultAdapter);
+        services.AddSingleton<IWorkflowToolSource>(serviceProvider =>
+            new AgentWorkflowToolSourceAdapter(
+                serviceProvider.GetServices<IAgentToolSource>()
+                    .Append(serviceProvider.GetRequiredService<NyxIdExecutionAgentToolSource>())
+                    .ToArray(),
+                serviceProvider.GetRequiredService<IAgentToolExecutionPort>(),
+                serviceProvider.GetRequiredService<ILogger<AgentWorkflowToolSourceAdapter>>()));
     }
 
     private static IAgentToolSource CreateToolSource<TSource>(IServiceProvider serviceProvider)

--- a/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
+++ b/test/Aevatar.Capabilities.Tests/MainnetHostCompositionTests.cs
@@ -854,6 +854,9 @@ public sealed class MainnetHostCompositionTests
         app.Services.GetServices<IAgentToolSource>()
             .Should()
             .NotContain(source => source is WorkflowExternalCapabilityAuthoringToolSource);
+        app.Services.GetServices<IAgentToolSource>()
+            .Should()
+            .NotContain(source => source is NyxIdExecutionAgentToolSource);
         app.Services.GetRequiredService<NyxIdConnectedServiceInventoryToolSource>()
             .Should()
             .NotBeNull();
@@ -950,6 +953,7 @@ public sealed class MainnetHostCompositionTests
             workflowTools.AddRange(tools);
         }
         var workflowToolNames = workflowTools.Select(static tool => tool.Name).ToArray();
+        workflowToolNames.Should().ContainSingle(name => name == "code_execute");
         workflowToolNames.Should().ContainSingle(name => name == "workflow_connected_service_resource_fetch");
         workflowToolNames.Should().NotContain(StudioLocalWorkflowToolNames);
         var agentWorkflowSource = workflowToolSources


### PR DESCRIPTION
## Problem

`NyxIdExecutionAgentToolSource` is isolated in the `nyxid.execution` turn tool set, but durable workflows still discover tools only from the global `IEnumerable<IAgentToolSource>`. HR-01 therefore reaches `normalize_person` and fails with `tool not found or no tool sources configured` for `code_execute`.

## Solution

- Replace the Mainnet workflow adapter registration with one composed from the existing global sources plus the exact `NyxIdExecutionAgentToolSource`.
- Keep the execution source out of the global agent source collection and `workspace.default` tool set.
- Assert durable workflow discovery contains exactly one `code_execute` and still has exactly one adapter.
- Refresh the NyxID conformance source pin for the changed Mainnet composition file.

## Impact

Durable workflows can execute admitted `code_execute` steps without widening any chat or workspace tool surface.

## Verification

- `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --filter FullyQualifiedName~AddAevatarMainnetHost_ShouldRegisterDefaultToolSets --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`

All passed locally.

## Merge note

Use a merge commit, not squash or rebase. The checked-in conformance pin references the first commit in this PR and requires it to remain an ancestor of the merged head.