### PR TITLE
Issue admission-scoped webhook Agent Keys

### DIFF
--- a/docs/adr/0050-code-execution-agent-key-runtime-authority.md
+++ b/docs/adr/0050-code-execution-agent-key-runtime-authority.md
@@ -28,6 +28,17 @@ preserve the strong typed kind `AgentKey` through workflow, tool execution, and
 code-execution ports. They never relabel that secret as `ProxyDelegation` or use a
 five-minute token as the sandbox program's NyxID credential.
 
+Webhook binding management credentials are admission credentials only. Aevatar
+must never persist a forwarded management Agent Key as the webhook runtime
+credential. When unattended effects are enabled, Aevatar obtains a
+source-readable management bearer from the binding's exact NyxID authority,
+requests an authoritative API-key scope plan for every NyxID UserService ID in
+the committed workflow admission plan (including `code_execute`), and creates a
+dedicated key with `allow_all_services=false`, `allow_all_nodes=false`, and the
+exact planned service and node allowlists. Binding creation fails closed if any
+of those steps is unavailable or if the returned actor, owner, or service set
+drifts from the committed admission.
+
 The exact shared `chrono-sandbox` UserService contract is:
 
 ```text
@@ -68,6 +79,11 @@ sequenceDiagram
 
 - Raw Agent Keys remain absent from actor state, events, projections, read models,
   logs, and API responses.
+- Webhook durable references persist the NyxID provider credential ID alongside
+  the Vault descriptor. Replacement, disablement, rejected writes, deletion, and
+  Vault-write rollback revoke both the provider credential and Vault secret.
+  Legacy webhook references without a provider ID may have only their Vault
+  secret revoked; they are invalid for new runtime dispatch.
 - Aevatar resolves the secret only at the outbound call. Rotation therefore takes
   effect on the next exchange.
 - Chrono rejects caller attempts to override `NYXID_API_KEY` or `NYXID_BASE_URL`
@@ -94,6 +110,9 @@ Tests must prove:
 
 - channel, webhook, scheduled, and restored durable Agent Key references retain
   the `AgentKey` kind through every mapper and dispatcher;
+- webhook binding materialization never stores the inbound management key,
+  scopes the dedicated runtime key to the exact committed admission service set,
+  and rolls provider credentials back when Vault or binding persistence fails;
 - route admission and convergence require forwarding, delegation injection, and
   both scopes without deleting unrelated scopes;
 - Chrono accepts an exact Agent Key only with a valid `sandbox:execute` delegation

--- a/src/Aevatar.Foundation.Abstractions/Credentials/DurableCallerAgentKeyContract.cs
+++ b/src/Aevatar.Foundation.Abstractions/Credentials/DurableCallerAgentKeyContract.cs
@@ -3,7 +3,10 @@ namespace Aevatar.Foundation.Abstractions.Credentials;
 public static class DurableCallerAgentKeyContract
 {
     public static bool Matches(DurableCallerCredentialRef? credential) =>
-        credential is not null && Matches(credential.SourceKind, credential.Purpose);
+        credential is not null &&
+        Matches(credential.SourceKind, credential.Purpose) &&
+        (credential.SourceKind != DurableCallerCredentialSourceKind.WebhookBinding ||
+         !string.IsNullOrWhiteSpace(credential.ProviderCredentialId));
 
     public static bool Matches(
         DurableCallerCredentialSourceKind sourceKind,

--- a/src/Aevatar.Foundation.Abstractions/Credentials/credential_secret_references.proto
+++ b/src/Aevatar.Foundation.Abstractions/Credentials/credential_secret_references.proto
@@ -42,6 +42,9 @@ message DurableCallerCredentialRef {
   // Exact vault descriptor captured when the durable handle is created.
   // New durable sources use this to fail closed on rotation/version drift.
   SecretReference secret_reference = 7;
+  // Provider-owned credential identity used for lifecycle revocation. Raw
+  // credential material remains exclusively in the referenced vault secret.
+  string provider_credential_id = 8;
 }
 
 message ScheduledCallerNyxIdAuthority {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Aevatar.Workflow.Infrastructure.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Application\Aevatar.Workflow.Application.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
     <ProjectReference Include="..\Aevatar.Workflow.Core\Aevatar.Workflow.Core.csproj" />

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowWebhookAgentKeyMaterializer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowWebhookAgentKeyMaterializer.cs
@@ -1,0 +1,486 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Credentials;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Workflow.Infrastructure.CapabilityApi;
+
+internal interface IWorkflowWebhookAgentKeyMaterializer
+{
+    Task<WorkflowWebhookAgentKeyMaterializationResult> MaterializeAsync(
+        WorkflowCallerNyxIdAuthority callerAuthority,
+        WorkflowCapabilityAdmissionPlan admissionPlan,
+        string scopeId,
+        string routeKey,
+        CancellationToken ct);
+
+    Task<bool> RevokeAsync(
+        WorkflowCallerNyxIdAuthority? callerAuthority,
+        DurableCallerCredentialRef credential,
+        string auditReason,
+        CancellationToken ct);
+}
+
+internal sealed record WorkflowWebhookAgentKeyMaterializationResult(
+    DurableCallerCredentialRef? Credential,
+    int StatusCode,
+    string ErrorCode)
+{
+    public bool Succeeded => Credential is not null;
+
+    public static WorkflowWebhookAgentKeyMaterializationResult Success(
+        DurableCallerCredentialRef credential) =>
+        new(credential, StatusCodes.Status200OK, string.Empty);
+
+    public static WorkflowWebhookAgentKeyMaterializationResult Failure(
+        string errorCode,
+        int statusCode) =>
+        new(null, statusCode, errorCode);
+}
+
+internal sealed class WorkflowWebhookAgentKeyMaterializer : IWorkflowWebhookAgentKeyMaterializer
+{
+    private const int CredentialNameDigestBytes = 12;
+    private static readonly JsonSerializerOptions CreateKeyJsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IWorkflowCallerAccessTokenProvider _accessTokenProvider;
+    private readonly INyxIdApiClientFactory _nyxIdApiClientFactory;
+    private readonly ISecretVault _secretVault;
+    private readonly ILogger<WorkflowWebhookAgentKeyMaterializer>? _logger;
+
+    public WorkflowWebhookAgentKeyMaterializer(
+        IWorkflowCallerAccessTokenProvider accessTokenProvider,
+        INyxIdApiClientFactory nyxIdApiClientFactory,
+        ISecretVault secretVault,
+        ILogger<WorkflowWebhookAgentKeyMaterializer>? logger = null)
+    {
+        _accessTokenProvider = accessTokenProvider ??
+            throw new ArgumentNullException(nameof(accessTokenProvider));
+        _nyxIdApiClientFactory = nyxIdApiClientFactory ??
+            throw new ArgumentNullException(nameof(nyxIdApiClientFactory));
+        _secretVault = secretVault ?? throw new ArgumentNullException(nameof(secretVault));
+        _logger = logger;
+    }
+
+    public async Task<WorkflowWebhookAgentKeyMaterializationResult> MaterializeAsync(
+        WorkflowCallerNyxIdAuthority callerAuthority,
+        WorkflowCapabilityAdmissionPlan admissionPlan,
+        string scopeId,
+        string routeKey,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(callerAuthority);
+        ArgumentNullException.ThrowIfNull(admissionPlan);
+        if (!TryResolveRequiredServiceIds(admissionPlan, callerAuthority, out var serviceIds))
+        {
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_SCOPE_INVALID",
+                StatusCodes.Status409Conflict);
+        }
+
+        var bearerToken = await IssueManagementBearerAsync(callerAuthority, ct);
+        if (bearerToken is null)
+        {
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_ISSUANCE_UNAVAILABLE",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var client = _nyxIdApiClientFactory.CreateClient();
+        string scopePlanResponse;
+        try
+        {
+            scopePlanResponse = await client.PlanApiKeyScopeAsync(
+                bearerToken,
+                serviceIds,
+                targetOrganizationId: null,
+                ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "NyxID webhook Agent Key scope planning failed.");
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_SCOPE_PLAN_UNAVAILABLE",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var parsedScopePlan = NyxIdApiAccessResponseParser.ParseScopePlan(scopePlanResponse);
+        if (!parsedScopePlan.Succeeded)
+        {
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_SCOPE_PLAN_FAILED",
+                NormalizeProviderStatus(parsedScopePlan.Failure?.HttpStatus));
+        }
+
+        var scopePlan = parsedScopePlan.Value!;
+        if (!ScopePlanMatches(scopePlan, callerAuthority, serviceIds))
+        {
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_SCOPE_CHANGED",
+                StatusCodes.Status409Conflict);
+        }
+
+        string createResponse;
+        try
+        {
+            createResponse = await client.CreateApiKeyAsync(
+                bearerToken,
+                JsonSerializer.Serialize(new
+                {
+                    name = BuildCredentialName(scopeId, routeKey, callerAuthority.ExternalUserId),
+                    scopes = "proxy",
+                    platform = "generic",
+                    allow_all_services = false,
+                    allow_all_nodes = false,
+                    allowed_service_ids = scopePlan.AllowedServiceIds,
+                    allowed_node_ids = scopePlan.AllowedNodeIds,
+                    scope_plan_digest = scopePlan.NormalizedGrantDigest,
+                }, CreateKeyJsonOptions),
+                ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "NyxID webhook Agent Key creation failed.");
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_CREATE_UNAVAILABLE",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!TryReadIssuedCredential(
+                createResponse,
+                out var providerCredentialId,
+                out var fullKey,
+                out var createStatus))
+        {
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_CREATE_FAILED",
+                NormalizeProviderStatus(createStatus));
+        }
+
+        try
+        {
+            var stored = await _secretVault.PutAsync(new StoreSecretRequest(
+                CredentialSecretPurposes.WorkflowWebhookBindingAgentKey,
+                scopeId,
+                callerAuthority.ExternalUserId,
+                fullKey,
+                "workflow-webhook-binding-agent-key"), ct);
+            return WorkflowWebhookAgentKeyMaterializationResult.Success(new DurableCallerCredentialRef
+            {
+                Ref = stored.Reference.Ref,
+                Purpose = stored.Reference.Purpose,
+                OwnerScopeKey = stored.Reference.OwnerScopeKey,
+                SubjectId = callerAuthority.ExternalUserId,
+                SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
+                SecretReference = stored.Reference.Clone(),
+                ProviderCredentialId = providerCredentialId,
+            });
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            await TryDeleteProviderCredentialAsync(
+                client,
+                bearerToken,
+                providerCredentialId,
+                CancellationToken.None);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Webhook Agent Key vault persistence failed.");
+            await TryDeleteProviderCredentialAsync(
+                client,
+                bearerToken,
+                providerCredentialId,
+                CancellationToken.None);
+            return WorkflowWebhookAgentKeyMaterializationResult.Failure(
+                "WEBHOOK_CALLER_CREDENTIAL_VAULT_UNAVAILABLE",
+                StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    public async Task<bool> RevokeAsync(
+        WorkflowCallerNyxIdAuthority? callerAuthority,
+        DurableCallerCredentialRef credential,
+        string auditReason,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        if (!IsWebhookVaultReference(credential))
+            return false;
+
+        var providerRevoked = string.IsNullOrWhiteSpace(credential.ProviderCredentialId);
+        if (!providerRevoked &&
+            callerAuthority is not null &&
+            string.Equals(
+                callerAuthority.ExternalUserId,
+                credential.SubjectId,
+                StringComparison.Ordinal))
+        {
+            var bearerToken = await IssueManagementBearerAsync(callerAuthority, ct);
+            if (bearerToken is not null)
+            {
+                providerRevoked = await TryDeleteProviderCredentialAsync(
+                    _nyxIdApiClientFactory.CreateClient(),
+                    bearerToken,
+                    credential.ProviderCredentialId,
+                    ct);
+            }
+        }
+
+        var vaultRevoked = false;
+        try
+        {
+            var result = await _secretVault.RevokeAsync(new RevokeSecretRequest(
+                credential.Ref,
+                credential.Purpose,
+                credential.OwnerScopeKey,
+                credential.SubjectId,
+                auditReason), ct);
+            vaultRevoked = result.Revoked;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Webhook Agent Key vault revocation failed.");
+        }
+
+        if (!providerRevoked || !vaultRevoked)
+        {
+            _logger?.LogError(
+                "Webhook Agent Key cleanup was incomplete. providerRevoked={ProviderRevoked} vaultRevoked={VaultRevoked}",
+                providerRevoked,
+                vaultRevoked);
+        }
+        return providerRevoked && vaultRevoked;
+    }
+
+    private async Task<string?> IssueManagementBearerAsync(
+        WorkflowCallerNyxIdAuthority callerAuthority,
+        CancellationToken ct)
+    {
+        try
+        {
+            var issued = await _accessTokenProvider.IssueAsync(callerAuthority, ct);
+            var parsed = WorkflowCallerCredentialTokens.ParseOptional(issued);
+            return parsed.IsValid ? parsed.NormalizedBearerToken : null;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Webhook Agent Key management bearer issuance failed.");
+            return null;
+        }
+    }
+
+    private async Task<bool> TryDeleteProviderCredentialAsync(
+        NyxIdApiClient client,
+        string bearerToken,
+        string providerCredentialId,
+        CancellationToken ct)
+    {
+        try
+        {
+            var response = await client.DeleteApiKeyAsync(bearerToken, providerCredentialId, ct);
+            if (string.IsNullOrWhiteSpace(response))
+                return true;
+            return !TryReadErrorEnvelope(response, out var status) || status == StatusCodes.Status404NotFound;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "NyxID webhook Agent Key revocation failed.");
+            return false;
+        }
+    }
+
+    private static bool TryResolveRequiredServiceIds(
+        WorkflowCapabilityAdmissionPlan plan,
+        WorkflowCallerNyxIdAuthority callerAuthority,
+        out IReadOnlyList<string> serviceIds)
+    {
+        serviceIds = [];
+        if (plan.ExecutionMode != ExternalCapabilityExecutionMode.Durable ||
+            !WorkflowCapabilityAdmissionPlanIntegrity.IsCanonicalDurableAuthorizationOwner(
+                plan.DurableAuthorizationOwner) ||
+            !string.Equals(
+                plan.DurableAuthorizationOwner.OwnerSubject,
+                callerAuthority.ExternalUserId,
+                StringComparison.Ordinal) ||
+            !string.Equals(
+                plan.AdmissionDigest,
+                WorkflowCapabilityAdmissionPlanIntegrity.ComputeAdmissionDigest(plan),
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        try
+        {
+            foreach (var admission in plan.InvocationAdmissions)
+            {
+                WorkflowCapabilityAdmissionPlanIntegrity
+                    .ValidateInvocationAdmissionIntrinsicIntegrity(admission);
+                var serviceId = admission.Capability.CapabilityCase switch
+                {
+                    ExternalWorkflowCapabilityRef.CapabilityOneofCase.NyxIdUserService =>
+                        admission.Capability.NyxIdUserService.UserServiceId,
+                    ExternalWorkflowCapabilityRef.CapabilityOneofCase.NyxIdUserRequest =>
+                        admission.Capability.NyxIdUserRequest.Request?.UserServiceId,
+                    ExternalWorkflowCapabilityRef.CapabilityOneofCase.CodeExecution =>
+                        admission.Capability.CodeExecution.UserServiceId,
+                    _ => null,
+                };
+                if (serviceId is null)
+                    continue;
+                if (string.IsNullOrWhiteSpace(serviceId) ||
+                    !string.Equals(serviceId, serviceId.Trim(), StringComparison.Ordinal))
+                {
+                    return false;
+                }
+                ids.Add(serviceId);
+            }
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
+        {
+            return false;
+        }
+
+        serviceIds = ids.Order(StringComparer.Ordinal).ToArray();
+        return serviceIds.Count > 0;
+    }
+
+    private static bool ScopePlanMatches(
+        NyxIdApiKeyScopePlan scopePlan,
+        WorkflowCallerNyxIdAuthority callerAuthority,
+        IReadOnlyList<string> serviceIds) =>
+        scopePlan.AuthenticatedActor.Kind == NyxIdScopePlanPrincipalKind.Personal &&
+        scopePlan.IntendedKeyOwner.Kind == NyxIdScopePlanPrincipalKind.Personal &&
+        string.Equals(
+            scopePlan.AuthenticatedActor.Id,
+            callerAuthority.ExternalUserId,
+            StringComparison.Ordinal) &&
+        string.Equals(
+            scopePlan.IntendedKeyOwner.Id,
+            callerAuthority.ExternalUserId,
+            StringComparison.Ordinal) &&
+        scopePlan.AllowedServiceIds.SequenceEqual(serviceIds, StringComparer.Ordinal);
+
+    private static bool TryReadIssuedCredential(
+        string response,
+        out string providerCredentialId,
+        out string fullKey,
+        out int? status)
+    {
+        providerCredentialId = string.Empty;
+        fullKey = string.Empty;
+        if (TryReadErrorEnvelope(response, out status))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            providerCredentialId = ReadNormalizedString(document.RootElement, "id") ?? string.Empty;
+            fullKey = ReadNormalizedString(document.RootElement, "full_key") ?? string.Empty;
+            return providerCredentialId.Length > 0 && fullKey.Length > 0;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadErrorEnvelope(string? response, out int? status)
+    {
+        status = null;
+        if (string.IsNullOrWhiteSpace(response))
+            return true;
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("error", out var error) ||
+                error.ValueKind is JsonValueKind.False or JsonValueKind.Null)
+            {
+                return false;
+            }
+            status = root.TryGetProperty("status", out var statusValue) &&
+                     statusValue.TryGetInt32(out var parsedStatus)
+                ? parsedStatus
+                : null;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsWebhookVaultReference(DurableCallerCredentialRef credential) =>
+        credential.SourceKind == DurableCallerCredentialSourceKind.WebhookBinding &&
+        DurableCallerAgentKeyContract.Matches(credential.SourceKind, credential.Purpose) &&
+        !string.IsNullOrWhiteSpace(credential.Ref) &&
+        !string.IsNullOrWhiteSpace(credential.OwnerScopeKey) &&
+        !string.IsNullOrWhiteSpace(credential.SubjectId);
+
+    private static string BuildCredentialName(
+        string scopeId,
+        string routeKey,
+        string subjectId)
+    {
+        var identity = string.Join("\0", scopeId, routeKey, subjectId);
+        var digest = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(identity))
+                    .AsSpan(0, CredentialNameDigestBytes))
+            .ToLowerInvariant();
+        return "aevatar-webhook-" + digest;
+    }
+
+    private static string? ReadNormalizedString(JsonElement root, string propertyName)
+    {
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+        var value = property.GetString();
+        return string.IsNullOrWhiteSpace(value) ||
+               !string.Equals(value, value.Trim(), StringComparison.Ordinal)
+            ? null
+            : value;
+    }
+
+    private static int NormalizeProviderStatus(int? status) =>
+        status is >= 400 and <= 599
+            ? status.Value
+            : StatusCodes.Status502BadGateway;
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowWebhookBindingEndpoints.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/CapabilityApi/WorkflowWebhookBindingEndpoints.cs
@@ -185,16 +185,6 @@ internal static class WorkflowWebhookBindingEndpoints
             unattendedAuthorization = authorization.Authorization;
         }
 
-        string? forwardedAgentKey = null;
-        string? credentialSubject = null;
-        if (request.EnableUnattendedEffects &&
-            TryGetForwardedAgentKey(http, out var capturedAgentKey) &&
-            AevatarPrincipalSubjectResolver.TryResolveNyxIdSubject(http.User, out var capturedSubject))
-        {
-            forwardedAgentKey = capturedAgentKey;
-            credentialSubject = capturedSubject;
-        }
-
         var hmacSecret = request.HmacSecret?.Trim();
         if (hmacSecret == null || Encoding.UTF8.GetByteCount(hmacSecret) < 32)
             return BadRequest(
@@ -246,37 +236,43 @@ internal static class WorkflowWebhookBindingEndpoints
             return BadRequest("WEBHOOK_TIME_ZONE_INVALID", "timeZoneId is invalid.");
         }
 
+        IWorkflowWebhookAgentKeyMaterializer? credentialMaterializer = null;
         DurableCallerCredentialRef? durableCredential = null;
-        ISecretVault? credentialVault = null;
-        if (forwardedAgentKey != null)
+        if (request.EnableUnattendedEffects)
         {
-            credentialVault = http.RequestServices.GetService<ISecretVault>();
-            if (credentialVault == null)
+            credentialMaterializer = ResolveCredentialMaterializer(http, out var materializerUnavailable);
+            if (credentialMaterializer == null)
+                return materializerUnavailable!;
+
+            var materialized = await credentialMaterializer.MaterializeAsync(
+                callerAuthority!,
+                target.CapabilityAdmissionPlan!,
+                scopeId,
+                normalizedRoute,
+                ct);
+            if (!materialized.Succeeded)
             {
                 return Results.Json(
                     new
                     {
-                        code = "WEBHOOK_CALLER_CREDENTIAL_VAULT_UNAVAILABLE",
-                        message = "Webhook caller credential vault is unavailable.",
+                        code = materialized.ErrorCode,
+                        message = "A dedicated webhook caller credential could not be issued.",
                     },
-                    statusCode: StatusCodes.Status503ServiceUnavailable);
+                    statusCode: materialized.StatusCode);
             }
-
-            var stored = await credentialVault.PutAsync(new StoreSecretRequest(
-                CredentialSecretPurposes.WorkflowWebhookBindingAgentKey,
-                scopeId,
-                credentialSubject!,
-                forwardedAgentKey,
-                "workflow-webhook-binding-agent-key"), ct);
-            durableCredential = new DurableCallerCredentialRef
+            durableCredential = materialized.Credential;
+        }
+        else
+        {
+            var existing = await bindingStore.GetAsync(normalizedRoute, ct);
+            if (existing?.CallerDurableCredential != null)
             {
-                Ref = stored.Reference.Ref,
-                Purpose = stored.Reference.Purpose,
-                OwnerScopeKey = stored.Reference.OwnerScopeKey,
-                SubjectId = credentialSubject,
-                SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
-                SecretReference = stored.Reference.Clone(),
-            };
+                credentialMaterializer = ResolveCredentialMaterializer(
+                    http,
+                    out var materializerUnavailable);
+                if (credentialMaterializer == null)
+                    return materializerUnavailable!;
+            }
         }
 
         var record = new WorkflowWebhookBindingRecord(
@@ -310,7 +306,8 @@ internal static class WorkflowWebhookBindingEndpoints
         catch
         {
             await RevokeBindingCredentialAsync(
-                credentialVault,
+                credentialMaterializer,
+                callerAuthority,
                 durableCredential,
                 "workflow-webhook-binding-write-failed",
                 logger: null,
@@ -321,7 +318,8 @@ internal static class WorkflowWebhookBindingEndpoints
         if (!put.Succeeded)
         {
             await RevokeBindingCredentialAsync(
-                credentialVault,
+                credentialMaterializer,
+                callerAuthority,
                 durableCredential,
                 "workflow-webhook-binding-write-rejected",
                 logger: null,
@@ -334,7 +332,8 @@ internal static class WorkflowWebhookBindingEndpoints
         var cleanupLogger = http.RequestServices.GetService<ILoggerFactory>()?
             .CreateLogger("Aevatar.Workflow.WebhookBinding");
         await RevokeBindingCredentialAsync(
-            http.RequestServices.GetService<ISecretVault>(),
+            credentialMaterializer ?? ResolveCredentialMaterializer(http, out _),
+            put.PreviousRecord?.CallerAuthority,
             put.PreviousRecord?.CallerDurableCredential,
             "workflow-webhook-binding-replaced",
             cleanupLogger,
@@ -379,16 +378,14 @@ internal static class WorkflowWebhookBindingEndpoints
             return BadRequest("WEBHOOK_ROUTE_REQUIRED", "Route key is required.");
 
         var existing = await bindingStore.GetAsync(normalizedRoute, ct);
-        if (existing?.CallerDurableCredential != null &&
-            http.RequestServices.GetService<ISecretVault>() == null)
+        IWorkflowWebhookAgentKeyMaterializer? credentialMaterializer = null;
+        if (existing?.CallerDurableCredential != null)
         {
-            return Results.Json(
-                new
-                {
-                    code = "WEBHOOK_CALLER_CREDENTIAL_VAULT_UNAVAILABLE",
-                    message = "Webhook caller credential vault is unavailable.",
-                },
-                statusCode: StatusCodes.Status503ServiceUnavailable);
+            credentialMaterializer = ResolveCredentialMaterializer(
+                http,
+                out var materializerUnavailable);
+            if (credentialMaterializer == null)
+                return materializerUnavailable!;
         }
 
         var deleted = await bindingStore.DeleteOwnedAsync(normalizedRoute, scopeId, ct);
@@ -398,7 +395,8 @@ internal static class WorkflowWebhookBindingEndpoints
         var logger = http.RequestServices.GetService<ILoggerFactory>()?
             .CreateLogger("Aevatar.Workflow.WebhookBinding");
         await RevokeBindingCredentialAsync(
-            http.RequestServices.GetService<ISecretVault>(),
+            credentialMaterializer ?? ResolveCredentialMaterializer(http, out _),
+            deleted.RemovedRecord?.CallerAuthority,
             deleted.RemovedRecord?.CallerDurableCredential,
             "workflow-webhook-binding-deleted",
             logger,
@@ -623,6 +621,32 @@ internal static class WorkflowWebhookBindingEndpoints
         return store;
     }
 
+    private static IWorkflowWebhookAgentKeyMaterializer? ResolveCredentialMaterializer(
+        HttpContext http,
+        out IResult? unavailable)
+    {
+        IWorkflowWebhookAgentKeyMaterializer? materializer;
+        try
+        {
+            materializer = http.RequestServices.GetService<IWorkflowWebhookAgentKeyMaterializer>();
+        }
+        catch (InvalidOperationException)
+        {
+            materializer = null;
+        }
+
+        unavailable = materializer != null
+            ? null
+            : Results.Json(
+                new
+                {
+                    code = "WEBHOOK_CALLER_CREDENTIAL_ISSUANCE_UNAVAILABLE",
+                    message = "Dedicated webhook caller credential issuance is unavailable.",
+                },
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        return materializer;
+    }
+
     private static bool TryGetForwardedAgentKey(HttpContext http, out string agentKey)
     {
         agentKey = string.Empty;
@@ -652,7 +676,8 @@ internal static class WorkflowWebhookBindingEndpoints
     }
 
     private static async Task<bool> RevokeBindingCredentialAsync(
-        ISecretVault? vault,
+        IWorkflowWebhookAgentKeyMaterializer? materializer,
+        ProtoWorkflowCallerNyxIdAuthority? callerAuthority,
         DurableCallerCredentialRef? reference,
         string auditReason,
         ILogger? logger,
@@ -660,35 +685,29 @@ internal static class WorkflowWebhookBindingEndpoints
     {
         if (reference == null)
             return true;
-        if (vault == null ||
-            reference.SourceKind != DurableCallerCredentialSourceKind.WebhookBinding ||
-            !string.Equals(
-                reference.Purpose,
-                CredentialSecretPurposes.WorkflowWebhookBindingAgentKey,
-                StringComparison.Ordinal) ||
-            string.IsNullOrWhiteSpace(reference.Ref) ||
-            string.IsNullOrWhiteSpace(reference.OwnerScopeKey) ||
-            string.IsNullOrWhiteSpace(reference.SubjectId))
+        if (materializer == null)
         {
+            logger?.LogError(
+                "Webhook binding caller credential cleanup is unavailable. credentialRef={CredentialRef}",
+                reference.Ref);
             return false;
         }
 
         try
         {
-            var result = await vault.RevokeAsync(new RevokeSecretRequest(
-                reference.Ref,
-                reference.Purpose,
-                reference.OwnerScopeKey,
-                reference.SubjectId,
-                auditReason), ct);
-            if (!result.Revoked)
+            var revoked = await materializer.RevokeAsync(
+                callerAuthority,
+                reference,
+                auditReason,
+                ct);
+            if (!revoked)
             {
                 logger?.LogError(
                     "Webhook binding caller credential cleanup was not committed. credentialRef={CredentialRef} reason={AuditReason}",
                     reference.Ref,
                     auditReason);
             }
-            return result.Revoked;
+            return revoked;
         }
         catch (Exception ex)
         {

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/WorkflowCapabilityServiceCollectionExtensions.cs
@@ -65,6 +65,9 @@ public static class WorkflowCapabilityServiceCollectionExtensions
                 $"Every enabled {WorkflowExternalApprovalCallbackOptions.SectionName} binding must configure an HMAC secret of at least {MinHmacSecretByteLength} UTF-8 bytes.")
             .ValidateOnStart();
         services.TryAddSingleton<WorkflowWebhookIngressRequestBuilder>();
+        services.TryAddSingleton<
+            IWorkflowWebhookAgentKeyMaterializer,
+            WorkflowWebhookAgentKeyMaterializer>();
         services.TryAddSingleton<Aevatar.Workflow.Application.Abstractions.Runs.IWorkflowWebhookReplayAdmissionPort, WorkflowWebhookReplayAdmissionPort>();
         // Zero-config default: hosts that already run on Garnet reuse the
         // actor-runtime connection for webhook replay/binding storage, and the

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -3684,6 +3684,9 @@ public sealed class AevatarInvocationToolSourceTests
             SubjectId = "agent-key-workflow",
             SourceKind = sourceKind,
             SecretReference = descriptor,
+            ProviderCredentialId = sourceKind == DurableCallerCredentialSourceKind.WebhookBinding
+                ? "provider-key-workflow"
+                : string.Empty,
         };
 
         using var _ = PushContext(

--- a/test/Aevatar.Foundation.Abstractions.Tests/CredentialReferenceProtoContractTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/CredentialReferenceProtoContractTests.cs
@@ -66,6 +66,7 @@ public sealed class CredentialReferenceProtoContractTests
             OwnerScopeKey = "schedule:schedule-1",
             SubjectId = "lark:tenant:user-1",
             SourceKind = DurableCallerCredentialSourceKind.ScheduledDispatch,
+            ProviderCredentialId = "provider-key-1",
         };
 
         var parsed = DurableCallerCredentialRef.Parser.ParseFrom(reference.ToByteArray());
@@ -75,6 +76,7 @@ public sealed class CredentialReferenceProtoContractTests
         parsed.OwnerScopeKey.ShouldBe(reference.OwnerScopeKey);
         parsed.SubjectId.ShouldBe(reference.SubjectId);
         parsed.SourceKind.ShouldBe(DurableCallerCredentialSourceKind.ScheduledDispatch);
+        parsed.ProviderCredentialId.ShouldBe(reference.ProviderCredentialId);
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.Abstractions.Tests/DurableCallerAgentKeyContractTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/DurableCallerAgentKeyContractTests.cs
@@ -33,4 +33,19 @@ public sealed class DurableCallerAgentKeyContractTests
             CredentialSecretPurposes.ChannelNyxIdAgentKey).ShouldBeFalse();
         DurableCallerAgentKeyContract.Matches(null).ShouldBeFalse();
     }
+
+    [Fact]
+    public void Matches_ShouldRequireProviderCredentialIdentityForWebhookReference()
+    {
+        var credential = new DurableCallerCredentialRef
+        {
+            SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
+            Purpose = CredentialSecretPurposes.WorkflowWebhookBindingAgentKey,
+        };
+
+        DurableCallerAgentKeyContract.Matches(credential).ShouldBeFalse();
+
+        credential.ProviderCredentialId = "provider-key-1";
+        DurableCallerAgentKeyContract.Matches(credential).ShouldBeTrue();
+    }
 }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationRegistrationAndExecutionTests.cs
@@ -483,6 +483,7 @@ public sealed class WorkflowApplicationRegistrationAndExecutionTests
             SubjectId = "owner-alpha",
             SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
             SecretReference = descriptor,
+            ProviderCredentialId = "provider-key-1",
         };
         var credential = new Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerCredential(
             NyxIdAuthority: new Aevatar.Workflow.Application.Abstractions.Runs.WorkflowCallerNyxIdAuthority(

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowCallerAccessTokenResolverTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowCallerAccessTokenResolverTests.cs
@@ -72,6 +72,7 @@ public sealed class WorkflowCallerAccessTokenResolverTests
                 OwnerScopeKey = "scope-1",
                 SubjectId = "owner-alpha",
                 SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
+                ProviderCredentialId = "provider-key-1",
             },
             NyxIdAuthority = CreateAuthority(),
             Kind = NyxIdCallerCredentialKind.AgentKey,

--- a/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/ToolCallModuleContextTests.cs
@@ -1646,6 +1646,9 @@ public sealed class ToolCallModuleContextTests
                 SubjectId = "agent-key-workflow",
                 SourceKind = sourceKind,
                 SecretReference = stored.Reference.Clone(),
+                ProviderCredentialId = sourceKind == DurableCallerCredentialSourceKind.WebhookBinding
+                    ? "provider-key-workflow"
+                    : string.Empty,
             },
             NyxIdAuthority = CreateCallerAuthority(),
             Kind = NyxIdCallerCredentialKind.AgentKey,

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRoleGAgentMappingTests.cs
@@ -782,6 +782,7 @@ public sealed class WorkflowRoleGAgentMappingTests
             SubjectId = "owner-alpha",
             SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
             SecretReference = stored.Reference.Clone(),
+            ProviderCredentialId = "provider-key-1",
         };
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowRuntimeModuleBranchTests.cs
@@ -624,6 +624,9 @@ public sealed class WorkflowRuntimeModuleBranchTests
                 OwnerScopeKey = "scope-workflow",
                 SubjectId = "agent-key-workflow",
                 SourceKind = sourceKind,
+                ProviderCredentialId = sourceKind == DurableCallerCredentialSourceKind.WebhookBinding
+                    ? "provider-key-workflow"
+                    : string.Empty,
             },
             Kind = NyxIdCallerCredentialKind.AgentKey,
         };

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowWebhookAgentKeyMaterializerTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowWebhookAgentKeyMaterializerTests.cs
@@ -1,0 +1,300 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.Foundation.Abstractions.Credentials;
+using Aevatar.Foundation.Abstractions.Credentials.Testing;
+using Aevatar.Workflow.Abstractions;
+using Aevatar.Workflow.Abstractions.Credentials;
+using Aevatar.Workflow.Infrastructure.CapabilityApi;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class WorkflowWebhookAgentKeyMaterializerTests
+{
+    [Fact]
+    public async Task Materialize_ShouldIssueExactAdmissionScopedKeyAndPersistOnlyIssuedMaterial()
+    {
+        const string issuedAgentKey = "nyxid_ag_dedicated_webhook_runtime_key";
+        var handler = new SequencedNyxIdHandler(
+            ScopePlanResponse(),
+            $$"""{"id":"provider-key-1","full_key":"{{issuedAgentKey}}"}""",
+            string.Empty);
+        var vault = new InMemorySecretVault();
+        var materializer = CreateMaterializer(handler, vault);
+
+        var result = await materializer.MaterializeAsync(
+            CallerAuthority(),
+            DurableAdmissionPlan(),
+            "scope-1",
+            "hr-01",
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.Credential!.ProviderCredentialId.Should().Be("provider-key-1");
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests.Select(static request => request.Authorization)
+            .Should().OnlyContain(static value => value == "Bearer management-bearer");
+
+        using (var scopePlanBody = JsonDocument.Parse(handler.Requests[0].Body!))
+        {
+            scopePlanBody.RootElement.GetProperty("selected_service_ids")
+                .EnumerateArray()
+                .Select(static item => item.GetString())
+                .Should().Equal("service-alpha", "service-chrono-sandbox");
+            scopePlanBody.RootElement.TryGetProperty("target_org_id", out _).Should().BeFalse();
+        }
+
+        using (var createBody = JsonDocument.Parse(handler.Requests[1].Body!))
+        {
+            var root = createBody.RootElement;
+            root.GetProperty("scopes").GetString().Should().Be("proxy");
+            root.GetProperty("allow_all_services").GetBoolean().Should().BeFalse();
+            root.GetProperty("allow_all_nodes").GetBoolean().Should().BeFalse();
+            root.GetProperty("allowed_service_ids")
+                .EnumerateArray()
+                .Select(static item => item.GetString())
+                .Should().Equal("service-alpha", "service-chrono-sandbox");
+            root.GetProperty("allowed_node_ids").GetArrayLength().Should().Be(0);
+            root.GetProperty("scope_plan_digest").GetString()
+                .Should().Be("sha256:" + new string('a', 64));
+        }
+
+        var resolved = await vault.ResolveAsync(new ResolveSecretRequest(
+            result.Credential.Ref,
+            result.Credential.Purpose,
+            result.Credential.OwnerScopeKey,
+            result.Credential.SubjectId,
+            "test-read"));
+        resolved.Secret.Should().Be(issuedAgentKey);
+        resolved.Secret.Should().NotBe("management-bearer");
+
+        var revoked = await materializer.RevokeAsync(
+            CallerAuthority(),
+            result.Credential,
+            "test-revoke",
+            CancellationToken.None);
+
+        revoked.Should().BeTrue();
+        handler.Requests[2].Method.Should().Be(HttpMethod.Delete);
+        handler.Requests[2].Uri.Should().EndWith("/api/v1/api-keys/provider-key-1");
+        var afterRevoke = await vault.ResolveAsync(new ResolveSecretRequest(
+            result.Credential.Ref,
+            result.Credential.Purpose,
+            result.Credential.OwnerScopeKey,
+            result.Credential.SubjectId,
+            "test-read-after-revoke"));
+        afterRevoke.FailureReason.Should().Be(SecretResolutionFailureReason.Revoked);
+    }
+
+    [Fact]
+    public async Task Materialize_WhenVaultWriteFails_ShouldRollbackIssuedProviderKey()
+    {
+        var handler = new SequencedNyxIdHandler(
+            ScopePlanResponse(),
+            """{"id":"provider-key-rollback","full_key":"nyxid_ag_rollback_runtime_key"}""",
+            string.Empty);
+        var materializer = CreateMaterializer(handler, new FailingPutSecretVault());
+
+        var result = await materializer.MaterializeAsync(
+            CallerAuthority(),
+            DurableAdmissionPlan(),
+            "scope-1",
+            "hr-01",
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_VAULT_UNAVAILABLE");
+        handler.Requests.Should().HaveCount(3);
+        handler.Requests[2].Method.Should().Be(HttpMethod.Delete);
+        handler.Requests[2].Uri.Should().EndWith("/api/v1/api-keys/provider-key-rollback");
+    }
+
+    private static WorkflowWebhookAgentKeyMaterializer CreateMaterializer(
+        HttpMessageHandler handler,
+        ISecretVault vault) => new(
+        new FixedAccessTokenProvider(),
+        new StaticApiClientFactory(handler),
+        vault,
+        NullLogger<WorkflowWebhookAgentKeyMaterializer>.Instance);
+
+    private static WorkflowCallerNyxIdAuthority CallerAuthority() => new()
+    {
+        Platform = "nyxid",
+        ExternalUserId = "owner-alpha",
+        Scope = "proxy",
+        BindingId = "binding-alpha",
+    };
+
+    private static WorkflowCapabilityAdmissionPlan DurableAdmissionPlan()
+    {
+        var policy = new NyxIdOperationExecutionPolicy
+        {
+            Risk = NyxIdOperationRisk.Write,
+            Approval = NyxIdOperationApproval.Required,
+            EnforcementOwner = NyxIdOperationEnforcementOwner.Aevatar,
+            AllowedExecutionModes =
+            {
+                ExternalCapabilityExecutionMode.Interactive,
+                ExternalCapabilityExecutionMode.Durable,
+            },
+        };
+        var codeExecution = new CodeExecutionCapabilityRef
+        {
+            UserServiceId = "service-chrono-sandbox",
+            ServiceSlugSnapshot = "chrono-sandbox",
+            CatalogServiceId = "catalog-chrono-sandbox",
+            AllowedExecutionModes =
+            {
+                ExternalCapabilityExecutionMode.Interactive,
+                ExternalCapabilityExecutionMode.Durable,
+            },
+        };
+        codeExecution.ContractDigest = WorkflowCapabilityAdmissionPlanIntegrity
+            .ComputeCodeExecutionCapabilityDigest(
+                codeExecution.UserServiceId,
+                codeExecution.ServiceSlugSnapshot,
+                codeExecution.CatalogServiceId);
+
+        var plan = new WorkflowCapabilityAdmissionPlan
+        {
+            SchemaVersion = WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion,
+            DefinitionDigest = "sha256:definition",
+            ExecutionMode = ExternalCapabilityExecutionMode.Durable,
+            DurableAuthorizationOwner = new ExternalCapabilityAuthorizationOwner
+            {
+                Authority = WorkflowCapabilityAdmissionPlanIntegrity.NyxIdAuthority,
+                OwnerKind = ExternalCapabilityAuthorizationOwnerKind.Personal,
+                OwnerSubject = "owner-alpha",
+            },
+        };
+        plan.InvocationAdmissions.Add(new WorkflowCapabilityInvocationAdmission
+        {
+            CallSiteId = "hr-01/create_request",
+            Capability = new ExternalWorkflowCapabilityRef
+            {
+                NyxIdUserService = new NyxIdUserServiceCapabilityRef
+                {
+                    UserServiceId = "service-alpha",
+                    ServiceSlugSnapshot = "api-lark-base",
+                    HttpMethod = "POST",
+                    PathTemplate = "/records",
+                    ContractDigest = "sha256:published-operation",
+                    EndpointId = "endpoint-create-record",
+                    ExecutionPolicy = policy,
+                },
+            },
+        });
+        plan.InvocationAdmissions.Add(new WorkflowCapabilityInvocationAdmission
+        {
+            CallSiteId = "hr-01/normalize_person",
+            Capability = new ExternalWorkflowCapabilityRef { CodeExecution = codeExecution },
+        });
+        plan.AdmissionDigest = WorkflowCapabilityAdmissionPlanIntegrity.ComputeAdmissionDigest(plan);
+        return plan;
+    }
+
+    private static string ScopePlanResponse() => $$"""
+        {
+          "authority": "nyxid",
+          "contract_version": "1",
+          "policy_version": "api-key-scope-v1",
+          "authenticated_actor": { "id": "owner-alpha", "type": "personal" },
+          "intended_key_owner": { "id": "owner-alpha", "type": "personal" },
+          "services": [
+            {
+              "user_service_id": "service-alpha",
+              "resource_owner": { "id": "owner-alpha", "type": "personal" },
+              "node_grant": { "type": "not_required" }
+            },
+            {
+              "user_service_id": "service-chrono-sandbox",
+              "resource_owner": { "id": "owner-alpha", "type": "personal" },
+              "node_grant": { "type": "not_required" }
+            }
+          ],
+          "allowed_service_ids": ["service-alpha", "service-chrono-sandbox"],
+          "allowed_node_ids": [],
+          "evaluated_at": "2026-08-23T08:09:10.123456789Z",
+          "normalized_grant_digest": "sha256:{{new string('a', 64)}}",
+          "freshness": {
+            "mode": "mutation_revalidated_snapshot",
+            "precondition_field": "scope_plan_digest",
+            "post_creation_drift": "fail_closed"
+          },
+          "completeness": {
+            "list_complete": true,
+            "no_duplicates": true,
+            "route_candidate_basis": "active_configured_routes",
+            "transient_node_state_excluded": true
+          }
+        }
+        """;
+
+    private sealed class FixedAccessTokenProvider : IWorkflowCallerAccessTokenProvider
+    {
+        public Task<string> IssueAsync(
+            WorkflowCallerNyxIdAuthority authority,
+            CancellationToken ct = default) => Task.FromResult("management-bearer");
+    }
+
+    private sealed class StaticApiClientFactory(HttpMessageHandler handler)
+        : INyxIdApiClientFactory
+    {
+        public NyxIdApiClient CreateClient() => new(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example/" },
+            new HttpClient(handler, disposeHandler: false),
+            NullLogger<NyxIdApiClient>.Instance);
+    }
+
+    private sealed class SequencedNyxIdHandler(params string[] responses) : HttpMessageHandler
+    {
+        private int _index;
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri!.ToString(),
+                request.Headers.Authorization?.ToString(),
+                request.Content is null
+                    ? null
+                    : await request.Content.ReadAsStringAsync(cancellationToken)));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responses[_index++], Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private sealed record RecordedRequest(
+        HttpMethod Method,
+        string Uri,
+        string? Authorization,
+        string? Body);
+
+    private sealed class FailingPutSecretVault : ISecretVault
+    {
+        public Task<StoreSecretResult> PutAsync(
+            StoreSecretRequest request,
+            CancellationToken ct = default) =>
+            Task.FromException<StoreSecretResult>(new InvalidOperationException("vault unavailable"));
+
+        public Task<ResolveSecretResult> ResolveAsync(
+            ResolveSecretRequest request,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<RotateSecretResult> RotateAsync(
+            RotateSecretRequest request,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<RevokeSecretResult> RevokeAsync(
+            RevokeSecretRequest request,
+            CancellationToken ct = default) => throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowWebhookAgentKeyMaterializerTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowWebhookAgentKeyMaterializerTests.cs
@@ -112,10 +112,200 @@ public sealed class WorkflowWebhookAgentKeyMaterializerTests
         handler.Requests[2].Uri.Should().EndWith("/api/v1/api-keys/provider-key-rollback");
     }
 
+    [Fact]
+    public async Task Materialize_WhenAdmissionPlanIsInvalid_ShouldFailBeforeCallingProvider()
+    {
+        var handler = new SequencedNyxIdHandler();
+        var materializer = CreateMaterializer(handler, new InMemorySecretVault());
+
+        var interactivePlan = DurableAdmissionPlan();
+        interactivePlan.ExecutionMode = ExternalCapabilityExecutionMode.Interactive;
+        var interactive = await materializer.MaterializeAsync(
+            CallerAuthority(), interactivePlan, "scope-1", "hr-01", CancellationToken.None);
+
+        var emptyPlan = DurableAdmissionPlan();
+        emptyPlan.InvocationAdmissions.Clear();
+        emptyPlan.AdmissionDigest = WorkflowCapabilityAdmissionPlanIntegrity.ComputeAdmissionDigest(emptyPlan);
+        var empty = await materializer.MaterializeAsync(
+            CallerAuthority(), emptyPlan, "scope-1", "hr-01", CancellationToken.None);
+
+        interactive.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_SCOPE_INVALID");
+        empty.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_SCOPE_INVALID");
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Materialize_WhenManagementBearerCannotBeIssued_ShouldFailClosed(bool throwOnIssue)
+    {
+        var handler = new SequencedNyxIdHandler();
+        var materializer = CreateMaterializer(
+            handler,
+            new InMemorySecretVault(),
+            new FailingAccessTokenProvider(throwOnIssue));
+
+        var result = await materializer.MaterializeAsync(
+            CallerAuthority(), DurableAdmissionPlan(), "scope-1", "hr-01", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_ISSUANCE_UNAVAILABLE");
+        result.StatusCode.Should().Be(503);
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Materialize_WhenScopePlanningFailsOrDrifts_ShouldReturnTypedFailure()
+    {
+        var unavailableHandler = new SequencedNyxIdHandler { ThrowAtRequestIndex = 0 };
+        var unavailable = await CreateMaterializer(unavailableHandler, new InMemorySecretVault())
+            .MaterializeAsync(
+                CallerAuthority(), DurableAdmissionPlan(), "scope-1", "hr-01", CancellationToken.None);
+
+        var rejectedHandler = new SequencedNyxIdHandler("""{"error":true,"status":429}""");
+        var rejected = await CreateMaterializer(rejectedHandler, new InMemorySecretVault())
+            .MaterializeAsync(
+                CallerAuthority(), DurableAdmissionPlan(), "scope-1", "hr-01", CancellationToken.None);
+
+        var driftedAuthority = CallerAuthority();
+        driftedAuthority.ExternalUserId = "owner-beta";
+        var driftedAdmissionPlan = DurableAdmissionPlan();
+        driftedAdmissionPlan.DurableAuthorizationOwner.OwnerSubject = "owner-beta";
+        driftedAdmissionPlan.AdmissionDigest = WorkflowCapabilityAdmissionPlanIntegrity
+            .ComputeAdmissionDigest(driftedAdmissionPlan);
+        var driftedHandler = new SequencedNyxIdHandler(ScopePlanResponse());
+        var drifted = await CreateMaterializer(driftedHandler, new InMemorySecretVault())
+            .MaterializeAsync(
+                driftedAuthority,
+                driftedAdmissionPlan,
+                "scope-1",
+                "hr-01",
+                CancellationToken.None);
+
+        unavailable.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_SCOPE_PLAN_FAILED");
+        unavailable.StatusCode.Should().Be(502);
+        rejected.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_SCOPE_PLAN_FAILED");
+        rejected.StatusCode.Should().Be(429);
+        drifted.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_SCOPE_CHANGED");
+        drifted.StatusCode.Should().Be(409);
+    }
+
+    [Fact]
+    public async Task Materialize_WhenProviderCreationTransportFails_ShouldReturnTypedFailure()
+    {
+        var handler = new SequencedNyxIdHandler(ScopePlanResponse())
+        {
+            ThrowAtRequestIndex = 1,
+        };
+
+        var result = await CreateMaterializer(handler, new InMemorySecretVault())
+            .MaterializeAsync(
+                CallerAuthority(), DurableAdmissionPlan(), "scope-1", "hr-01", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_CREATE_FAILED");
+        result.StatusCode.Should().Be(502);
+    }
+
+    [Theory]
+    [InlineData("", 502)]
+    [InlineData("[]", 502)]
+    [InlineData("{not-json", 502)]
+    [InlineData("{}", 502)]
+    [InlineData("{\"error\":true}", 502)]
+    [InlineData("{\"error\":true,\"status\":409}", 409)]
+    [InlineData("{\"id\":\" provider-key\",\"full_key\":\"nyxid_ag_key\"}", 502)]
+    [InlineData("{\"id\":\"provider-key\",\"full_key\":\" \"}", 502)]
+    public async Task Materialize_WhenProviderCreationResponseIsInvalid_ShouldNormalizeStatus(
+        string createResponse,
+        int expectedStatus)
+    {
+        var handler = new SequencedNyxIdHandler(ScopePlanResponse(), createResponse);
+
+        var result = await CreateMaterializer(handler, new InMemorySecretVault())
+            .MaterializeAsync(
+                CallerAuthority(), DurableAdmissionPlan(), "scope-1", "hr-01", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("WEBHOOK_CALLER_CREDENTIAL_CREATE_FAILED");
+        result.StatusCode.Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public async Task Revoke_WhenReferenceOrAuthorityIsInvalid_ShouldFailClosed()
+    {
+        var handler = new SequencedNyxIdHandler();
+        var materializer = CreateMaterializer(handler, new ConfigurableSecretVault(revoked: true));
+        var invalidReference = WebhookCredential(providerCredentialId: string.Empty);
+        invalidReference.Purpose = "other-purpose";
+
+        var invalid = await materializer.RevokeAsync(
+            CallerAuthority(), invalidReference, "test-revoke", CancellationToken.None);
+
+        var mismatchedAuthority = CallerAuthority();
+        mismatchedAuthority.ExternalUserId = "owner-beta";
+        var mismatched = await materializer.RevokeAsync(
+            mismatchedAuthority,
+            WebhookCredential(providerCredentialId: "provider-key-mismatch"),
+            "test-revoke",
+            CancellationToken.None);
+
+        invalid.Should().BeFalse();
+        mismatched.Should().BeFalse();
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("{}", true)]
+    [InlineData("{\"error\":true,\"status\":404}", true)]
+    [InlineData("{\"error\":true,\"status\":500}", false)]
+    public async Task Revoke_ShouldCombineProviderAndVaultOutcomes(
+        string providerResponse,
+        bool expected)
+    {
+        var handler = new SequencedNyxIdHandler(providerResponse);
+        var materializer = CreateMaterializer(handler, new ConfigurableSecretVault(revoked: true));
+
+        var result = await materializer.RevokeAsync(
+            CallerAuthority(),
+            WebhookCredential(providerCredentialId: "provider-key-1"),
+            "test-revoke",
+            CancellationToken.None);
+
+        result.Should().Be(expected);
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].Method.Should().Be(HttpMethod.Delete);
+    }
+
+    [Fact]
+    public async Task Revoke_WhenCleanupDependenciesFail_ShouldReturnFalse()
+    {
+        var providerFailureHandler = new SequencedNyxIdHandler { ThrowAtRequestIndex = 0 };
+        var providerFailure = await CreateMaterializer(
+                providerFailureHandler,
+                new ConfigurableSecretVault(revoked: true))
+            .RevokeAsync(
+                CallerAuthority(),
+                WebhookCredential(providerCredentialId: "provider-key-1"),
+                "test-revoke",
+                CancellationToken.None);
+
+        var vaultFailure = await CreateMaterializer(
+                new SequencedNyxIdHandler(),
+                new ConfigurableSecretVault(revoked: false, throwOnRevoke: true))
+            .RevokeAsync(
+                CallerAuthority(),
+                WebhookCredential(providerCredentialId: string.Empty),
+                "test-revoke",
+                CancellationToken.None);
+
+        providerFailure.Should().BeFalse();
+        vaultFailure.Should().BeFalse();
+    }
+
     private static WorkflowWebhookAgentKeyMaterializer CreateMaterializer(
         HttpMessageHandler handler,
-        ISecretVault vault) => new(
-        new FixedAccessTokenProvider(),
+        ISecretVault vault,
+        IWorkflowCallerAccessTokenProvider? accessTokenProvider = null) => new(
+        accessTokenProvider ?? new FixedAccessTokenProvider(),
         new StaticApiClientFactory(handler),
         vault,
         NullLogger<WorkflowWebhookAgentKeyMaterializer>.Instance);
@@ -126,6 +316,16 @@ public sealed class WorkflowWebhookAgentKeyMaterializerTests
         ExternalUserId = "owner-alpha",
         Scope = "proxy",
         BindingId = "binding-alpha",
+    };
+
+    private static DurableCallerCredentialRef WebhookCredential(string providerCredentialId) => new()
+    {
+        Ref = "sec-webhook-binding-1",
+        Purpose = CredentialSecretPurposes.WorkflowWebhookBindingAgentKey,
+        OwnerScopeKey = "scope-1",
+        SubjectId = "owner-alpha",
+        SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
+        ProviderCredentialId = providerCredentialId,
     };
 
     private static WorkflowCapabilityAdmissionPlan DurableAdmissionPlan()
@@ -240,6 +440,16 @@ public sealed class WorkflowWebhookAgentKeyMaterializerTests
             CancellationToken ct = default) => Task.FromResult("management-bearer");
     }
 
+    private sealed class FailingAccessTokenProvider(bool throwOnIssue)
+        : IWorkflowCallerAccessTokenProvider
+    {
+        public Task<string> IssueAsync(
+            WorkflowCallerNyxIdAuthority authority,
+            CancellationToken ct = default) => throwOnIssue
+            ? Task.FromException<string>(new InvalidOperationException("bearer issuance unavailable"))
+            : Task.FromResult(string.Empty);
+    }
+
     private sealed class StaticApiClientFactory(HttpMessageHandler handler)
         : INyxIdApiClientFactory
     {
@@ -253,6 +463,7 @@ public sealed class WorkflowWebhookAgentKeyMaterializerTests
     {
         private int _index;
         public List<RecordedRequest> Requests { get; } = [];
+        public int? ThrowAtRequestIndex { get; init; }
 
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -265,6 +476,8 @@ public sealed class WorkflowWebhookAgentKeyMaterializerTests
                 request.Content is null
                     ? null
                     : await request.Content.ReadAsStringAsync(cancellationToken)));
+            if (_index == ThrowAtRequestIndex)
+                throw new HttpRequestException("NyxID unavailable");
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(responses[_index++], Encoding.UTF8, "application/json"),
@@ -296,5 +509,27 @@ public sealed class WorkflowWebhookAgentKeyMaterializerTests
         public Task<RevokeSecretResult> RevokeAsync(
             RevokeSecretRequest request,
             CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class ConfigurableSecretVault(bool revoked, bool throwOnRevoke = false)
+        : ISecretVault
+    {
+        public Task<StoreSecretResult> PutAsync(
+            StoreSecretRequest request,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<ResolveSecretResult> ResolveAsync(
+            ResolveSecretRequest request,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<RotateSecretResult> RotateAsync(
+            RotateSecretRequest request,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<RevokeSecretResult> RevokeAsync(
+            RevokeSecretRequest request,
+            CancellationToken ct = default) => throwOnRevoke
+            ? Task.FromException<RevokeSecretResult>(new InvalidOperationException("vault unavailable"))
+            : Task.FromResult(new RevokeSecretResult(revoked));
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowWebhookBindingEndpointsTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowWebhookBindingEndpointsTests.cs
@@ -377,17 +377,19 @@ public sealed class WorkflowWebhookBindingEndpointsTests
     }
 
     [Fact]
-    public async Task Put_WithForwardedAgentKey_ShouldStoreOnlyVaultReference()
+    public async Task Put_WithForwardedAgentKey_ShouldMaterializeDedicatedCredentialWithoutPersistingInboundKey()
     {
         const string agentKey = "nyxid_ag_webhook_exact_service_secret";
         var store = new InMemoryWorkflowWebhookBindingStore();
         var vault = new RecordingSecretVault();
+        var materializer = new RecordingWebhookAgentKeyMaterializer();
         var http = CreateHttpContext(
             store,
             bindingReader: new FakeActorBindingReader(DefinitionBinding(plan: DurableWritePlan())),
             authenticationEnabled: true,
             bindingQuery: new FakeBindingQuery("bnd-owner-alpha"),
-            secretVault: vault);
+            secretVault: vault,
+            webhookAgentKeyMaterializer: materializer);
         ApplyProxyDelegationAuthentication(http, "owner-alpha", "scope-1");
         http.Request.Headers.Authorization = $"Bearer {agentKey}";
 
@@ -398,28 +400,33 @@ public sealed class WorkflowWebhookBindingEndpointsTests
             ExactPutRequest() with { EnableUnattendedEffects = true });
 
         ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status200OK);
-        vault.PutRequests.Should().ContainSingle();
-        vault.PutRequests[0].Secret.Should().Be(agentKey);
-        vault.PutRequests[0].Purpose.Should().Be(CredentialSecretPurposes.WorkflowWebhookBindingAgentKey);
+        vault.PutRequests.Should().BeEmpty();
+        materializer.MaterializeCalls.Should().ContainSingle();
+        materializer.MaterializeCalls[0].Authority.ExternalUserId.Should().Be("owner-alpha");
+        materializer.MaterializeCalls[0].ScopeId.Should().Be("scope-1");
+        materializer.MaterializeCalls[0].RouteKey.Should().Be("status-event-route");
         var stored = (await store.GetAsync("status-event-route"))!;
         stored.CallerDurableCredential.Should().NotBeNull();
         stored.CallerDurableCredential!.SourceKind.Should().Be(DurableCallerCredentialSourceKind.WebhookBinding);
+        stored.CallerDurableCredential.ProviderCredentialId.Should().NotBeNullOrWhiteSpace();
         stored.CallerDurableCredential.SecretReference.Fingerprint.Should().NotBeNullOrWhiteSpace();
         System.Text.Json.JsonSerializer.Serialize(stored).Should().NotContain(agentKey);
         System.Text.Json.JsonSerializer.Serialize(((IValueHttpResult)result).Value).Should().NotContain(agentKey);
     }
 
     [Fact]
-    public async Task Put_WithOrdinaryOAuthBearer_ShouldNotStoreCredentialInVault()
+    public async Task Put_WithOrdinaryOAuthBearer_ShouldAlsoMaterializeDedicatedCredential()
     {
         var store = new InMemoryWorkflowWebhookBindingStore();
         var vault = new RecordingSecretVault();
+        var materializer = new RecordingWebhookAgentKeyMaterializer();
         var http = CreateHttpContext(
             store,
             bindingReader: new FakeActorBindingReader(DefinitionBinding(plan: DurableWritePlan())),
             authenticationEnabled: true,
             bindingQuery: new FakeBindingQuery("bnd-owner-alpha"),
-            secretVault: vault);
+            secretVault: vault,
+            webhookAgentKeyMaterializer: materializer);
         ApplyHumanAuthentication(http, "owner-alpha", "scope-1");
 
         var result = await WorkflowWebhookBindingEndpoints.HandlePutAsync(
@@ -430,7 +437,32 @@ public sealed class WorkflowWebhookBindingEndpointsTests
 
         ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status200OK);
         vault.PutRequests.Should().BeEmpty();
-        (await store.GetAsync("status-event-route"))!.CallerDurableCredential.Should().BeNull();
+        materializer.MaterializeCalls.Should().ContainSingle();
+        (await store.GetAsync("status-event-route"))!.CallerDurableCredential.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Put_WhenDedicatedCredentialMaterializerIsUnavailable_ShouldFailWithoutMutation()
+    {
+        var store = new InMemoryWorkflowWebhookBindingStore();
+        var http = CreateHttpContext(
+            store,
+            bindingReader: new FakeActorBindingReader(DefinitionBinding(plan: DurableWritePlan())),
+            authenticationEnabled: true,
+            bindingQuery: new FakeBindingQuery("bnd-owner-alpha"),
+            registerDefaultWebhookAgentKeyMaterializer: false);
+        ApplyHumanAuthentication(http, "owner-alpha", "scope-1");
+
+        var result = await WorkflowWebhookBindingEndpoints.HandlePutAsync(
+            http,
+            "scope-1",
+            "status-event-route",
+            ExactPutRequest() with { EnableUnattendedEffects = true });
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        System.Text.Json.JsonSerializer.Serialize(((IValueHttpResult)result).Value)
+            .Should().Contain("WEBHOOK_CALLER_CREDENTIAL_ISSUANCE_UNAVAILABLE");
+        (await store.GetAsync("status-event-route")).Should().BeNull();
     }
 
     [Fact]
@@ -438,13 +470,13 @@ public sealed class WorkflowWebhookBindingEndpointsTests
     {
         var store = new InMemoryWorkflowWebhookBindingStore();
         await SeedAsync(store, BindingRecord("status-event-route", "scope-other"));
-        var vault = new RecordingSecretVault();
+        var materializer = new RecordingWebhookAgentKeyMaterializer();
         var http = CreateHttpContext(
             store,
             bindingReader: new FakeActorBindingReader(DefinitionBinding(plan: DurableWritePlan())),
             authenticationEnabled: true,
             bindingQuery: new FakeBindingQuery("bnd-owner-alpha"),
-            secretVault: vault);
+            webhookAgentKeyMaterializer: materializer);
         ApplyProxyDelegationAuthentication(http, "owner-alpha", "scope-1");
         http.Request.Headers.Authorization = "Bearer nyxid_ag_rejected_route_secret";
 
@@ -455,22 +487,23 @@ public sealed class WorkflowWebhookBindingEndpointsTests
             ExactPutRequest() with { EnableUnattendedEffects = true });
 
         ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status409Conflict);
-        vault.PutRequests.Should().ContainSingle();
-        vault.RevokeRequests.Should().ContainSingle();
-        vault.RevokeRequests[0].Ref.Should().Be(vault.PutResults[0].Reference.Ref);
+        materializer.MaterializeCalls.Should().ContainSingle();
+        materializer.RevokeCalls.Should().ContainSingle();
+        materializer.RevokeCalls[0].Credential.Ref.Should()
+            .Be(materializer.MaterializedCredentials[0].Ref);
     }
 
     [Fact]
     public async Task ReplaceAndDelete_ShouldRevokeOnlyTheReplacedAgentKeyReferences()
     {
         var store = new InMemoryWorkflowWebhookBindingStore();
-        var vault = new RecordingSecretVault();
+        var materializer = new RecordingWebhookAgentKeyMaterializer();
         var http = CreateHttpContext(
             store,
             bindingReader: new FakeActorBindingReader(DefinitionBinding(plan: DurableWritePlan())),
             authenticationEnabled: true,
             bindingQuery: new FakeBindingQuery("bnd-owner-alpha"),
-            secretVault: vault);
+            webhookAgentKeyMaterializer: materializer);
         ApplyProxyDelegationAuthentication(http, "owner-alpha", "scope-1");
 
         http.Request.Headers.Authorization = "Bearer nyxid_ag_first_secret";
@@ -491,23 +524,23 @@ public sealed class WorkflowWebhookBindingEndpointsTests
             .Should().Be(StatusCodes.Status200OK);
         var secondRef = (await store.GetAsync("status-event-route"))!.CallerDurableCredential!.Ref;
 
-        vault.RevokeRequests.Select(static request => request.Ref).Should().ContainSingle(firstRef);
+        materializer.RevokeCalls.Select(static call => call.Credential.Ref).Should().ContainSingle(firstRef);
         (await WorkflowWebhookBindingEndpoints.HandleDeleteAsync(http, "scope-1", "status-event-route"))
             .Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.NoContent>();
-        vault.RevokeRequests.Select(static request => request.Ref).Should().Equal(firstRef, secondRef);
+        materializer.RevokeCalls.Select(static call => call.Credential.Ref).Should().Equal(firstRef, secondRef);
     }
 
     [Fact]
     public async Task ReplaceAndDelete_WhenCleanupIsNotCommitted_ShouldReportTheCommittedBindingOutcome()
     {
         var store = new InMemoryWorkflowWebhookBindingStore();
-        var vault = new RecordingSecretVault { CommitRevocation = false };
+        var materializer = new RecordingWebhookAgentKeyMaterializer { CommitRevocation = false };
         var http = CreateHttpContext(
             store,
             bindingReader: new FakeActorBindingReader(DefinitionBinding(plan: DurableWritePlan())),
             authenticationEnabled: true,
             bindingQuery: new FakeBindingQuery("bnd-owner-alpha"),
-            secretVault: vault);
+            webhookAgentKeyMaterializer: materializer);
         ApplyProxyDelegationAuthentication(http, "owner-alpha", "scope-1");
 
         http.Request.Headers.Authorization = "Bearer nyxid_ag_first_secret";
@@ -529,13 +562,13 @@ public sealed class WorkflowWebhookBindingEndpointsTests
         ((IStatusCodeHttpResult)replace).StatusCode.Should().Be(StatusCodes.Status200OK);
         var secondRef = (await store.GetAsync("status-event-route"))!.CallerDurableCredential!.Ref;
         secondRef.Should().NotBe(firstRef);
-        vault.RevokeRequests.Select(static request => request.Ref).Should().ContainSingle(firstRef);
+        materializer.RevokeCalls.Select(static call => call.Credential.Ref).Should().ContainSingle(firstRef);
 
         var delete = await WorkflowWebhookBindingEndpoints.HandleDeleteAsync(http, "scope-1", "status-event-route");
 
         delete.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.NoContent>();
         (await store.GetAsync("status-event-route")).Should().BeNull();
-        vault.RevokeRequests.Select(static request => request.Ref).Should().Equal(firstRef, secondRef);
+        materializer.RevokeCalls.Select(static call => call.Credential.Ref).Should().Equal(firstRef, secondRef);
     }
 
     [Fact]
@@ -1255,6 +1288,7 @@ public sealed class WorkflowWebhookBindingEndpointsTests
             SubjectId = "owner-alpha",
             SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
             SecretReference = descriptor,
+            ProviderCredentialId = "provider-webhook-binding",
         };
     }
 
@@ -1308,6 +1342,19 @@ public sealed class WorkflowWebhookBindingEndpointsTests
                 .ComputeNyxIdExplicitRequestGrantDigest(grant),
             ExecutionPolicy = policy,
         };
+        var codeExecution = new CodeExecutionCapabilityRef
+        {
+            UserServiceId = "service-chrono-sandbox",
+            ServiceSlugSnapshot = "chrono-sandbox",
+            CatalogServiceId = "catalog-chrono-sandbox",
+        };
+        codeExecution.ContractDigest = WorkflowCapabilityAdmissionPlanIntegrity
+            .ComputeCodeExecutionCapabilityDigest(
+                codeExecution.UserServiceId,
+                codeExecution.ServiceSlugSnapshot,
+                codeExecution.CatalogServiceId);
+        codeExecution.AllowedExecutionModes.Add(ExternalCapabilityExecutionMode.Interactive);
+        codeExecution.AllowedExecutionModes.Add(ExternalCapabilityExecutionMode.Durable);
         var plan = new WorkflowCapabilityAdmissionPlan
         {
             SchemaVersion = WorkflowCapabilityAdmissionPlanIntegrity.SchemaVersion,
@@ -1320,6 +1367,11 @@ public sealed class WorkflowWebhookBindingEndpointsTests
                 OwnerSubject = "owner-alpha",
             },
         };
+        plan.InvocationAdmissions.Add(new WorkflowCapabilityInvocationAdmission
+        {
+            CallSiteId = "workflow-alpha/normalize_person",
+            Capability = new ExternalWorkflowCapabilityRef { CodeExecution = codeExecution },
+        });
         plan.InvocationAdmissions.Add(new WorkflowCapabilityInvocationAdmission
         {
             CallSiteId = grant.CallSiteId,
@@ -1352,7 +1404,9 @@ public sealed class WorkflowWebhookBindingEndpointsTests
         bool authenticationEnabled = false,
         IExternalIdentityBindingQueryPort? bindingQuery = null,
         IWorkflowCallerAccessTokenProvider? callerAccessTokenProvider = null,
-        ISecretVault? secretVault = null)
+        ISecretVault? secretVault = null,
+        IWorkflowWebhookAgentKeyMaterializer? webhookAgentKeyMaterializer = null,
+        bool registerDefaultWebhookAgentKeyMaterializer = true)
     {
         var services = new ServiceCollection();
         services.AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance);
@@ -1378,6 +1432,11 @@ public sealed class WorkflowWebhookBindingEndpointsTests
             services.AddSingleton(callerAccessTokenProvider);
         if (secretVault != null)
             services.AddSingleton(secretVault);
+        if (webhookAgentKeyMaterializer != null)
+            services.AddSingleton(webhookAgentKeyMaterializer);
+        else if (registerDefaultWebhookAgentKeyMaterializer)
+            services.AddSingleton<IWorkflowWebhookAgentKeyMaterializer,
+                RecordingWebhookAgentKeyMaterializer>();
         var http = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
         http.Response.Body = new MemoryStream();
         return http;
@@ -1525,6 +1584,72 @@ public sealed class WorkflowWebhookBindingEndpointsTests
             return CommitRevocation
                 ? _inner.RevokeAsync(request, ct)
                 : Task.FromResult(new RevokeSecretResult(false));
+        }
+    }
+
+    private sealed class RecordingWebhookAgentKeyMaterializer
+        : IWorkflowWebhookAgentKeyMaterializer
+    {
+        private int _sequence;
+
+        public List<(
+            ProtoWorkflowCallerNyxIdAuthority Authority,
+            WorkflowCapabilityAdmissionPlan AdmissionPlan,
+            string ScopeId,
+            string RouteKey)> MaterializeCalls { get; } = [];
+
+        public List<DurableCallerCredentialRef> MaterializedCredentials { get; } = [];
+
+        public List<(
+            ProtoWorkflowCallerNyxIdAuthority? Authority,
+            DurableCallerCredentialRef Credential,
+            string AuditReason)> RevokeCalls { get; } = [];
+
+        public bool CommitRevocation { get; init; } = true;
+
+        public Task<WorkflowWebhookAgentKeyMaterializationResult> MaterializeAsync(
+            ProtoWorkflowCallerNyxIdAuthority callerAuthority,
+            WorkflowCapabilityAdmissionPlan admissionPlan,
+            string scopeId,
+            string routeKey,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            MaterializeCalls.Add((callerAuthority.Clone(), admissionPlan.Clone(), scopeId, routeKey));
+            var sequence = Interlocked.Increment(ref _sequence);
+            var descriptor = new SecretReference
+            {
+                Ref = $"sec-webhook-binding-{sequence}",
+                Purpose = CredentialSecretPurposes.WorkflowWebhookBindingAgentKey,
+                Fingerprint = $"sha256:test-{sequence}",
+                Version = 1,
+                OwnerScopeKey = scopeId,
+                CreatedAtUnixMs = sequence,
+            };
+            var credential = new DurableCallerCredentialRef
+            {
+                Ref = descriptor.Ref,
+                Purpose = descriptor.Purpose,
+                OwnerScopeKey = descriptor.OwnerScopeKey,
+                SubjectId = callerAuthority.ExternalUserId,
+                SourceKind = DurableCallerCredentialSourceKind.WebhookBinding,
+                SecretReference = descriptor,
+                ProviderCredentialId = $"provider-webhook-binding-{sequence}",
+            };
+            MaterializedCredentials.Add(credential.Clone());
+            return Task.FromResult(
+                WorkflowWebhookAgentKeyMaterializationResult.Success(credential));
+        }
+
+        public Task<bool> RevokeAsync(
+            ProtoWorkflowCallerNyxIdAuthority? callerAuthority,
+            DurableCallerCredentialRef credential,
+            string auditReason,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            RevokeCalls.Add((callerAuthority?.Clone(), credential.Clone(), auditReason));
+            return Task.FromResult(CommitRevocation);
         }
     }
 


### PR DESCRIPTION
## Problem

Webhook binding management persisted the inbound Agent Key as the durable runtime credential. That credential was authorized to manage the binding but did not necessarily include every service in the committed workflow admission plan. HR-01 therefore reached `normalize_person` and failed with `NYXID_PROXY_FORBIDDEN` because the stored key could not call `chrono-sandbox`.

## Solution

- Treat inbound webhook credentials as management authorization only.
- Resolve a source-readable NyxID bearer from the exact binding authority.
- Union every NyxID UserService ID from the committed admission plan, including `CodeExecution.UserServiceId`.
- Request NyxID's authoritative scope plan and verify the exact actor, owner, and service set.
- Create a dedicated `proxy` key with exact service/node allowlists and the scope-plan digest, then store only its `full_key` in Vault.
- Persist the provider credential ID and revoke provider/Vault credentials on rollback, replacement, disablement, and deletion.
- Fail closed for new webhook references without a provider credential ID while retaining legacy Vault-only cleanup.

## Impact

Unattended webhook workflows receive a least-privilege runtime Agent Key that matches the committed admission plan. The management key is no longer reused or persisted as runtime authority.

## Verification

- Foundation credential contract tests: 9 passed
- Workflow Core credential/mapping tests: 27 passed
- Workflow Application registration/execution tests: 24 passed
- Webhook binding/materializer tests: 38 passed
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/workflow_binding_boundary_guard.sh`
- `bash tools/ci/architecture_guards.sh`
- `git diff --check`

All passed locally. The repository-wide `dotnet format --verify-no-changes` remains blocked by pre-existing import-order findings outside this change.

## Merge note

Use a merge commit, not squash or rebase, to preserve the branch history used by the integration line.
