### PR TITLE
Fix NyxID Agent Key proxy transport

### DIFF
--- a/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.Durable.cs
+++ b/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.Durable.cs
@@ -66,6 +66,7 @@ internal sealed partial class NyxIdCodeExecutionPort
         {
             response = await SendDurableProxyAsync(
                     executionCredential,
+                    execution.Caller!.ExecutionCredentialKind,
                     route,
                     DurableSubmitPath,
                     HttpMethod.Post.Method,
@@ -137,6 +138,7 @@ internal sealed partial class NyxIdCodeExecutionPort
             };
         var response = await ExchangeKnownOperationAsync(
                 token!,
+                request.Caller!.ExecutionCredentialKind,
                 request.Route,
                 StatusPath(request.ProviderOperationId),
                 HttpMethod.Get.Method,
@@ -205,6 +207,7 @@ internal sealed partial class NyxIdCodeExecutionPort
         var localDiagnosticId = CreateLocalDiagnosticId();
         var exchange = await ExchangeKnownOperationAsync(
                 token!,
+                request.Caller!.ExecutionCredentialKind,
                 request.Route,
                 ResultPath(request.ProviderOperationId),
                 HttpMethod.Get.Method,
@@ -265,6 +268,7 @@ internal sealed partial class NyxIdCodeExecutionPort
         var localDiagnosticId = CreateLocalDiagnosticId();
         var exchange = await ExchangeKnownOperationAsync(
                 token!,
+                request.Caller!.ExecutionCredentialKind,
                 request.Route,
                 CancelPath(request.ProviderOperationId),
                 HttpMethod.Post.Method,
@@ -372,6 +376,7 @@ internal sealed partial class NyxIdCodeExecutionPort
 
     private async Task<DurableExchangeOutcome> ExchangeKnownOperationAsync(
         string token,
+        CodeExecutionNyxIdCredentialKind credentialKind,
         CodeExecutionRouteIdentity route,
         string path,
         string method,
@@ -385,6 +390,7 @@ internal sealed partial class NyxIdCodeExecutionPort
         {
             var response = await SendDurableProxyAsync(
                     token,
+                    credentialKind,
                     route,
                     path,
                     method,
@@ -428,6 +434,7 @@ internal sealed partial class NyxIdCodeExecutionPort
 
     private async Task<NyxIdProxyTextResponse> SendDurableProxyAsync(
         string token,
+        CodeExecutionNyxIdCredentialKind credentialKind,
         CodeExecutionRouteIdentity route,
         string path,
         string method,
@@ -441,17 +448,29 @@ internal sealed partial class NyxIdCodeExecutionPort
         if (!client.HasPublicApiEndpoint)
             throw new DurablePublicApiNotConfiguredException();
 
-        return await client.ProxyPublicRequestBoundedAsync(
-                token,
-                route.ServiceSlug,
-                route.UserServiceId!,
-                path,
-                method,
-                body,
-                extraHeaders,
-                MaxResponseBytes,
-                callCts.Token)
-            .ConfigureAwait(false);
+        return credentialKind == CodeExecutionNyxIdCredentialKind.AgentKey
+            ? await client.ProxyPublicRequestBoundedWithApiKeyAsync(
+                    token,
+                    route.ServiceSlug,
+                    route.UserServiceId!,
+                    path,
+                    method,
+                    body,
+                    extraHeaders,
+                    MaxResponseBytes,
+                    callCts.Token)
+                .ConfigureAwait(false)
+            : await client.ProxyPublicRequestBoundedAsync(
+                    token,
+                    route.ServiceSlug,
+                    route.UserServiceId!,
+                    path,
+                    method,
+                    body,
+                    extraHeaders,
+                    MaxResponseBytes,
+                    callCts.Token)
+                .ConfigureAwait(false);
     }
 
     private DurableCodeExecutionFailure ClassifyDurableHttpFailure(

--- a/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.cs
+++ b/src/Aevatar.AI.Infrastructure.ChronoSandbox/NyxIdCodeExecutionPort.cs
@@ -156,17 +156,29 @@ internal sealed partial class NyxIdCodeExecutionPort(
         NyxIdProxyTextResponse response;
         try
         {
-            response = await client.ProxyRequestBoundedAsync(
-                    executionCredential,
-                    route.ServiceSlug,
-                    resolvedUserServiceId,
-                    ExecutionPath,
-                    HttpMethod.Post.Method,
-                    body,
-                    extraHeaders: null,
-                    MaxResponseBytes,
-                    ct)
-                .ConfigureAwait(false);
+            response = request.Caller!.ExecutionCredentialKind ==
+                       CodeExecutionNyxIdCredentialKind.AgentKey
+                ? await client.ProxyRequestBoundedWithApiKeyAsync(
+                        executionCredential,
+                        route.ServiceSlug,
+                        resolvedUserServiceId,
+                        ExecutionPath,
+                        HttpMethod.Post.Method,
+                        body,
+                        MaxResponseBytes,
+                        ct)
+                    .ConfigureAwait(false)
+                : await client.ProxyRequestBoundedAsync(
+                        executionCredential,
+                        route.ServiceSlug,
+                        resolvedUserServiceId,
+                        ExecutionPath,
+                        HttpMethod.Post.Method,
+                        body,
+                        extraHeaders: null,
+                        MaxResponseBytes,
+                        ct)
+                    .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
@@ -588,6 +588,36 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
             ct);
     }
 
+    /// <summary>
+    /// Sends one bounded Agent Key proxy exchange through the configured public NyxID API endpoint.
+    /// The key is transported only in <c>X-API-Key</c>; it is never reinterpreted as a bearer token.
+    /// </summary>
+    public Task<NyxIdProxyTextResponse> ProxyPublicRequestBoundedWithApiKeyAsync(
+        string apiKey,
+        string slug,
+        string userServiceId,
+        string path,
+        string method,
+        string? body,
+        Dictionary<string, string>? extraHeaders,
+        long maxBytes,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userServiceId);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxBytes);
+        return ProxyPublicRequestBoundedWithApiKeyCoreAsync(
+            apiKey,
+            slug,
+            userServiceId.Trim(),
+            path,
+            method,
+            body,
+            extraHeaders,
+            maxBytes,
+            ct);
+    }
+
     public Task<NyxIdProxyTextResponse> ProxyRequestBoundedWithApiKeyAsync(
         string apiKey,
         string slug,
@@ -767,6 +797,35 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
             method,
             body,
             extraHeaders,
+            publicApiOnly: true,
+            applyAmbientIdempotencyKey: false);
+        return await SendTextResponseAsync(
+            request,
+            maxBytes,
+            ct,
+            allowPublicTransportFallback: false);
+    }
+
+    private async Task<NyxIdProxyTextResponse> ProxyPublicRequestBoundedWithApiKeyCoreAsync(
+        string apiKey,
+        string slug,
+        string userServiceId,
+        string path,
+        string method,
+        string? body,
+        Dictionary<string, string>? extraHeaders,
+        long maxBytes,
+        CancellationToken ct)
+    {
+        using var request = CreateProxyRequest(
+            apiKey,
+            slug,
+            userServiceId,
+            path,
+            method,
+            body,
+            extraHeaders,
+            ProxyCredentialTransport.ApiKeyHeader,
             publicApiOnly: true,
             applyAmbientIdempotencyKey: false);
         return await SendTextResponseAsync(

--- a/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdCodeExecutionPortTests.cs
+++ b/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdCodeExecutionPortTests.cs
@@ -106,7 +106,8 @@ public sealed class NyxIdCodeExecutionPortTests
         handler.Requests[0].Method.Should().Be(HttpMethod.Post.Method);
         handler.Requests[0].PathAndQuery.Should().Be(
             "/api/v1/proxy/s/chrono-sandbox/execute?_nyxid_via=us-code-alpha");
-        handler.Requests[0].Authorization.Should().Be("Bearer scheduled-agent-key");
+        handler.Requests[0].Authorization.Should().BeNull();
+        handler.Requests[0].ApiKeys.Should().Equal("scheduled-agent-key");
     }
 
     [Fact]
@@ -143,6 +144,8 @@ public sealed class NyxIdCodeExecutionPortTests
         handler.Requests.Should().ContainSingle();
         handler.Requests[0].PathAndQuery.Should().Be(
             "/api/v1/proxy/s/chrono-sandbox-aevatar/execute?_nyxid_via=us-code-aevatar");
+        handler.Requests[0].Authorization.Should().BeNull();
+        handler.Requests[0].ApiKeys.Should().Equal("scheduled-agent-key");
     }
 
     [Fact]

--- a/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdDurableCodeExecutionPortTests.cs
+++ b/test/Aevatar.AI.Infrastructure.ChronoSandbox.Tests/NyxIdDurableCodeExecutionPortTests.cs
@@ -97,6 +97,39 @@ public sealed class NyxIdDurableCodeExecutionPortTests
     }
 
     [Fact]
+    public async Task SubmitAsync_AgentKeyUsesApiKeyHeaderOnPublicEndpoint()
+    {
+        var handler = new SequenceHandler(_ => Response(
+            HttpStatusCode.Accepted,
+            $$"""
+              {
+                "operation_id":"{{OperationId}}",
+                "status":"queued",
+                "created_at":"2026-08-14T10:00:00Z",
+                "expires_at":"2026-08-15T10:00:00Z"
+              }
+              """));
+        var port = CreatePort(handler);
+        var execution = ExecutionRequest() with
+        {
+            Caller = new CodeExecutionCallerContext(
+                "scheduled-agent-key",
+                null,
+                CodeExecutionNyxIdCredentialKind.AgentKey),
+        };
+
+        var outcome = await port.SubmitAsync(new DurableCodeExecutionSubmitRequest(
+            execution,
+            IdempotencyKey));
+
+        outcome.Failure.Should().BeNull();
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].Headers.Should().NotContainKey("Authorization");
+        handler.Requests[0].Headers["X-API-Key"].Should().Equal("scheduled-agent-key");
+        handler.Requests[0].Headers["Idempotency-Key"].Should().Equal(IdempotencyKey);
+    }
+
+    [Fact]
     public async Task SubmitAsync_PersonalExecutionRouteUsesItsAdmittedSlug()
     {
         var handler = new SequenceHandler(_ => Response(
@@ -151,6 +184,31 @@ public sealed class NyxIdDurableCodeExecutionPortTests
             $"/executions/{OperationId}?_nyxid_via=us-code-alpha");
         handler.Requests[0].Headers["If-None-Match"].Should().Equal("\"v6\"");
         handler.Requests[0].Headers.Should().NotContainKey("Idempotency-Key");
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_AgentKeyUsesApiKeyHeaderOnPublicEndpoint()
+    {
+        var handler = new SequenceHandler(_ => Response(
+            HttpStatusCode.NotModified,
+            string.Empty,
+            response => response.Headers.ETag = new EntityTagHeaderValue("\"v7\"")));
+        var port = CreatePort(handler);
+        var request = OperationRequest("\"v6\"") with
+        {
+            Caller = new CodeExecutionCallerContext(
+                "scheduled-agent-key",
+                null,
+                CodeExecutionNyxIdCredentialKind.AgentKey),
+        };
+
+        var outcome = await port.GetStatusAsync(request);
+
+        outcome.Failure.Should().BeNull();
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].Headers.Should().NotContainKey("Authorization");
+        handler.Requests[0].Headers["X-API-Key"].Should().Equal("scheduled-agent-key");
+        handler.Requests[0].Headers["If-None-Match"].Should().Equal("\"v6\"");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Code execution recognized Agent Key credentials but sent them as `Authorization: Bearer`, while NyxID validates Agent Keys only through `X-API-Key`. Durable workflow execution therefore failed with `NYXID_PROXY_UNAUTHORIZED`.

## Solution

- route Agent Key credentials through `X-API-Key` for bounded proxy requests
- preserve Bearer transport for bearer credentials
- apply the credential-kind dispatch to durable submit, status, result, and cancel calls
- keep durable public transport fallback disabled and preserve explicit idempotency/ETag headers

## Impact

NyxID-backed normal and durable code execution can use admitted Agent Keys without changing caller scope or credential issuance.

## Verification

- `Aevatar.AI.Infrastructure.ChronoSandbox.Tests`: 348 passed
- `Aevatar.AI.Tests` NyxIdApiClient filter: 75 passed
- `Aevatar.Workflow.Host.Api.Tests`: 1275 passed, 1 skipped
- `tools/ci/test_stability_guards.sh`: passed
- `tools/ci/workflow_binding_boundary_guard.sh`: passed
- `tools/ci/architecture_guards.sh`: passed
- `git diff --check`: passed