### PR TITLE
Align workflow templates with Studio schema

### DIFF
--- a/workflows/codex_long_running_handoff.yaml
+++ b/workflows/codex_long_running_handoff.yaml
@@ -3,7 +3,6 @@ description: "Dispatch long-running Codex work, wait for an external callback, t
 roles:
   - id: reviewer
     name: Reviewer
-    agent_kind: workflow.role-agent
     system_prompt: "Review worker output for correctness and actionable issues."
     allowed_tools: []
 steps:

--- a/workflows/simple_qa.yaml
+++ b/workflows/simple_qa.yaml
@@ -7,4 +7,4 @@ roles:
 steps:
   - id: answer
     type: llm_call
-    role: assistant
+    target_role: assistant


### PR DESCRIPTION
## Summary
- Remove the unsupported `agent_kind` field from the Codex handoff workflow template.
- Export the simple QA template with canonical `target_role` instead of the legacy `role` alias.
- Keep the template fix scoped to YAML files based on latest `feature/integrate`.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~WorkflowTemplateParseTests.StartupWorkflow_ShouldParse"` - passed, 12/12
- [x] `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~WorkflowCompatibilityProfileTests|FullyQualifiedName~EditorControllerSerializationTests"` - passed, 92/92

🤖 Generated with [Claude Code](https://claude.com/claude-code)