### PR TITLE
Add coverage hang blame diagnostics

### DIFF
--- a/tools/ci/coverage_quality_guard.sh
+++ b/tools/ci/coverage_quality_guard.sh
@@ -47,7 +47,10 @@ dotnet test aevatar.slnx \
   -p:UseSharedCompilation=false \
   -p:NuGetAudit=false \
   --collect:"XPlat Code Coverage" \
-  --results-directory "${raw_dir}"
+  --results-directory "${raw_dir}" \
+  --blame-hang \
+  --blame-hang-timeout 2m \
+  --blame-hang-dump-type none
 test_exit=$?
 set -e
 


### PR DESCRIPTION
## Summary
- Enable VSTest blame-hang for the coverage-quality dotnet test run.
- Keep dump collection disabled while preserving sequence files under the existing coverage artifact path.

## Test plan
- [x] bash -n tools/ci/coverage_quality_guard.sh
- [ ] GitHub Actions coverage-quality should rerun and upload blame sequence output if the hang reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)