### PR TITLE
Add dinner date mock workflow

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/INyxIdBrokerCallbackClient.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/INyxIdBrokerCallbackClient.cs
@@ -45,6 +45,17 @@ public interface INyxIdBrokerCallbackClient
         CancellationToken ct = default);
 
     /// <summary>
+    /// Exchanges an OAuth authorization code whose authorize/token request carried explicit
+    /// RFC 8707 resource indicators for an interactive service-access review.
+    /// </summary>
+    Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+        string authorizationCode,
+        string codeVerifier,
+        string redirectUri,
+        IReadOnlyList<string>? resourceUris,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Resolves the NyxID owner of an existing binding through the owning
     /// client's binding-introspection endpoint. Used only to migrate legacy
     /// Aevatar binding documents that predate <c>owner_scope_id</c>.

--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -98,6 +98,13 @@ public sealed class NyxIdRemoteCapabilityBroker :
             _options.RequiredLlmServiceSlug,
             _options.AdditionalRequiredServiceSlugs);
 
+    private static string[] NormalizeResourceUris(IReadOnlyList<string>? resourceUris) =>
+        (resourceUris ?? [])
+            .Select(static resourceUri => resourceUri?.Trim() ?? string.Empty)
+            .Where(static resourceUri => !string.IsNullOrWhiteSpace(resourceUri))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
     public async Task<BindingChallenge> StartExternalBindingAsync(
         ExternalSubjectRef externalSubject,
         CancellationToken ct = default)
@@ -364,6 +371,7 @@ public sealed class NyxIdRemoteCapabilityBroker :
             codeVerifier,
             ResolveRedirectUri(),
             requireProvisionedRedirectUri: true,
+            resourceUris: null,
             ct);
     }
 
@@ -377,11 +385,31 @@ public sealed class NyxIdRemoteCapabilityBroker :
         ArgumentException.ThrowIfNullOrWhiteSpace(codeVerifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
 
+        return ExchangeAuthorizationCodeAsync(
+            authorizationCode,
+            codeVerifier,
+            redirectUri,
+            resourceUris: null,
+            ct);
+    }
+
+    public Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+        string authorizationCode,
+        string codeVerifier,
+        string redirectUri,
+        IReadOnlyList<string>? resourceUris,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(authorizationCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(codeVerifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
+
         return ExchangeAuthorizationCodeCoreAsync(
             authorizationCode,
             codeVerifier,
             redirectUri.Trim(),
             requireProvisionedRedirectUri: false,
+            resourceUris,
             ct);
     }
 
@@ -434,14 +462,13 @@ public sealed class NyxIdRemoteCapabilityBroker :
         string codeVerifier,
         string redirectUri,
         bool requireProvisionedRedirectUri,
+        IReadOnlyList<string>? resourceUris,
         CancellationToken ct)
     {
         var snapshot = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
         if (requireProvisionedRedirectUri)
             EnsureClientCurrent(snapshot, redirectUri);
 
-        // The authorization code already carries the user's finalized Consent selection.
-        // Repeating resource here would narrow that grant to Aevatar's minimum runtime set.
         var form = new List<KeyValuePair<string, string>>
         {
             new("grant_type", "authorization_code"),
@@ -450,6 +477,8 @@ public sealed class NyxIdRemoteCapabilityBroker :
             new("redirect_uri", redirectUri),
             new("client_id", snapshot.ClientId),
         };
+        foreach (var resourceUri in NormalizeResourceUris(resourceUris))
+            form.Add(new KeyValuePair<string, string>("resource", resourceUri));
 
         using var request = new HttpRequestMessage(
             HttpMethod.Post,

--- a/docs/history/2026-08-24-dinner-date-workflow-spec.md
+++ b/docs/history/2026-08-24-dinner-date-workflow-spec.md
@@ -13,36 +13,31 @@ This document is a non-authoritative implementation note for the UC5 dinner-date
 ```mermaid
 %%{init: {"flowchart": {"curve": "basis"}}}%%
 flowchart TD
-    A["Start: user request"] --> B["Prepare context"]
-    B --> C["Load participant context"]
-    C --> D["Load optional calendar context"]
-    D --> E["Discover restaurant candidates"]
-    E --> F["Build shortlist from candidates"]
-    F --> G["Show options"]
-    G --> H["Emit options_shown"]
-    H --> I["Persist wait state"]
-    I --> J{"Input outcome"}
+    A["Start: user request"] --> B["Prepare request context"]
+    B --> C["Discover restaurant candidates"]
+    C --> D["Build shortlist from candidates"]
+    D --> E["Show options"]
+    E --> F["Emit options_shown"]
+    F --> G{"Input outcome"}
 
-    J -->|"selected venue"| K["Record selected venue"]
-    K --> L["Assert selected-only hold policy"]
-    L --> M["Hold selected venue"]
-    M --> N["Verify selected hold proof"]
-    N --> O["Optional calendar post-action"]
-    O --> P["Emit completed"]
-    P --> Q["Final artifact: completed"]
+    G -->|"selected venue"| H["Record selected venue"]
+    H --> I["Assert selected-only hold policy"]
+    I --> J["Hold selected venue"]
+    J --> K["Verify selected hold proof"]
+    K --> L["Emit completed"]
+    L --> M["Final artifact: completed"]
 
-    J -->|"timeout / no_reply"| R["Wait silence timeout"]
-    R --> S["Hold all candidate venues<br/>tell restaurants decision comes tonight"]
-    S --> T["Verify hold proofs"]
-    T --> U["Wait for user choice after holds"]
-    U --> V["Release unselected venues"]
-    V --> W["Verify release proofs"]
-    W --> X["Optional calendar post-action"]
-    X --> Y["Emit completed"]
-    Y --> Z["Final artifact: completed"]
+    G -->|"timeout / no_reply"| N["Mark silence timeout"]
+    N --> O["Hold all candidate venues<br/>tell restaurants decision comes tonight"]
+    O --> P["Verify hold proofs"]
+    P --> Q["Wait for user choice after holds"]
+    Q --> R["Release unselected venues"]
+    R --> S["Verify release proofs"]
+    S --> T["Emit completed"]
+    T --> U["Final artifact: completed"]
 
-    J -->|"deposit required"| AA["Final artifact: failed"]
-    J -->|"ambiguous phone outcome"| AB["Final artifact: needs_attention"]
+    G -->|"deposit required"| V["Final artifact: failed"]
+    G -->|"ambiguous phone outcome"| W["Final artifact: needs_attention"]
 ```
 
 ## Current Template Nodes
@@ -51,16 +46,12 @@ The executable template is `workflows/dinner_date_mock.yaml`. These nodes are in
 
 | Boundary node | Current implementation | Replace with real connector? | Notes |
 |---|---|---:|---|
-| `load_participant_context` | `assign` mock | Optional | Can read Gmail, user memory, or profile data. Not required for core success. |
-| `load_optional_calendar_context` | `assign` mock | Optional | Calendar read only. Must not block the core workflow. |
 | `discover_restaurant_candidates` | `assign` mock | Recommended | Replace with search and page-fetch connectors. |
 | `build_shortlist_from_candidates` | `assign` mock | Maybe | Can remain LLM/internal planner if candidate discovery returns structured data. |
 | `hold_selected_venue` | `assign` mock | Required | Replace with one phone hold connector for the venue selected before timeout. |
 | `hold_candidate_*` | `assign` mock | Required | Replace with phone hold connectors for timeout hold-all path; each call should say the user decision comes tonight and unselected holds will be released. |
 | `release_unselected_*` | `assign` mock | Required | Replace with phone release connector. |
 | `handle_ambiguous_hold_outcome` | `assign` mock | Required behavior | Can become an output branch of the real phone connector rather than a separate tool. |
-| `decide_optional_calendar_selected_only` | `assign` skip | Optional | Replace with Calendar create/readback only after selected hold succeeds. |
-| `decide_optional_calendar_after_holds` | `assign` skip | Optional | Replace with Calendar create/readback only after final hold/release proof succeeds. |
 
 ## External Dependencies
 
@@ -111,24 +102,6 @@ venues:
     hold_status: not_started
 ```
 
-### Optional Google Context And Post-Action
-
-| Dependency | NyxID service | Used by template node(s) | Core success dependency? |
-|---|---|---|---:|
-| Gmail/history read | `api-google` | `load_participant_context` | No |
-| Calendar read | `api-google` | `load_optional_calendar_context` | No |
-| Calendar write/readback | `api-google` | `decide_optional_calendar_selected_only`, `decide_optional_calendar_after_holds` | No |
-
-Observed `api-google` default scopes were only:
-
-```text
-openid
-email
-profile
-```
-
-Those scopes are not enough for Gmail or Calendar. Enabling Google context requires explicit Gmail read and/or Calendar read/write scopes. Calendar write must remain an optional post-action: failure to create or verify a calendar event must not change a completed reservation flow into a failed workflow.
-
 ## Non-Connector Workflow Rules
 
 These nodes represent orchestration or policy and should generally stay stable when replacing mocks:
@@ -138,7 +111,7 @@ These nodes represent orchestration or policy and should generally stay stable w
 | `validate_no_external_effect_before_options` | No restaurant call, hold, release, or payment before visible options. |
 | `mark_options_shown` / `emit_options_shown` | Establish the boundary after which no-cost phone holds are allowed. |
 | `route_user_choice_before_timeout` | Route selected, timeout, deposit-required, and ambiguous outcomes. |
-| `assert_only_selected_hold_allowed` | If the user chooses before timeout, only the selected venue may be held. |
+| `assert_selected_hold_policy` | If the user chooses before timeout, only the selected venue may be held. |
 | `assert_hold_all_policy_after_timeout` | If the user is silent until timeout, no-cost holds may be attempted for all candidates. |
 | `verify_*` | Confirm that effect-capable connector outputs include proof and do not imply payment. |
 | `final_artifact_*` | Report completed, failed, or needs-attention outcomes without hiding uncertainty. |
@@ -153,12 +126,9 @@ Observed during local testing:
 | `tavily-search-chrono-ai` | Connected/available. |
 | `api-twilio` | Catalog exists, not observed connected in the current service list. |
 | `api-elevenlabs` | Catalog exists, not observed connected in the current service list. |
-| `api-google` | Catalog exists; observed default scopes are insufficient for Gmail/Calendar. |
 
 ## Open Questions
 
 1. Should candidate discovery require connected search/Firecrawl, or allow user-provided candidate restaurants as a fallback?
 2. Should timeout `hold_candidate_*` remain per-venue nodes, or collapse into one connector node once workflow support for array outputs and iteration is sufficient?
 3. Should ambiguous phone outcomes be represented as a separate workflow branch or only as `external_effect: unverified` from the phone connector?
-4. What exact Google OAuth scopes should be requested if optional Gmail/Calendar features are enabled?
-5. Should calendar creation be user-triggered after the final artifact, or automatic when Calendar write is connected?

--- a/docs/history/2026-08-24-dinner-date-workflow-spec.md
+++ b/docs/history/2026-08-24-dinner-date-workflow-spec.md
@@ -1,0 +1,301 @@
+---
+title: Dinner Date Workflow Spec Draft
+status: history
+owner: platform
+---
+
+# Dinner Date Workflow Spec Draft
+
+This document is a non-authoritative analysis draft derived from the UC5 "Dinner date" target-state transcript at `https://nyx-chat-wf.surge.sh/?lang=en#uc5`. It is not a canon architecture document. Use it as a working reference for turning the transcript into a workflow contract.
+
+## Goal
+
+Plan a dinner date with Priya this week while preserving these guarantees:
+
+- Show candidate restaurants before any phone hold or reservation action.
+- If the user is silent for ten minutes, hold all candidate restaurants by phone because holds cost no money under the stated user policy.
+- After the user chooses one restaurant, release every unchosen hold.
+- Produce a proof artifact backed by call records and transcripts.
+- Treat calendar creation as an optional post-action, not a core success condition.
+
+## Core Workflow
+
+### 1. Intake
+
+Trigger: user sends a plain-text request such as:
+
+```text
+Plan a dinner date with Priya this week.
+```
+
+Actions:
+
+- Create workflow task `task-uc5`.
+- Acknowledge that the assistant will read existing context, check availability, and return several options.
+- State explicitly that no restaurant will be phoned before the options are shown.
+
+Core state created:
+
+```yaml
+task_id: task-uc5
+revision: 1
+participant: Priya
+user_choice: null
+shortlist: []
+holds: []
+proofs: []
+```
+
+### 2. Context And Research
+
+Purpose: build a shortlist without external side effects.
+
+Steps:
+
+| Step | Source | External effect | Required for core workflow |
+|---|---|---:|---:|
+| Read past dinner confirmations | `api-google` Gmail | No | No |
+| Read Friday calendar availability | `api-google` Calendar | No | No |
+| Research relevant date/city context | web search or internal search skill | No | Recommended |
+| Fetch venue pages/photos/menu details | `api-firecrawl` | No | Recommended |
+| Build three-venue shortlist | LLM/internal planner | No | Yes |
+| Show options card | UI/workflow output | No | Yes |
+
+Notes:
+
+- Google context is useful, but the workflow can continue if Google is unavailable by asking the user for missing date/time/party-size assumptions.
+- Firecrawl/search improves candidate quality, but the workflow can also use user-provided candidate restaurants.
+- The options card is informational only. It must not be the only control surface; the user can choose by ordinary chat text.
+
+### 3. User Gate And Silence Timer
+
+After options are shown, the workflow waits for one of two events:
+
+```yaml
+wait_for:
+  - user_choice_text
+  - silence_timeout: 10m
+```
+
+Rules:
+
+- The ten-minute timer must be durable workflow/actor state.
+- It must not be implemented as process-local sleep, in-memory state, or a transient callback that can fire twice after restart.
+- If the user chooses before timeout, cancel the timer and hold only the selected restaurant.
+- If the timer fires first, cancel the pending input row and enter the hold-all branch.
+
+### 4. Hold Branch
+
+There are two legal hold paths.
+
+#### 4A. User Chooses Before Timeout
+
+If the user names one restaurant before the timer fires:
+
+- Call only that restaurant.
+- Ask for the requested time, indoor table, and allergy accommodations.
+- Verify the call record and transcript.
+- Continue to final artifact.
+
+#### 4B. User Is Silent For Ten Minutes
+
+If the user is silent for ten minutes:
+
+- Hold all three shortlisted restaurants by phone.
+- Do not choose for the user.
+- Tell each restaurant that a decision is coming tonight.
+- Record availability, seating, and allergy answers for each venue.
+
+For each venue, run the reusable `call-and-verify` step.
+
+```yaml
+call_and_verify:
+  - open_elevenlabs_channel
+  - create_twilio_call
+  - verify_twilio_call_record
+  - verify_elevenlabs_transcript
+```
+
+Required proof per hold:
+
+- Twilio call record exists and is completed.
+- ElevenLabs transcript exists and contains the restaurant answer.
+- Hold status is extracted from the transcript, not assumed from call success alone.
+
+### 5. Choice Continuation
+
+When the user later chooses a restaurant, start a continuation task such as `task-uc5b`.
+
+Reason: the prior task produced hold context; the later user choice is a new turn and should not be grafted into the old plan revision as if the user had answered earlier.
+
+Actions:
+
+- Record selected restaurant.
+- Record selection rationale if supplied by the user, such as pine nut allergy.
+- Release every held restaurant that was not selected.
+- Verify release calls with call records and transcripts.
+- Produce final artifact.
+
+### 6. Release Calls
+
+For every unchosen held venue:
+
+```yaml
+release_venue:
+  condition:
+    - venue.hold_status == confirmed
+    - venue.name != selected_venue
+  steps:
+    - open_elevenlabs_channel
+    - create_twilio_release_call
+    - verify_twilio_call_record
+    - verify_elevenlabs_transcript
+```
+
+Rules:
+
+- Do not release the selected venue.
+- Do not call a venue that was never held unless the workflow has explicit reason to reconcile ambiguous state.
+- Release calls are external effects and must be proven by transcript or call record evidence.
+
+### 7. Final Artifact
+
+The core workflow completes when the selected restaurant is held/confirmed, unchosen holds are released, and proof exists.
+
+Artifact fields:
+
+```yaml
+artifact:
+  title: Dinner date confirmation
+  kept:
+    venue: selected_venue
+    time: confirmed_time
+    party_size: 2
+    seating: indoors
+    hold_source: phone
+  released:
+    - venue_name
+  rationale:
+    - allergy_or_preference_reason
+    - availability_reason
+  assumptions:
+    - date_source
+    - time_source
+    - party_size_source
+  proof:
+    call_records: required
+    transcripts: required
+    calendar_readback: optional
+  approvals:
+    money_spent: false
+    user_visible_approval_count: 0
+    reason: reservation calls are auto-allowed and no money is spent
+```
+
+## Optional Post-Action: Calendar
+
+Calendar creation is not required for workflow success.
+
+```yaml
+optional_post_actions:
+  - id: create-calendar-event
+    service: api-google
+    required_for_workflow_success: false
+    condition:
+      - selected_venue_confirmed == true
+      - api-google.connected == true
+      - api-google.scopes includes calendar.write
+      - user_calendar_write_enabled == true
+    steps:
+      - create_calendar_event
+      - verify_calendar_event_by_readback
+    failure_handling:
+      calendar_scope_missing:
+        action: skip_optional_post_action
+        workflow_success_unchanged: true
+      calendar_write_failed:
+        action: report_optional_post_action_failed
+        workflow_success_unchanged: true
+```
+
+Calendar can improve user convenience, but the dinner date workflow is already successful if the reservation hold/release state and proof artifact are complete.
+
+## NyxID And External Dependency Points
+
+### Required For Core Workflow
+
+| Dependency | NyxID service | Why it is needed | Current availability observed |
+|---|---|---|---|
+| Outbound restaurant calls | `api-twilio` | Place hold and release calls | Catalog exists; not observed as connected in current service list |
+| Call transcript/proof | `api-elevenlabs` | Open call channel and read conversation transcript | Catalog exists; not observed as connected in current service list |
+| Restaurant phone endpoint | Not a NyxID service | Actual human-side hold/release happens by telephone | External real-world dependency |
+
+### Recommended For Better Shortlist
+
+| Dependency | NyxID service | Why it is useful | Current availability observed |
+|---|---|---|---|
+| Venue page scrape/photos/menu hints | `api-firecrawl` | Fetch venue-owned pages, images, allergy/menu evidence | Connected via ChronoAI org, allowed |
+| Search | custom/search service such as `tavily-search-chrono-ai` or internal search skill | Find candidate venues and date-specific city context | `tavily-search-chrono-ai` connected via ChronoAI org, allowed |
+
+### Optional Context Or Post-Action
+
+| Dependency | NyxID service | Why it is useful | Required? |
+|---|---|---|---:|
+| Gmail history | `api-google` | Infer usual dinner time, party size, preference history | No |
+| Calendar read | `api-google` | Check whether Friday evening is free | No |
+| Calendar write | `api-google` | Add final dinner plan to user's calendar | No |
+
+Important Google scope note:
+
+The NyxID catalog entry for `api-google` exists, but its default scopes were observed as only:
+
+```text
+openid
+email
+profile
+```
+
+Those scopes are not enough for Gmail or Calendar. A real workflow needs explicit Gmail read and Calendar read/write scopes if those optional features are enabled.
+
+## Policy And Approval Rules
+
+Core policy from the transcript:
+
+- No money may be spent.
+- Restaurant holds are treated as no-cost holds.
+- Reservation calls are auto-allowed under the user's preconfigured spending rules.
+- Nothing may be held before the user has seen the options.
+
+Required runtime behavior:
+
+- If a restaurant asks for a deposit, credit card, prepaid booking, cancellation fee, or any money commitment, stop that venue path and ask the user.
+- The workflow must not silently reinterpret a paid reservation as a no-cost hold.
+- Any effect-capable call must have a postcondition readback.
+
+## Open Questions
+
+1. Should the workflow require `api-firecrawl`, or allow a fallback where the user provides candidate restaurants manually?
+2. What exact service should implement web search: an internal `aevatar-web-search-skill`, `tavily-search-chrono-ai`, Firecrawl search, or another NyxID service?
+3. What exact Google OAuth scopes should be requested if optional Gmail/Calendar features are enabled?
+4. Should the ten-minute silence timeout be configurable, or fixed by the published workflow spec?
+5. Does auto-holding all three restaurants need an organization-level approval policy record, or is the user's stated spending rule enough?
+6. How should the workflow reconcile ambiguous telephone outcomes, such as a completed call with missing transcript or a transcript that does not clearly confirm the hold?
+7. Should release calls retry automatically if Twilio succeeds but the restaurant does not answer?
+8. Should final artifact generation require all releases to be proven, or can it complete with a warning if one release remains unverified?
+9. Where should venue phone numbers come from when Firecrawl/search results disagree?
+10. Should `task-uc5b` be represented as a child workflow, a continuation run, or a new workflow run linked by correlation id?
+11. Is there a need to notify the user before auto-holding all three, or is the prior visible ten-minute warning sufficient?
+12. Should calendar creation be offered as a user-visible optional action after the artifact, or run automatically when Google Calendar write is connected?
+
+## Minimal Success Contract
+
+A minimal implementation satisfies the transcript if all of these are true:
+
+- The user sees the shortlist before any restaurant is called.
+- The workflow waits for explicit text choice or a durable ten-minute silence timeout.
+- The workflow never spends money or gives payment details.
+- Every hold/release call has Twilio and transcript evidence, or is reported as unverified.
+- The selected venue is kept.
+- Unselected held venues are released or explicitly reported as release-unverified.
+- The final artifact clearly separates confirmed facts from assumptions.
+- Calendar creation is optional and cannot change core workflow success.

--- a/docs/history/2026-08-24-dinner-date-workflow-spec.md
+++ b/docs/history/2026-08-24-dinner-date-workflow-spec.md
@@ -20,25 +20,29 @@ flowchart TD
     E --> F["Build shortlist from candidates"]
     F --> G["Show options"]
     G --> H["Emit options_shown"]
-    H --> I{"User choice before timeout?"}
+    H --> I["Persist wait state"]
+    I --> J{"Input outcome"}
 
-    I -->|"selected venue"| J["Hold selected venue"]
-    J --> K["Verify selected hold proof"]
-    K --> L["Optional calendar post-action"]
-    L --> M["Emit completed"]
-    M --> N["Final artifact: completed"]
+    J -->|"selected venue"| K["Record selected venue"]
+    K --> L["Assert selected-only hold policy"]
+    L --> M["Hold selected venue"]
+    M --> N["Verify selected hold proof"]
+    N --> O["Optional calendar post-action"]
+    O --> P["Emit completed"]
+    P --> Q["Final artifact: completed"]
 
-    I -->|"silence timeout"| O["Hold candidate venues"]
-    O --> P["Verify hold proof"]
-    P --> Q["Receive user choice after holds"]
-    Q --> R["Release unselected venues"]
-    R --> S["Verify release proof"]
-    S --> T["Optional calendar post-action"]
-    T --> U["Emit completed"]
-    U --> V["Final artifact: completed"]
+    J -->|"timeout / no_reply"| R["Wait silence timeout"]
+    R --> S["Hold all candidate venues<br/>tell restaurants decision comes tonight"]
+    S --> T["Verify hold proofs"]
+    T --> U["Wait for user choice after holds"]
+    U --> V["Release unselected venues"]
+    V --> W["Verify release proofs"]
+    W --> X["Optional calendar post-action"]
+    X --> Y["Emit completed"]
+    Y --> Z["Final artifact: completed"]
 
-    I -->|"deposit required"| W["Final artifact: failed"]
-    I -->|"ambiguous phone outcome"| X["Final artifact: needs_attention"]
+    J -->|"deposit required"| AA["Final artifact: failed"]
+    J -->|"ambiguous phone outcome"| AB["Final artifact: needs_attention"]
 ```
 
 ## Current Template Nodes
@@ -51,8 +55,8 @@ The executable template is `workflows/dinner_date_mock.yaml`. These nodes are in
 | `load_optional_calendar_context` | `assign` mock | Optional | Calendar read only. Must not block the core workflow. |
 | `discover_restaurant_candidates` | `assign` mock | Recommended | Replace with search and page-fetch connectors. |
 | `build_shortlist_from_candidates` | `assign` mock | Maybe | Can remain LLM/internal planner if candidate discovery returns structured data. |
-| `hold_selected_*` | `assign` mock | Required | Replace with phone hold connector for selected-only path. |
-| `hold_candidate_*` | `assign` mock | Required | Replace with phone hold connector for timeout hold-all path. |
+| `hold_selected_venue` | `assign` mock | Required | Replace with one phone hold connector for the venue selected before timeout. |
+| `hold_candidate_*` | `assign` mock | Required | Replace with phone hold connectors for timeout hold-all path; each call should say the user decision comes tonight and unselected holds will be released. |
 | `release_unselected_*` | `assign` mock | Required | Replace with phone release connector. |
 | `handle_ambiguous_hold_outcome` | `assign` mock | Required behavior | Can become an output branch of the real phone connector rather than a separate tool. |
 | `decide_optional_calendar_selected_only` | `assign` skip | Optional | Replace with Calendar create/readback only after selected hold succeeds. |
@@ -64,9 +68,9 @@ The executable template is `workflows/dinner_date_mock.yaml`. These nodes are in
 
 | Dependency | NyxID service | Used by template node(s) | Required output fields |
 |---|---|---|---|
-| Outbound restaurant calls | `api-twilio` | `hold_selected_*`, `hold_candidate_*`, `release_unselected_*` | `twilio_call_record`, call status, call duration, error reason if failed |
-| Voice agent / transcript extraction | `api-elevenlabs` | `hold_selected_*`, `hold_candidate_*`, `release_unselected_*` | `elevenlabs_transcript`, extracted hold/release status, extracted payment request flag |
-| Restaurant phone endpoint | Not a NyxID service | `hold_selected_*`, `hold_candidate_*`, `release_unselected_*` | Real phone number, reachable status, restaurant-side answer |
+| Outbound restaurant calls | `api-twilio` | `hold_selected_venue`, `hold_candidate_*`, `release_unselected_*` | `twilio_call_record`, call status, call duration, error reason if failed |
+| Voice agent / transcript extraction | `api-elevenlabs` | `hold_selected_venue`, `hold_candidate_*`, `release_unselected_*` | `elevenlabs_transcript`, extracted hold/release status, extracted payment request flag |
+| Restaurant phone endpoint | Not a NyxID service | `hold_selected_venue`, `hold_candidate_*`, `release_unselected_*` | Real phone number, reachable status, restaurant-side answer |
 
 Required phone connector result shape:
 
@@ -75,6 +79,7 @@ venue: string
 venue_id: string
 action: hold | release
 external_effect: confirmed | unverified | failed
+restaurant_message: string
 twilio_call_record: string
 elevenlabs_transcript: string
 payment_requested: boolean
@@ -153,7 +158,7 @@ Observed during local testing:
 ## Open Questions
 
 1. Should candidate discovery require connected search/Firecrawl, or allow user-provided candidate restaurants as a fallback?
-2. Should `hold_selected_*` / `hold_candidate_*` remain per-venue nodes, or collapse into one connector node once workflow support for array outputs and iteration is sufficient?
+2. Should timeout `hold_candidate_*` remain per-venue nodes, or collapse into one connector node once workflow support for array outputs and iteration is sufficient?
 3. Should ambiguous phone outcomes be represented as a separate workflow branch or only as `external_effect: unverified` from the phone connector?
 4. What exact Google OAuth scopes should be requested if optional Gmail/Calendar features are enabled?
 5. Should calendar creation be user-triggered after the final artifact, or automatic when Calendar write is connected?

--- a/docs/history/2026-08-24-dinner-date-workflow-spec.md
+++ b/docs/history/2026-08-24-dinner-date-workflow-spec.md
@@ -6,248 +6,115 @@ owner: platform
 
 # Dinner Date Workflow Spec Draft
 
-This document is a non-authoritative analysis draft derived from the UC5 "Dinner date" target-state transcript at `https://nyx-chat-wf.surge.sh/?lang=en#uc5`. It is not a canon architecture document. Use it as a working reference for turning the transcript into a workflow contract.
+This document is a non-authoritative implementation note for the UC5 dinner-date workflow. It focuses on the executable workflow shape, connector replacement points, and external dependencies.
 
-## Goal
+## Main Flow
 
-Plan a dinner date with Priya this week while preserving these guarantees:
+```mermaid
+%%{init: {"flowchart": {"curve": "basis"}}}%%
+flowchart TD
+    A["Start: user request"] --> B["Prepare context"]
+    B --> C["Load participant context"]
+    C --> D["Load optional calendar context"]
+    D --> E["Discover restaurant candidates"]
+    E --> F["Build shortlist from candidates"]
+    F --> G["Show options"]
+    G --> H["Emit options_shown"]
+    H --> I{"User choice before timeout?"}
 
-- Show candidate restaurants before any phone hold or reservation action.
-- If the user is silent for ten minutes, hold all candidate restaurants by phone because holds cost no money under the stated user policy.
-- After the user chooses one restaurant, release every unchosen hold.
-- Produce a proof artifact backed by call records and transcripts.
-- Treat calendar creation as an optional post-action, not a core success condition.
+    I -->|"selected venue"| J["Hold selected venue"]
+    J --> K["Verify selected hold proof"]
+    K --> L["Optional calendar post-action"]
+    L --> M["Emit completed"]
+    M --> N["Final artifact: completed"]
 
-## Core Workflow
+    I -->|"silence timeout"| O["Hold candidate venues"]
+    O --> P["Verify hold proof"]
+    P --> Q["Receive user choice after holds"]
+    Q --> R["Release unselected venues"]
+    R --> S["Verify release proof"]
+    S --> T["Optional calendar post-action"]
+    T --> U["Emit completed"]
+    U --> V["Final artifact: completed"]
 
-### 1. Intake
-
-Trigger: user sends a plain-text request such as:
-
-```text
-Plan a dinner date with Priya this week.
+    I -->|"deposit required"| W["Final artifact: failed"]
+    I -->|"ambiguous phone outcome"| X["Final artifact: needs_attention"]
 ```
 
-Actions:
+## Current Template Nodes
 
-- Create workflow task `task-uc5`.
-- Acknowledge that the assistant will read existing context, check availability, and return several options.
-- State explicitly that no restaurant will be phoned before the options are shown.
+The executable template is `workflows/dinner_date_mock.yaml`. These nodes are intentionally named as connector boundaries even though they currently use deterministic `assign` mock outputs.
 
-Core state created:
+| Boundary node | Current implementation | Replace with real connector? | Notes |
+|---|---|---:|---|
+| `load_participant_context` | `assign` mock | Optional | Can read Gmail, user memory, or profile data. Not required for core success. |
+| `load_optional_calendar_context` | `assign` mock | Optional | Calendar read only. Must not block the core workflow. |
+| `discover_restaurant_candidates` | `assign` mock | Recommended | Replace with search and page-fetch connectors. |
+| `build_shortlist_from_candidates` | `assign` mock | Maybe | Can remain LLM/internal planner if candidate discovery returns structured data. |
+| `hold_selected_*` | `assign` mock | Required | Replace with phone hold connector for selected-only path. |
+| `hold_candidate_*` | `assign` mock | Required | Replace with phone hold connector for timeout hold-all path. |
+| `release_unselected_*` | `assign` mock | Required | Replace with phone release connector. |
+| `handle_ambiguous_hold_outcome` | `assign` mock | Required behavior | Can become an output branch of the real phone connector rather than a separate tool. |
+| `decide_optional_calendar_selected_only` | `assign` skip | Optional | Replace with Calendar create/readback only after selected hold succeeds. |
+| `decide_optional_calendar_after_holds` | `assign` skip | Optional | Replace with Calendar create/readback only after final hold/release proof succeeds. |
 
-```yaml
-task_id: task-uc5
-revision: 1
-participant: Priya
-user_choice: null
-shortlist: []
-holds: []
-proofs: []
-```
+## External Dependencies
 
-### 2. Context And Research
+### Required For Real Core Flow
 
-Purpose: build a shortlist without external side effects.
-
-Steps:
-
-| Step | Source | External effect | Required for core workflow |
-|---|---|---:|---:|
-| Read past dinner confirmations | `api-google` Gmail | No | No |
-| Read Friday calendar availability | `api-google` Calendar | No | No |
-| Research relevant date/city context | web search or internal search skill | No | Recommended |
-| Fetch venue pages/photos/menu details | `api-firecrawl` | No | Recommended |
-| Build three-venue shortlist | LLM/internal planner | No | Yes |
-| Show options card | UI/workflow output | No | Yes |
-
-Notes:
-
-- Google context is useful, but the workflow can continue if Google is unavailable by asking the user for missing date/time/party-size assumptions.
-- Firecrawl/search improves candidate quality, but the workflow can also use user-provided candidate restaurants.
-- The options card is informational only. It must not be the only control surface; the user can choose by ordinary chat text.
-
-### 3. User Gate And Silence Timer
-
-After options are shown, the workflow waits for one of two events:
-
-```yaml
-wait_for:
-  - user_choice_text
-  - silence_timeout: 10m
-```
-
-Rules:
-
-- The ten-minute timer must be durable workflow/actor state.
-- It must not be implemented as process-local sleep, in-memory state, or a transient callback that can fire twice after restart.
-- If the user chooses before timeout, cancel the timer and hold only the selected restaurant.
-- If the timer fires first, cancel the pending input row and enter the hold-all branch.
-
-### 4. Hold Branch
-
-There are two legal hold paths.
-
-#### 4A. User Chooses Before Timeout
-
-If the user names one restaurant before the timer fires:
-
-- Call only that restaurant.
-- Ask for the requested time, indoor table, and allergy accommodations.
-- Verify the call record and transcript.
-- Continue to final artifact.
-
-#### 4B. User Is Silent For Ten Minutes
-
-If the user is silent for ten minutes:
-
-- Hold all three shortlisted restaurants by phone.
-- Do not choose for the user.
-- Tell each restaurant that a decision is coming tonight.
-- Record availability, seating, and allergy answers for each venue.
-
-For each venue, run the reusable `call-and-verify` step.
-
-```yaml
-call_and_verify:
-  - open_elevenlabs_channel
-  - create_twilio_call
-  - verify_twilio_call_record
-  - verify_elevenlabs_transcript
-```
-
-Required proof per hold:
-
-- Twilio call record exists and is completed.
-- ElevenLabs transcript exists and contains the restaurant answer.
-- Hold status is extracted from the transcript, not assumed from call success alone.
-
-### 5. Choice Continuation
-
-When the user later chooses a restaurant, start a continuation task such as `task-uc5b`.
-
-Reason: the prior task produced hold context; the later user choice is a new turn and should not be grafted into the old plan revision as if the user had answered earlier.
-
-Actions:
-
-- Record selected restaurant.
-- Record selection rationale if supplied by the user, such as pine nut allergy.
-- Release every held restaurant that was not selected.
-- Verify release calls with call records and transcripts.
-- Produce final artifact.
-
-### 6. Release Calls
-
-For every unchosen held venue:
-
-```yaml
-release_venue:
-  condition:
-    - venue.hold_status == confirmed
-    - venue.name != selected_venue
-  steps:
-    - open_elevenlabs_channel
-    - create_twilio_release_call
-    - verify_twilio_call_record
-    - verify_elevenlabs_transcript
-```
-
-Rules:
-
-- Do not release the selected venue.
-- Do not call a venue that was never held unless the workflow has explicit reason to reconcile ambiguous state.
-- Release calls are external effects and must be proven by transcript or call record evidence.
-
-### 7. Final Artifact
-
-The core workflow completes when the selected restaurant is held/confirmed, unchosen holds are released, and proof exists.
-
-Artifact fields:
-
-```yaml
-artifact:
-  title: Dinner date confirmation
-  kept:
-    venue: selected_venue
-    time: confirmed_time
-    party_size: 2
-    seating: indoors
-    hold_source: phone
-  released:
-    - venue_name
-  rationale:
-    - allergy_or_preference_reason
-    - availability_reason
-  assumptions:
-    - date_source
-    - time_source
-    - party_size_source
-  proof:
-    call_records: required
-    transcripts: required
-    calendar_readback: optional
-  approvals:
-    money_spent: false
-    user_visible_approval_count: 0
-    reason: reservation calls are auto-allowed and no money is spent
-```
-
-## Optional Post-Action: Calendar
-
-Calendar creation is not required for workflow success.
-
-```yaml
-optional_post_actions:
-  - id: create-calendar-event
-    service: api-google
-    required_for_workflow_success: false
-    condition:
-      - selected_venue_confirmed == true
-      - api-google.connected == true
-      - api-google.scopes includes calendar.write
-      - user_calendar_write_enabled == true
-    steps:
-      - create_calendar_event
-      - verify_calendar_event_by_readback
-    failure_handling:
-      calendar_scope_missing:
-        action: skip_optional_post_action
-        workflow_success_unchanged: true
-      calendar_write_failed:
-        action: report_optional_post_action_failed
-        workflow_success_unchanged: true
-```
-
-Calendar can improve user convenience, but the dinner date workflow is already successful if the reservation hold/release state and proof artifact are complete.
-
-## NyxID And External Dependency Points
-
-### Required For Core Workflow
-
-| Dependency | NyxID service | Why it is needed | Current availability observed |
+| Dependency | NyxID service | Used by template node(s) | Required output fields |
 |---|---|---|---|
-| Outbound restaurant calls | `api-twilio` | Place hold and release calls | Catalog exists; not observed as connected in current service list |
-| Call transcript/proof | `api-elevenlabs` | Open call channel and read conversation transcript | Catalog exists; not observed as connected in current service list |
-| Restaurant phone endpoint | Not a NyxID service | Actual human-side hold/release happens by telephone | External real-world dependency |
+| Outbound restaurant calls | `api-twilio` | `hold_selected_*`, `hold_candidate_*`, `release_unselected_*` | `twilio_call_record`, call status, call duration, error reason if failed |
+| Voice agent / transcript extraction | `api-elevenlabs` | `hold_selected_*`, `hold_candidate_*`, `release_unselected_*` | `elevenlabs_transcript`, extracted hold/release status, extracted payment request flag |
+| Restaurant phone endpoint | Not a NyxID service | `hold_selected_*`, `hold_candidate_*`, `release_unselected_*` | Real phone number, reachable status, restaurant-side answer |
 
-### Recommended For Better Shortlist
+Required phone connector result shape:
 
-| Dependency | NyxID service | Why it is useful | Current availability observed |
+```yaml
+venue: string
+venue_id: string
+action: hold | release
+external_effect: confirmed | unverified | failed
+twilio_call_record: string
+elevenlabs_transcript: string
+payment_requested: boolean
+confirmed_time: string | null
+allergy_answer: string | null
+failure_reason: string | null
+```
+
+If `payment_requested` is true, the workflow must stop that path and return `deposit_required_failed`; it must not attempt payment or silently treat the reservation as free.
+
+### Recommended For Candidate Discovery
+
+| Dependency | NyxID service | Used by template node(s) | Purpose |
 |---|---|---|---|
-| Venue page scrape/photos/menu hints | `api-firecrawl` | Fetch venue-owned pages, images, allergy/menu evidence | Connected via ChronoAI org, allowed |
-| Search | custom/search service such as `tavily-search-chrono-ai` or internal search skill | Find candidate venues and date-specific city context | `tavily-search-chrono-ai` connected via ChronoAI org, allowed |
+| Web search | `tavily-search-chrono-ai` or equivalent | `discover_restaurant_candidates` | Find candidate restaurants, phone sources, hours, and venue-owned pages. |
+| Page fetch / extraction | `api-firecrawl` | `discover_restaurant_candidates`, possibly `build_shortlist_from_candidates` | Fetch menu, location, phone, allergy hints, reservation pages, and source evidence. |
 
-### Optional Context Or Post-Action
+Candidate discovery result should provide enough structured data for downstream calls:
 
-| Dependency | NyxID service | Why it is useful | Required? |
+```yaml
+venues:
+  - id: string
+    name: string
+    location: string
+    phone: string
+    requested_time: string
+    source_urls: [string]
+    menu_or_allergy_hint: string | null
+    hold_status: not_started
+```
+
+### Optional Google Context And Post-Action
+
+| Dependency | NyxID service | Used by template node(s) | Core success dependency? |
 |---|---|---|---:|
-| Gmail history | `api-google` | Infer usual dinner time, party size, preference history | No |
-| Calendar read | `api-google` | Check whether Friday evening is free | No |
-| Calendar write | `api-google` | Add final dinner plan to user's calendar | No |
+| Gmail/history read | `api-google` | `load_participant_context` | No |
+| Calendar read | `api-google` | `load_optional_calendar_context` | No |
+| Calendar write/readback | `api-google` | `decide_optional_calendar_selected_only`, `decide_optional_calendar_after_holds` | No |
 
-Important Google scope note:
-
-The NyxID catalog entry for `api-google` exists, but its default scopes were observed as only:
+Observed `api-google` default scopes were only:
 
 ```text
 openid
@@ -255,47 +122,38 @@ email
 profile
 ```
 
-Those scopes are not enough for Gmail or Calendar. A real workflow needs explicit Gmail read and Calendar read/write scopes if those optional features are enabled.
+Those scopes are not enough for Gmail or Calendar. Enabling Google context requires explicit Gmail read and/or Calendar read/write scopes. Calendar write must remain an optional post-action: failure to create or verify a calendar event must not change a completed reservation flow into a failed workflow.
 
-## Policy And Approval Rules
+## Non-Connector Workflow Rules
 
-Core policy from the transcript:
+These nodes represent orchestration or policy and should generally stay stable when replacing mocks:
 
-- No money may be spent.
-- Restaurant holds are treated as no-cost holds.
-- Reservation calls are auto-allowed under the user's preconfigured spending rules.
-- Nothing may be held before the user has seen the options.
+| Node | Rule |
+|---|---|
+| `validate_no_external_effect_before_options` | No restaurant call, hold, release, or payment before visible options. |
+| `mark_options_shown` / `emit_options_shown` | Establish the boundary after which no-cost phone holds are allowed. |
+| `route_user_choice_before_timeout` | Route selected, timeout, deposit-required, and ambiguous outcomes. |
+| `assert_only_selected_hold_allowed` | If the user chooses before timeout, only the selected venue may be held. |
+| `assert_hold_all_policy_after_timeout` | If the user is silent until timeout, no-cost holds may be attempted for all candidates. |
+| `verify_*` | Confirm that effect-capable connector outputs include proof and do not imply payment. |
+| `final_artifact_*` | Report completed, failed, or needs-attention outcomes without hiding uncertainty. |
 
-Required runtime behavior:
+## Current NyxID Availability Notes
 
-- If a restaurant asks for a deposit, credit card, prepaid booking, cancellation fee, or any money commitment, stop that venue path and ask the user.
-- The workflow must not silently reinterpret a paid reservation as a no-cost hold.
-- Any effect-capable call must have a postcondition readback.
+Observed during local testing:
+
+| Service | Status |
+|---|---|
+| `api-firecrawl` | Connected/available. |
+| `tavily-search-chrono-ai` | Connected/available. |
+| `api-twilio` | Catalog exists, not observed connected in the current service list. |
+| `api-elevenlabs` | Catalog exists, not observed connected in the current service list. |
+| `api-google` | Catalog exists; observed default scopes are insufficient for Gmail/Calendar. |
 
 ## Open Questions
 
-1. Should the workflow require `api-firecrawl`, or allow a fallback where the user provides candidate restaurants manually?
-2. What exact service should implement web search: an internal `aevatar-web-search-skill`, `tavily-search-chrono-ai`, Firecrawl search, or another NyxID service?
-3. What exact Google OAuth scopes should be requested if optional Gmail/Calendar features are enabled?
-4. Should the ten-minute silence timeout be configurable, or fixed by the published workflow spec?
-5. Does auto-holding all three restaurants need an organization-level approval policy record, or is the user's stated spending rule enough?
-6. How should the workflow reconcile ambiguous telephone outcomes, such as a completed call with missing transcript or a transcript that does not clearly confirm the hold?
-7. Should release calls retry automatically if Twilio succeeds but the restaurant does not answer?
-8. Should final artifact generation require all releases to be proven, or can it complete with a warning if one release remains unverified?
-9. Where should venue phone numbers come from when Firecrawl/search results disagree?
-10. Should `task-uc5b` be represented as a child workflow, a continuation run, or a new workflow run linked by correlation id?
-11. Is there a need to notify the user before auto-holding all three, or is the prior visible ten-minute warning sufficient?
-12. Should calendar creation be offered as a user-visible optional action after the artifact, or run automatically when Google Calendar write is connected?
-
-## Minimal Success Contract
-
-A minimal implementation satisfies the transcript if all of these are true:
-
-- The user sees the shortlist before any restaurant is called.
-- The workflow waits for explicit text choice or a durable ten-minute silence timeout.
-- The workflow never spends money or gives payment details.
-- Every hold/release call has Twilio and transcript evidence, or is reported as unverified.
-- The selected venue is kept.
-- Unselected held venues are released or explicitly reported as release-unverified.
-- The final artifact clearly separates confirmed facts from assumptions.
-- Calendar creation is optional and cannot change core workflow success.
+1. Should candidate discovery require connected search/Firecrawl, or allow user-provided candidate restaurants as a fallback?
+2. Should `hold_selected_*` / `hold_candidate_*` remain per-venue nodes, or collapse into one connector node once workflow support for array outputs and iteration is sufficient?
+3. Should ambiguous phone outcomes be represented as a separate workflow branch or only as `external_effect: unverified` from the phone connector?
+4. What exact Google OAuth scopes should be requested if optional Gmail/Calendar features are enabled?
+5. Should calendar creation be user-triggered after the final artifact, or automatic when Calendar write is connected?

--- a/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/NyxIdLoginFinalizationEndpoints.cs
@@ -227,11 +227,19 @@ public static class NyxIdLoginFinalizationEndpoints
         if (string.IsNullOrWhiteSpace(request.RedirectUri))
             return LoginFinalizationProblem(StatusCodes.Status400BadRequest, "redirect_uri_missing", "The login redirect URI is required.");
 
+        var resourceUris = request.ServiceAccessReview
+            ? NormalizeResourceUris(request.ResourceUris)
+            : Array.Empty<string>();
         BrokerAuthorizationCodeResult exchange;
         try
         {
             exchange = await brokerCallback
-                .ExchangeAuthorizationCodeAsync(request.Code.Trim(), request.CodeVerifier.Trim(), request.RedirectUri.Trim(), ct)
+                .ExchangeAuthorizationCodeAsync(
+                    request.Code.Trim(),
+                    request.CodeVerifier.Trim(),
+                    request.RedirectUri.Trim(),
+                    resourceUris,
+                    ct)
                 .ConfigureAwait(false);
         }
         catch (NyxIdRequiredServiceAccessException ex)
@@ -307,6 +315,15 @@ public static class NyxIdLoginFinalizationEndpoints
             ExternalUserId = user.Sub.Trim(),
         };
         var ownerScopeId = user.Sub.Trim();
+
+        if (!AccessTokenGrantsRequiredUserServices(exchange.AccessToken!, request.RequiredUserServiceIds))
+        {
+            await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+            return LoginFinalizationProblem(
+                StatusCodes.Status409Conflict,
+                "required_service_access_missing",
+                "Return to NyxID and keep every service marked as required by Aevatar selected.");
+        }
 
         var existingBinding = await bindingQueryPort.ResolveAsync(subject, ct).ConfigureAwait(false);
         if (existingBinding != null)
@@ -807,6 +824,76 @@ public static class NyxIdLoginFinalizationEndpoints
         return serviceIds.Length == 0 ? null : serviceIds;
     }
 
+    private static string[] NormalizeResourceUris(IReadOnlyList<string>? resourceUris) =>
+        (resourceUris ?? [])
+            .Select(static resourceUri => resourceUri?.Trim() ?? string.Empty)
+            .Where(static resourceUri => !string.IsNullOrWhiteSpace(resourceUri))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+    private static bool AccessTokenGrantsRequiredUserServices(
+        string accessToken,
+        IReadOnlyList<string>? requiredUserServiceIds)
+    {
+        var required = (requiredUserServiceIds ?? [])
+            .Select(static serviceId => serviceId?.Trim() ?? string.Empty)
+            .Where(static serviceId => !string.IsNullOrWhiteSpace(serviceId))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (required.Length == 0)
+            return true;
+
+        var parts = accessToken.Split('.');
+        if (parts.Length != 3)
+            return false;
+
+        try
+        {
+            var payload = parts[1]
+                .Replace('-', '+')
+                .Replace('_', '/');
+            payload = payload.PadRight(payload.Length + ((4 - payload.Length % 4) % 4), '=');
+            using var document = JsonDocument.Parse(Convert.FromBase64String(payload));
+            var root = document.RootElement;
+
+            if (root.TryGetProperty("allow_all_services", out var allowAllServices) &&
+                allowAllServices.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+                allowAllServices.GetBoolean())
+            {
+                return true;
+            }
+
+            var allowedServiceIds = ReadStringSet(root, "allowed_service_ids", out var hasAllowedServiceIds);
+            if (hasAllowedServiceIds)
+                return required.All(allowedServiceIds.Contains);
+
+            ReadStringSet(root, "resources", out var hasResourceRestriction);
+            return !hasResourceRestriction;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static HashSet<string> ReadStringSet(JsonElement owner, string propertyName, out bool present)
+    {
+        present = owner.TryGetProperty(propertyName, out var values)
+                  && values.ValueKind == JsonValueKind.Array;
+        return present
+            ? values.EnumerateArray()
+                .Where(static item => item.ValueKind == JsonValueKind.String)
+                .Select(static item => item.GetString()!)
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim())
+                .ToHashSet(StringComparer.Ordinal)
+            : [];
+    }
+
     private static string ToCatalogRefreshStatus(NyxIdAuthorizationCatalogRefreshStatus status) => status switch
     {
         NyxIdAuthorizationCatalogRefreshStatus.Observed => "observed",
@@ -963,6 +1050,7 @@ public sealed record NyxIdLoginFinalizationRequest
     public string? CodeVerifier { get; init; }
     public string? RedirectUri { get; init; }
     public bool ServiceAccessReview { get; init; }
+    public IReadOnlyList<string>? ResourceUris { get; init; }
     public IReadOnlyList<string>? RequiredUserServiceIds { get; init; }
 }
 

--- a/src/workflow/Aevatar.Workflow.Abstractions/NyxIdRequestSelectorContract.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/NyxIdRequestSelectorContract.cs
@@ -152,7 +152,8 @@ public static class NyxIdRequestSelectorContract
         NyxIdOperationRisk risk) => risk switch
         {
             NyxIdOperationRisk.ReadOnly =>
-                method is NyxIdRequestMethod.Get or NyxIdRequestMethod.Head or NyxIdRequestMethod.Options,
+                method is NyxIdRequestMethod.Get or NyxIdRequestMethod.Head or NyxIdRequestMethod.Options or
+                    NyxIdRequestMethod.Post,
             NyxIdOperationRisk.Write or NyxIdOperationRisk.Destructive => true,
             _ => false,
         };

--- a/test/Aevatar.AI.Tests/NyxIdExplicitWorkflowCapabilitySourceTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdExplicitWorkflowCapabilitySourceTests.cs
@@ -298,21 +298,30 @@ public sealed class NyxIdExplicitWorkflowCapabilitySourceTests
     }
 
     [Fact]
-    public async Task InspectAsync_ShouldAdmitExplicitReadOnlyPostForInteractiveExecutionOnly()
+    public async Task InspectAsync_ShouldAdmitExplicitReadOnlyPostForDurableExecution()
     {
-        var source = CreateSource(new InventoryHandler(UserServiceKeys(Service())));
+        var catalog = new RecordingCatalogQueryPort(ReadyCatalogSnapshot());
+        var source = CreateSource(new InventoryHandler(UserServiceKeys(Service())), catalog);
 
         var result = await source.InspectAsync(
             Access(),
             Selector(NyxIdRequestMethod.Post, NyxIdOperationRisk.ReadOnly),
-            ExternalCapabilityExecutionMode.Interactive,
+            ExternalCapabilityExecutionMode.Durable,
             CancellationToken.None);
 
         result.Status.Should().Be(ExternalCapabilityReadinessStatus.Ready);
         var policy = result.SelectedCapability.NyxIdUserRequest.ExecutionPolicy;
         policy.Risk.Should().Be(NyxIdOperationRisk.ReadOnly);
         policy.Approval.Should().Be(NyxIdOperationApproval.None);
-        policy.AllowedExecutionModes.Should().Equal(ExternalCapabilityExecutionMode.Interactive);
+        policy.AllowedExecutionModes.Should().Equal(
+            ExternalCapabilityExecutionMode.Interactive,
+            ExternalCapabilityExecutionMode.Durable);
+        result.Sources.Select(static source => source.SourceKind).Should().BeEquivalentTo(new[]
+        {
+            ExternalCapabilitySourceKind.NyxIdUserServices,
+            ExternalCapabilitySourceKind.DurableAuthorizationCatalog,
+        });
+        catalog.ReadCount.Should().Be(1);
     }
 
     [Theory]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -136,6 +136,38 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
     }
 
     [Fact]
+    public async Task ExchangeAuthorizationCodeAsync_WithResourceUris_AppendsResourceIndicators()
+    {
+        var handler = StubHandler.Text(HttpStatusCode.OK,
+            """
+            {
+              "binding_id": "bnd-user",
+              "access_token": "access-token",
+              "id_token": "id-token",
+              "token_type": "Bearer"
+            }
+            """);
+        var broker = NewBroker(
+            NewSnapshot(NyxIdRedirectUriResolver.Resolve()),
+            httpHandler: handler);
+
+        await broker.ExchangeAuthorizationCodeAsync(
+            "auth-code",
+            "verifier",
+            "http://localhost/auth/callback",
+            [
+                " https://api.example.test/api/v1/proxy/s/tavily ",
+                "https://api.example.test/api/v1/proxy/s/tavily",
+                "https://api.example.test/api/v1/proxy/s/aevatar",
+            ]);
+
+        var form = QueryHelpers.ParseQuery($"?{handler.LastRequestBody}");
+        form["resource"].Should().Equal(
+            "https://api.example.test/api/v1/proxy/s/tavily",
+            "https://api.example.test/api/v1/proxy/s/aevatar");
+    }
+
+    [Fact]
     public async Task StartExternalBindingAsync_EmitsAuthorizeUrlOnlyWhenRedirectUriMatches()
     {
         var expectedRedirectUri = NyxIdRedirectUriResolver.Resolve();

--- a/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/NyxIdLoginFinalizationEndpointsTests.cs
@@ -461,6 +461,11 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         var catalog = new RecordingCatalogQueryPort(CatalogSnapshot(
             23,
             services: [CatalogService("user-service-local-aevatar")]));
+        var accessToken = CreateAccessToken(new
+        {
+            allowed_service_ids = new[] { "user-service-local-aevatar" },
+            allow_all_services = false,
+        });
         var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
             new NyxIdLoginFinalizationRequest
             {
@@ -472,7 +477,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
                 "binding-alpha",
                 CreateIdToken(new { uid = "nyx-owner-alpha" }),
-                "bearer-alpha")),
+                accessToken)),
             new UsableCapabilityBroker(),
             new FakeExternalIdentityBindingQueryPort(),
             new RecordingBindingDispatch(),
@@ -493,10 +498,46 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             OwnerKind = AuthorizationOwnerKind.Personal,
             OwnerSubject = "nyx-owner-alpha",
         });
-        targeted.BearerToken.Should().Be("bearer-alpha");
+        targeted.BearerToken.Should().Be(accessToken);
         targeted.Request.RequiredServices.Should().ContainSingle()
             .Which.UserServiceId.Should().Be("user-service-local-aevatar");
         targeted.Request.LLMTarget.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Finalize_WithRequiredUserServiceIds_ShouldRejectBindingWhenAccessTokenGrantIsMissingService()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            "binding-alpha",
+            CreateIdToken(new { uid = "nyx-owner-alpha" }),
+            CreateAccessToken(new
+            {
+                allowed_service_ids = new[] { "user-service-other" },
+                allow_all_services = false,
+            })));
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+                RequiredUserServiceIds = ["user-service-local-aevatar"],
+            },
+            broker,
+            new UsableCapabilityBroker(),
+            new FakeExternalIdentityBindingQueryPort(),
+            new RecordingBindingDispatch(),
+            new RecordingBindingReplaceDispatch(),
+            NullLoggerFactory.Instance);
+
+        var (statusCode, payload) = await ExecuteJsonAsync<LoginErrorResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status409Conflict);
+        payload.Should().Be(new LoginErrorResponse(
+            "required_service_access_missing",
+            "Return to NyxID and keep every service marked as required by Aevatar selected."));
+        broker.RevokedBindingIds.Should().Equal("binding-alpha");
     }
 
     [Fact]
@@ -724,7 +765,11 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
 
         var (statusCode, payload) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
 
-        broker.Exchanges.Should().ContainSingle().Which.Should().Be(("auth-code", "pkce-verifier", "http://localhost/auth/callback"));
+        var exchange = broker.Exchanges.Should().ContainSingle().Which;
+        exchange.Code.Should().Be("auth-code");
+        exchange.CodeVerifier.Should().Be("pkce-verifier");
+        exchange.RedirectUri.Should().Be("http://localhost/auth/callback");
+        exchange.ResourceUris.Should().BeEmpty();
         statusCode.Should().Be(StatusCodes.Status200OK);
         payload.Should().NotBeNull();
         payload!.BindingDispatchAccepted.Should().BeTrue();
@@ -744,6 +789,50 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             BindingId = "bnd-owner-1",
             OwnerScopeId = "owner-user-1",
         });
+    }
+
+    [Fact]
+    public async Task Finalize_WithServiceAccessReview_ShouldForwardRequestedResources()
+    {
+        var broker = new RecordingBrokerCallback(new BrokerAuthorizationCodeResult(
+            BindingId: "bnd-owner-1",
+            IdToken: CreateIdToken(new { uid = "owner-user-1" }),
+            AccessToken: CreateAccessToken(new
+            {
+                allowed_service_ids = new[] { "svc-tavily" },
+                allow_all_services = false,
+            })));
+        var queryPort = new FakeExternalIdentityBindingQueryPort();
+
+        var result = await NyxIdLoginFinalizationEndpoints.HandleFinalizeAsync(
+            new NyxIdLoginFinalizationRequest
+            {
+                Code = "auth-code",
+                CodeVerifier = "pkce-verifier",
+                RedirectUri = "http://localhost/auth/callback",
+                ServiceAccessReview = true,
+                ResourceUris =
+                [
+                    " https://nyx.example/api/v1/proxy/s/tavily ",
+                    "https://nyx.example/api/v1/proxy/s/tavily",
+                    "https://nyx.example/api/v1/proxy/s/aevatar",
+                ],
+                RequiredUserServiceIds = ["svc-tavily"],
+            },
+            broker,
+            new UsableCapabilityBroker(),
+            queryPort,
+            new RecordingBindingDispatch(),
+            new RecordingBindingReplaceDispatch(),
+            NullLoggerFactory.Instance);
+
+        var (statusCode, _) = await ExecuteJsonAsync<NyxIdLoginFinalizationResponse>(result);
+
+        statusCode.Should().Be(StatusCodes.Status200OK);
+        var exchange = broker.Exchanges.Should().ContainSingle().Which;
+        exchange.ResourceUris.Should().Equal(
+            "https://nyx.example/api/v1/proxy/s/tavily",
+            "https://nyx.example/api/v1/proxy/s/aevatar");
     }
 
     [Fact]
@@ -1323,6 +1412,13 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
         return $"{header}.{body}.";
     }
 
+    private static string CreateAccessToken(object payload)
+    {
+        var header = Base64Url(JsonSerializer.SerializeToUtf8Bytes(new { alg = "none" }));
+        var body = Base64Url(JsonSerializer.SerializeToUtf8Bytes(payload));
+        return $"{header}.{body}.";
+    }
+
     private static string Base64Url(byte[] bytes) =>
         Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
@@ -1516,7 +1612,7 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
     {
         public Exception? ExchangeError { get; init; }
         public List<string> RevokedBindingIds { get; } = [];
-        public List<(string Code, string CodeVerifier, string RedirectUri)> Exchanges { get; } = [];
+        public List<(string Code, string CodeVerifier, string RedirectUri, IReadOnlyList<string>? ResourceUris)> Exchanges { get; } = [];
 
         public Task<CallbackStateDecode> TryDecodeStateTokenAsync(string stateToken, CancellationToken ct = default) =>
             Task.FromResult(CallbackStateDecode.Failed("not_supported"));
@@ -1531,9 +1627,17 @@ public sealed class NyxIdLoginFinalizationEndpointsTests
             string authorizationCode,
             string codeVerifier,
             string redirectUri,
+            CancellationToken ct = default) =>
+            ExchangeAuthorizationCodeAsync(authorizationCode, codeVerifier, redirectUri, null, ct);
+
+        public Task<BrokerAuthorizationCodeResult> ExchangeAuthorizationCodeAsync(
+            string authorizationCode,
+            string codeVerifier,
+            string redirectUri,
+            IReadOnlyList<string>? resourceUris,
             CancellationToken ct = default)
         {
-            Exchanges.Add((authorizationCode, codeVerifier, redirectUri));
+            Exchanges.Add((authorizationCode, codeVerifier, redirectUri, resourceUris));
             if (ExchangeError is not null)
                 return Task.FromException<BrokerAuthorizationCodeResult>(ExchangeError);
             return Task.FromResult(result);

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowExternalCapabilityAdmissionServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowExternalCapabilityAdmissionServiceTests.cs
@@ -606,7 +606,7 @@ public sealed class WorkflowExternalCapabilityAdmissionServiceTests
     }
 
     [Fact]
-    public void Create_ShouldRejectDurableExplicitReadOnlyPostGrant()
+    public void Create_ShouldAcceptDurableExplicitReadOnlyPostGrant()
     {
         var admission = ExplicitAdmissionFor(
             NyxIdRequestMethod.Post,
@@ -614,7 +614,7 @@ public sealed class WorkflowExternalCapabilityAdmissionServiceTests
             ExternalCapabilityExecutionMode.Interactive,
             ExternalCapabilityExecutionMode.Durable);
 
-        var act = () => WorkflowCapabilityAdmissionPlanIntegrity.Create(
+        var plan = WorkflowCapabilityAdmissionPlanIntegrity.Create(
             "name: explicit-workflow\nsteps: []\n",
             new Dictionary<string, string>(),
             ExternalCapabilityExecutionMode.Durable,
@@ -624,8 +624,9 @@ public sealed class WorkflowExternalCapabilityAdmissionServiceTests
             workflowId: ExplicitWorkflowId,
             revisionId: ExplicitRevisionId);
 
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("*durable*");
+        plan.InvocationAdmissions.Should().ContainSingle().Which
+            .Capability.NyxIdUserRequest.ExecutionPolicy.AllowedExecutionModes.Should()
+            .Contain(ExternalCapabilityExecutionMode.Durable);
     }
 
     [Theory]

--- a/test/Aevatar.Workflow.Core.Tests/NyxIdRequestSelectorContractTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/NyxIdRequestSelectorContractTests.cs
@@ -33,7 +33,7 @@ public sealed class NyxIdRequestSelectorContractTests
     }
 
     [Fact]
-    public void IsDurableEligible_ShouldRejectExplicitReadOnlyPost()
+    public void IsDurableEligible_ShouldAcceptExplicitReadOnlyPost()
     {
         var selector = ValidSelector("/api/query");
         selector.Method = NyxIdRequestMethod.Post;
@@ -47,7 +47,7 @@ public sealed class NyxIdRequestSelectorContractTests
             out var effectiveRisk).Should().BeTrue();
         NyxIdRequestSelectorContract.SupportsDurableExecution(
             selector.Method,
-            effectiveRisk).Should().BeFalse();
+            effectiveRisk).Should().BeTrue();
     }
 
     [Fact]

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -1,6 +1,6 @@
 name: dinner_date_mock
-description: Template-oriented executable workflow for the UC5 dinner-date flow. Connector boundary nodes currently use deterministic mock assign outputs and can later be replaced with real NyxID-backed tool calls without changing the orchestration backbone.
-when_to_use: Use to validate the dinner-date shortlist, policy gates, silence timeout, hold-all, release, proof artifact, and optional calendar flow before replacing connector boundary nodes for Google, Firecrawl, Twilio, ElevenLabs, or restaurant calls.
+description: Executable mock workflow for the UC5 dinner-date restaurant discovery and phone reservation flow. Restaurant research and phone outcomes are deterministic mock assign nodes.
+when_to_use: Use to validate shortlist, option gate, selected hold, timeout hold-all/release, deposit-blocked, ambiguous-outcome, and proof artifact flow before replacing connector boundary nodes.
 configuration:
   closed_world_mode: true
 roles: []
@@ -16,98 +16,35 @@ steps:
     type: assign
     parameters:
       target: dinner_date_context
-      value: '{"task_id":"task-uc5","revision":1,"participant":"Priya","requested_window":"this week","party_size":2,"preferred_day":"Friday","preferred_time":"19:30","policy":{"money_spend_allowed":false,"reservation_calls_auto_allowed":true,"no_hold_before_options_shown":true},"external_dependency_mode":"mock","status":"initialized"}'
-    next: normalize_request
-
-  - id: normalize_request
-    type: assign
-    parameters:
-      target: normalized_request
-      value: '{"intent":"plan_dinner_date","participant":"Priya","requested_window":"this week","constraints":["show_options_before_calls","no_money_spent","phone_holds_allowed_after_options","release_unchosen_holds","proof_required"],"input_choice_hint":"${steps.capture_user_choice.output}"}'
-    next: resolve_assumptions
-
-  - id: resolve_assumptions
-    type: assign
-    parameters:
-      target: planning_assumptions
-      value: '{"date_source":"mock_calendar_and_history","time_source":"mock_history_preference","party_size_source":"mock_history_preference","assumptions":["Friday evening is available","party size is two","indoor seating preferred"],"requires_user_clarification":false}'
-    next: validate_no_external_effect_before_options
-
-  - id: validate_no_external_effect_before_options
-    type: assign
-    parameters:
-      target: pre_options_policy_check
-      value: '{"options_shown":false,"restaurant_calls_started":false,"money_spent":false,"result":"pass","enforced_rules":["no_hold_before_options_shown","no_payment_without_user_approval"]}'
-    next: load_participant_context
-
-  - id: load_participant_context
-    type: assign
-    parameters:
-      target: google_history_context
-      value: '{"mocked_service":"api-google","required_for_core_workflow":false,"status":"skipped_or_mocked","facts":{"past_confirmations":4,"latest_confirmation":"2026-03-14","usual_day":"Friday","usual_time":"19:30","party_size":2,"dietary_note":"one old vegetarian note, owner unknown"}}'
-    next: load_optional_calendar_context
-
-  - id: load_optional_calendar_context
-    type: assign
-    parameters:
-      target: google_calendar_context
-      value: '{"mocked_service":"api-google","required_for_core_workflow":false,"status":"skipped_or_mocked","facts":{"friday_evening_free":true},"calendar_write":"optional_post_action_only"}'
-    next: build_research_plan
-
-  - id: build_research_plan
-    type: assign
-    parameters:
-      target: venue_research_plan
-      value: '{"query":"romantic indoor dinner near Keong Saik or Duxton Friday 19:30","candidate_count_target":3,"evidence_needed":["availability","phone","menu_or_allergy_hint","venue_owned_page"],"side_effects_allowed":false}'
+      value: '{"task_id":"task-uc5","participant":"Priya","window":"this week","party_size":2,"day":"Friday","time":"19:30","policy":{"show_options_before_calls":true,"money_spend_allowed":false,"reservation_calls_auto_allowed":true},"mode":"mock"}'
     next: discover_restaurant_candidates
 
   - id: discover_restaurant_candidates
     type: assign
     parameters:
       target: venue_research_context
-      value: '{"mocked_services":["web-search","api-firecrawl"],"required_for_core_workflow":false,"recommended":true,"facts":{"date_context":"seventh lunar month; indoor seating preferred","photo_source":"mock venue-owned pages","candidate_count":3,"candidate_source_quality":"sufficient_for_mock"}}'
+      value: '{"mocked_services":["web-search","api-firecrawl"],"query":"romantic indoor dinner near Keong Saik or Duxton Friday 19:30","candidate_count":3,"side_effects_allowed":false}'
     next: build_shortlist_from_candidates
 
   - id: build_shortlist_from_candidates
     type: assign
     parameters:
       target: dinner_shortlist
-      value: '{"options_shown":false,"venues":[{"id":"ember_oak","name":"Ember & Oak","location":"Keong Saik","phone":"mock-phone-ember-oak","requested_time":"19:30","seating":"indoors","note":"menu lists no nuts anywhere; verify by phone","hold_status":"not_started"},{"id":"casa_nera","name":"Casa Nera","location":"Duxton Hill","phone":"mock-phone-casa-nera","requested_time":"19:30","seating":"indoors","note":"visited three times; verify pine nuts by phone","hold_status":"not_started"},{"id":"atlas_row","name":"Atlas Row","location":"Amoy Street","phone":"mock-phone-atlas-row","requested_time":"19:30","seating":"indoors","note":"best reviewed kitchen; verify availability and nuts by phone","hold_status":"not_started"}]}'
-    next: validate_shortlist
-
-  - id: validate_shortlist
-    type: assign
-    parameters:
-      target: shortlist_validation
-      value: '{"venue_count":3,"has_phone_for_each":true,"has_user_visible_choice_key_for_each":true,"has_allergy_question_for_each":true,"result":"pass"}'
-    next: render_options_card
-
-  - id: render_options_card
-    type: assign
-    parameters:
-      target: options_card
-      value: '{"title":"Dinner date options","body":"Three options are ready. No restaurant has been called or held yet.","options":[{"choice_key":"ember_oak","label":"Ember & Oak","summary":"Keong Saik, indoor table, strongest nut-safety signal"},{"choice_key":"casa_nera","label":"Casa Nera","summary":"Duxton Hill, familiar venue, pine nuts must be checked"},{"choice_key":"atlas_row","label":"Atlas Row","summary":"Amoy Street, strong reviews, availability may be 20:00"}],"external_effect":"not_applied"}'
+      value: '{"venues":[{"id":"ember_oak","name":"Ember & Oak","phone":"mock-phone-ember-oak","time":"19:30","note":"nut-free kitchen claim; verify by phone"},{"id":"casa_nera","name":"Casa Nera","phone":"mock-phone-casa-nera","time":"19:30","note":"verify pine nuts by phone"},{"id":"atlas_row","name":"Atlas Row","phone":"mock-phone-atlas-row","time":"20:00","note":"verify availability and nuts by phone"}]}'
     next: mark_options_shown
 
   - id: mark_options_shown
     type: assign
     parameters:
       target: options_gate
-      value: '{"options_shown":true,"external_effect":"not_applied","message":"Three options have been shown. No restaurant has been called or held yet.","available_user_action":"name one venue in plain text","silence_timeout_ms":2000,"production_timeout":"10m"}'
+      value: '{"options_shown":true,"restaurant_calls_started":false,"money_spent":false,"silence_timeout_ms":2000,"production_timeout":"10m"}'
     next: emit_options_shown
 
   - id: emit_options_shown
     type: emit
     parameters:
       event_type: "dinner_date.options_shown"
-      payload: "${steps.options_card.output}"
-    next: persist_wait_state
-
-  - id: persist_wait_state
-    type: assign
-    parameters:
-      target: wait_state
-      value: '{"wait_id":"wait-task-uc5-choice","stored_in":"mock_durable_workflow_state","accepted_signals":["ember_oak","casa_nera","atlas_row"],"timeout":"10m","test_timeout_ms":2000,"status":"armed"}'
+      payload: "${steps.build_shortlist_from_candidates.output}"
     next: route_user_choice_before_timeout
 
   - id: route_user_choice_before_timeout
@@ -117,49 +54,30 @@ steps:
       branch.timeout: wait_for_silence_timeout
       branch.no_reply: wait_for_silence_timeout
       branch.deposit: final_artifact_payment_blocked
+      branch.deposit_required: final_artifact_payment_blocked
       branch.ambiguous: handle_ambiguous_hold_outcome
-      branch._default: record_selected_venue_before_timeout
+      branch._default: hold_selected_venue
     branches:
       timeout: wait_for_silence_timeout
       no_reply: wait_for_silence_timeout
       deposit: final_artifact_payment_blocked
+      deposit_required: final_artifact_payment_blocked
       ambiguous: handle_ambiguous_hold_outcome
-      _default: record_selected_venue_before_timeout
-
-  - id: record_selected_venue_before_timeout
-    type: assign
-    parameters:
-      target: user_gate_result
-      value: '{"status":"answered_before_timeout","selected_venue":"${steps.capture_user_choice.output}","timeout_cancelled":true,"pending_input_status":"answered"}'
-    next: assert_only_selected_hold_allowed
-
-  - id: assert_only_selected_hold_allowed
-    type: assign
-    parameters:
-      target: selected_only_policy_check
-      value: '{"path":"user_choice_before_timeout","hold_all_allowed":false,"unselected_holds_started":false,"result":"pass"}'
-    next: hold_selected_venue
+      _default: hold_selected_venue
 
   - id: hold_selected_venue
     type: assign
-    idempotency_key: "${run_id}:hold:selected_venue:selected_only"
+    idempotency_key: "${run_id}:hold:selected_venue"
     parameters:
       target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"${steps.capture_user_choice.output}","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-selected-venue","elevenlabs_transcript":"mock-transcript-hold-selected-venue","confirmed_time":"19:30","allergy_answer":"mock connector verified availability and allergy notes for the selected venue","payment_requested":false}'
+      value: '{"mocked_services":["api-twilio","api-elevenlabs","restaurant-phone"],"venue":"${steps.capture_user_choice.output}","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-selected-venue","elevenlabs_transcript":"mock-transcript-hold-selected-venue","confirmed_time":"19:30","allergy_answer":"availability and allergy notes verified for selected venue","payment_requested":false}'
     next: verify_selected_hold_record
 
   - id: verify_selected_hold_record
     type: assign
     parameters:
       target: selected_hold_verification
-      value: '{"call_record_present":true,"call_completed":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
-    next: decide_optional_calendar_selected_only
-
-  - id: decide_optional_calendar_selected_only
-    type: assign
-    parameters:
-      target: optional_calendar_decision
-      value: '{"post_action":"calendar_create","required_for_workflow_success":false,"api_google_calendar_write_connected":false,"decision":"skip_optional_post_action","workflow_success_unchanged":true}'
+      value: '{"hold_confirmed":true,"call_record_present":true,"transcript_present":true,"payment_requested":false,"result":"pass"}'
     next: emit_selected_only_completed
 
   - id: emit_selected_only_completed
@@ -173,7 +91,7 @@ steps:
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.hold_selected_venue.json.venue}","released":[],"calendar_post_action":"optional_skipped","proof":{"call_records":["${steps.hold_selected_venue.json.twilio_call_record}"],"transcripts":["${steps.hold_selected_venue.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+      value: '{"workflow_status":"completed","path":"selected_venue_mainline","kept":"${steps.hold_selected_venue.json.venue}","released":[],"proof":{"call_records":["${steps.hold_selected_venue.json.twilio_call_record}"],"transcripts":["${steps.hold_selected_venue.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
     next: ""
 
   - id: wait_for_silence_timeout
@@ -186,14 +104,7 @@ steps:
     type: assign
     parameters:
       target: user_gate_result
-      value: '{"status":"timeout","production_timeout":"10m","test_timeout_ms":2000,"pending_input_status":"cancelled","next_branch":"hold_all"}'
-    next: assert_hold_all_policy_after_timeout
-
-  - id: assert_hold_all_policy_after_timeout
-    type: assign
-    parameters:
-      target: hold_all_policy_check
-      value: '{"path":"silence_timeout","options_shown":true,"timeout_elapsed":true,"reservation_calls_auto_allowed":true,"money_spend_allowed":false,"result":"pass"}'
+      value: '{"status":"timeout","next_branch":"hold_all","message":"Holding all three because no choice arrived before timeout."}'
     next: hold_candidate_ember_oak
 
   - id: hold_candidate_ember_oak
@@ -201,14 +112,7 @@ steps:
     idempotency_key: "${run_id}:hold:ember_oak:timeout"
     parameters:
       target: hold_ember_oak
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; user decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false,"duration":"1m12s"}'
-    next: verify_hold_ember_oak
-
-  - id: verify_hold_ember_oak
-    type: assign
-    parameters:
-      target: hold_ember_oak_verification
-      value: '{"venue":"Ember & Oak","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
+      value: '{"mocked_services":["api-twilio","api-elevenlabs","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false}'
     next: hold_candidate_casa_nera
 
   - id: hold_candidate_casa_nera
@@ -216,14 +120,7 @@ steps:
     idempotency_key: "${run_id}:hold:casa_nera:timeout"
     parameters:
       target: hold_casa_nera
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; user decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false,"duration":"1m48s"}'
-    next: verify_hold_casa_nera
-
-  - id: verify_hold_casa_nera
-    type: assign
-    parameters:
-      target: hold_casa_nera_verification
-      value: '{"venue":"Casa Nera","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
+      value: '{"mocked_services":["api-twilio","api-elevenlabs","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false}'
     next: hold_candidate_atlas_row
 
   - id: hold_candidate_atlas_row
@@ -231,42 +128,21 @@ steps:
     idempotency_key: "${run_id}:hold:atlas_row:timeout"
     parameters:
       target: hold_atlas_row
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; user decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false,"duration":"2m03s"}'
-    next: verify_hold_atlas_row
-
-  - id: verify_hold_atlas_row
-    type: assign
-    parameters:
-      target: hold_atlas_row_verification
-      value: '{"venue":"Atlas Row","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
-    next: aggregate_hold_results
-
-  - id: aggregate_hold_results
-    type: assign
-    parameters:
-      target: hold_summary
-      value: '{"status":"all_three_held","selected_venue":null,"message":"All three mock holds are confirmed. Workflow is waiting for the user to choose one.","holds":["${steps.hold_candidate_ember_oak.output}","${steps.hold_candidate_casa_nera.output}","${steps.hold_candidate_atlas_row.output}"],"proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
+      value: '{"mocked_services":["api-twilio","api-elevenlabs","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false}'
     next: publish_holds_wait_state
 
   - id: publish_holds_wait_state
     type: assign
     parameters:
       target: post_timeout_wait_state
-      value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"mock_signal_choice":"ember_oak"}'
+      value: '{"status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"mock_signal_choice":"ember_oak","hold_proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
     next: mock_user_choice_signal_after_holds
 
   - id: mock_user_choice_signal_after_holds
     type: assign
     parameters:
       target: user_choice_after_holds
-      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_signal","mode":"test_only_user_choice_signal_after_holds"}'
-    next: compute_release_plan
-
-  - id: compute_release_plan
-    type: assign
-    parameters:
-      target: release_plan
-      value: '{"selected_venue":"Ember & Oak","keep":["Ember & Oak"],"release":["Casa Nera","Atlas Row"],"do_not_release_selected":true,"release_only_confirmed_holds":true,"result":"pass"}'
+      value: '{"selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","source":"mock_user_signal","mode":"test_only_user_choice_signal_after_holds"}'
     next: release_unselected_casa_nera
 
   - id: release_unselected_casa_nera
@@ -274,14 +150,7 @@ steps:
     idempotency_key: "${run_id}:release:casa_nera"
     parameters:
       target: release_casa_nera
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-casa-nera","elevenlabs_transcript":"mock-transcript-release-casa-nera"}'
-    next: verify_release_casa_nera
-
-  - id: verify_release_casa_nera
-    type: assign
-    parameters:
-      target: release_casa_nera_verification
-      value: '{"venue":"Casa Nera","call_record_present":true,"transcript_present":true,"release_status_extracted_from_transcript":"confirmed","result":"pass"}'
+      value: '{"mocked_services":["api-twilio","api-elevenlabs","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-casa-nera","elevenlabs_transcript":"mock-transcript-release-casa-nera"}'
     next: release_unselected_atlas_row
 
   - id: release_unselected_atlas_row
@@ -289,28 +158,14 @@ steps:
     idempotency_key: "${run_id}:release:atlas_row"
     parameters:
       target: release_atlas_row
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-atlas-row","elevenlabs_transcript":"mock-transcript-release-atlas-row"}'
-    next: verify_release_atlas_row
-
-  - id: verify_release_atlas_row
-    type: assign
-    parameters:
-      target: release_atlas_row_verification
-      value: '{"venue":"Atlas Row","call_record_present":true,"transcript_present":true,"release_status_extracted_from_transcript":"confirmed","result":"pass"}'
+      value: '{"mocked_services":["api-twilio","api-elevenlabs","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-atlas-row","elevenlabs_transcript":"mock-transcript-release-atlas-row"}'
     next: verify_final_contract_after_holds
 
   - id: verify_final_contract_after_holds
     type: assign
     parameters:
       target: final_contract_check
-      value: '{"selected_venue_kept":true,"unselected_confirmed_holds_released":true,"selected_venue_not_released":true,"all_effectful_calls_have_proof":true,"money_spent":false,"calendar_required":false,"result":"pass"}'
-    next: decide_optional_calendar_after_holds
-
-  - id: decide_optional_calendar_after_holds
-    type: assign
-    parameters:
-      target: optional_calendar_decision
-      value: '{"post_action":"calendar_create","required_for_workflow_success":false,"api_google_calendar_write_connected":false,"decision":"skip_optional_post_action","workflow_success_unchanged":true}'
+      value: '{"selected_venue_kept":true,"unselected_confirmed_holds_released":true,"all_effectful_calls_have_proof":true,"money_spent":false,"result":"pass"}'
     next: emit_hold_all_completed
 
   - id: emit_hold_all_completed
@@ -324,14 +179,14 @@ steps:
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"why":"no pine nuts in the Ember & Oak kitchen","calendar_post_action":"optional_skipped","proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"hold_verifications":["${steps.verify_hold_ember_oak.output}","${steps.verify_hold_casa_nera.output}","${steps.verify_hold_atlas_row.output}"],"release_verifications":["${steps.verify_release_casa_nera.output}","${steps.verify_release_atlas_row.output}"],"calendar_readback":"optional_skipped"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true,"calendar_is_optional":true}}'
+      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"verification":"${steps.verify_final_contract_after_holds.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
     next: ""
 
   - id: final_artifact_payment_blocked
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"failed","path":"deposit_required_failed","reason":"restaurant requested a deposit, and this mock workflow only supports free reservations","money_spent":false,"held":false,"requires_user_decision":false,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"deposit_request_returns_failure_reason":true}}'
+      value: '{"workflow_status":"failed","path":"deposit_required_failed","reason":"restaurant requested a deposit; workflow only supports free reservations","money_spent":false,"held":false,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"deposit_request_returns_failure_reason":true}}'
     next: ""
 
   - id: handle_ambiguous_hold_outcome
@@ -339,7 +194,7 @@ steps:
     idempotency_key: "${run_id}:hold:ambiguous"
     parameters:
       target: ambiguous_call_outcome
-      value: '{"scenario":"completed_call_missing_clear_hold_confirmation","options_shown":true,"venue":"Mock Ambiguous Venue","twilio_call_record":"mock-call-ambiguous","elevenlabs_transcript":"mock-transcript-ambiguous","hold_status_extracted_from_transcript":"unknown","external_effect":"unverified"}'
+      value: '{"venue":"Mock Ambiguous Venue","external_effect":"unverified","twilio_call_record":"mock-call-ambiguous","elevenlabs_transcript":"mock-transcript-ambiguous","hold_status_extracted_from_transcript":"unknown"}'
     next: final_artifact_unverified_hold
 
   - id: final_artifact_unverified_hold

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -135,14 +135,14 @@ steps:
     type: assign
     parameters:
       target: post_timeout_wait_state
-      value: '{"status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"mock_signal_choice":"ember_oak","hold_proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
+      value: '{"status":"waiting_for_user_confirmation_after_holds","held":["ember_oak","casa_nera","atlas_row"],"accepted_signals":["ember_oak","casa_nera","atlas_row"],"message":"All three mock holds are confirmed. Workflow is waiting for the user to confirm one venue before releasing the other two.","mock_resume_signal":"ember_oak","hold_proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
     next: mock_user_choice_signal_after_holds
 
   - id: mock_user_choice_signal_after_holds
     type: assign
     parameters:
       target: user_choice_after_holds
-      value: '{"selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","source":"mock_user_signal","mode":"test_only_user_choice_signal_after_holds"}'
+      value: '{"selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","source":"test_only_resume_signal","mode":"mock_user_confirmation_after_holds"}'
     next: release_unselected_casa_nera
 
   - id: release_unselected_casa_nera
@@ -179,7 +179,7 @@ steps:
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"verification":"${steps.verify_final_contract_after_holds.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_user_confirmed","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"user_confirmation":"${steps.mock_user_choice_signal_after_holds.json.source}","proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"verification":"${steps.verify_final_contract_after_holds.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"all_three_venues_held_after_timeout":true,"awaits_user_confirmation_before_release":true,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
     next: ""
 
   - id: final_artifact_payment_blocked

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -114,42 +114,23 @@ steps:
     type: switch
     parameters:
       on: "${steps.capture_user_choice.output}"
-      branch.ember_oak: record_selected_ember_oak_before_timeout
-      branch.casa_nera: record_selected_casa_nera_before_timeout
-      branch.atlas_row: record_selected_atlas_row_before_timeout
+      branch.timeout: wait_for_silence_timeout
+      branch.no_reply: wait_for_silence_timeout
       branch.deposit: final_artifact_payment_blocked
       branch.ambiguous: handle_ambiguous_hold_outcome
-      branch._default: wait_for_silence_timeout
+      branch._default: record_selected_venue_before_timeout
     branches:
-      ember_oak: record_selected_ember_oak_before_timeout
-      "Ember & Oak": record_selected_ember_oak_before_timeout
-      casa_nera: record_selected_casa_nera_before_timeout
-      "Casa Nera": record_selected_casa_nera_before_timeout
-      atlas_row: record_selected_atlas_row_before_timeout
-      "Atlas Row": record_selected_atlas_row_before_timeout
+      timeout: wait_for_silence_timeout
+      no_reply: wait_for_silence_timeout
       deposit: final_artifact_payment_blocked
       ambiguous: handle_ambiguous_hold_outcome
-      _default: wait_for_silence_timeout
+      _default: record_selected_venue_before_timeout
 
-  - id: record_selected_ember_oak_before_timeout
+  - id: record_selected_venue_before_timeout
     type: assign
     parameters:
       target: user_gate_result
-      value: '{"status":"answered_before_timeout","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","timeout_cancelled":true,"pending_input_status":"answered"}'
-    next: assert_only_selected_hold_allowed
-
-  - id: record_selected_casa_nera_before_timeout
-    type: assign
-    parameters:
-      target: user_gate_result
-      value: '{"status":"answered_before_timeout","selected_venue":"Casa Nera","selected_venue_id":"casa_nera","timeout_cancelled":true,"pending_input_status":"answered"}'
-    next: assert_only_selected_hold_allowed
-
-  - id: record_selected_atlas_row_before_timeout
-    type: assign
-    parameters:
-      target: user_gate_result
-      value: '{"status":"answered_before_timeout","selected_venue":"Atlas Row","selected_venue_id":"atlas_row","timeout_cancelled":true,"pending_input_status":"answered"}'
+      value: '{"status":"answered_before_timeout","selected_venue":"${steps.capture_user_choice.output}","timeout_cancelled":true,"pending_input_status":"answered"}'
     next: assert_only_selected_hold_allowed
 
   - id: assert_only_selected_hold_allowed
@@ -157,47 +138,14 @@ steps:
     parameters:
       target: selected_only_policy_check
       value: '{"path":"user_choice_before_timeout","hold_all_allowed":false,"unselected_holds_started":false,"result":"pass"}'
-    next: route_selected_hold
+    next: hold_selected_venue
 
-  - id: route_selected_hold
-    type: switch
-    parameters:
-      on: "${steps.capture_user_choice.output}"
-      branch.ember_oak: hold_selected_ember_oak
-      branch.casa_nera: hold_selected_casa_nera
-      branch.atlas_row: hold_selected_atlas_row
-      branch._default: final_artifact_invalid_selected_choice
-    branches:
-      ember_oak: hold_selected_ember_oak
-      "Ember & Oak": hold_selected_ember_oak
-      casa_nera: hold_selected_casa_nera
-      "Casa Nera": hold_selected_casa_nera
-      atlas_row: hold_selected_atlas_row
-      "Atlas Row": hold_selected_atlas_row
-      _default: final_artifact_invalid_selected_choice
-
-  - id: hold_selected_ember_oak
+  - id: hold_selected_venue
     type: assign
-    idempotency_key: "${run_id}:hold:ember_oak:selected_only"
+    idempotency_key: "${run_id}:hold:selected_venue:selected_only"
     parameters:
       target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false}'
-    next: verify_selected_hold_record
-
-  - id: hold_selected_casa_nera
-    type: assign
-    idempotency_key: "${run_id}:hold:casa_nera:selected_only"
-    parameters:
-      target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false}'
-    next: verify_selected_hold_record
-
-  - id: hold_selected_atlas_row
-    type: assign
-    idempotency_key: "${run_id}:hold:atlas_row:selected_only"
-    parameters:
-      target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"${steps.capture_user_choice.output}","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-selected-venue","elevenlabs_transcript":"mock-transcript-hold-selected-venue","confirmed_time":"19:30","allergy_answer":"mock connector verified availability and allergy notes for the selected venue","payment_requested":false}'
     next: verify_selected_hold_record
 
   - id: verify_selected_hold_record
@@ -225,7 +173,7 @@ steps:
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.hold_selected_ember_oak.json.venue}${steps.hold_selected_casa_nera.json.venue}${steps.hold_selected_atlas_row.json.venue}","released":[],"calendar_post_action":"optional_skipped","proof":{"call_records":["${steps.hold_selected_ember_oak.json.twilio_call_record}${steps.hold_selected_casa_nera.json.twilio_call_record}${steps.hold_selected_atlas_row.json.twilio_call_record}"],"transcripts":["${steps.hold_selected_ember_oak.json.elevenlabs_transcript}${steps.hold_selected_casa_nera.json.elevenlabs_transcript}${steps.hold_selected_atlas_row.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.hold_selected_venue.json.venue}","released":[],"calendar_post_action":"optional_skipped","proof":{"call_records":["${steps.hold_selected_venue.json.twilio_call_record}"],"transcripts":["${steps.hold_selected_venue.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
     next: ""
 
   - id: wait_for_silence_timeout
@@ -399,11 +347,4 @@ steps:
     parameters:
       target: dinner_date_artifact
       value: '{"workflow_status":"needs_attention","path":"ambiguous_hold_unverified","held":false,"reason":"call completed but transcript did not clearly confirm hold","proof":{"call_records":["mock-call-ambiguous"],"transcripts":["mock-transcript-ambiguous"],"verification":"hold_status_unknown"},"requires_user_decision":true,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"ambiguous_hold_not_reported_as_confirmed":true}}'
-    next: ""
-
-  - id: final_artifact_invalid_selected_choice
-    type: assign
-    parameters:
-      target: dinner_date_artifact
-      value: '{"workflow_status":"blocked","path":"invalid_choice","reason":"user choice did not match a shown venue","known_choices":["ember_oak","casa_nera","atlas_row"],"money_spent":false,"external_effect":"not_applied"}'
     next: ""

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -94,6 +94,13 @@ steps:
     parameters:
       target: options_gate
       value: '{"options_shown":true,"external_effect":"not_applied","message":"Three options have been shown. No restaurant has been called or held yet.","available_user_action":"name one venue in plain text","silence_timeout_ms":2000,"production_timeout":"10m"}'
+    next: emit_options_shown
+
+  - id: emit_options_shown
+    type: emit
+    parameters:
+      event_type: "dinner_date.options_shown"
+      payload: "${steps.options_card.output}"
     next: persist_wait_state
 
   - id: persist_wait_state
@@ -110,14 +117,14 @@ steps:
       branch.ember_oak: record_selected_ember_oak_before_timeout
       branch.casa_nera: record_selected_casa_nera_before_timeout
       branch.atlas_row: record_selected_atlas_row_before_timeout
-      branch.deposit: mock_paid_hold_attempt
+      branch.deposit: final_artifact_payment_blocked
       branch.ambiguous: mock_ambiguous_call_outcome
       branch._default: wait_for_silence_timeout
     branches:
       ember_oak: record_selected_ember_oak_before_timeout
       casa_nera: record_selected_casa_nera_before_timeout
       atlas_row: record_selected_atlas_row_before_timeout
-      deposit: mock_paid_hold_attempt
+      deposit: final_artifact_payment_blocked
       ambiguous: mock_ambiguous_call_outcome
       _default: wait_for_silence_timeout
 
@@ -165,6 +172,7 @@ steps:
 
   - id: mock_hold_selected_ember_oak
     type: assign
+    idempotency_key: "${run_id}:hold:ember_oak:selected_only"
     parameters:
       target: selected_only_hold
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false}'
@@ -172,6 +180,7 @@ steps:
 
   - id: mock_hold_selected_casa_nera
     type: assign
+    idempotency_key: "${run_id}:hold:casa_nera:selected_only"
     parameters:
       target: selected_only_hold
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false}'
@@ -179,6 +188,7 @@ steps:
 
   - id: mock_hold_selected_atlas_row
     type: assign
+    idempotency_key: "${run_id}:hold:atlas_row:selected_only"
     parameters:
       target: selected_only_hold
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false}'
@@ -196,6 +206,13 @@ steps:
     parameters:
       target: optional_calendar_decision
       value: '{"post_action":"calendar_create","required_for_workflow_success":false,"api_google_calendar_write_connected":false,"decision":"skip_optional_post_action","workflow_success_unchanged":true}'
+    next: emit_selected_only_completed
+
+  - id: emit_selected_only_completed
+    type: emit
+    parameters:
+      event_type: "dinner_date.completed"
+      payload: "${steps.verify_selected_hold_record.output}"
     next: final_artifact_selected_only
 
   - id: final_artifact_selected_only
@@ -227,6 +244,7 @@ steps:
 
   - id: mock_hold_ember_oak
     type: assign
+    idempotency_key: "${run_id}:hold:ember_oak:timeout"
     parameters:
       target: hold_ember_oak
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false,"duration":"1m12s"}'
@@ -241,6 +259,7 @@ steps:
 
   - id: mock_hold_casa_nera
     type: assign
+    idempotency_key: "${run_id}:hold:casa_nera:timeout"
     parameters:
       target: hold_casa_nera
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false,"duration":"1m48s"}'
@@ -255,6 +274,7 @@ steps:
 
   - id: mock_hold_atlas_row
     type: assign
+    idempotency_key: "${run_id}:hold:atlas_row:timeout"
     parameters:
       target: hold_atlas_row
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false,"duration":"2m03s"}'
@@ -297,6 +317,7 @@ steps:
 
   - id: mock_release_casa_nera
     type: assign
+    idempotency_key: "${run_id}:release:casa_nera"
     parameters:
       target: release_casa_nera
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-casa-nera","elevenlabs_transcript":"mock-transcript-release-casa-nera"}'
@@ -311,6 +332,7 @@ steps:
 
   - id: mock_release_atlas_row
     type: assign
+    idempotency_key: "${run_id}:release:atlas_row"
     parameters:
       target: release_atlas_row
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-atlas-row","elevenlabs_transcript":"mock-transcript-release-atlas-row"}'
@@ -335,6 +357,13 @@ steps:
     parameters:
       target: optional_calendar_decision
       value: '{"post_action":"calendar_create","required_for_workflow_success":false,"api_google_calendar_write_connected":false,"decision":"skip_optional_post_action","workflow_success_unchanged":true}'
+    next: emit_hold_all_completed
+
+  - id: emit_hold_all_completed
+    type: emit
+    parameters:
+      event_type: "dinner_date.completed"
+      payload: "${steps.verify_final_contract_after_holds.output}"
     next: final_artifact_after_holds
 
   - id: final_artifact_after_holds
@@ -344,22 +373,16 @@ steps:
       value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"why":"no pine nuts in the Ember & Oak kitchen","calendar_post_action":"optional_skipped","proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"hold_verifications":["${steps.verify_hold_ember_oak.output}","${steps.verify_hold_casa_nera.output}","${steps.verify_hold_atlas_row.output}"],"release_verifications":["${steps.verify_release_casa_nera.output}","${steps.verify_release_atlas_row.output}"],"calendar_readback":"optional_skipped"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true,"calendar_is_optional":true}}'
     next: ""
 
-  - id: mock_paid_hold_attempt
-    type: assign
-    parameters:
-      target: paid_hold_attempt
-      value: '{"scenario":"restaurant_requests_deposit","options_shown":true,"venue":"Mock Paid Venue","payment_requested":true,"money_spend_allowed":false,"external_effect":"stopped_before_payment","result":"blocked_for_user_approval"}'
-    next: final_artifact_payment_blocked
-
   - id: final_artifact_payment_blocked
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"blocked","path":"payment_required_stop","reason":"restaurant requested deposit or payment commitment","money_spent":false,"held":false,"requires_user_decision":true,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"paid_reservation_not_silently_accepted":true}}'
+      value: '{"workflow_status":"failed","path":"deposit_required_failed","reason":"restaurant requested a deposit, and this mock workflow only supports free reservations","money_spent":false,"held":false,"requires_user_decision":false,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"deposit_request_returns_failure_reason":true}}'
     next: ""
 
   - id: mock_ambiguous_call_outcome
     type: assign
+    idempotency_key: "${run_id}:hold:ambiguous"
     parameters:
       target: ambiguous_call_outcome
       value: '{"scenario":"completed_call_missing_clear_hold_confirmation","options_shown":true,"venue":"Mock Ambiguous Venue","twilio_call_record":"mock-call-ambiguous","elevenlabs_transcript":"mock-transcript-ambiguous","hold_status_extracted_from_transcript":"unknown","external_effect":"unverified"}'

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -1,6 +1,6 @@
 name: dinner_date_mock
 description: Executable mock workflow for the UC5 dinner-date flow. External NyxID services are represented by deterministic mock assign nodes so the orchestration can be validated before wiring real connectors.
-when_to_use: Use to validate the dinner-date shortlist, silence timeout, hold-all, release, and artifact flow without calling Google, Firecrawl, Twilio, ElevenLabs, or restaurants.
+when_to_use: Use to validate the dinner-date shortlist, policy gates, silence timeout, hold-all, release, proof artifact, and optional calendar flow without calling Google, Firecrawl, Twilio, ElevenLabs, or restaurants.
 configuration:
   closed_world_mode: true
 roles: []
@@ -16,7 +16,28 @@ steps:
     type: assign
     parameters:
       target: dinner_date_context
-      value: '{"task_id":"task-uc5","participant":"Priya","requested_window":"this week","party_size":2,"preferred_day":"Friday","preferred_time":"19:30","policy":{"money_spend_allowed":false,"reservation_calls_auto_allowed":true,"no_hold_before_options_shown":true},"external_dependency_mode":"mock"}'
+      value: '{"task_id":"task-uc5","revision":1,"participant":"Priya","requested_window":"this week","party_size":2,"preferred_day":"Friday","preferred_time":"19:30","policy":{"money_spend_allowed":false,"reservation_calls_auto_allowed":true,"no_hold_before_options_shown":true},"external_dependency_mode":"mock","status":"initialized"}'
+    next: normalize_request
+
+  - id: normalize_request
+    type: assign
+    parameters:
+      target: normalized_request
+      value: '{"intent":"plan_dinner_date","participant":"Priya","requested_window":"this week","constraints":["show_options_before_calls","no_money_spent","phone_holds_allowed_after_options","release_unchosen_holds","proof_required"],"input_choice_hint":"${steps.capture_user_choice.output}"}'
+    next: resolve_assumptions
+
+  - id: resolve_assumptions
+    type: assign
+    parameters:
+      target: planning_assumptions
+      value: '{"date_source":"mock_calendar_and_history","time_source":"mock_history_preference","party_size_source":"mock_history_preference","assumptions":["Friday evening is available","party size is two","indoor seating preferred"],"requires_user_clarification":false}'
+    next: validate_no_external_effect_before_options
+
+  - id: validate_no_external_effect_before_options
+    type: assign
+    parameters:
+      target: pre_options_policy_check
+      value: '{"options_shown":false,"restaurant_calls_started":false,"money_spent":false,"result":"pass","enforced_rules":["no_hold_before_options_shown","no_payment_without_user_approval"]}'
     next: mock_read_history
 
   - id: mock_read_history
@@ -31,20 +52,41 @@ steps:
     parameters:
       target: google_calendar_context
       value: '{"mocked_service":"api-google","required_for_core_workflow":false,"status":"skipped_or_mocked","facts":{"friday_evening_free":true},"calendar_write":"optional_post_action_only"}'
+    next: build_research_plan
+
+  - id: build_research_plan
+    type: assign
+    parameters:
+      target: venue_research_plan
+      value: '{"query":"romantic indoor dinner near Keong Saik or Duxton Friday 19:30","candidate_count_target":3,"evidence_needed":["availability","phone","menu_or_allergy_hint","venue_owned_page"],"side_effects_allowed":false}'
     next: mock_research_context
 
   - id: mock_research_context
     type: assign
     parameters:
       target: venue_research_context
-      value: '{"mocked_services":["web-search","api-firecrawl"],"required_for_core_workflow":false,"recommended":true,"facts":{"date_context":"seventh lunar month; indoor seating preferred","photo_source":"mock venue-owned pages","candidate_count":3}}'
+      value: '{"mocked_services":["web-search","api-firecrawl"],"required_for_core_workflow":false,"recommended":true,"facts":{"date_context":"seventh lunar month; indoor seating preferred","photo_source":"mock venue-owned pages","candidate_count":3,"candidate_source_quality":"sufficient_for_mock"}}'
     next: build_mock_shortlist
 
   - id: build_mock_shortlist
     type: assign
     parameters:
       target: dinner_shortlist
-      value: '{"options_shown":false,"venues":[{"name":"Ember & Oak","location":"Keong Saik","requested_time":"19:30","seating":"indoors","note":"menu lists no nuts anywhere; verify by phone","hold_status":"not_started"},{"name":"Casa Nera","location":"Duxton Hill","requested_time":"19:30","seating":"indoors","note":"visited three times; verify pine nuts by phone","hold_status":"not_started"},{"name":"Atlas Row","location":"Amoy Street","requested_time":"19:30","seating":"indoors","note":"best reviewed kitchen; verify availability and nuts by phone","hold_status":"not_started"}]}'
+      value: '{"options_shown":false,"venues":[{"id":"ember_oak","name":"Ember & Oak","location":"Keong Saik","phone":"mock-phone-ember-oak","requested_time":"19:30","seating":"indoors","note":"menu lists no nuts anywhere; verify by phone","hold_status":"not_started"},{"id":"casa_nera","name":"Casa Nera","location":"Duxton Hill","phone":"mock-phone-casa-nera","requested_time":"19:30","seating":"indoors","note":"visited three times; verify pine nuts by phone","hold_status":"not_started"},{"id":"atlas_row","name":"Atlas Row","location":"Amoy Street","phone":"mock-phone-atlas-row","requested_time":"19:30","seating":"indoors","note":"best reviewed kitchen; verify availability and nuts by phone","hold_status":"not_started"}]}'
+    next: validate_shortlist
+
+  - id: validate_shortlist
+    type: assign
+    parameters:
+      target: shortlist_validation
+      value: '{"venue_count":3,"has_phone_for_each":true,"has_user_visible_choice_key_for_each":true,"has_allergy_question_for_each":true,"result":"pass"}'
+    next: render_options_card
+
+  - id: render_options_card
+    type: assign
+    parameters:
+      target: options_card
+      value: '{"title":"Dinner date options","body":"Three options are ready. No restaurant has been called or held yet.","options":[{"choice_key":"ember_oak","label":"Ember & Oak","summary":"Keong Saik, indoor table, strongest nut-safety signal"},{"choice_key":"casa_nera","label":"Casa Nera","summary":"Duxton Hill, familiar venue, pine nuts must be checked"},{"choice_key":"atlas_row","label":"Atlas Row","summary":"Amoy Street, strong reviews, availability may be 20:00"}],"external_effect":"not_applied"}'
     next: mark_options_shown
 
   - id: mark_options_shown
@@ -52,21 +94,116 @@ steps:
     parameters:
       target: options_gate
       value: '{"options_shown":true,"external_effect":"not_applied","message":"Three options have been shown. No restaurant has been called or held yet.","available_user_action":"name one venue in plain text","silence_timeout_ms":2000,"production_timeout":"10m"}'
+    next: persist_wait_state
+
+  - id: persist_wait_state
+    type: assign
+    parameters:
+      target: wait_state
+      value: '{"wait_id":"wait-task-uc5-choice","stored_in":"mock_durable_workflow_state","accepted_signals":["ember_oak","casa_nera","atlas_row"],"timeout":"10m","test_timeout_ms":2000,"status":"armed"}'
     next: route_user_choice_before_timeout
 
   - id: route_user_choice_before_timeout
     type: switch
     parameters:
       on: "${steps.capture_user_choice.output}"
+      branch.ember_oak: record_selected_ember_oak_before_timeout
+      branch.casa_nera: record_selected_casa_nera_before_timeout
+      branch.atlas_row: record_selected_atlas_row_before_timeout
+      branch.deposit: mock_paid_hold_attempt
+      branch.ambiguous: mock_ambiguous_call_outcome
+      branch._default: wait_for_silence_timeout
+    branches:
+      ember_oak: record_selected_ember_oak_before_timeout
+      casa_nera: record_selected_casa_nera_before_timeout
+      atlas_row: record_selected_atlas_row_before_timeout
+      deposit: mock_paid_hold_attempt
+      ambiguous: mock_ambiguous_call_outcome
+      _default: wait_for_silence_timeout
+
+  - id: record_selected_ember_oak_before_timeout
+    type: assign
+    parameters:
+      target: user_gate_result
+      value: '{"status":"answered_before_timeout","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","timeout_cancelled":true,"pending_input_status":"answered"}'
+    next: assert_only_selected_hold_allowed
+
+  - id: record_selected_casa_nera_before_timeout
+    type: assign
+    parameters:
+      target: user_gate_result
+      value: '{"status":"answered_before_timeout","selected_venue":"Casa Nera","selected_venue_id":"casa_nera","timeout_cancelled":true,"pending_input_status":"answered"}'
+    next: assert_only_selected_hold_allowed
+
+  - id: record_selected_atlas_row_before_timeout
+    type: assign
+    parameters:
+      target: user_gate_result
+      value: '{"status":"answered_before_timeout","selected_venue":"Atlas Row","selected_venue_id":"atlas_row","timeout_cancelled":true,"pending_input_status":"answered"}'
+    next: assert_only_selected_hold_allowed
+
+  - id: assert_only_selected_hold_allowed
+    type: assign
+    parameters:
+      target: selected_only_policy_check
+      value: '{"path":"user_choice_before_timeout","hold_all_allowed":false,"unselected_holds_started":false,"result":"pass"}'
+    next: route_selected_hold
+
+  - id: route_selected_hold
+    type: switch
+    parameters:
+      on: "${steps.capture_user_choice.output}"
       branch.ember_oak: mock_hold_selected_ember_oak
       branch.casa_nera: mock_hold_selected_casa_nera
       branch.atlas_row: mock_hold_selected_atlas_row
-      branch._default: wait_for_silence_timeout
+      branch._default: mock_invalid_selected_choice
     branches:
       ember_oak: mock_hold_selected_ember_oak
       casa_nera: mock_hold_selected_casa_nera
       atlas_row: mock_hold_selected_atlas_row
-      _default: wait_for_silence_timeout
+      _default: mock_invalid_selected_choice
+
+  - id: mock_hold_selected_ember_oak
+    type: assign
+    parameters:
+      target: selected_only_hold
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false}'
+    next: verify_selected_hold_record
+
+  - id: mock_hold_selected_casa_nera
+    type: assign
+    parameters:
+      target: selected_only_hold
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false}'
+    next: verify_selected_hold_record
+
+  - id: mock_hold_selected_atlas_row
+    type: assign
+    parameters:
+      target: selected_only_hold
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false}'
+    next: verify_selected_hold_record
+
+  - id: verify_selected_hold_record
+    type: assign
+    parameters:
+      target: selected_hold_verification
+      value: '{"call_record_present":true,"call_completed":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
+    next: decide_optional_calendar_selected_only
+
+  - id: decide_optional_calendar_selected_only
+    type: assign
+    parameters:
+      target: optional_calendar_decision
+      value: '{"post_action":"calendar_create","required_for_workflow_success":false,"api_google_calendar_write_connected":false,"decision":"skip_optional_post_action","workflow_success_unchanged":true}'
+    next: final_artifact_selected_only
+
+  - id: final_artifact_selected_only
+    type: assign
+    parameters:
+      target: dinner_date_artifact
+      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.mock_hold_selected_ember_oak.json.venue}${steps.mock_hold_selected_casa_nera.json.venue}${steps.mock_hold_selected_atlas_row.json.venue}","released":[],"calendar_post_action":"optional_skipped","proof":{"call_records":["${steps.mock_hold_selected_ember_oak.json.twilio_call_record}${steps.mock_hold_selected_casa_nera.json.twilio_call_record}${steps.mock_hold_selected_atlas_row.json.twilio_call_record}"],"transcripts":["${steps.mock_hold_selected_ember_oak.json.elevenlabs_transcript}${steps.mock_hold_selected_casa_nera.json.elevenlabs_transcript}${steps.mock_hold_selected_atlas_row.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+    next: ""
 
   - id: wait_for_silence_timeout
     type: delay
@@ -79,87 +216,165 @@ steps:
     parameters:
       target: user_gate_result
       value: '{"status":"timeout","production_timeout":"10m","test_timeout_ms":2000,"pending_input_status":"cancelled","next_branch":"hold_all"}'
+    next: assert_hold_all_policy_after_timeout
+
+  - id: assert_hold_all_policy_after_timeout
+    type: assign
+    parameters:
+      target: hold_all_policy_check
+      value: '{"path":"silence_timeout","options_shown":true,"timeout_elapsed":true,"reservation_calls_auto_allowed":true,"money_spend_allowed":false,"result":"pass"}'
     next: mock_hold_ember_oak
 
   - id: mock_hold_ember_oak
     type: assign
     parameters:
       target: hold_ember_oak
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","duration":"1m12s"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false,"duration":"1m12s"}'
+    next: verify_hold_ember_oak
+
+  - id: verify_hold_ember_oak
+    type: assign
+    parameters:
+      target: hold_ember_oak_verification
+      value: '{"venue":"Ember & Oak","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
     next: mock_hold_casa_nera
 
   - id: mock_hold_casa_nera
     type: assign
     parameters:
       target: hold_casa_nera
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","duration":"1m48s"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false,"duration":"1m48s"}'
+    next: verify_hold_casa_nera
+
+  - id: verify_hold_casa_nera
+    type: assign
+    parameters:
+      target: hold_casa_nera_verification
+      value: '{"venue":"Casa Nera","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
     next: mock_hold_atlas_row
 
   - id: mock_hold_atlas_row
     type: assign
     parameters:
       target: hold_atlas_row
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","duration":"2m03s"}'
-    next: report_mock_holds
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false,"duration":"2m03s"}'
+    next: verify_hold_atlas_row
 
-  - id: report_mock_holds
+  - id: verify_hold_atlas_row
+    type: assign
+    parameters:
+      target: hold_atlas_row_verification
+      value: '{"venue":"Atlas Row","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
+    next: aggregate_hold_results
+
+  - id: aggregate_hold_results
     type: assign
     parameters:
       target: hold_summary
-      value: '{"status":"all_three_held","selected_venue":null,"message":"All three mock holds are confirmed. Workflow is waiting for the user to choose one.","proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
+      value: '{"status":"all_three_held","selected_venue":null,"message":"All three mock holds are confirmed. Workflow is waiting for the user to choose one.","holds":["${steps.hold_ember_oak.output}","${steps.hold_casa_nera.output}","${steps.hold_atlas_row.output}"],"proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
+    next: publish_holds_wait_state
+
+  - id: publish_holds_wait_state
+    type: assign
+    parameters:
+      target: post_timeout_wait_state
+      value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"default_mock_choice":"ember_oak"}'
     next: mock_user_selects_after_holds
 
   - id: mock_user_selects_after_holds
     type: assign
     parameters:
       target: user_choice_after_holds
-      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_text"}'
+      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_text"}'
+    next: compute_release_plan
+
+  - id: compute_release_plan
+    type: assign
+    parameters:
+      target: release_plan
+      value: '{"selected_venue":"Ember & Oak","keep":["Ember & Oak"],"release":["Casa Nera","Atlas Row"],"do_not_release_selected":true,"release_only_confirmed_holds":true,"result":"pass"}'
     next: mock_release_casa_nera
 
   - id: mock_release_casa_nera
     type: assign
     parameters:
       target: release_casa_nera
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-casa-nera","elevenlabs_transcript":"mock-transcript-release-casa-nera"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-casa-nera","elevenlabs_transcript":"mock-transcript-release-casa-nera"}'
+    next: verify_release_casa_nera
+
+  - id: verify_release_casa_nera
+    type: assign
+    parameters:
+      target: release_casa_nera_verification
+      value: '{"venue":"Casa Nera","call_record_present":true,"transcript_present":true,"release_status_extracted_from_transcript":"confirmed","result":"pass"}'
     next: mock_release_atlas_row
 
   - id: mock_release_atlas_row
     type: assign
     parameters:
       target: release_atlas_row
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-atlas-row","elevenlabs_transcript":"mock-transcript-release-atlas-row"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-atlas-row","elevenlabs_transcript":"mock-transcript-release-atlas-row"}'
+    next: verify_release_atlas_row
+
+  - id: verify_release_atlas_row
+    type: assign
+    parameters:
+      target: release_atlas_row_verification
+      value: '{"venue":"Atlas Row","call_record_present":true,"transcript_present":true,"release_status_extracted_from_transcript":"confirmed","result":"pass"}'
+    next: verify_final_contract_after_holds
+
+  - id: verify_final_contract_after_holds
+    type: assign
+    parameters:
+      target: final_contract_check
+      value: '{"selected_venue_kept":true,"unselected_confirmed_holds_released":true,"selected_venue_not_released":true,"all_effectful_calls_have_proof":true,"money_spent":false,"calendar_required":false,"result":"pass"}'
+    next: decide_optional_calendar_after_holds
+
+  - id: decide_optional_calendar_after_holds
+    type: assign
+    parameters:
+      target: optional_calendar_decision
+      value: '{"post_action":"calendar_create","required_for_workflow_success":false,"api_google_calendar_write_connected":false,"decision":"skip_optional_post_action","workflow_success_unchanged":true}'
     next: final_artifact_after_holds
-
-  - id: mock_hold_selected_ember_oak
-    type: assign
-    parameters:
-      target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all"}'
-    next: final_artifact_selected_only
-
-  - id: mock_hold_selected_casa_nera
-    type: assign
-    parameters:
-      target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request"}'
-    next: final_artifact_selected_only
-
-  - id: mock_hold_selected_atlas_row
-    type: assign
-    parameters:
-      target: selected_only_hold
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not"}'
-    next: final_artifact_selected_only
-
-  - id: final_artifact_selected_only
-    type: assign
-    parameters:
-      target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.mock_hold_selected_ember_oak.json.venue}${steps.mock_hold_selected_casa_nera.json.venue}${steps.mock_hold_selected_atlas_row.json.venue}","released":[],"calendar_post_action":"optional_not_run","required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
-    next: ""
 
   - id: final_artifact_after_holds
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"why":"no pine nuts in the Ember & Oak kitchen","calendar_post_action":"optional_not_run","proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"calendar_readback":"optional"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"why":"no pine nuts in the Ember & Oak kitchen","calendar_post_action":"optional_skipped","proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"hold_verifications":["${steps.verify_hold_ember_oak.output}","${steps.verify_hold_casa_nera.output}","${steps.verify_hold_atlas_row.output}"],"release_verifications":["${steps.verify_release_casa_nera.output}","${steps.verify_release_atlas_row.output}"],"calendar_readback":"optional_skipped"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true,"calendar_is_optional":true}}'
+    next: ""
+
+  - id: mock_paid_hold_attempt
+    type: assign
+    parameters:
+      target: paid_hold_attempt
+      value: '{"scenario":"restaurant_requests_deposit","options_shown":true,"venue":"Mock Paid Venue","payment_requested":true,"money_spend_allowed":false,"external_effect":"stopped_before_payment","result":"blocked_for_user_approval"}'
+    next: final_artifact_payment_blocked
+
+  - id: final_artifact_payment_blocked
+    type: assign
+    parameters:
+      target: dinner_date_artifact
+      value: '{"workflow_status":"blocked","path":"payment_required_stop","reason":"restaurant requested deposit or payment commitment","money_spent":false,"held":false,"requires_user_decision":true,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"paid_reservation_not_silently_accepted":true}}'
+    next: ""
+
+  - id: mock_ambiguous_call_outcome
+    type: assign
+    parameters:
+      target: ambiguous_call_outcome
+      value: '{"scenario":"completed_call_missing_clear_hold_confirmation","options_shown":true,"venue":"Mock Ambiguous Venue","twilio_call_record":"mock-call-ambiguous","elevenlabs_transcript":"mock-transcript-ambiguous","hold_status_extracted_from_transcript":"unknown","external_effect":"unverified"}'
+    next: final_artifact_unverified_hold
+
+  - id: final_artifact_unverified_hold
+    type: assign
+    parameters:
+      target: dinner_date_artifact
+      value: '{"workflow_status":"needs_attention","path":"ambiguous_hold_unverified","held":false,"reason":"call completed but transcript did not clearly confirm hold","proof":{"call_records":["mock-call-ambiguous"],"transcripts":["mock-transcript-ambiguous"],"verification":"hold_status_unknown"},"requires_user_decision":true,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"ambiguous_hold_not_reported_as_confirmed":true}}'
+    next: ""
+
+  - id: mock_invalid_selected_choice
+    type: assign
+    parameters:
+      target: dinner_date_artifact
+      value: '{"workflow_status":"blocked","path":"invalid_choice","reason":"user choice did not match a shown venue","known_choices":["ember_oak","casa_nera","atlas_row"],"money_spent":false,"external_effect":"not_applied"}'
+    next: ""

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -1,0 +1,165 @@
+name: dinner_date_mock
+description: Executable mock workflow for the UC5 dinner-date flow. External NyxID services are represented by deterministic mock assign nodes so the orchestration can be validated before wiring real connectors.
+when_to_use: Use to validate the dinner-date shortlist, silence timeout, hold-all, release, and artifact flow without calling Google, Firecrawl, Twilio, ElevenLabs, or restaurants.
+configuration:
+  closed_world_mode: true
+roles: []
+steps:
+  - id: capture_user_choice
+    type: assign
+    parameters:
+      target: simulated_user_choice
+      value: "$input"
+    next: initialize_context
+
+  - id: initialize_context
+    type: assign
+    parameters:
+      target: dinner_date_context
+      value: '{"task_id":"task-uc5","participant":"Priya","requested_window":"this week","party_size":2,"preferred_day":"Friday","preferred_time":"19:30","policy":{"money_spend_allowed":false,"reservation_calls_auto_allowed":true,"no_hold_before_options_shown":true},"external_dependency_mode":"mock"}'
+    next: mock_read_history
+
+  - id: mock_read_history
+    type: assign
+    parameters:
+      target: google_history_context
+      value: '{"mocked_service":"api-google","required_for_core_workflow":false,"status":"skipped_or_mocked","facts":{"past_confirmations":4,"latest_confirmation":"2026-03-14","usual_day":"Friday","usual_time":"19:30","party_size":2,"dietary_note":"one old vegetarian note, owner unknown"}}'
+    next: mock_read_calendar
+
+  - id: mock_read_calendar
+    type: assign
+    parameters:
+      target: google_calendar_context
+      value: '{"mocked_service":"api-google","required_for_core_workflow":false,"status":"skipped_or_mocked","facts":{"friday_evening_free":true},"calendar_write":"optional_post_action_only"}'
+    next: mock_research_context
+
+  - id: mock_research_context
+    type: assign
+    parameters:
+      target: venue_research_context
+      value: '{"mocked_services":["web-search","api-firecrawl"],"required_for_core_workflow":false,"recommended":true,"facts":{"date_context":"seventh lunar month; indoor seating preferred","photo_source":"mock venue-owned pages","candidate_count":3}}'
+    next: build_mock_shortlist
+
+  - id: build_mock_shortlist
+    type: assign
+    parameters:
+      target: dinner_shortlist
+      value: '{"options_shown":false,"venues":[{"name":"Ember & Oak","location":"Keong Saik","requested_time":"19:30","seating":"indoors","note":"menu lists no nuts anywhere; verify by phone","hold_status":"not_started"},{"name":"Casa Nera","location":"Duxton Hill","requested_time":"19:30","seating":"indoors","note":"visited three times; verify pine nuts by phone","hold_status":"not_started"},{"name":"Atlas Row","location":"Amoy Street","requested_time":"19:30","seating":"indoors","note":"best reviewed kitchen; verify availability and nuts by phone","hold_status":"not_started"}]}'
+    next: mark_options_shown
+
+  - id: mark_options_shown
+    type: assign
+    parameters:
+      target: options_gate
+      value: '{"options_shown":true,"external_effect":"not_applied","message":"Three options have been shown. No restaurant has been called or held yet.","available_user_action":"name one venue in plain text","silence_timeout_ms":2000,"production_timeout":"10m"}'
+    next: route_user_choice_before_timeout
+
+  - id: route_user_choice_before_timeout
+    type: switch
+    parameters:
+      on: "${steps.capture_user_choice.output}"
+      branch.ember_oak: mock_hold_selected_ember_oak
+      branch.casa_nera: mock_hold_selected_casa_nera
+      branch.atlas_row: mock_hold_selected_atlas_row
+      branch._default: wait_for_silence_timeout
+    branches:
+      ember_oak: mock_hold_selected_ember_oak
+      casa_nera: mock_hold_selected_casa_nera
+      atlas_row: mock_hold_selected_atlas_row
+      _default: wait_for_silence_timeout
+
+  - id: wait_for_silence_timeout
+    type: delay
+    parameters:
+      duration_ms: "2000"
+    next: mark_silence_timeout
+
+  - id: mark_silence_timeout
+    type: assign
+    parameters:
+      target: user_gate_result
+      value: '{"status":"timeout","production_timeout":"10m","test_timeout_ms":2000,"pending_input_status":"cancelled","next_branch":"hold_all"}'
+    next: mock_hold_ember_oak
+
+  - id: mock_hold_ember_oak
+    type: assign
+    parameters:
+      target: hold_ember_oak
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","duration":"1m12s"}'
+    next: mock_hold_casa_nera
+
+  - id: mock_hold_casa_nera
+    type: assign
+    parameters:
+      target: hold_casa_nera
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","duration":"1m48s"}'
+    next: mock_hold_atlas_row
+
+  - id: mock_hold_atlas_row
+    type: assign
+    parameters:
+      target: hold_atlas_row
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","duration":"2m03s"}'
+    next: report_mock_holds
+
+  - id: report_mock_holds
+    type: assign
+    parameters:
+      target: hold_summary
+      value: '{"status":"all_three_held","selected_venue":null,"message":"All three mock holds are confirmed. Workflow is waiting for the user to choose one.","proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
+    next: mock_user_selects_after_holds
+
+  - id: mock_user_selects_after_holds
+    type: assign
+    parameters:
+      target: user_choice_after_holds
+      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_text"}'
+    next: mock_release_casa_nera
+
+  - id: mock_release_casa_nera
+    type: assign
+    parameters:
+      target: release_casa_nera
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-casa-nera","elevenlabs_transcript":"mock-transcript-release-casa-nera"}'
+    next: mock_release_atlas_row
+
+  - id: mock_release_atlas_row
+    type: assign
+    parameters:
+      target: release_atlas_row
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","action":"release","external_effect":"confirmed","twilio_call_record":"mock-call-release-atlas-row","elevenlabs_transcript":"mock-transcript-release-atlas-row"}'
+    next: final_artifact_after_holds
+
+  - id: mock_hold_selected_ember_oak
+    type: assign
+    parameters:
+      target: selected_only_hold
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all"}'
+    next: final_artifact_selected_only
+
+  - id: mock_hold_selected_casa_nera
+    type: assign
+    parameters:
+      target: selected_only_hold
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request"}'
+    next: final_artifact_selected_only
+
+  - id: mock_hold_selected_atlas_row
+    type: assign
+    parameters:
+      target: selected_only_hold
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not"}'
+    next: final_artifact_selected_only
+
+  - id: final_artifact_selected_only
+    type: assign
+    parameters:
+      target: dinner_date_artifact
+      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.mock_hold_selected_ember_oak.json.venue}${steps.mock_hold_selected_casa_nera.json.venue}${steps.mock_hold_selected_atlas_row.json.venue}","released":[],"calendar_post_action":"optional_not_run","required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+    next: ""
+
+  - id: final_artifact_after_holds
+    type: assign
+    parameters:
+      target: dinner_date_artifact
+      value: '{"workflow_status":"completed","path":"silence_timeout_hold_all_then_choose","kept":"Ember & Oak","released":["Casa Nera","Atlas Row"],"why":"no pine nuts in the Ember & Oak kitchen","calendar_post_action":"optional_not_run","proof":{"call_records":["mock-call-hold-ember-oak","mock-call-hold-casa-nera","mock-call-hold-atlas-row","mock-call-release-casa-nera","mock-call-release-atlas-row"],"transcripts":["mock-transcript-hold-ember-oak","mock-transcript-hold-casa-nera","mock-transcript-hold-atlas-row","mock-transcript-release-casa-nera","mock-transcript-release-atlas-row"],"calendar_readback":"optional"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -122,8 +122,11 @@ steps:
       branch._default: wait_for_silence_timeout
     branches:
       ember_oak: record_selected_ember_oak_before_timeout
+      "Ember & Oak": record_selected_ember_oak_before_timeout
       casa_nera: record_selected_casa_nera_before_timeout
+      "Casa Nera": record_selected_casa_nera_before_timeout
       atlas_row: record_selected_atlas_row_before_timeout
+      "Atlas Row": record_selected_atlas_row_before_timeout
       deposit: final_artifact_payment_blocked
       ambiguous: handle_ambiguous_hold_outcome
       _default: wait_for_silence_timeout
@@ -166,8 +169,11 @@ steps:
       branch._default: final_artifact_invalid_selected_choice
     branches:
       ember_oak: hold_selected_ember_oak
+      "Ember & Oak": hold_selected_ember_oak
       casa_nera: hold_selected_casa_nera
+      "Casa Nera": hold_selected_casa_nera
       atlas_row: hold_selected_atlas_row
+      "Atlas Row": hold_selected_atlas_row
       _default: final_artifact_invalid_selected_choice
 
   - id: hold_selected_ember_oak
@@ -298,14 +304,14 @@ steps:
     type: assign
     parameters:
       target: post_timeout_wait_state
-      value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"default_mock_choice":"ember_oak"}'
-    next: receive_user_choice_after_holds
+      value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds_mocked","accepted_signals":["ember_oak","casa_nera","atlas_row"],"default_mock_choice":"ember_oak"}'
+    next: simulate_user_choice_after_holds
 
-  - id: receive_user_choice_after_holds
+  - id: simulate_user_choice_after_holds
     type: assign
     parameters:
       target: user_choice_after_holds
-      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_text"}'
+      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_text","mode":"simulated_post_timeout_choice"}'
     next: compute_release_plan
 
   - id: compute_release_plan

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -201,7 +201,7 @@ steps:
     idempotency_key: "${run_id}:hold:ember_oak:timeout"
     parameters:
       target: hold_ember_oak
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false,"duration":"1m12s"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; user decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false,"duration":"1m12s"}'
     next: verify_hold_ember_oak
 
   - id: verify_hold_ember_oak
@@ -216,7 +216,7 @@ steps:
     idempotency_key: "${run_id}:hold:casa_nera:timeout"
     parameters:
       target: hold_casa_nera
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false,"duration":"1m48s"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; user decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false,"duration":"1m48s"}'
     next: verify_hold_casa_nera
 
   - id: verify_hold_casa_nera
@@ -231,7 +231,7 @@ steps:
     idempotency_key: "${run_id}:hold:atlas_row:timeout"
     parameters:
       target: hold_atlas_row
-      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false,"duration":"2m03s"}'
+      value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Atlas Row","venue_id":"atlas_row","action":"hold","external_effect":"confirmed","restaurant_message":"temporary hold; user decision comes tonight; unselected holds will be released immediately","twilio_call_record":"mock-call-hold-atlas-row","elevenlabs_transcript":"mock-transcript-hold-atlas-row","confirmed_time":"20:00","allergy_answer":"pesto is nut-free; evening special is not","payment_requested":false,"duration":"2m03s"}'
     next: verify_hold_atlas_row
 
   - id: verify_hold_atlas_row
@@ -252,14 +252,14 @@ steps:
     type: assign
     parameters:
       target: post_timeout_wait_state
-      value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds_mocked","accepted_signals":["ember_oak","casa_nera","atlas_row"],"default_mock_choice":"ember_oak"}'
-    next: simulate_user_choice_after_holds
+      value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"mock_signal_choice":"ember_oak"}'
+    next: mock_user_choice_signal_after_holds
 
-  - id: simulate_user_choice_after_holds
+  - id: mock_user_choice_signal_after_holds
     type: assign
     parameters:
       target: user_choice_after_holds
-      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_text","mode":"simulated_post_timeout_choice"}'
+      value: '{"task_id":"task-uc5b","selected_venue":"Ember & Oak","selected_venue_id":"ember_oak","selection_reason":"pine nut allergy makes the no-nuts kitchen safest","source":"mock_user_signal","mode":"test_only_user_choice_signal_after_holds"}'
     next: compute_release_plan
 
   - id: compute_release_plan

--- a/workflows/dinner_date_mock.yaml
+++ b/workflows/dinner_date_mock.yaml
@@ -1,6 +1,6 @@
 name: dinner_date_mock
-description: Executable mock workflow for the UC5 dinner-date flow. External NyxID services are represented by deterministic mock assign nodes so the orchestration can be validated before wiring real connectors.
-when_to_use: Use to validate the dinner-date shortlist, policy gates, silence timeout, hold-all, release, proof artifact, and optional calendar flow without calling Google, Firecrawl, Twilio, ElevenLabs, or restaurants.
+description: Template-oriented executable workflow for the UC5 dinner-date flow. Connector boundary nodes currently use deterministic mock assign outputs and can later be replaced with real NyxID-backed tool calls without changing the orchestration backbone.
+when_to_use: Use to validate the dinner-date shortlist, policy gates, silence timeout, hold-all, release, proof artifact, and optional calendar flow before replacing connector boundary nodes for Google, Firecrawl, Twilio, ElevenLabs, or restaurant calls.
 configuration:
   closed_world_mode: true
 roles: []
@@ -38,16 +38,16 @@ steps:
     parameters:
       target: pre_options_policy_check
       value: '{"options_shown":false,"restaurant_calls_started":false,"money_spent":false,"result":"pass","enforced_rules":["no_hold_before_options_shown","no_payment_without_user_approval"]}'
-    next: mock_read_history
+    next: load_participant_context
 
-  - id: mock_read_history
+  - id: load_participant_context
     type: assign
     parameters:
       target: google_history_context
       value: '{"mocked_service":"api-google","required_for_core_workflow":false,"status":"skipped_or_mocked","facts":{"past_confirmations":4,"latest_confirmation":"2026-03-14","usual_day":"Friday","usual_time":"19:30","party_size":2,"dietary_note":"one old vegetarian note, owner unknown"}}'
-    next: mock_read_calendar
+    next: load_optional_calendar_context
 
-  - id: mock_read_calendar
+  - id: load_optional_calendar_context
     type: assign
     parameters:
       target: google_calendar_context
@@ -59,16 +59,16 @@ steps:
     parameters:
       target: venue_research_plan
       value: '{"query":"romantic indoor dinner near Keong Saik or Duxton Friday 19:30","candidate_count_target":3,"evidence_needed":["availability","phone","menu_or_allergy_hint","venue_owned_page"],"side_effects_allowed":false}'
-    next: mock_research_context
+    next: discover_restaurant_candidates
 
-  - id: mock_research_context
+  - id: discover_restaurant_candidates
     type: assign
     parameters:
       target: venue_research_context
       value: '{"mocked_services":["web-search","api-firecrawl"],"required_for_core_workflow":false,"recommended":true,"facts":{"date_context":"seventh lunar month; indoor seating preferred","photo_source":"mock venue-owned pages","candidate_count":3,"candidate_source_quality":"sufficient_for_mock"}}'
-    next: build_mock_shortlist
+    next: build_shortlist_from_candidates
 
-  - id: build_mock_shortlist
+  - id: build_shortlist_from_candidates
     type: assign
     parameters:
       target: dinner_shortlist
@@ -118,14 +118,14 @@ steps:
       branch.casa_nera: record_selected_casa_nera_before_timeout
       branch.atlas_row: record_selected_atlas_row_before_timeout
       branch.deposit: final_artifact_payment_blocked
-      branch.ambiguous: mock_ambiguous_call_outcome
+      branch.ambiguous: handle_ambiguous_hold_outcome
       branch._default: wait_for_silence_timeout
     branches:
       ember_oak: record_selected_ember_oak_before_timeout
       casa_nera: record_selected_casa_nera_before_timeout
       atlas_row: record_selected_atlas_row_before_timeout
       deposit: final_artifact_payment_blocked
-      ambiguous: mock_ambiguous_call_outcome
+      ambiguous: handle_ambiguous_hold_outcome
       _default: wait_for_silence_timeout
 
   - id: record_selected_ember_oak_before_timeout
@@ -160,17 +160,17 @@ steps:
     type: switch
     parameters:
       on: "${steps.capture_user_choice.output}"
-      branch.ember_oak: mock_hold_selected_ember_oak
-      branch.casa_nera: mock_hold_selected_casa_nera
-      branch.atlas_row: mock_hold_selected_atlas_row
-      branch._default: mock_invalid_selected_choice
+      branch.ember_oak: hold_selected_ember_oak
+      branch.casa_nera: hold_selected_casa_nera
+      branch.atlas_row: hold_selected_atlas_row
+      branch._default: final_artifact_invalid_selected_choice
     branches:
-      ember_oak: mock_hold_selected_ember_oak
-      casa_nera: mock_hold_selected_casa_nera
-      atlas_row: mock_hold_selected_atlas_row
-      _default: mock_invalid_selected_choice
+      ember_oak: hold_selected_ember_oak
+      casa_nera: hold_selected_casa_nera
+      atlas_row: hold_selected_atlas_row
+      _default: final_artifact_invalid_selected_choice
 
-  - id: mock_hold_selected_ember_oak
+  - id: hold_selected_ember_oak
     type: assign
     idempotency_key: "${run_id}:hold:ember_oak:selected_only"
     parameters:
@@ -178,7 +178,7 @@ steps:
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Ember & Oak","venue_id":"ember_oak","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-ember-oak","elevenlabs_transcript":"mock-transcript-hold-ember-oak","confirmed_time":"19:30","allergy_answer":"no nuts in the kitchen at all","payment_requested":false}'
     next: verify_selected_hold_record
 
-  - id: mock_hold_selected_casa_nera
+  - id: hold_selected_casa_nera
     type: assign
     idempotency_key: "${run_id}:hold:casa_nera:selected_only"
     parameters:
@@ -186,7 +186,7 @@ steps:
       value: '{"mocked_services":["api-elevenlabs","api-twilio","restaurant-phone"],"venue":"Casa Nera","venue_id":"casa_nera","action":"hold","external_effect":"confirmed","twilio_call_record":"mock-call-hold-casa-nera","elevenlabs_transcript":"mock-transcript-hold-casa-nera","confirmed_time":"19:30","allergy_answer":"pesto has pine nuts; kitchen can omit on request","payment_requested":false}'
     next: verify_selected_hold_record
 
-  - id: mock_hold_selected_atlas_row
+  - id: hold_selected_atlas_row
     type: assign
     idempotency_key: "${run_id}:hold:atlas_row:selected_only"
     parameters:
@@ -219,7 +219,7 @@ steps:
     type: assign
     parameters:
       target: dinner_date_artifact
-      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.mock_hold_selected_ember_oak.json.venue}${steps.mock_hold_selected_casa_nera.json.venue}${steps.mock_hold_selected_atlas_row.json.venue}","released":[],"calendar_post_action":"optional_skipped","proof":{"call_records":["${steps.mock_hold_selected_ember_oak.json.twilio_call_record}${steps.mock_hold_selected_casa_nera.json.twilio_call_record}${steps.mock_hold_selected_atlas_row.json.twilio_call_record}"],"transcripts":["${steps.mock_hold_selected_ember_oak.json.elevenlabs_transcript}${steps.mock_hold_selected_casa_nera.json.elevenlabs_transcript}${steps.mock_hold_selected_atlas_row.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
+      value: '{"workflow_status":"completed","path":"user_choice_before_timeout","kept":"${steps.hold_selected_ember_oak.json.venue}${steps.hold_selected_casa_nera.json.venue}${steps.hold_selected_atlas_row.json.venue}","released":[],"calendar_post_action":"optional_skipped","proof":{"call_records":["${steps.hold_selected_ember_oak.json.twilio_call_record}${steps.hold_selected_casa_nera.json.twilio_call_record}${steps.hold_selected_atlas_row.json.twilio_call_record}"],"transcripts":["${steps.hold_selected_ember_oak.json.elevenlabs_transcript}${steps.hold_selected_casa_nera.json.elevenlabs_transcript}${steps.hold_selected_atlas_row.json.elevenlabs_transcript}"],"verification":"${steps.verify_selected_hold_record.output}"},"required_external_dependencies_mocked":["api-twilio","api-elevenlabs","restaurant-phone"],"recommended_dependencies_mocked":["api-firecrawl","web-search"],"optional_dependencies_mocked":["api-google"],"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"selected_venue_confirmed":true,"unselected_holds_released":true,"proof_artifact_contains_call_records_and_transcripts":true}}'
     next: ""
 
   - id: wait_for_silence_timeout
@@ -240,9 +240,9 @@ steps:
     parameters:
       target: hold_all_policy_check
       value: '{"path":"silence_timeout","options_shown":true,"timeout_elapsed":true,"reservation_calls_auto_allowed":true,"money_spend_allowed":false,"result":"pass"}'
-    next: mock_hold_ember_oak
+    next: hold_candidate_ember_oak
 
-  - id: mock_hold_ember_oak
+  - id: hold_candidate_ember_oak
     type: assign
     idempotency_key: "${run_id}:hold:ember_oak:timeout"
     parameters:
@@ -255,9 +255,9 @@ steps:
     parameters:
       target: hold_ember_oak_verification
       value: '{"venue":"Ember & Oak","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
-    next: mock_hold_casa_nera
+    next: hold_candidate_casa_nera
 
-  - id: mock_hold_casa_nera
+  - id: hold_candidate_casa_nera
     type: assign
     idempotency_key: "${run_id}:hold:casa_nera:timeout"
     parameters:
@@ -270,9 +270,9 @@ steps:
     parameters:
       target: hold_casa_nera_verification
       value: '{"venue":"Casa Nera","call_record_present":true,"transcript_present":true,"hold_status_extracted_from_transcript":"confirmed","payment_requested":false,"result":"pass"}'
-    next: mock_hold_atlas_row
+    next: hold_candidate_atlas_row
 
-  - id: mock_hold_atlas_row
+  - id: hold_candidate_atlas_row
     type: assign
     idempotency_key: "${run_id}:hold:atlas_row:timeout"
     parameters:
@@ -291,7 +291,7 @@ steps:
     type: assign
     parameters:
       target: hold_summary
-      value: '{"status":"all_three_held","selected_venue":null,"message":"All three mock holds are confirmed. Workflow is waiting for the user to choose one.","holds":["${steps.hold_ember_oak.output}","${steps.hold_casa_nera.output}","${steps.hold_atlas_row.output}"],"proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
+      value: '{"status":"all_three_held","selected_venue":null,"message":"All three mock holds are confirmed. Workflow is waiting for the user to choose one.","holds":["${steps.hold_candidate_ember_oak.output}","${steps.hold_candidate_casa_nera.output}","${steps.hold_candidate_atlas_row.output}"],"proofs":["mock-call-hold-ember-oak","mock-transcript-hold-ember-oak","mock-call-hold-casa-nera","mock-transcript-hold-casa-nera","mock-call-hold-atlas-row","mock-transcript-hold-atlas-row"]}'
     next: publish_holds_wait_state
 
   - id: publish_holds_wait_state
@@ -299,9 +299,9 @@ steps:
     parameters:
       target: post_timeout_wait_state
       value: '{"task_id":"task-uc5b","parent_task_id":"task-uc5","stored_in":"mock_durable_workflow_state","status":"waiting_for_user_choice_after_holds","accepted_signals":["ember_oak","casa_nera","atlas_row"],"default_mock_choice":"ember_oak"}'
-    next: mock_user_selects_after_holds
+    next: receive_user_choice_after_holds
 
-  - id: mock_user_selects_after_holds
+  - id: receive_user_choice_after_holds
     type: assign
     parameters:
       target: user_choice_after_holds
@@ -313,9 +313,9 @@ steps:
     parameters:
       target: release_plan
       value: '{"selected_venue":"Ember & Oak","keep":["Ember & Oak"],"release":["Casa Nera","Atlas Row"],"do_not_release_selected":true,"release_only_confirmed_holds":true,"result":"pass"}'
-    next: mock_release_casa_nera
+    next: release_unselected_casa_nera
 
-  - id: mock_release_casa_nera
+  - id: release_unselected_casa_nera
     type: assign
     idempotency_key: "${run_id}:release:casa_nera"
     parameters:
@@ -328,9 +328,9 @@ steps:
     parameters:
       target: release_casa_nera_verification
       value: '{"venue":"Casa Nera","call_record_present":true,"transcript_present":true,"release_status_extracted_from_transcript":"confirmed","result":"pass"}'
-    next: mock_release_atlas_row
+    next: release_unselected_atlas_row
 
-  - id: mock_release_atlas_row
+  - id: release_unselected_atlas_row
     type: assign
     idempotency_key: "${run_id}:release:atlas_row"
     parameters:
@@ -380,7 +380,7 @@ steps:
       value: '{"workflow_status":"failed","path":"deposit_required_failed","reason":"restaurant requested a deposit, and this mock workflow only supports free reservations","money_spent":false,"held":false,"requires_user_decision":false,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"deposit_request_returns_failure_reason":true}}'
     next: ""
 
-  - id: mock_ambiguous_call_outcome
+  - id: handle_ambiguous_hold_outcome
     type: assign
     idempotency_key: "${run_id}:hold:ambiguous"
     parameters:
@@ -395,7 +395,7 @@ steps:
       value: '{"workflow_status":"needs_attention","path":"ambiguous_hold_unverified","held":false,"reason":"call completed but transcript did not clearly confirm hold","proof":{"call_records":["mock-call-ambiguous"],"transcripts":["mock-transcript-ambiguous"],"verification":"hold_status_unknown"},"requires_user_decision":true,"success_contract":{"options_shown_before_any_call":true,"money_spent":false,"ambiguous_hold_not_reported_as_confirmed":true}}'
     next: ""
 
-  - id: mock_invalid_selected_choice
+  - id: final_artifact_invalid_selected_choice
     type: assign
     parameters:
       target: dinner_date_artifact


### PR DESCRIPTION
## Summary
- Add a non-authoritative UC5 dinner-date workflow spec draft with external dependency points and open questions.
- Add an executable `dinner_date_mock` workflow that validates shortlist, timeout, hold-all, release, selected-only, and artifact flow using deterministic mock nodes.
- Keep required external calls mocked and model Google Calendar as an optional post-action outside core workflow success.

## Test plan
- [x] `dotnet test /private/tmp/aevatar-dinner-date-pr/test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter 'FullyQualifiedName~WorkflowParserConfigurationTests|FullyQualifiedName~WorkflowParserForeignDialectRejectionTests|FullyQualifiedName~WorkflowParserCoverageTests'`
- [x] `dotnet test /private/tmp/aevatar-dinner-date-pr/test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter 'FullyQualifiedName~WorkflowCatalog|FullyQualifiedName~WorkflowAdmission|FullyQualifiedName~WorkflowYaml'`
- [x] Local Mainnet runtime validation through NyxID proxy: default timeout path completed successfully.
- [x] Local Mainnet runtime validation through NyxID proxy: `ember_oak` selected path completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)