### PR TITLE
Admit code execution routes from keys auto_connected

### DIFF
--- a/docs/contracts/nyxid-assistant-conformance/v1/sources.json
+++ b/docs/contracts/nyxid-assistant-conformance/v1/sources.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "aevatar": {
     "repository": "https://github.com/AevatarAI/aevatar.git",
-    "revision": "0b8ec500087331c3d12819b532e7dfa29e740fb4",
-    "contract_files_sha256": "0d05d7c2d12437b8281c5ee8a0210b51d9a2757c0ae9be237aab485050524420",
+    "revision": "2c66f55aa907a96e96b01edd84ebc8e417af0731",
+    "contract_files_sha256": "d0daddc0594a0f92fe7c2057c4433a7dbb06f2d8097aa0d079e67f5eab361c50",
     "files": {
       "agents/Aevatar.GAgents.NyxidChat/NyxIdActionPostconditionPort.cs": "23fd2cf48541c4b8da3fa1ef07277a7700c8478f9c638be8221465bf877fbb31",
       "agents/Aevatar.GAgents.NyxidChat/NyxIdAssistantActionRegistry.cs": "60e6f67c94ae11b1bf0dac036ad8ac0c35901e31787b1f0c8173964f6a12d263",
@@ -13,7 +13,7 @@
       "agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto": "523b8182bdd0a30224e001a7257ad42450226f42a84542a363e97816e34f23d9",
       "docs/adr/0048-nyxid-assistant-operation-class-boundary.md": "884aca09774e773e68154c923fec8078610b2cf8e97f581fedc36e10451ccec3",
       "src/Aevatar.AI.Abstractions/ai_messages.proto": "7ca08d69adbd97d82b89fc041d8d0eebd81e3ca125e2c4798bf012f1c29dc26d",
-      "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs": "2c679f03818997d1759b5bc60560b37119214bd6d5ee64f41578e02fa44cc9ee",
+      "src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs": "f209169e3ccb63ec9135b7d1f50d61987890f195efbde5676bbfa38680169748",
       "src/Aevatar.AI.ToolProviders.NyxId/NyxIdAssistantToolSource.cs": "1b033df9cb55c741e9b52054cbd4a91067f03c8c3797bd076a7e3d6133eb0fcb",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyCreateTool.cs": "2c4f2cda99154f2e667c6cfd291497e697ef11df17f081f96ec70070a8af8b8c",
       "src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdRequestKeyRotateTool.cs": "18212bb64644cfbca401065bccce439ea5fa00316deff57d730a0d9ac2650e53",

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs
@@ -117,7 +117,8 @@ public sealed record NyxIdUserServiceKey(
     NyxIdUserServiceCredentialSource CredentialSource,
     string? CatalogServiceId,
     string? CatalogServiceSlug,
-    bool Connected);
+    bool Connected,
+    bool? AutoConnected = null);
 
 public sealed record NyxIdUserServiceKeys(IReadOnlyList<NyxIdUserServiceKey> Services);
 
@@ -425,7 +426,8 @@ public static class NyxIdApiAccessResponseParser
                     JsonValueKind.Object)),
                 ReadOptionalNormalizedString(serviceElement, "catalog_service_id"),
                 ReadOptionalNormalizedString(serviceElement, "catalog_service_slug"),
-                RequireBoolean(serviceElement, "connected")));
+                RequireBoolean(serviceElement, "connected"),
+                ReadOptionalBoolean(serviceElement, "auto_connected")));
         }
 
         return new NyxIdUserServiceKeys(services);

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
@@ -285,6 +285,12 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
     public Task<string> CreateServiceAsync(string token, string body, CancellationToken ct) =>
         PostAsync(token, "/api/v1/keys", body, ct);
 
+    internal Task<NyxIdProxyTextResponse> CreateServiceResponseAsync(
+        string token,
+        string body,
+        CancellationToken ct) =>
+        PostTextResponseAsync(token, "/api/v1/keys", body, ct);
+
     // ─── Session Refresh ───
 
     public async Task<NyxIdSessionRefreshResult> RefreshSessionAsync(string refreshToken, CancellationToken ct)
@@ -1309,6 +1315,17 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
     public Task<string> UpdateServiceRouteAsync(string token, string id, string body, CancellationToken ct) =>
         PutAsync(token, $"/api/v1/user-services/{Uri.EscapeDataString(id)}", body, ct);
 
+    internal Task<NyxIdProxyTextResponse> UpdateServiceRouteResponseAsync(
+        string token,
+        string id,
+        string body,
+        CancellationToken ct) =>
+        PutTextResponseAsync(
+            token,
+            $"/api/v1/user-services/{Uri.EscapeDataString(id)}",
+            body,
+            ct);
+
     // ─── Proxy (additions) ───
 
     public Task<string> DiscoverProxyServicesAsync(string token, CancellationToken ct) =>
@@ -1886,12 +1903,19 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
     }
 
     internal async Task<string> PostAsync(string token, string path, string body, CancellationToken ct)
+        => (await PostTextResponseAsync(token, path, body, ct)).Content;
+
+    private async Task<NyxIdProxyTextResponse> PostTextResponseAsync(
+        string token,
+        string path,
+        string body,
+        CancellationToken ct)
     {
         var url = $"{GetPublicApiBaseUrl()}{path}";
         using var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         request.Content = new StringContent(body, Encoding.UTF8, "application/json");
-        return await SendAsync(request, ct);
+        return await SendTextResponseAsync(request, ct);
     }
 
     internal async Task<string> PostWithoutAuthAsync(string path, string body, CancellationToken ct)
@@ -1912,12 +1936,19 @@ public sealed class NyxIdApiClient : IDisposable, INyxIdUserReadApi
     }
 
     internal async Task<string> PutAsync(string token, string path, string body, CancellationToken ct)
+        => (await PutTextResponseAsync(token, path, body, ct)).Content;
+
+    private async Task<NyxIdProxyTextResponse> PutTextResponseAsync(
+        string token,
+        string path,
+        string body,
+        CancellationToken ct)
     {
         var url = $"{GetPublicApiBaseUrl()}{path}";
         using var request = new HttpRequestMessage(HttpMethod.Put, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         request.Content = new StringContent(body, Encoding.UTF8, "application/json");
-        return await SendAsync(request, ct);
+        return await SendTextResponseAsync(request, ct);
     }
 
     internal async Task<string> DeleteAsync(string token, string path, CancellationToken ct)

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRoutePolicyReconciler.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRoutePolicyReconciler.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Aevatar.AI.Abstractions.CodeExecution;
 
 namespace Aevatar.AI.ToolProviders.NyxId;
@@ -8,6 +10,7 @@ public enum NyxIdCodeExecutionRouteRepairFailureKind
     None = 0,
     UpdateException = 1,
     PostconditionMismatch = 2,
+    MutationRejected = 3,
 }
 
 public sealed record NyxIdCodeExecutionRouteReconciliation(
@@ -74,10 +77,14 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
                 Verified: postconditionSatisfied,
                 FailureKind: postconditionSatisfied
                     ? NyxIdCodeExecutionRouteRepairFailureKind.None
-                    : convergence.FailureKind ==
-                      NyxIdUserServiceRouteConvergenceFailureKind.UpdateException
-                        ? NyxIdCodeExecutionRouteRepairFailureKind.UpdateException
-                        : NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch);
+                    : convergence.FailureKind switch
+                    {
+                        NyxIdUserServiceRouteConvergenceFailureKind.UpdateException =>
+                            NyxIdCodeExecutionRouteRepairFailureKind.UpdateException,
+                        NyxIdUserServiceRouteConvergenceFailureKind.MutationRejected =>
+                            NyxIdCodeExecutionRouteRepairFailureKind.MutationRejected,
+                        _ => NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch,
+                    });
         }
 
         if (!CanCreatePersonalRoute(before, resolution, exactUserServiceId))
@@ -137,14 +144,13 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
             .Where(service =>
                 CodeExecutionContract.IsSupportedServiceSlug(service.Slug) &&
                 snapshot.TryGetExact(service.Id, out var authority) &&
-                authority is { IsExecutionReady: true } &&
+                authority is { IsExecutionReady: true, Execution.AutoConnected: true } &&
                 string.Equals(
                     authority.Execution.CatalogServiceSlug,
                     CodeExecutionContract.ServiceSlug,
                     StringComparison.Ordinal))
             .ToArray();
         return canonical.Length == 1 &&
-               canonical[0].AutoConnected &&
                string.Equals(
                    canonical[0].Slug,
                    CodeExecutionContract.ServiceSlug,
@@ -156,23 +162,24 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
         NyxIdUserServiceRouteMutationAuthority mutationAuthority,
         CancellationToken cancellationToken)
     {
-        var createFailed = false;
+        var createFailure = NyxIdCodeExecutionRouteRepairFailureKind.None;
         try
         {
-            var body = JsonSerializer.Serialize(new
-            {
-                service_slug = CodeExecutionContract.ServiceSlug,
-                slug = CodeExecutionContract.PersonalServiceSlug,
-                forward_access_token = true,
-                inject_delegation_token = true,
-                delegation_token_scope = "proxy:* sandbox:execute",
-            });
-            _ = await _clientFactory.CreateClient()
-                .CreateServiceAsync(
+            var body = JsonSerializer.Serialize(new CreatePersonalRouteRequest(
+                CodeExecutionContract.ServiceSlug,
+                CodeExecutionContract.PersonalServiceSlug,
+                "Aevatar Code Execution",
+                true,
+                true,
+                "proxy:* sandbox:execute"));
+            var response = await _clientFactory.CreateClient()
+                .CreateServiceResponseAsync(
                     mutationAuthority.BearerToken,
                     body,
                     cancellationToken)
                 .ConfigureAwait(false);
+            if (!response.Succeeded && response.HttpStatus != (int)HttpStatusCode.Conflict)
+                createFailure = NyxIdCodeExecutionRouteRepairFailureKind.MutationRejected;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -180,7 +187,7 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
         }
         catch
         {
-            createFailed = true;
+            createFailure = NyxIdCodeExecutionRouteRepairFailureKind.UpdateException;
         }
 
         var after = await _converger.ReadAsync(mutationAuthority, cancellationToken)
@@ -196,9 +203,9 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
             Verified: verified,
             FailureKind: verified
                 ? NyxIdCodeExecutionRouteRepairFailureKind.None
-                : createFailed
-                    ? NyxIdCodeExecutionRouteRepairFailureKind.UpdateException
-                    : NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch);
+                : createFailure == NyxIdCodeExecutionRouteRepairFailureKind.None
+                    ? NyxIdCodeExecutionRouteRepairFailureKind.PostconditionMismatch
+                    : createFailure);
     }
 
     private static NyxIdUserService? SelectVerifiedPersonalRoute(
@@ -213,10 +220,9 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
                     service.Slug,
                     CodeExecutionContract.PersonalServiceSlug,
                     StringComparison.Ordinal) &&
-                !service.AutoConnected &&
                 service.CredentialSource.Kind == NyxIdUserServiceCredentialSourceKind.Personal &&
                 snapshot.TryGetExact(service.Id, out var authority) &&
-                authority is { IsExecutionReady: true } &&
+                authority is { IsExecutionReady: true, Execution.AutoConnected: false } &&
                 string.Equals(
                     authority.Execution.CatalogServiceSlug,
                     CodeExecutionContract.ServiceSlug,
@@ -225,4 +231,12 @@ public sealed class NyxIdCodeExecutionRoutePolicyReconciler
             .ToArray();
         return candidates.Length == 1 ? candidates[0] : null;
     }
+
+    private sealed record CreatePersonalRouteRequest(
+        [property: JsonPropertyName("service_slug")] string ServiceSlug,
+        [property: JsonPropertyName("slug")] string Slug,
+        [property: JsonPropertyName("label")] string Label,
+        [property: JsonPropertyName("forward_access_token")] bool ForwardAccessToken,
+        [property: JsonPropertyName("inject_delegation_token")] bool InjectDelegationToken,
+        [property: JsonPropertyName("delegation_token_scope")] string DelegationTokenScope);
 }

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdUserServiceRouteConverger.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdUserServiceRouteConverger.cs
@@ -216,7 +216,9 @@ public sealed record NyxIdUserServiceAuthority(
             : Execution.NodeStatus == NyxIdUserServiceNodeStatus.Online);
 
     public bool CanManageRoute =>
-        !Route.AutoConnected && IsExecutionReady && Route.CredentialSource.Kind switch
+        Execution.AutoConnected == false &&
+        IsExecutionReady &&
+        Route.CredentialSource.Kind switch
         {
             NyxIdUserServiceCredentialSourceKind.Personal => true,
             NyxIdUserServiceCredentialSourceKind.Organization =>
@@ -240,7 +242,7 @@ public sealed record NyxIdUserServiceAuthority(
             Execution.CatalogServiceSlug,
             other.Execution.CatalogServiceSlug,
             StringComparison.Ordinal) &&
-        Route.AutoConnected == other.Route.AutoConnected &&
+        Execution.AutoConnected == other.Execution.AutoConnected &&
         SameAuthority(Execution.CredentialSource, other.Execution.CredentialSource);
 
     private static bool SameAuthority(
@@ -291,9 +293,29 @@ public sealed class NyxIdUserServiceAuthorityReader(INyxIdApiClientFactory clien
                 bearerToken.Trim(),
                 cancellationToken)
             .ConfigureAwait(false);
+        var routes = NyxIdApiAccessResponseParser.ParseUserServiceRoutes(routeResponse);
+        var executionInventory = NyxIdApiAccessResponseParser.ParseUserServiceKeys(executionResponse);
         return new NyxIdUserServiceAuthoritySnapshot(
-            NyxIdApiAccessResponseParser.ParseUserServiceRoutes(routeResponse),
-            NyxIdApiAccessResponseParser.ParseUserServiceKeys(executionResponse));
+            ApplyExecutionProvenance(routes, executionInventory),
+            executionInventory);
+    }
+
+    private static NyxIdApiAccessResult<NyxIdUserServices> ApplyExecutionProvenance(
+        NyxIdApiAccessResult<NyxIdUserServices> routes,
+        NyxIdApiAccessResult<NyxIdUserServiceKeys> executionInventory)
+    {
+        if (!routes.Succeeded || !executionInventory.Succeeded)
+            return routes;
+
+        var executionById = executionInventory.Value!.Services
+            .ToDictionary(static service => service.Id, StringComparer.Ordinal);
+        var normalizedRoutes = routes.Value!.Services
+            .Select(route => executionById.TryGetValue(route.Id, out var execution)
+                ? route with { AutoConnected = execution.AutoConnected == true }
+                : route)
+            .ToArray();
+        return NyxIdApiAccessResult<NyxIdUserServices>.Success(
+            new NyxIdUserServices(normalizedRoutes));
     }
 }
 
@@ -306,6 +328,7 @@ public enum NyxIdUserServiceRouteConvergenceFailureKind
     RouteNotWritable = 4,
     UpdateException = 5,
     PostconditionMismatch = 6,
+    MutationRejected = 7,
 }
 
 public sealed record NyxIdUserServiceRouteConvergence(
@@ -380,13 +403,15 @@ public sealed class NyxIdUserServiceRouteConverger(INyxIdApiClientFactory client
         try
         {
             var body = NyxIdUserServiceRouteUpdateAdapter.Serialize(plan.Patch);
-            _ = await clientFactory.CreateClient()
-                .UpdateServiceRouteAsync(
+            var response = await clientFactory.CreateClient()
+                .UpdateServiceRouteResponseAsync(
                     authority.BearerToken,
                     current.Route.Id,
                     body,
                     cancellationToken)
                 .ConfigureAwait(false);
+            if (!response.Succeeded)
+                updateFailure = NyxIdUserServiceRouteConvergenceFailureKind.MutationRejected;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/test/Aevatar.AI.Tests/NyxIdCodeExecutionRouteAdmissionPreparerTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdCodeExecutionRouteAdmissionPreparerTests.cs
@@ -22,7 +22,9 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
             AutoConnectedKeysInventory(),
             AutoConnectedInventory(),
             AutoConnectedKeysInventory(),
-            """{"error":true,"status":409,"body":"concurrent create"}""",
+            new SequenceResponse(
+                HttpStatusCode.Conflict,
+                """{"error":"concurrent create"}"""),
             PersonalExecutionInventory(),
             PersonalExecutionKeysInventory(),
             PersonalExecutionInventory(),
@@ -79,6 +81,8 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
         {
             body.RootElement.GetProperty("service_slug").GetString().Should().Be("chrono-sandbox");
             body.RootElement.GetProperty("slug").GetString().Should().Be("chrono-sandbox-aevatar");
+            body.RootElement.GetProperty("label").GetString().Should()
+                .Be("Aevatar Code Execution");
             body.RootElement.GetProperty("forward_access_token").GetBoolean().Should().BeTrue();
             body.RootElement.GetProperty("inject_delegation_token").GetBoolean().Should().BeTrue();
             body.RootElement.GetProperty("delegation_token_scope").GetString().Should()
@@ -88,6 +92,91 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
         proof.UserServiceId.Should().Be("us-code-aevatar");
         proof.ServiceSlugSnapshot.Should().Be("chrono-sandbox-aevatar");
         proof.CatalogServiceId.Should().Be("catalog-chrono-sandbox");
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_PersonalRouteCreationRejected_PreservesMutationFailure()
+    {
+        var handler = new SequenceHandler(
+            AutoConnectedInventory(),
+            AutoConnectedKeysInventory(),
+            new SequenceResponse(
+                HttpStatusCode.UnprocessableEntity,
+                """{"error":"missing field `label`"}"""),
+            AutoConnectedInventory(),
+            AutoConnectedKeysInventory());
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyx.example" };
+        var reconciler = new NyxIdCodeExecutionRoutePolicyReconciler(
+            new TestClientFactory(new NyxIdApiClient(options, new HttpClient(handler))));
+        NyxIdUserServiceRouteMutationAuthority.TryCreate(
+                NyxIdCallerCredentialSelection.DirectUserBearer("source-readable-alpha"),
+                out var mutationAuthority)
+            .Should().BeTrue();
+
+        var result = await reconciler.ReconcileAsync(mutationAuthority!);
+
+        result.Attempted.Should().BeTrue();
+        result.Verified.Should().BeFalse();
+        result.FailureKind.Should().Be(NyxIdCodeExecutionRouteRepairFailureKind.MutationRejected);
+        handler.Requests.Select(static request => request.Method).Should().Equal(
+            HttpMethod.Get,
+            HttpMethod.Get,
+            HttpMethod.Post,
+            HttpMethod.Get,
+            HttpMethod.Get);
+    }
+
+    [Fact]
+    public async Task ConvergeAsync_RouteMutationRejected_PreservesMutationFailure()
+    {
+        var handler = new SequenceHandler(
+            Inventory("personal", false, true, "proxy:*"),
+            KeysInventory("personal"),
+            new SequenceResponse(HttpStatusCode.Forbidden, """{"error":"forbidden"}"""),
+            Inventory("personal", false, true, "proxy:*"),
+            KeysInventory("personal"));
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyx.example" };
+        var converger = new NyxIdUserServiceRouteConverger(
+            new TestClientFactory(new NyxIdApiClient(options, new HttpClient(handler))));
+        NyxIdUserServiceRouteMutationAuthority.TryCreate(
+                NyxIdCallerCredentialSelection.DirectUserBearer("source-readable-alpha"),
+                out var mutationAuthority)
+            .Should().BeTrue();
+
+        var result = await converger.ConvergeAsync(
+            mutationAuthority!,
+            "us-code-alpha",
+            new NyxIdUserServiceRouteContract(
+                NyxIdUserServiceBooleanRequirement.Enabled,
+                NyxIdUserServiceBooleanRequirement.Enabled,
+                ["proxy:*", "sandbox:execute"]));
+
+        result.Attempted.Should().BeTrue();
+        result.Verified.Should().BeFalse();
+        result.FailureKind.Should().Be(
+            NyxIdUserServiceRouteConvergenceFailureKind.MutationRejected);
+    }
+
+    [Fact]
+    public async Task ReconcileAsync_KeysOmitAutoConnected_DoesNotGuessWritable()
+    {
+        var handler = new SequenceHandler(
+            AutoConnectedInventory(),
+            AutoConnectedKeysInventoryOmittingAutoConnected());
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyx.example" };
+        var reconciler = new NyxIdCodeExecutionRoutePolicyReconciler(
+            new TestClientFactory(new NyxIdApiClient(options, new HttpClient(handler))));
+        NyxIdUserServiceRouteMutationAuthority.TryCreate(
+                NyxIdCallerCredentialSelection.DirectUserBearer("source-readable-alpha"),
+                out var mutationAuthority)
+            .Should().BeTrue();
+
+        var result = await reconciler.ReconcileAsync(mutationAuthority!);
+
+        result.Attempted.Should().BeFalse();
+        result.Verified.Should().BeFalse();
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests.Should().OnlyContain(static request => request.Method == HttpMethod.Get);
     }
 
     [Fact]
@@ -443,6 +532,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                 "is_active": true,
                 "status": "expired",
                 "connected": true,
+                "auto_connected": false,
                 "credential_source": { "type": "personal" }
               }]
             }
@@ -653,6 +743,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = false,
                     credential_source = credentialSource,
                 },
             },
@@ -670,7 +761,6 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     slug = "chrono-sandbox",
                     catalog_service_id = "catalog-chrono-sandbox",
                     is_active = true,
-                    auto_connected = true,
                     forward_access_token = true,
                     inject_delegation_token = true,
                     delegation_token_scope = "proxy:*",
@@ -680,6 +770,26 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
         });
 
     private static string AutoConnectedKeysInventory() =>
+        JsonSerializer.Serialize(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    id = "us-code-platform",
+                    slug = "chrono-sandbox",
+                    catalog_service_id = "catalog-chrono-sandbox",
+                    catalog_service_slug = "chrono-sandbox",
+                    is_active = true,
+                    status = "active",
+                    connected = true,
+                    auto_connected = true,
+                    credential_source = new { type = "personal" },
+                },
+            },
+        });
+
+    private static string AutoConnectedKeysInventoryOmittingAutoConnected() =>
         JsonSerializer.Serialize(new
         {
             keys = new[]
@@ -709,7 +819,6 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     slug = "chrono-sandbox",
                     catalog_service_id = "catalog-chrono-sandbox",
                     is_active = true,
-                    auto_connected = true,
                     forward_access_token = true,
                     inject_delegation_token = true,
                     delegation_token_scope = "proxy:*",
@@ -721,7 +830,6 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     slug = "chrono-sandbox-aevatar",
                     catalog_service_id = "catalog-chrono-sandbox",
                     is_active = true,
-                    auto_connected = false,
                     forward_access_token = true,
                     inject_delegation_token = true,
                     delegation_token_scope = "proxy:* sandbox:execute",
@@ -744,6 +852,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = true,
                     credential_source = new { type = "personal" },
                 },
                 new
@@ -755,6 +864,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = false,
                     credential_source = new { type = "personal" },
                 },
             },
@@ -813,6 +923,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = false,
                     credential_source = new { type = "personal" },
                 },
                 new
@@ -824,6 +935,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = false,
                     credential_source = new
                     {
                         type = "org",
@@ -850,6 +962,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = false,
                     credential_source = new { type = "personal" },
                 },
                 new
@@ -861,6 +974,7 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
                     is_active = true,
                     status = "active",
                     connected = true,
+                    auto_connected = false,
                     credential_source = new { type = "personal" },
                 },
             },
@@ -914,9 +1028,15 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
             CancellationToken ct = default) => throw new InvalidOperationException("Unexpected inline bundle parse.");
     }
 
-    private sealed class SequenceHandler(params string[] responses) : HttpMessageHandler
+    private sealed class SequenceHandler(params object[] responses) : HttpMessageHandler
     {
-        private readonly Queue<string> _responses = new(responses);
+        private readonly Queue<SequenceResponse> _responses = new(responses.Select(static response =>
+            response switch
+            {
+                string body => new SequenceResponse(HttpStatusCode.OK, body),
+                SequenceResponse typed => typed,
+                _ => throw new ArgumentException("Unsupported response fixture.", nameof(responses)),
+            }));
 
         public List<RecordedRequest> Requests { get; } = [];
 
@@ -935,15 +1055,18 @@ public sealed class NyxIdCodeExecutionRouteAdmissionPreparerTests
             if (_responses.Count == 0)
                 throw new InvalidOperationException("Unexpected NyxID request.");
 
-            return new HttpResponseMessage(HttpStatusCode.OK)
+            var response = _responses.Dequeue();
+            return new HttpResponseMessage(response.StatusCode)
             {
                 Content = new StringContent(
-                    _responses.Dequeue(),
+                    response.Body,
                     Encoding.UTF8,
                     "application/json"),
             };
         }
     }
+
+    private sealed record SequenceResponse(HttpStatusCode StatusCode, string Body);
 
     private sealed record RecordedRequest(
         HttpMethod Method,


### PR DESCRIPTION
## Problem

NyxID `GET /api/v1/user-services` does not return `auto_connected`. Only `GET /api/v1/keys` does. Aevatar read the routing projection, defaulted the missing field to `false`, treated platform-hosted chrono-sandbox routes as writable, and sent `PUT /api/v1/user-services/{id}`. Production rejected those updates (403). Personal fallback `POST /api/v1/keys` omitted the required `label` (422). Non-2xx bodies were unwrapped as ordinary strings and reported as `PostconditionMismatch`, which then surfaced as `CODE_EXECUTION_ROUTE_REPAIR_UNVERIFIED`.

This blocked `code_execute` admission for operator scopes that already had a healthy platform-hosted route (#3429 / #3290).

## Solution

- Parse `auto_connected` as optional from `/keys` only.
- Join execution authority by exact UserService id; never infer writability from slug, 403 text, or a missing field.
- `CanManageRoute` requires `Execution.AutoConnected == false`.
- Personal fallback create sends label `Aevatar Code Execution`.
- Preserve HTTP rejection as `MutationRejected` instead of swallowing it into postcondition mismatch.
- Platform-hosted routes are not PUT; personal create is idempotent on 409.

Second commit refreshes the NyxID conformance pin for `NyxIdApiAccessContracts.cs`. Channel/query WIP in the working tree is not included.

## Impact

- `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiAccessContracts.cs`
- `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs`
- `src/Aevatar.AI.ToolProviders.NyxId/NyxIdCodeExecutionRoutePolicyReconciler.cs`
- `src/Aevatar.AI.ToolProviders.NyxId/NyxIdUserServiceRouteConverger.cs`
- `test/Aevatar.AI.Tests/NyxIdCodeExecutionRouteAdmissionPreparerTests.cs`
- `docs/contracts/nyxid-assistant-conformance/v1/sources.json`

## Verification

```
dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter "FullyQualifiedName~NyxIdCodeExecutionRouteAdmissionPreparerTests|FullyQualifiedName~NyxIdAdversarialCorpusTests"
# Passed: 35
bash tools/ci/test_stability_guards.sh
# passed
python3 tools/ci/nyxid_conformance_guard.py --refresh-aevatar-revision HEAD
# pin refreshed from 2c66f55aa
```

`unknown-wire-members` in the adversarial corpus already passes on current HEAD and is not part of the admission commit.

Production HR (#3429) and Finance (#3290) `submit=false` admission, >8 minute Lark identity, and FIN/HR timings remain **pending deploy**.