### PR TITLE
Export target_role in workflow templates

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/Skills/SkillDirectWorkflowYamlSynthesizer.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Skills/SkillDirectWorkflowYamlSynthesizer.cs
@@ -27,7 +27,7 @@ internal static class SkillDirectWorkflowYamlSynthesizer
         builder.Append("steps:\n");
         builder.Append("  - id: answer\n");
         builder.Append("    type: llm_call\n");
-        builder.Append("    role: assistant\n");
+        builder.Append("    target_role: assistant\n");
         return builder.ToString();
     }
 

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -48,7 +48,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
         steps:
           - id: reply
             type: llm_call
-            role: assistant
+            target_role: assistant
             parameters: {}
         """;
 
@@ -424,7 +424,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
         steps:
           - id: reply
             type: llm_call
-            role: studio
+            target_role: studio
             parameters: {}
         """;
 
@@ -563,8 +563,8 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             $"      - Authorable top-level keys: {WorkflowYamlRootSchema.FormatAuthorableRootFields()}",
             $"      - Do NOT use top-level keys from other workflow dialects, including {WorkflowYamlRootSchema.FormatUnsupportedDialectRootFields()}",
             "      - roles: list of {id, name, system_prompt, allowed_tools}; every role used by llm_call must declare allowed_tools, and an empty list is valid; prefer omitting provider/model so runtime default is used",
-            "      - steps: list of {id, type, role, parameters, next, branches}",
-            "      - Step objects may only use these root keys: id, type, role, target_role, parameters, next, branches, children, retry, on_error, timeout_ms",
+            "      - steps: list of {id, type, target_role, parameters, next, branches}",
+            "      - Step objects may only use these root keys: id, type, target_role, parameters, next, branches, children, retry, on_error, timeout_ms",
             "      - Do NOT add unsupported step-level fields such as description, title, summary, notes, input_schema, output_schema, metadata, or examples",
             "      - Available step types: llm_call, transform, assign, guard, conditional, switch,",
             "        while, foreach, parallel, race, map_reduce, evaluate, reflect, connector_call, secure_connector_call,",
@@ -614,7 +614,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             "      steps:",
             "        - id: summarize_review",
             "          type: llm_call",
-            "          role: reviewer",
+            "          target_role: reviewer",
             "          parameters:",
             "            prompt: \"Summarize the input and call out urgent issues.\"",
             "          next: gate_urgent",
@@ -663,7 +663,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
         [
             "  - id: classify_route",
             "    type: llm_call",
-            "    role: planner",
+            "    target_role: planner",
             "    parameters:",
             "      prompt_prefix: \"Classify the user request into exactly one route token: direct or workflow. Respond with only one lowercase token and no extra text.\\n\\n\"",
             "    next: route_intent",
@@ -684,7 +684,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             string.Empty,
             "  - id: generate_workflow_yaml",
             "    type: llm_call",
-            "    role: planner",
+            "    target_role: planner",
             "    parameters:",
             "      prompt_prefix: \"Generate a complete workflow YAML for the user request below. Return only a single ```yaml fenced block.\\n\\n\"",
             "    next: validate_yaml",
@@ -698,7 +698,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             string.Empty,
             "  - id: reply_direct",
             "    type: llm_call",
-            "    role: assistant",
+            "    target_role: assistant",
             "    next: done",
             string.Empty,
             "  - id: validate_yaml",
@@ -719,7 +719,7 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
             string.Empty,
             "  - id: refine_yaml",
             "    type: llm_call",
-            "    role: planner",
+            "    target_role: planner",
             "    parameters:",
             "      prompt_prefix: \"Please refine the workflow YAML based on the validation error or user feedback below. Return a corrected full workflow YAML only in a single ```yaml fenced block. Do not include unsupported step-level fields such as description, title, summary, notes, metadata, input_schema, or output_schema. Primitive-specific options must be placed under step.parameters.\\n\\n\"",
             "    next: validate_yaml",

--- a/test/Aevatar.Capabilities.Tests/WorkflowSkillsDirectYamlSynthesizerTests.cs
+++ b/test/Aevatar.Capabilities.Tests/WorkflowSkillsDirectYamlSynthesizerTests.cs
@@ -21,7 +21,7 @@ public sealed class WorkflowSkillsDirectYamlSynthesizerTests
 
         yaml.Should().Contain("name: ornn-skill-abc-123");
         yaml.Should().Contain("type: llm_call");
-        yaml.Should().Contain("role: assistant");
+        yaml.Should().Contain("target_role: assistant");
         yaml.Should().Contain("system_prompt: |");
         // Instruction lines are indented under the block scalar (6 spaces); colons/blank lines survive.
         yaml.Should().Contain("      Line one");

--- a/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConfigurationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Primitives/WorkflowParserConfigurationTests.cs
@@ -610,7 +610,7 @@ public class WorkflowParserConfigurationTests
                 next: classify_route
               - id: classify_route
                 type: llm_call
-                role: planner
+                target_role: planner
                 parameters:
                   prompt_prefix: "Return one token: direct or workflow."
                 next: route_intent
@@ -628,7 +628,7 @@ public class WorkflowParserConfigurationTests
                 next: generate_workflow_yaml
               - id: generate_workflow_yaml
                 type: llm_call
-                role: planner
+                target_role: planner
                 next: validate_yaml
               - id: validate_yaml
                 type: workflow_yaml_validate
@@ -645,7 +645,7 @@ public class WorkflowParserConfigurationTests
                   "false": refine_yaml
               - id: refine_yaml
                 type: llm_call
-                role: assistant
+                target_role: assistant
                 next: validate_yaml
               - id: extract_and_execute
                 type: dynamic_workflow
@@ -658,7 +658,7 @@ public class WorkflowParserConfigurationTests
                 next: reply_direct
               - id: reply_direct
                 type: llm_call
-                role: assistant
+                target_role: assistant
                 next: done
               - id: done
                 type: assign

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowDefinitionCatalogTests.cs
@@ -255,6 +255,20 @@ public class WorkflowDefinitionCatalogTests
     }
 
     [Fact]
+    public void BuiltInYaml_ShouldExportTargetRoleField()
+    {
+        var builtInYaml = string.Join('\n',
+            WorkflowDefinitionCatalog.BuiltInDirectYaml,
+            WorkflowDefinitionCatalog.BuiltInStudioYaml,
+            WorkflowDefinitionCatalog.CreateBuiltInAutoYaml(),
+            WorkflowDefinitionCatalog.CreateBuiltInAutoReviewYaml());
+
+        builtInYaml.Should().Contain("target_role:");
+        builtInYaml.Should().NotContain("\n    role:");
+        builtInYaml.Should().NotContain("\n          role:");
+    }
+
+    [Fact]
     public void BuiltInStudioYaml_ShouldParseAsMemberProvisionStudioRoleWithToolAllowlist()
     {
         var workflow = new WorkflowParser().Parse(WorkflowDefinitionCatalog.BuiltInStudioYaml);


### PR DESCRIPTION
## Summary
- Update built-in workflow catalog YAML to emit Studio's canonical `target_role` field instead of the legacy `role` alias.
- Update direct skill fallback YAML synthesis and related tests so refreshed readmodels no longer trigger role-alias validation warnings.

## Test plan
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowDefinitionCatalogTests"`
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/Aevatar.Workflow.Core.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowParserConfigurationTests"`
- [x] `dotnet test test/Aevatar.Capabilities.Tests/Aevatar.Capabilities.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowSkillsDirectYamlSynthesizerTests"`
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] Local Host refresh probe: after changing built-in direct YAML and restarting `src/Aevatar.Mainnet.Host.Api/boot.sh --mode local --port 19081`, `/api/workflows/direct` returned the changed YAML from the workflow detail readmodel.

Generated with [Claude Code](https://claude.com/claude-code)