### PR TITLE
Issue #3525: [NyxID Chat] Conversation 级类型化结构化档案附件（typed structured context attachment）

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -343,6 +343,10 @@ public sealed partial class ConversationGAgent :
             runCopy.TargetActorId = Id;
             runCopy.TargetRef = targetRef.Clone();
             runCopy.AgentProfile = State.AgentProfile?.Clone();
+            // Fix (review round 1, F6):
+            //   The transient Channel run copied its profile pin but omitted sealed attachments.
+            //   Copy the sibling authority field without adding Channel bind or admission behavior.
+            runCopy.ContextAttachments = State.ContextAttachments?.Clone();
             // Refactor (iter98/cluster-002): Old=ConversationGAgent filled run_id from correlation_id; New=producer must supply run_id before this handoff.
             runCopy.RunId = NormalizeOptional(runCopy.RunId)!;
             ApplyRuntimeReplyToken(runCopy, runtimeContext);

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -88,6 +88,7 @@ message NeedsLlmReplyEvent {
   // transient run command so the chat LLM path can include recent image context
   // or inject an honest degradation warning.
   repeated RecentConversationAttachmentActivity recent_attachment_activities = 14;
+  aevatar.ai.ConversationContextAttachmentSet context_attachments = 18;
   // Durable handle to the encrypted, TTL-bound relay reply token. The raw token
   // remains runtime-only; this reference lets a transient actor-dispatch failure
   // retry without silently abandoning the accepted inbound turn.

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
@@ -42,6 +42,7 @@ message ConversationGAgentState {
   // Immutable profile pinned by the first completed profiled run. Later runs reuse this exact
   // snapshot; route/profile binding changes apply only to new conversations.
   aevatar.ai.AgentProfileSnapshot agent_profile = 18;
+  aevatar.ai.ConversationContextAttachmentSet context_attachments = 19;
 }
 
 // Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):

--- a/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
+++ b/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\..\src\Aevatar.AGUI.Contracts\Aevatar.AGUI.Contracts.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Studio.Application.Abstractions\Aevatar.Studio.Application.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Studio.Application\Aevatar.Studio.Application.csproj" />
     <ProjectReference Include="..\..\src\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\workflow\Aevatar.Workflow.Abstractions\Aevatar.Workflow.Abstractions.csproj" />
   </ItemGroup>

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -1774,7 +1774,8 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                     ?? NormalizeOptional(request.Activity?.TransportExtras?.NyxUserAccessToken);
         return new ChatAttachmentInputContext(
             request.RecentAttachmentActivities.Select(entry => entry.Clone()).ToArray(),
-            token);
+            token,
+            request.ContextAttachments?.Clone());
     }
 
     private async Task<LLMControlContext> ApplyBotOwnerLlmConfigAsync(

--- a/agents/Aevatar.GAgents.NyxidChat/ContentArtifactConversationPromptLayerMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ContentArtifactConversationPromptLayerMaterializer.cs
@@ -1,0 +1,207 @@
+using System.Text;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.Prompting;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+/// <summary>
+/// Materializes the sealed conversation attachment set from the verified artifact read path.
+/// The materialized body is turn-local and is never copied into actor state or transcript history.
+/// </summary>
+public sealed class ContentArtifactConversationPromptLayerMaterializer
+{
+    public const int MaximumAttachmentBytes = ConversationContextAttachmentAdmission.MaximumAttachmentBytes;
+    public const int MaximumLayerBytes = 131072;
+    public const int MaximumLayerTokens = 32768;
+
+    private readonly IContentArtifactQueryPort _artifacts;
+
+    public ContentArtifactConversationPromptLayerMaterializer(IContentArtifactQueryPort artifacts)
+    {
+        _artifacts = artifacts ?? throw new ArgumentNullException(nameof(artifacts));
+    }
+
+    public async Task<ConversationContextPromptLayer> MaterializeAsync(
+        string scopeId,
+        ContentArtifactPrincipalContract requester,
+        ConversationContextAttachmentSet? attachments,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = scopeId.Trim();
+        var sections = new StringBuilder();
+        var diagnostics = new List<PromptLayerDiagnostic>();
+        var unavailable = new List<ConversationContextAttachmentUnavailablePlaceholder>();
+        var usedBytes = 0;
+
+        foreach (var attachment in attachments?.Attachments ?? [])
+        {
+            var artifactId = attachment.ArtifactId.Trim();
+            var revisionId = attachment.PinnedRevisionId.Trim();
+            try
+            {
+                var artifact = await _artifacts.GetAsync(normalizedScopeId, artifactId, ct);
+                if (artifact is null)
+                {
+                    AppendUnavailable(
+                        sections,
+                        diagnostics,
+                        unavailable,
+                        artifactId,
+                        revisionId,
+                        ConversationContextAttachmentUnavailableReason.NotFound);
+                    continue;
+                }
+
+                if (!string.Equals(artifact.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal))
+                {
+                    AppendUnavailable(
+                        sections,
+                        diagnostics,
+                        unavailable,
+                        artifactId,
+                        revisionId,
+                        artifact.LifecycleStatus == ContentArtifactLifecycleStatusNames.Tombstoned
+                            ? ConversationContextAttachmentUnavailableReason.Tombstoned
+                            : ConversationContextAttachmentUnavailableReason.Inactive);
+                    continue;
+                }
+
+                if (!ConversationContextAttachmentAdmission.IsAllowedKind(artifact.Kind) ||
+                    !ConversationContextAttachmentAdmission.IsAuthorized(artifact, requester.PrincipalId))
+                {
+                    AppendUnavailable(
+                        sections,
+                        diagnostics,
+                        unavailable,
+                        artifactId,
+                        revisionId,
+                        ConversationContextAttachmentUnavailableReason.AccessDenied);
+                    continue;
+                }
+
+                revisionId = attachment.RevisionMode == ConversationContextAttachmentRevisionMode.PinnedRevision
+                    ? revisionId
+                    : artifact.CurrentRevisionId?.Trim() ?? string.Empty;
+                var revision = artifact.Revisions.FirstOrDefault(item =>
+                    string.Equals(item.RevisionId, revisionId, StringComparison.Ordinal));
+                if (revision is null)
+                {
+                    AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                        ConversationContextAttachmentUnavailableReason.RevisionUnavailable);
+                    continue;
+                }
+
+                if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+                {
+                    AppendUnavailable(
+                        sections,
+                        diagnostics,
+                        unavailable,
+                        artifactId,
+                        revisionId,
+                        revision.Availability switch
+                        {
+                            ContentArtifactRevisionAvailabilityNames.Redacted => ConversationContextAttachmentUnavailableReason.Redacted,
+                            ContentArtifactRevisionAvailabilityNames.RetentionExpired => ConversationContextAttachmentUnavailableReason.RetentionExpired,
+                            _ => ConversationContextAttachmentUnavailableReason.RevisionUnavailable,
+                        });
+                    continue;
+                }
+
+                var content = await _artifacts.GetRevisionContentAsync(
+                    normalizedScopeId,
+                    artifactId,
+                    revisionId,
+                    requester,
+                    ct);
+                if (content.Content.LongLength > MaximumAttachmentBytes)
+                {
+                    AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                        ConversationContextAttachmentUnavailableReason.OverBudget);
+                    continue;
+                }
+
+                var header = $"[content-artifact artifact_id={artifactId} revision_id={revisionId} " +
+                             $"content_hash={PrefixHash(content.Reference.ContentHash)} media_type={content.Reference.MediaType}]\n";
+                var body = Encoding.UTF8.GetString(content.Content);
+                var section = header + body + "\n[/content-artifact]\n";
+                var sectionBytes = Encoding.UTF8.GetByteCount(section);
+                if (usedBytes + sectionBytes > MaximumLayerBytes)
+                {
+                    AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                        ConversationContextAttachmentUnavailableReason.OverBudget);
+                    continue;
+                }
+
+                sections.Append(section);
+                usedBytes += sectionBytes;
+            }
+            catch (ContentArtifactContentUnavailableException exception)
+            {
+                AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                    MapUnavailableReason(exception.Message));
+            }
+            catch (ContentArtifactNotFoundException)
+            {
+                AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                    ConversationContextAttachmentUnavailableReason.NotFound);
+            }
+            catch
+            {
+                AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                    ConversationContextAttachmentUnavailableReason.ReadModelUnavailable);
+            }
+        }
+
+        return new ConversationContextPromptLayer(
+            sections.ToString(),
+            new ConversationContextPromptProvenance("content-artifact-verified-read"),
+            new PromptLayerBounds(MaximumLayerBytes, MaximumLayerTokens),
+            diagnostics);
+    }
+
+    private static void AppendUnavailable(
+        StringBuilder sections,
+        List<PromptLayerDiagnostic> diagnostics,
+        List<ConversationContextAttachmentUnavailablePlaceholder> unavailable,
+        string artifactId,
+        string revisionId,
+        ConversationContextAttachmentUnavailableReason reason)
+    {
+        var placeholder = new ConversationContextAttachmentUnavailablePlaceholder
+        {
+            ArtifactId = artifactId,
+            RevisionId = revisionId,
+            Reason = reason,
+        };
+        unavailable.Add(placeholder);
+        sections.Append("[content-artifact-unavailable artifact_id=")
+            .Append(artifactId)
+            .Append(" revision_id=")
+            .Append(revisionId)
+            .Append(" reason=")
+            .Append(reason.ToString())
+            .Append("]\n");
+        diagnostics.Add(new PromptLayerDiagnostic(
+            PromptLayerDiagnosticCode.ProviderReported,
+            $"content artifact {artifactId} revision {revisionId} unavailable: {reason}"));
+    }
+
+    private static string PrefixHash(string? hash) =>
+        string.IsNullOrWhiteSpace(hash)
+            ? "unknown"
+            : hash.Trim()[..Math.Min(16, hash.Trim().Length)];
+
+    private static ConversationContextAttachmentUnavailableReason MapUnavailableReason(string detail) =>
+        detail.Contains("tombstoned", StringComparison.OrdinalIgnoreCase)
+            ? ConversationContextAttachmentUnavailableReason.Tombstoned
+            : detail.Contains("redacted", StringComparison.OrdinalIgnoreCase)
+                ? ConversationContextAttachmentUnavailableReason.Redacted
+                : detail.Contains("retention", StringComparison.OrdinalIgnoreCase)
+                    ? ConversationContextAttachmentUnavailableReason.RetentionExpired
+                    : detail.Contains("backing", StringComparison.OrdinalIgnoreCase)
+                        ? ConversationContextAttachmentUnavailableReason.BackingUnavailable
+                        : ConversationContextAttachmentUnavailableReason.ReadModelUnavailable;
+}

--- a/agents/Aevatar.GAgents.NyxidChat/ContentArtifactConversationPromptLayerMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ContentArtifactConversationPromptLayerMaterializer.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.Prompting;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
 
@@ -23,6 +24,60 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
         _artifacts = artifacts ?? throw new ArgumentNullException(nameof(artifacts));
     }
 
+    // Fix (review round 1, F2/F3):
+    //   Sealed attachments were omitted when the read port or caller authority was unavailable.
+    //   Every declared attachment now degrades to a paired placeholder and diagnostic.
+    internal static async Task<ConversationContextPromptLayer?> MaterializeOrDegradeAsync(
+        ContentArtifactConversationPromptLayerMaterializer? materializer,
+        ConversationContextAttachmentSet? attachments,
+        string? scopeId,
+        string? principalId,
+        CancellationToken ct = default,
+        ILogger? logger = null)
+    {
+        if (attachments is not { Attachments.Count: > 0 })
+            return null;
+        if (materializer is null)
+        {
+            return CreateUnavailableLayer(
+                attachments,
+                ConversationContextAttachmentUnavailableReason.ReadModelUnavailable);
+        }
+
+        var normalizedScopeId = scopeId?.Trim();
+        var normalizedPrincipalId = principalId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedScopeId) ||
+            string.IsNullOrWhiteSpace(normalizedPrincipalId))
+        {
+            return CreateUnavailableLayer(
+                attachments,
+                ConversationContextAttachmentUnavailableReason.AccessDenied);
+        }
+
+        try
+        {
+            return await materializer.MaterializeAsync(
+                    normalizedScopeId,
+                    new ContentArtifactPrincipalContract(normalizedPrincipalId, "nyxid"),
+                    attachments,
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger?.LogWarning(
+                exception,
+                "Conversation context attachment materialization failed closed to a degraded layer.");
+            return CreateUnavailableLayer(
+                attachments,
+                ConversationContextAttachmentUnavailableReason.ReadModelUnavailable);
+        }
+    }
+
     public async Task<ConversationContextPromptLayer> MaterializeAsync(
         string scopeId,
         ContentArtifactPrincipalContract requester,
@@ -32,7 +87,6 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
         var normalizedScopeId = scopeId.Trim();
         var sections = new StringBuilder();
         var diagnostics = new List<PromptLayerDiagnostic>();
-        var unavailable = new List<ConversationContextAttachmentUnavailablePlaceholder>();
         var usedBytes = 0;
 
         foreach (var attachment in attachments?.Attachments ?? [])
@@ -47,7 +101,6 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     AppendUnavailable(
                         sections,
                         diagnostics,
-                        unavailable,
                         artifactId,
                         revisionId,
                         ConversationContextAttachmentUnavailableReason.NotFound);
@@ -59,7 +112,6 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     AppendUnavailable(
                         sections,
                         diagnostics,
-                        unavailable,
                         artifactId,
                         revisionId,
                         artifact.LifecycleStatus == ContentArtifactLifecycleStatusNames.Tombstoned
@@ -74,7 +126,6 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     AppendUnavailable(
                         sections,
                         diagnostics,
-                        unavailable,
                         artifactId,
                         revisionId,
                         ConversationContextAttachmentUnavailableReason.AccessDenied);
@@ -88,7 +139,7 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     string.Equals(item.RevisionId, revisionId, StringComparison.Ordinal));
                 if (revision is null)
                 {
-                    AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                    AppendUnavailable(sections, diagnostics, artifactId, revisionId,
                         ConversationContextAttachmentUnavailableReason.RevisionUnavailable);
                     continue;
                 }
@@ -98,7 +149,6 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     AppendUnavailable(
                         sections,
                         diagnostics,
-                        unavailable,
                         artifactId,
                         revisionId,
                         revision.Availability switch
@@ -118,7 +168,7 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     ct);
                 if (content.Content.LongLength > MaximumAttachmentBytes)
                 {
-                    AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                    AppendUnavailable(sections, diagnostics, artifactId, revisionId,
                         ConversationContextAttachmentUnavailableReason.OverBudget);
                     continue;
                 }
@@ -130,7 +180,7 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                 var sectionBytes = Encoding.UTF8.GetByteCount(section);
                 if (usedBytes + sectionBytes > MaximumLayerBytes)
                 {
-                    AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                    AppendUnavailable(sections, diagnostics, artifactId, revisionId,
                         ConversationContextAttachmentUnavailableReason.OverBudget);
                     continue;
                 }
@@ -138,45 +188,45 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                 sections.Append(section);
                 usedBytes += sectionBytes;
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (ContentArtifactContentUnavailableException exception)
             {
-                AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
-                    MapUnavailableReason(exception.Message));
+                AppendUnavailable(sections, diagnostics, artifactId, revisionId,
+                    MapUnavailableReason(exception.Reason));
             }
             catch (ContentArtifactNotFoundException)
             {
-                AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                AppendUnavailable(sections, diagnostics, artifactId, revisionId,
                     ConversationContextAttachmentUnavailableReason.NotFound);
+            }
+            catch (IOException)
+            {
+                AppendUnavailable(sections, diagnostics, artifactId, revisionId,
+                    ConversationContextAttachmentUnavailableReason.BackingUnavailable);
             }
             catch
             {
-                AppendUnavailable(sections, diagnostics, unavailable, artifactId, revisionId,
+                AppendUnavailable(sections, diagnostics, artifactId, revisionId,
                     ConversationContextAttachmentUnavailableReason.ReadModelUnavailable);
             }
         }
 
-        return new ConversationContextPromptLayer(
-            sections.ToString(),
-            new ConversationContextPromptProvenance("content-artifact-verified-read"),
-            new PromptLayerBounds(MaximumLayerBytes, MaximumLayerTokens),
-            diagnostics);
+        return CreateLayer(sections, diagnostics);
     }
 
+    // Fix (review round 1, F5):
+    //   Typed placeholder objects were allocated into a list that no consumer observed.
+    //   The visible marker and its diagnostic are now emitted directly from the typed reason.
     private static void AppendUnavailable(
         StringBuilder sections,
         List<PromptLayerDiagnostic> diagnostics,
-        List<ConversationContextAttachmentUnavailablePlaceholder> unavailable,
         string artifactId,
         string revisionId,
         ConversationContextAttachmentUnavailableReason reason)
     {
-        var placeholder = new ConversationContextAttachmentUnavailablePlaceholder
-        {
-            ArtifactId = artifactId,
-            RevisionId = revisionId,
-            Reason = reason,
-        };
-        unavailable.Add(placeholder);
         sections.Append("[content-artifact-unavailable artifact_id=")
             .Append(artifactId)
             .Append(" revision_id=")
@@ -189,19 +239,47 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
             $"content artifact {artifactId} revision {revisionId} unavailable: {reason}"));
     }
 
+    private static ConversationContextPromptLayer CreateUnavailableLayer(
+        ConversationContextAttachmentSet attachments,
+        ConversationContextAttachmentUnavailableReason reason)
+    {
+        var sections = new StringBuilder();
+        var diagnostics = new List<PromptLayerDiagnostic>();
+        foreach (var attachment in attachments.Attachments)
+        {
+            AppendUnavailable(
+                sections,
+                diagnostics,
+                attachment.ArtifactId.Trim(),
+                attachment.PinnedRevisionId.Trim(),
+                reason);
+        }
+
+        return CreateLayer(sections, diagnostics);
+    }
+
+    private static ConversationContextPromptLayer CreateLayer(
+        StringBuilder sections,
+        List<PromptLayerDiagnostic> diagnostics) =>
+        new(
+            sections.ToString(),
+            new ConversationContextPromptProvenance("content-artifact-verified-read"),
+            new PromptLayerBounds(MaximumLayerBytes, MaximumLayerTokens),
+            diagnostics);
+
     private static string PrefixHash(string? hash) =>
         string.IsNullOrWhiteSpace(hash)
             ? "unknown"
             : hash.Trim()[..Math.Min(16, hash.Trim().Length)];
 
-    private static ConversationContextAttachmentUnavailableReason MapUnavailableReason(string detail) =>
-        detail.Contains("tombstoned", StringComparison.OrdinalIgnoreCase)
-            ? ConversationContextAttachmentUnavailableReason.Tombstoned
-            : detail.Contains("redacted", StringComparison.OrdinalIgnoreCase)
-                ? ConversationContextAttachmentUnavailableReason.Redacted
-                : detail.Contains("retention", StringComparison.OrdinalIgnoreCase)
-                    ? ConversationContextAttachmentUnavailableReason.RetentionExpired
-                    : detail.Contains("backing", StringComparison.OrdinalIgnoreCase)
-                        ? ConversationContextAttachmentUnavailableReason.BackingUnavailable
-                        : ConversationContextAttachmentUnavailableReason.ReadModelUnavailable;
+    private static ConversationContextAttachmentUnavailableReason MapUnavailableReason(
+        ContentArtifactContentUnavailableReason reason) =>
+        reason switch
+        {
+            ContentArtifactContentUnavailableReason.Tombstoned => ConversationContextAttachmentUnavailableReason.Tombstoned,
+            ContentArtifactContentUnavailableReason.Redacted => ConversationContextAttachmentUnavailableReason.Redacted,
+            ContentArtifactContentUnavailableReason.RetentionExpired => ConversationContextAttachmentUnavailableReason.RetentionExpired,
+            ContentArtifactContentUnavailableReason.BackingUnavailable => ConversationContextAttachmentUnavailableReason.BackingUnavailable,
+            _ => ConversationContextAttachmentUnavailableReason.ReadModelUnavailable,
+        };
 }

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationContextAttachmentAdmission.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationContextAttachmentAdmission.cs
@@ -1,0 +1,80 @@
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.AI.Abstractions;
+using Google.Protobuf;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+internal static class ConversationContextAttachmentAdmission
+{
+    public const int MaximumAttachments = 4;
+    public const int MaximumAttachmentBytes = 65536;
+
+    public static ConversationContextAttachmentSet CloneSet(
+        IEnumerable<ConversationContextAttachment>? attachments)
+    {
+        var result = new ConversationContextAttachmentSet();
+        if (attachments is not null)
+            result.Attachments.Add(attachments.Where(static item => item is not null).Select(static item => item.Clone()));
+        return result;
+    }
+
+    public static ConversationContextAttachmentSet? CloneOptionalSet(
+        IEnumerable<ConversationContextAttachment>? attachments)
+    {
+        var result = CloneSet(attachments);
+        return result.Attachments.Count == 0 ? null : result;
+    }
+
+    public static bool HasAttachments(ConversationContextAttachmentSet? set) =>
+        set is { Attachments.Count: > 0 };
+
+    public static bool ByteEquivalent(
+        ConversationContextAttachmentSet left,
+        ConversationContextAttachmentSet right) =>
+        left.ToByteArray().AsSpan().SequenceEqual(right.ToByteArray());
+
+    public static bool TryNormalize(
+        ConversationContextAttachmentSet? source,
+        out ConversationContextAttachmentSet normalized)
+    {
+        normalized = CloneSet(source?.Attachments);
+        if (normalized.Attachments.Count > MaximumAttachments)
+            return false;
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var attachment in normalized.Attachments)
+        {
+            attachment.ArtifactId = attachment.ArtifactId.Trim();
+            attachment.PinnedRevisionId = attachment.PinnedRevisionId.Trim();
+            if (string.IsNullOrWhiteSpace(attachment.ArtifactId) ||
+                !ids.Add(attachment.ArtifactId))
+                return false;
+
+            if (attachment.RevisionMode == ConversationContextAttachmentRevisionMode.PinnedRevision)
+            {
+                if (string.IsNullOrWhiteSpace(attachment.PinnedRevisionId))
+                    return false;
+            }
+            else if (attachment.RevisionMode == ConversationContextAttachmentRevisionMode.FollowCurrent)
+            {
+                attachment.PinnedRevisionId = string.Empty;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool IsAuthorized(ContentArtifactCurrentStateResponse artifact, string principalId)
+    {
+        var principal = principalId.Trim();
+        return string.Equals(artifact.Owner.PrincipalId, principal, StringComparison.Ordinal) ||
+               artifact.ReaderPrincipalIds.Any(item => string.Equals(item, principal, StringComparison.Ordinal));
+    }
+
+    public static bool IsAllowedKind(string kind) =>
+        kind is "text" or "markdown" or "structured_document";
+}

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -16,6 +16,8 @@ using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using UglyToad.PdfPig;
@@ -103,6 +105,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     private readonly ISystemSkillOverlayProvider? _overlayProvider;
     private readonly IBuiltInPromptFloorProvider _builtInPromptFloorProvider;
     private readonly IAgentToolDiscoveryService _toolDiscoveryService;
+    private readonly ContentArtifactConversationPromptLayerMaterializer? _contentArtifactPromptLayerMaterializer;
     private readonly ILogger<NyxIdConversationReplyGenerator> _logger;
 
     // Refactor (issue1318/first-slice): Old: unbound sender still saw tool dispatch + unknown
@@ -148,7 +151,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         IAgentToolExecutionPort? toolExecutionPort = null,
         IRemoteSkillAccessTokenResolver? remoteSkillAccessTokenResolver = null,
         IEnumerable<IAgentToolSource>? nyxIdChatToolSources = null,
-        IAgentToolDiscoveryService? toolDiscoveryService = null)
+        IAgentToolDiscoveryService? toolDiscoveryService = null,
+        IContentArtifactQueryPort? contentArtifactQueryPort = null)
     {
         _llmProviderFactory = llmProviderFactory ?? throw new ArgumentNullException(nameof(llmProviderFactory));
         _toolSources = (toolSources ?? []).ToArray();
@@ -170,6 +174,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         _builtInPromptFloorProvider = builtInPromptFloorProvider ??
                                       throw new ArgumentNullException(nameof(builtInPromptFloorProvider));
         _toolDiscoveryService = toolDiscoveryService ?? AgentToolDiscoveryService.Instance;
+        _contentArtifactPromptLayerMaterializer = contentArtifactQueryPort is null
+            ? null
+            : new ContentArtifactConversationPromptLayerMaterializer(contentArtifactQueryPort);
         _logger = logger ?? NullLogger<NyxIdConversationReplyGenerator>.Instance;
     }
 
@@ -372,6 +379,12 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                 ct)
             .ConfigureAwait(false);
         var inputFileRefs = CollectInputFileRefs(input.Parts);
+        var conversationLayer = await MaterializeConversationContextLayerAsync(
+                attachmentContext,
+                effectiveToolContext,
+                activity,
+                ct)
+            .ConfigureAwait(false);
         effectiveToolContext = WithInputFileRefs(effectiveToolContext, inputFileRefs)!;
         var ownerFallbackToolContext = WithInputFileRefs(replyPlan.OwnerFallbackToolContext, inputFileRefs);
         LogChannelLlmToolPlan(
@@ -391,7 +404,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             effectiveToolContext,
             externalMetadata,
             tools,
-            input.AttachmentVisibilityInstruction);
+            input.AttachmentVisibilityInstruction,
+            conversationLayer);
 
         // The unbound-sender gate (issue #1318) detaches the entire tool surface while
         // the kernel prompt still documents those tools; without this override the
@@ -408,8 +422,9 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
                     ? UnboundSenderToolsDisabledNotice
                     : effectiveTurnCatalog is { ExactTools.Count: 0 }
                         ? RestrictedEmptyCatalogNotice
-                        : null,
-                effectiveTurnCatalog)),
+                : null,
+                effectiveTurnCatalog,
+                conversationLayer)),
         };
         initialMessages.AddRange((priorHistory ?? []).Where(IsReplayableHistoryEntry).TakeLast(MaxRecentPriorHistoryMessages).Select(ToChatMessage));
         initialMessages.Add(ChatMessage.User(input.Parts, input.Text));
@@ -2029,7 +2044,8 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         AgentToolExecutionContext toolContext,
         IReadOnlyDictionary<string, string> externalMetadata,
         ToolManager tools,
-        string? attachmentVisibilityInstruction)
+        string? attachmentVisibilityInstruction,
+        ConversationContextPromptLayer? conversationLayer = null)
     {
         var history = new global::Aevatar.AI.Core.Chat.ChatHistory
         {
@@ -2049,7 +2065,11 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             {
                 Messages =
                 [
-                    ChatMessage.System(BuildSystemPrompt(externalMetadata, toolContext, attachmentVisibilityInstruction)),
+                    ChatMessage.System(BuildSystemPrompt(
+                        externalMetadata,
+                        toolContext,
+                        attachmentVisibilityInstruction,
+                        conversation: conversationLayer)),
                 ],
                 Metadata = externalMetadata,
                 ToolContext = toolContext,
@@ -2375,12 +2395,52 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         return valid.Length == 0 ? null : valid;
     }
 
+    private async Task<ConversationContextPromptLayer?> MaterializeConversationContextLayerAsync(
+        ChatAttachmentInputContext? attachmentContext,
+        AgentToolExecutionContext toolContext,
+        ChatActivity activity,
+        CancellationToken ct)
+    {
+        if (_contentArtifactPromptLayerMaterializer is null ||
+            attachmentContext?.ContextAttachments is not { Attachments.Count: > 0 })
+            return null;
+
+        var scopeId = NormalizeOptional(toolContext.Caller.ScopeId) ??
+                      NormalizeOptional(activity.Conversation?.CanonicalKey);
+        var principalId = NormalizeOptional(toolContext.Caller.OwnerSubject);
+        if (scopeId is null || principalId is null)
+            return null;
+
+        try
+        {
+            return await _contentArtifactPromptLayerMaterializer.MaterializeAsync(
+                    scopeId,
+                    new ContentArtifactPrincipalContract(principalId, "nyxid"),
+                    attachmentContext.ContextAttachments,
+                    ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Conversation context attachment materialization failed closed. activityId={ActivityId}",
+                activity.Id);
+            return null;
+        }
+    }
+
     private string BuildSystemPrompt(
         IReadOnlyDictionary<string, string> metadata,
         AgentToolExecutionContext toolContext,
         string? attachmentVisibilityInstruction = null,
         string? runtimeNotice = null,
-        AgentTurnToolCatalog? turnCatalog = null)
+        AgentTurnToolCatalog? turnCatalog = null,
+        ConversationContextPromptLayer? conversation = null)
     {
         var runtimeFacts = new StringBuilder();
         AppendRuntimeFact(
@@ -2416,7 +2476,7 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
             turnCatalog?.ProfilePromptLayer,
             turnCatalog?.SelectedSkillPromptLayer,
             runtime,
-            conversation: null).Prompt;
+            conversation).Prompt;
     }
 
     // The typed channel context is the authoritative platform source: the per-step plan path hands

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationReplyGenerator.cs
@@ -17,7 +17,6 @@ using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Studio.Application.Studio.Abstractions;
-using Aevatar.Studio.Application.Studio.Contracts;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using UglyToad.PdfPig;
@@ -382,7 +381,6 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
         var conversationLayer = await MaterializeConversationContextLayerAsync(
                 attachmentContext,
                 effectiveToolContext,
-                activity,
                 ct)
             .ConfigureAwait(false);
         effectiveToolContext = WithInputFileRefs(effectiveToolContext, inputFileRefs)!;
@@ -2398,40 +2396,19 @@ public sealed class NyxIdConversationReplyGenerator : IAgentRunStepConversationR
     private async Task<ConversationContextPromptLayer?> MaterializeConversationContextLayerAsync(
         ChatAttachmentInputContext? attachmentContext,
         AgentToolExecutionContext toolContext,
-        ChatActivity activity,
         CancellationToken ct)
     {
-        if (_contentArtifactPromptLayerMaterializer is null ||
-            attachmentContext?.ContextAttachments is not { Attachments.Count: > 0 })
-            return null;
-
-        var scopeId = NormalizeOptional(toolContext.Caller.ScopeId) ??
-                      NormalizeOptional(activity.Conversation?.CanonicalKey);
-        var principalId = NormalizeOptional(toolContext.Caller.OwnerSubject);
-        if (scopeId is null || principalId is null)
-            return null;
-
-        try
-        {
-            return await _contentArtifactPromptLayerMaterializer.MaterializeAsync(
-                    scopeId,
-                    new ContentArtifactPrincipalContract(principalId, "nyxid"),
-                    attachmentContext.ContextAttachments,
-                    ct)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            _logger.LogWarning(
-                exception,
-                "Conversation context attachment materialization failed closed. activityId={ActivityId}",
-                activity.Id);
-            return null;
-        }
+        // Fix (review round 1, F3):
+        //   Conversation CanonicalKey was incorrectly used as a ContentArtifact owner scope.
+        //   Only the typed caller scope is used; a missing scope degrades without identity guessing.
+        return await ContentArtifactConversationPromptLayerMaterializer.MaterializeOrDegradeAsync(
+                _contentArtifactPromptLayerMaterializer,
+                attachmentContext?.ContextAttachments,
+                NormalizeOptional(toolContext.Caller.ScopeId),
+                NormalizeOptional(toolContext.Caller.OwnerSubject),
+                ct,
+                _logger)
+            .ConfigureAwait(false);
     }
 
     private string BuildSystemPrompt(

--- a/agents/Aevatar.GAgents.NyxidChat/ITypedConversationReplyGenerator.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ITypedConversationReplyGenerator.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Core.Chat;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.GAgents.Channel.Abstractions;
@@ -61,4 +62,5 @@ public sealed record AgentRunReplyStepPlan(
 
 internal sealed record ChatAttachmentInputContext(
     IReadOnlyList<RecentConversationAttachmentActivity> RecentAttachmentActivities,
-    string? UserAccessToken);
+    string? UserAccessToken,
+    ConversationContextAttachmentSet? ContextAttachments = null);

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatConversationGAgent.cs
@@ -94,6 +94,7 @@ public sealed class NyxIdChatConversationGAgent
         var next = StateTransitionMatcher
             .Match(current, evt)
             .On<AgentProfileBoundEvent>(ApplyAgentProfileBound)
+            .On<ConversationContextAttachmentsBoundEvent>(ApplyContextAttachmentsBound)
             .On<NyxIdChatConversationCreationStartedEvent>(ApplyConversationCreationStarted)
             .On<NyxIdChatConversationRegistrationAcceptedEvent>(ApplyConversationRegistrationAccepted)
             .On<NyxIdChatPendingCreationFirstTurnFinalizedEvent>(
@@ -214,6 +215,14 @@ public sealed class NyxIdChatConversationGAgent
             return;
         }
         if (command.FirstTurn is not null &&
+            State.ContextAttachments is not null &&
+            !ConversationContextAttachmentAdmission.HasAttachments(command.ContextAttachments))
+        {
+            throw new InvalidOperationException("A conversation cannot remove its context attachments.");
+        }
+        if (command.FirstTurn is not null && State.ContextAttachments is not null)
+            await BindContextAttachmentsAsync(command.ContextAttachments);
+        if (command.FirstTurn is not null &&
             string.Equals(State.ScopeId, scopeId, StringComparison.Ordinal) &&
             string.Equals(State.ConversationActorId, Id, StringComparison.Ordinal) &&
             !string.IsNullOrWhiteSpace(State.HistoryInitializationOperationId))
@@ -245,6 +254,7 @@ public sealed class NyxIdChatConversationGAgent
         var correlationId = ActiveInboundEnvelope?.Propagation?.CorrelationId ?? commandId;
 
         await BindAgentProfileAsync(command.AgentProfile);
+        await BindContextAttachmentsAsync(command.ContextAttachments);
         await PersistDomainEventAsync(new NyxIdChatConversationCreationStartedEvent
         {
             ScopeId = scopeId,
@@ -1656,6 +1666,7 @@ public sealed class NyxIdChatConversationGAgent
                 AgentProfile = turnAuthority is null ? null : State.AgentProfile?.Clone(),
                 AgentProfileTurnAuthority = turnAuthority?.Clone(),
                 Intent = intent,
+                ContextAttachments = State.ContextAttachments?.Clone(),
             },
         };
         await DispatchFirstOperationAsync(
@@ -2908,6 +2919,7 @@ public sealed class NyxIdChatConversationGAgent
             OwnerSubject = State.OwnerSubject,
             RoleConfiguration = State.RoleConfiguration?.Clone(),
             AgentProfile = State.AgentProfile?.Clone(),
+            ContextAttachments = State.ContextAttachments?.Clone(),
             ActiveTurn = turn,
             LatestTurn = turn.Clone(),
             ActiveTask = task,
@@ -3034,6 +3046,7 @@ public sealed class NyxIdChatConversationGAgent
             CommandAttemptId = command.CommandId.Trim(),
             ToolContext = BuildActorOwnedToolContext(command.ToolContext).ToPayload(),
             LlmControl = command.LlmControl?.Clone(),
+            ContextAttachments = State.ContextAttachments?.Clone(),
         };
         request.InputParts.AddRange(command.InputParts.Select(static part => part.Clone()));
         return request;
@@ -3170,6 +3183,27 @@ public sealed class NyxIdChatConversationGAgent
 
         var next = current.Clone();
         next.AgentProfile = evt.Profile.Clone();
+        return next;
+    }
+
+    private static NyxIdChatConversationGAgentState ApplyContextAttachmentsBound(
+        NyxIdChatConversationGAgentState current,
+        ConversationContextAttachmentsBoundEvent evt)
+    {
+        var incoming = evt.Attachments ?? new ConversationContextAttachmentSet();
+        if (!ConversationContextAttachmentAdmission.TryNormalize(incoming, out var normalized))
+            throw new InvalidOperationException("Conversation context attachment binding is invalid.");
+        if (!ConversationContextAttachmentAdmission.HasAttachments(normalized))
+            return current;
+        if (current.ContextAttachments is not null)
+        {
+            if (!ConversationContextAttachmentAdmission.ByteEquivalent(current.ContextAttachments, normalized))
+                throw new InvalidOperationException("A conversation cannot replace its context attachments.");
+            return current;
+        }
+
+        var next = current.Clone();
+        next.ContextAttachments = normalized;
         return next;
     }
 
@@ -3761,6 +3795,24 @@ public sealed class NyxIdChatConversationGAgent
 
         if (!AgentProfileSnapshotCodec.ByteEquivalent(State.AgentProfile, profile))
             throw new InvalidOperationException("A conversation cannot replace its bound agent profile.");
+    }
+
+    private async Task BindContextAttachmentsAsync(ConversationContextAttachmentSet? attachments)
+    {
+        if (!ConversationContextAttachmentAdmission.TryNormalize(attachments, out var normalized))
+            throw new InvalidOperationException("The conversation context attachment set is invalid.");
+        if (!ConversationContextAttachmentAdmission.HasAttachments(normalized))
+            return;
+        if (State.ContextAttachments is null)
+        {
+            await PersistDomainEventAsync(
+                new ConversationContextAttachmentsBoundEvent { Attachments = normalized },
+                CancellationToken.None);
+            return;
+        }
+
+        if (!ConversationContextAttachmentAdmission.ByteEquivalent(State.ContextAttachments, normalized))
+            throw new InvalidOperationException("A conversation cannot replace its context attachments.");
     }
 
     private NyxIdChatConversationGAgentState PrepareHistoryInitializationState(string scopeId)

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
@@ -278,7 +278,8 @@ public static partial class NyxIdChatEndpoints
                     turnId,
                     prompt,
                     rawInputParts,
-                    agentProfileReference);
+                    agentProfileReference,
+                    request.ContextAttachments?.Select(static attachment => attachment.ToProto()));
 
                 // Streaming endpoints do not pre-read runtime state before command dispatch.
                 // The shared CQRS resolver owns actor lookup and attach-existing observation.
@@ -299,7 +300,8 @@ public static partial class NyxIdChatEndpoints
                         OwnerSubject: ownerSubject,
                         AgentProfileReference: agentProfileReference,
                         NyxIdCredentialKind: credentials.NyxIdCredentialKind,
-                        InputPartsFingerprint: NyxIdChatPublicIdentity.CreateInputPartsFingerprint(rawInputParts)),
+                        InputPartsFingerprint: NyxIdChatPublicIdentity.CreateInputPartsFingerprint(rawInputParts),
+                        ContextAttachments: request.ContextAttachments?.Select(static attachment => attachment.ToProto()).ToArray()),
                     EmitAsync,
                     null,
                     interactionCancellation.Token);
@@ -1147,7 +1149,28 @@ public static partial class NyxIdChatEndpoints
         string? Type = null,
         string? OriginTurnId = null,
         IReadOnlyList<NyxIdChatActionReportDto>? Actions = null,
-        NyxIdChatAgentProfileReferenceDto? AgentProfile = null);
+        NyxIdChatAgentProfileReferenceDto? AgentProfile = null,
+        IReadOnlyList<NyxIdChatContextAttachmentDto>? ContextAttachments = null);
+
+    [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+    public sealed record NyxIdChatContextAttachmentDto(
+        string? ArtifactId,
+        string? RevisionMode,
+        string? PinnedRevisionId)
+    {
+        public ConversationContextAttachment ToProto() =>
+            new()
+            {
+                ArtifactId = ArtifactId?.Trim() ?? string.Empty,
+                RevisionMode = RevisionMode?.Trim().ToUpperInvariant() switch
+                {
+                    "FOLLOW_CURRENT" => ConversationContextAttachmentRevisionMode.FollowCurrent,
+                    "PINNED_REVISION" => ConversationContextAttachmentRevisionMode.PinnedRevision,
+                    _ => ConversationContextAttachmentRevisionMode.Unspecified,
+                },
+                PinnedRevisionId = PinnedRevisionId?.Trim() ?? string.Empty,
+            };
+    }
 
     [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     public sealed record NyxIdChatAgentProfileReferenceDto(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
@@ -18,6 +18,7 @@ using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Google.Protobuf;
@@ -49,6 +50,8 @@ public sealed class NyxIdChatGAgent : RoleGAgent
     private readonly NyxIdRelayOptions? _relayOptions;
     private readonly TimeProvider _timeProvider;
     private readonly AgentTurnToolCatalogMaterializer? _turnCatalogMaterializer;
+    private readonly ContentArtifactConversationPromptLayerMaterializer? _contentArtifactPromptLayerMaterializer;
+    private ConversationContextPromptLayer? _activeConversationPromptLayer;
     private AgentProfileTelemetryContext? _activeAgentProfileTelemetryContext;
     private int _systemSkillOverlayPromptLogCounter;
 
@@ -68,7 +71,8 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         TimeProvider? timeProvider = null,
         AgentTurnToolCatalogMaterializer? turnCatalogMaterializer = null,
         RoleChatExecutionOptions? chatExecutionOptions = null,
-        ISecretVault? chatToolRecoverySecretVault = null)
+        ISecretVault? chatToolRecoverySecretVault = null,
+        IContentArtifactQueryPort? contentArtifactQueryPort = null)
         : base(toolExecutionPort, llmProviderFactory, additionalHooks, agentMiddlewares, llmMiddlewares, toolSources,
                remoteToolApprovalPort: remoteToolApprovalPort,
                remoteToolApprovalNotificationPort: remoteToolApprovalNotificationPort,
@@ -83,6 +87,9 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         _relayOptions = relayOptions;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _turnCatalogMaterializer = turnCatalogMaterializer;
+        _contentArtifactPromptLayerMaterializer = contentArtifactQueryPort is null
+            ? null
+            : new ContentArtifactConversationPromptLayerMaterializer(contentArtifactQueryPort);
     }
 
     protected override TimeProvider ChatRequestTimeProvider => _timeProvider;
@@ -142,7 +149,7 @@ public sealed class NyxIdChatGAgent : RoleGAgent
             turnCatalog?.ProfilePromptLayer,
             turnCatalog?.SelectedSkillPromptLayer,
             runtime,
-            conversation: null);
+            _activeConversationPromptLayer);
 
         if (global is not null && _systemSkillOverlayPromptLogCounter++ % SystemSkillOverlayPromptLogSampleRate == 0)
         {
@@ -163,6 +170,34 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         AgentToolExecutionContext toolContext,
         CancellationToken ct)
     {
+        _activeConversationPromptLayer = null;
+        if (_contentArtifactPromptLayerMaterializer is not null &&
+            request.ContextAttachments is { Attachments.Count: > 0 } &&
+            !string.IsNullOrWhiteSpace(toolContext.Caller.ScopeId) &&
+            !string.IsNullOrWhiteSpace(toolContext.Caller.OwnerSubject))
+        {
+            try
+            {
+                _activeConversationPromptLayer = await _contentArtifactPromptLayerMaterializer.MaterializeAsync(
+                        toolContext.Caller.ScopeId,
+                        new ContentArtifactPrincipalContract(toolContext.Caller.OwnerSubject, "nyxid"),
+                        request.ContextAttachments,
+                        ct)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                Logger.LogWarning(
+                    exception,
+                    "Direct NyxID conversation attachment materialization failed closed. sessionId={SessionId}",
+                    request.SessionId);
+            }
+        }
+
         var profile = State.AgentProfile;
         if (profile is null)
             return null;

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatGAgent.cs
@@ -18,7 +18,6 @@ using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
-using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Google.Protobuf;
@@ -171,32 +170,18 @@ public sealed class NyxIdChatGAgent : RoleGAgent
         CancellationToken ct)
     {
         _activeConversationPromptLayer = null;
-        if (_contentArtifactPromptLayerMaterializer is not null &&
-            request.ContextAttachments is { Attachments.Count: > 0 } &&
-            !string.IsNullOrWhiteSpace(toolContext.Caller.ScopeId) &&
-            !string.IsNullOrWhiteSpace(toolContext.Caller.OwnerSubject))
-        {
-            try
-            {
-                _activeConversationPromptLayer = await _contentArtifactPromptLayerMaterializer.MaterializeAsync(
-                        toolContext.Caller.ScopeId,
-                        new ContentArtifactPrincipalContract(toolContext.Caller.OwnerSubject, "nyxid"),
-                        request.ContextAttachments,
-                        ct)
-                    .ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception exception)
-            {
-                Logger.LogWarning(
-                    exception,
-                    "Direct NyxID conversation attachment materialization failed closed. sessionId={SessionId}",
-                    request.SessionId);
-            }
-        }
+        // Fix (review round 1, F2):
+        //   Direct chat silently dropped sealed attachments when materialization could not run.
+        //   The shared boundary now returns one paired degraded entry per attachment.
+        _activeConversationPromptLayer =
+            await ContentArtifactConversationPromptLayerMaterializer.MaterializeOrDegradeAsync(
+                    _contentArtifactPromptLayerMaterializer,
+                    request.ContextAttachments,
+                    toolContext.Caller.ScopeId,
+                    toolContext.Caller.OwnerSubject,
+                    ct,
+                    Logger)
+                .ConfigureAwait(false);
 
         var profile = State.AgentProfile;
         if (profile is null)

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -33,7 +33,8 @@ public sealed record NyxIdChatCommand(
     AgentProfileReference? AgentProfileReference = null,
     AgentToolNyxIdCredentialKind NyxIdCredentialKind =
         AgentToolNyxIdCredentialKind.Unspecified,
-    string? InputPartsFingerprint = null)
+    string? InputPartsFingerprint = null,
+    IReadOnlyList<ConversationContextAttachment>? ContextAttachments = null)
     : ICommandContextSeed
 {
     public IReadOnlyDictionary<string, string>? Headers => null;
@@ -67,7 +68,8 @@ internal static class NyxIdChatPublicIdentity
         string turnId,
         string prompt,
         IEnumerable<Aevatar.AI.Abstractions.ChatContentPart> inputParts,
-        AgentProfileReference? agentProfileReference)
+        AgentProfileReference? agentProfileReference,
+        IEnumerable<ConversationContextAttachment>? contextAttachments = null)
     {
         var payload = new NyxIdChatStartTurnCommand
         {
@@ -78,6 +80,7 @@ internal static class NyxIdChatPublicIdentity
             Prompt = prompt,
         };
         payload.InputParts.Add(inputParts.Select(static part => part.Clone()));
+        payload.ContextAttachments = ConversationContextAttachmentAdmission.CloneOptionalSet(contextAttachments);
 
         return Build(
             "command",
@@ -402,6 +405,17 @@ internal sealed class NyxIdChatCommandTargetResolver
             ScopeId = command.ScopeId,
             RequestedActorId = command.ActorId,
             AgentProfileReference = command.AgentProfileReference?.Clone(),
+            ContextAttachments = ConversationContextAttachmentAdmission.CloneOptionalSet(command.ContextAttachments),
+            FirstTurn = new NyxIdChatStartTurnCommand
+            {
+                ToolContext = new AgentToolExecutionContextPayload
+                {
+                    Caller = new AgentToolCallerContextPayload
+                    {
+                        OwnerSubject = command.OwnerSubject?.Trim() ?? string.Empty,
+                    },
+                },
+            },
         };
         var resolved = await _createResolver().ResolveAsync(create, ct);
         if (!resolved.Succeeded || resolved.Target is null)
@@ -527,6 +541,7 @@ internal sealed class NyxIdChatCommandEnvelopeFactory : ICommandEnvelopeFactory<
         };
         startTurn.LlmControl = effectiveControl.ToPayload();
         startTurn.ToolContext = BuildToolContext(command, effectiveControl).ToPayload();
+        startTurn.ContextAttachments = ConversationContextAttachmentAdmission.CloneOptionalSet(command.ContextAttachments);
         AppendExternalContext(startTurn.ToolContext.ExternalMetadata, command.Metadata);
 
         if (!command.CreateIfMissing)
@@ -538,6 +553,7 @@ internal sealed class NyxIdChatCommandEnvelopeFactory : ICommandEnvelopeFactory<
             CreatedLocally = command.CreatedLocally,
             AgentProfile = command.AgentProfile?.Clone(),
             AgentProfileReference = command.AgentProfileReference?.Clone(),
+            ContextAttachments = ConversationContextAttachmentAdmission.CloneOptionalSet(command.ContextAttachments),
             RequestedActorId = command.ActorId,
             FirstTurn = startTurn,
         });

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatLifecycleFacade.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatLifecycleFacade.cs
@@ -1,5 +1,6 @@
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
+using Aevatar.AI.Abstractions;
 using Aevatar.AI.Core.AgentProfiles;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
@@ -7,6 +8,7 @@ using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Capabilities;
 using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
@@ -179,18 +181,21 @@ internal sealed class NyxIdChatConversationCreateCommandTargetResolver
     private readonly IChatRoutePolicyQueryPort _routeQueryPort;
     private readonly ChatRouteResolver _routeResolver;
     private readonly INyxIdChatAgentProfileResolver _agentProfileResolver;
+    private readonly IContentArtifactQueryPort? _contentArtifactQueryPort;
 
     public NyxIdChatConversationCreateCommandTargetResolver(
         IActorRuntime actorRuntime,
         IChatRoutePolicyQueryPort routeQueryPort,
         ChatRouteResolver routeResolver,
-        INyxIdChatAgentProfileResolver agentProfileResolver)
+        INyxIdChatAgentProfileResolver agentProfileResolver,
+        IContentArtifactQueryPort? contentArtifactQueryPort = null)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _routeQueryPort = routeQueryPort ?? throw new ArgumentNullException(nameof(routeQueryPort));
         _routeResolver = routeResolver ?? throw new ArgumentNullException(nameof(routeResolver));
         _agentProfileResolver = agentProfileResolver ??
                                 throw new ArgumentNullException(nameof(agentProfileResolver));
+        _contentArtifactQueryPort = contentArtifactQueryPort;
     }
 
     public async Task<CommandTargetResolution<NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandStartError>> ResolveAsync(
@@ -222,6 +227,12 @@ internal sealed class NyxIdChatConversationCreateCommandTargetResolver
                 return CommandTargetResolution<NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandStartError>.Failure(
                     NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
             }
+        }
+
+        if (!await ValidateContextAttachmentsAsync(command, ct))
+        {
+            return CommandTargetResolution<NyxIdChatConversationCreateCommandTarget, NyxIdChatLifecycleCommandStartError>.Failure(
+                NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
         }
 
         var callerScope = OwnerScope.ForNyxIdNative(command.ScopeId);
@@ -268,6 +279,58 @@ internal sealed class NyxIdChatConversationCreateCommandTargetResolver
                 createdActor,
                 createdLocally: true,
                 NyxIdChatConversationCreateStatus.Accepted));
+    }
+
+    private async Task<bool> ValidateContextAttachmentsAsync(
+        NyxIdChatConversationCreateCommand command,
+        CancellationToken ct)
+    {
+        if (!ConversationContextAttachmentAdmission.TryNormalize(
+                command.ContextAttachments,
+                out var normalized))
+            return false;
+        command.ContextAttachments = normalized;
+        if (normalized.Attachments.Count == 0)
+            return true;
+        if (_contentArtifactQueryPort is null)
+            return false;
+
+        var requester = command.FirstTurn?.ToolContext?.Caller?.OwnerSubject?.Trim();
+        if (string.IsNullOrWhiteSpace(requester))
+            return false;
+
+        foreach (var attachment in normalized.Attachments)
+        {
+            ContentArtifactCurrentStateResponse? artifact;
+            try
+            {
+                artifact = await _contentArtifactQueryPort.GetAsync(
+                    command.ScopeId.Trim(),
+                    attachment.ArtifactId,
+                    ct);
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (artifact is null ||
+                !string.Equals(artifact.LifecycleStatus, ContentArtifactLifecycleStatusNames.Active, StringComparison.Ordinal) ||
+                !ConversationContextAttachmentAdmission.IsAllowedKind(artifact.Kind) ||
+                !ConversationContextAttachmentAdmission.IsAuthorized(artifact, requester))
+                return false;
+
+            if (attachment.RevisionMode == ConversationContextAttachmentRevisionMode.PinnedRevision)
+            {
+                var revision = artifact.Revisions.FirstOrDefault(item =>
+                    string.Equals(item.RevisionId, attachment.PinnedRevisionId, StringComparison.Ordinal));
+                if (revision is null ||
+                    !string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
+                    return false;
+            }
+        }
+
+        return true;
     }
 }
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatPublicEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatPublicEndpoints.cs
@@ -259,7 +259,8 @@ public static partial class NyxIdChatEndpoints
             Type: streamType,
             OriginTurnId: request.OriginTurnId,
             Actions: request.Actions,
-            AgentProfile: request.AgentProfile);
+            AgentProfile: request.AgentProfile,
+            ContextAttachments: request.ContextAttachments);
         await HandleStreamMessageCoreAsync(
             http,
             scopeId,
@@ -400,7 +401,8 @@ public static partial class NyxIdChatEndpoints
         IReadOnlyList<ContentPartDto>? InputParts,
         string? OriginTurnId,
         IReadOnlyList<NyxIdChatActionReportDto>? Actions,
-        NyxIdChatAgentProfileReferenceDto? AgentProfile);
+        NyxIdChatAgentProfileReferenceDto? AgentProfile,
+        IReadOnlyList<NyxIdChatContextAttachmentDto>? ContextAttachments);
 
     [JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
     private sealed record PublicApprovalRequest(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTurnOperationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatTurnOperationExecutor.cs
@@ -2351,6 +2351,7 @@ public sealed class NyxIdChatTurnOperationExecutor
             Activity = activity,
             ToolContext = MergeDirectInputFileRefs(chat.ToolContext, chat.InputParts),
             LlmControl = chat.LlmControl?.Clone(),
+            ContextAttachments = chat.ContextAttachments?.Clone(),
         };
         foreach (var pair in chat.Metadata)
             request.Metadata[pair.Key] = pair.Value;

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -220,7 +220,8 @@ public static class ServiceCollectionExtensions
                 larkOutboundClientFactory: sp.GetService<ILarkOutboundClientFactory>(),
                 toolExecutionPort: sp.GetRequiredService<IAgentToolExecutionPort>(),
                 remoteSkillAccessTokenResolver: sp.GetService<IRemoteSkillAccessTokenResolver>(),
-                nyxIdChatToolSources: ResolveNyxIdChatToolSources(sp)));
+                nyxIdChatToolSources: ResolveNyxIdChatToolSources(sp),
+                contentArtifactQueryPort: sp.GetService<IContentArtifactQueryPort>()));
         services.TryAddSingleton<ChannelNyxIdConnectedServiceInventoryToolSource>();
         services.TryAddSingleton<IAgentRunReplyGenerationExecutorPort, AgentRunReplyGenerationExecutor>();
         services.TryAddSingleton<INyxIdActionPostconditionPort>(sp =>

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -1011,6 +1011,7 @@ message NyxIdChatConversationCreateCommand {
   NyxIdChatStartTurnCommand first_turn = 4;
   string requested_actor_id = 5;
   aevatar.gagentservice.AgentProfileReference agent_profile_reference = 6;
+  aevatar.ai.ConversationContextAttachmentSet context_attachments = 7;
 }
 
 message NyxIdChatConversationDeleteCommand {

--- a/agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/nyxid_chat_task.proto
@@ -1182,6 +1182,7 @@ message NyxIdChatConversationGAgentState {
   // joining the registry or replaying events.
   bool deleted = 46;
   google.protobuf.Timestamp deleted_at = 47;
+  aevatar.ai.ConversationContextAttachmentSet context_attachments = 48;
 }
 
 message NyxIdChatOperationResultAcknowledgementFence {
@@ -1482,6 +1483,7 @@ message NyxIdChatLLMOperationInput {
   // Safe typed fact for one verified browser-authorization continuation.
   // Runtime credentials remain exclusively in the transient request context.
   NyxIdChatVerifiedAuthorizationContinuation verified_authorization_continuation = 7;
+  aevatar.ai.ConversationContextAttachmentSet context_attachments = 8;
 }
 
 message NyxIdChatToolOperationInput {
@@ -1861,6 +1863,7 @@ message NyxIdChatStartTurnCommand {
   // Server-authored, transient execution context for a steering continuation.
   // It is never copied into actor state, projections, or transcript history.
   NyxIdChatSteeringExecutionContext steering_execution_context = 16;
+  aevatar.ai.ConversationContextAttachmentSet context_attachments = 17;
 }
 
 message NyxIdChatStopCommand {

--- a/docs/canon/conversation-context-and-memory.md
+++ b/docs/canon/conversation-context-and-memory.md
@@ -20,6 +20,7 @@ owner: architecture
 | Prompt context | 无长期事实 owner；它由发起下一次 LLM 调用的执行模块临时派生 | continuation selector、`UserMemoryPromptContextProvider` 与 `ChatRuntime` 生产；下一次 `ChatStreamAsync` 消费 | 有界、可丢弃的执行输入，不是 committed fact，不提供独立 query API |
 | Conversation transcript | 每个 conversation 的 `ChatConversationGAgent` | terminal history delivery command 生产；conversation history API 与 prompt-context selector 消费 | committed conversation fact，经 `ChatConversationCurrentStateDocument` 和正式 transcript query port 查询 |
 | User memory | 每个用户 scope 的 `UserMemoryGAgent` | 经过授权的 typed add/remove/clear command 生产；`IUserMemoryQueryPort` 与 prompt-context provider 消费 | 跨 conversation 的 committed user fact，经 `UserMemoryCurrentStateDocument` 查询 |
+| Structured context attachment | `NyxIdChatConversationGAgent`（仅拥有引用集合，不拥有档案正文） | create command 固化 typed `ConversationContextAttachmentSet`；turn execution 通过 `IContentArtifactQueryPort` verified read 消费 | ContentArtifact current-state read model 与 verified revision read；附件正文永不写入 Conversation state/transcript |
 
 `conversationId`、`sessionId/turnId` 与 user-memory owner scope 是隔离身份。代码、
 route helper 和测试不得假设它们相等，也不得从 actor ID 前缀推导另一类身份。fixture
@@ -36,6 +37,15 @@ route helper 和测试不得假设它们相等，也不得从 actor ID 前缀推
 
 如果未来需要 transcript archive、user-memory 向量检索或不同 retention，必须先定义新的
 owner、typed lifecycle 和正式 query contract；不得在 prompt 截断或 query adapter 中静默实现。
+
+Conversation structured attachments are create-only, immutable references. Each entry selects
+`FOLLOW_CURRENT` or `PINNED_REVISION`; the set is bounded to four artifact identities and is
+sealed by `ConversationContextAttachmentsBoundEvent`. Replaying the same deterministic protobuf
+bytes is idempotent; a different or missing set cannot replace an existing binding. Create
+admission reads only the ContentArtifact read model and fails closed with `ADMISSION_UNAVAILABLE`
+for missing, inactive, unauthorized, unsupported-kind, duplicate/over-limit, or unavailable
+pinned revisions. A turn may degrade to a typed unavailable placeholder when a later verified
+read is redacted, tombstoned, expired, over budget, or temporarily unavailable.
 
 ## 3. Protobuf 与写侧契约
 
@@ -123,3 +133,4 @@ message window、`RoleGAgent` session tracking limit、user-memory 50 条上限�
 5. fixture 是否使用不同的 conversation/session/user identity？
 6. 是否把核心 category/source/recovery/control 语义建模为 Protobuf，而非 generic bag？
 7. 是否意外新增了统一 memory framework 或 LLM provider 对 user-memory lifecycle 的所有权？
+8. 附件是否只经 read model + verified read 注入，且 identity header 标明实际 revision/hash/media type？

--- a/docs/canon/nyxid-chat-agent-profile-binding.md
+++ b/docs/canon/nyxid-chat-agent-profile-binding.md
@@ -67,6 +67,26 @@ connected-service selector 可以额外封存 `readiness.requested_scopes`，用
 
 Request-local `AgentTurnToolCatalog` 不是 DI service、cache 或进程级上下文。非 Profile consumer 必须显式传 `null`；当前只有 genuinely unprofiled NyxID Chat 允许这个值表达未绑定。
 
+## Structured context attachments
+
+Conversation creation may carry a typed `ConversationContextAttachmentSet` alongside the profile
+reference. This is a separate authority: an attachment names an exact ContentArtifact identity
+and chooses `FOLLOW_CURRENT` or `PINNED_REVISION`; it does not grant write access or turn the
+artifact into profile content. The create resolver validates the artifact read model before actor
+creation (active lifecycle, owner/reader ACL, `TEXT`/`MARKDOWN`/`STRUCTURED_DOCUMENT` kind, and
+available pinned revision). Any failure is `ADMISSION_UNAVAILABLE` and no actor is created.
+
+The Conversation actor commits `ConversationContextAttachmentsBoundEvent` once. Equal protobuf
+bytes are idempotent; a different or absent later declaration is rejected. The sealed set is
+passed through transient LLM operation carriers and materialized each turn into the existing
+conversation prompt layer. `FOLLOW_CURRENT` therefore observes a newly committed current
+revision on the next turn while `PINNED_REVISION` remains stable. Materialization uses the
+verified ContentArtifact read path and emits an identity header (`artifact_id`, actual
+`revision_id`, content hash prefix, media type). Redaction, tombstone, retention expiry, ACL or
+backing failures, read-model unavailability, and either prompt budget produce a typed unavailable
+placeholder plus diagnostic; content is never truncated or persisted in Conversation state,
+read models, or transcript history.
+
 ## Static route tool ceiling
 
 Profiled 与 genuinely unprofiled NyxID Chat 共用 Host 静态注册的

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -77,6 +77,7 @@ message ChatRequestEvent  {
   AgentToolNyxIdCredentialKindPayload caller_nyx_id_credential_kind = 16;
   string caller_source_readable_nyx_id_bearer_token = 17;
   WorkflowLlmCompletionDeliveryContext workflow_llm_completion_delivery_context = 18;
+  ConversationContextAttachmentSet context_attachments = 19;
 }
 message ChatResponseEvent { string content = 1; string session_id = 2; }
 
@@ -1118,6 +1119,46 @@ message AgentProfileBoundEvent {
   AgentProfileSnapshot profile = 1;
 }
 
+enum ConversationContextAttachmentRevisionMode {
+  CONVERSATION_CONTEXT_ATTACHMENT_REVISION_MODE_UNSPECIFIED = 0;
+  CONVERSATION_CONTEXT_ATTACHMENT_REVISION_MODE_FOLLOW_CURRENT = 1;
+  CONVERSATION_CONTEXT_ATTACHMENT_REVISION_MODE_PINNED_REVISION = 2;
+}
+
+message ConversationContextAttachment {
+  string artifact_id = 1;
+  ConversationContextAttachmentRevisionMode revision_mode = 2;
+  string pinned_revision_id = 3;
+}
+
+message ConversationContextAttachmentSet {
+  repeated ConversationContextAttachment attachments = 1;
+}
+
+enum ConversationContextAttachmentUnavailableReason {
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_UNSPECIFIED = 0;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_NOT_FOUND = 1;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_ACCESS_DENIED = 2;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_INACTIVE = 3;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_REVISION_UNAVAILABLE = 4;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_REDACTED = 5;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_RETENTION_EXPIRED = 6;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_TOMBSTONED = 7;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_BACKING_UNAVAILABLE = 8;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_OVER_BUDGET = 9;
+  CONVERSATION_CONTEXT_ATTACHMENT_UNAVAILABLE_REASON_READ_MODEL_UNAVAILABLE = 10;
+}
+
+message ConversationContextAttachmentUnavailablePlaceholder {
+  string artifact_id = 1;
+  string revision_id = 2;
+  ConversationContextAttachmentUnavailableReason reason = 3;
+}
+
+message ConversationContextAttachmentsBoundEvent {
+  ConversationContextAttachmentSet attachments = 1;
+}
+
 enum AgentProfileTurnAuthorityKind {
   AGENT_PROFILE_TURN_AUTHORITY_KIND_UNSPECIFIED = 0;
   AGENT_PROFILE_TURN_AUTHORITY_KIND_RESTRICTED_EMPTY = 1;
@@ -1273,6 +1314,7 @@ message RoleGAgentState {
   reserved "system_skill_overlay";
   AgentProfileSnapshot agent_profile = 12;
   AgentProfileTurnAuthorityState agent_profile_turn_authority = 13;
+  ConversationContextAttachmentSet context_attachments = 14;
 }
 
 // ─── Multi-turn tool approval continuation ───

--- a/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/ContentArtifactContracts.cs
@@ -18,6 +18,15 @@ public static class ContentArtifactRevisionAvailabilityNames
     public const string RetentionExpired = "retention_expired";
 }
 
+public enum ContentArtifactContentUnavailableReason
+{
+    Unspecified = 0,
+    Tombstoned = 1,
+    Redacted = 2,
+    RetentionExpired = 3,
+    BackingUnavailable = 4,
+}
+
 public sealed record ContentArtifactPrincipalContract(
     string PrincipalId,
     string PrincipalKind);
@@ -216,8 +225,31 @@ public sealed class ContentArtifactIdentityConflictException : InvalidOperationE
 
 public sealed class ContentArtifactContentUnavailableException : InvalidOperationException
 {
-    public ContentArtifactContentUnavailableException(string artifactId, string revisionId, string reason)
-        : base($"ContentArtifact '{artifactId}' revision '{revisionId}' content is unavailable: {reason}")
+    // Fix (review round 1, F4):
+    //   Unavailable control flow was parsed from exception message text.
+    //   The exception now carries a typed reason while preserving a useful message.
+    public ContentArtifactContentUnavailableException(
+        string artifactId,
+        string revisionId,
+        ContentArtifactContentUnavailableReason reason)
+        : base($"ContentArtifact '{artifactId}' revision '{revisionId}' content is unavailable: {FormatReason(reason)}")
     {
+        ArtifactId = artifactId;
+        RevisionId = revisionId;
+        Reason = reason;
     }
+
+    public string ArtifactId { get; }
+    public string RevisionId { get; }
+    public ContentArtifactContentUnavailableReason Reason { get; }
+
+    private static string FormatReason(ContentArtifactContentUnavailableReason reason) =>
+        reason switch
+        {
+            ContentArtifactContentUnavailableReason.Tombstoned => "artifact is tombstoned",
+            ContentArtifactContentUnavailableReason.Redacted => ContentArtifactRevisionAvailabilityNames.Redacted,
+            ContentArtifactContentUnavailableReason.RetentionExpired => ContentArtifactRevisionAvailabilityNames.RetentionExpired,
+            ContentArtifactContentUnavailableReason.BackingUnavailable => "backing content is unavailable",
+            _ => "unspecified",
+        };
 }

--- a/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
@@ -95,7 +95,7 @@ public sealed class ContentArtifactService : IContentArtifactService
             throw new ContentArtifactContentUnavailableException(
                 current.ArtifactId,
                 string.Empty,
-                "artifact is tombstoned");
+                ContentArtifactContentUnavailableReason.Tombstoned);
         }
         if (string.IsNullOrWhiteSpace(current.CurrentRevisionId))
             throw new ContentArtifactNotFoundException(current.ScopeId, current.ArtifactId);
@@ -116,7 +116,7 @@ public sealed class ContentArtifactService : IContentArtifactService
             throw new ContentArtifactContentUnavailableException(
                 current.ArtifactId,
                 revision.RevisionId,
-                "artifact is tombstoned");
+                ContentArtifactContentUnavailableReason.Tombstoned);
         }
         if (revision.Availability is ContentArtifactRevisionAvailabilityNames.Redacted or
             ContentArtifactRevisionAvailabilityNames.RetentionExpired)
@@ -124,7 +124,9 @@ public sealed class ContentArtifactService : IContentArtifactService
             throw new ContentArtifactContentUnavailableException(
                 current.ArtifactId,
                 revision.RevisionId,
-                revision.Availability);
+                revision.Availability == ContentArtifactRevisionAvailabilityNames.Redacted
+                    ? ContentArtifactContentUnavailableReason.Redacted
+                    : ContentArtifactContentUnavailableReason.RetentionExpired);
         }
         if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
             throw new InvalidOperationException("ContentArtifact revision availability is invalid.");

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionContentArtifactQueryPort.cs
@@ -122,7 +122,7 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
             throw new ContentArtifactContentUnavailableException(
                 normalizedArtifactId,
                 normalizedRevisionId,
-                "artifact is tombstoned");
+                ContentArtifactContentUnavailableReason.Tombstoned);
         }
         if (revision.Availability is ContentArtifactRevisionAvailabilityNames.Redacted or
             ContentArtifactRevisionAvailabilityNames.RetentionExpired)
@@ -130,7 +130,9 @@ public sealed class ProjectionContentArtifactQueryPort : IContentArtifactQueryPo
             throw new ContentArtifactContentUnavailableException(
                 normalizedArtifactId,
                 normalizedRevisionId,
-                revision.Availability);
+                revision.Availability == ContentArtifactRevisionAvailabilityNames.Redacted
+                    ? ContentArtifactContentUnavailableReason.Redacted
+                    : ContentArtifactContentUnavailableReason.RetentionExpired);
         }
         if (!string.Equals(revision.Availability, ContentArtifactRevisionAvailabilityNames.Available, StringComparison.Ordinal))
             throw new InvalidDataException("ContentArtifact revision availability is invalid.");

--- a/test/Aevatar.AI.Tests/ConversationContextAttachmentTests.cs
+++ b/test/Aevatar.AI.Tests/ConversationContextAttachmentTests.cs
@@ -1,0 +1,79 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.GAgents.NyxidChat;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class ConversationContextAttachmentTests
+{
+    [Fact]
+    public void AttachmentSet_NormalizationRejectsDuplicatesAndRequiresPinnedRevision()
+    {
+        var duplicate = new ConversationContextAttachmentSet();
+        duplicate.Attachments.Add(new ConversationContextAttachment
+        {
+            ArtifactId = "artifact-a",
+            RevisionMode = ConversationContextAttachmentRevisionMode.FollowCurrent,
+        });
+        duplicate.Attachments.Add(duplicate.Attachments[0].Clone());
+
+        ConversationContextAttachmentAdmission.TryNormalize(duplicate, out _).Should().BeFalse();
+
+        var missingRevision = new ConversationContextAttachmentSet();
+        missingRevision.Attachments.Add(new ConversationContextAttachment
+        {
+            ArtifactId = "artifact-a",
+            RevisionMode = ConversationContextAttachmentRevisionMode.PinnedRevision,
+        });
+        ConversationContextAttachmentAdmission.TryNormalize(missingRevision, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Materializer_UsesCurrentRevisionAndEmitsIdentityHeader()
+    {
+        var query = new FakeContentArtifactQueryPort(
+            new ContentArtifactCurrentStateResponse(
+                "artifact-a", "scope-a", null, "text", "Report", "plain", "active", "rev-2", 2, 2,
+                new ContentArtifactPrincipalContract("user-a", "user"), [], [], null, null,
+                [
+                    new ContentArtifactRevisionResponse("rev-1", 1, null, "text/plain", 5, "hash-one", "available", true, false, new ContentArtifactExecutionProvenanceContract("scope-a"), [], DateTimeOffset.UtcNow),
+                    new ContentArtifactRevisionResponse("rev-2", 2, "rev-1", "text/plain", 5, "hash-two", "available", true, false, new ContentArtifactExecutionProvenanceContract("scope-a"), [], DateTimeOffset.UtcNow),
+                ], DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new byte[] { 1, 2, 3 });
+        var set = new ConversationContextAttachmentSet();
+        set.Attachments.Add(new ConversationContextAttachment
+        {
+            ArtifactId = "artifact-a",
+            RevisionMode = ConversationContextAttachmentRevisionMode.FollowCurrent,
+        });
+
+        var layer = await new ContentArtifactConversationPromptLayerMaterializer(query)
+            .MaterializeAsync("scope-a", new ContentArtifactPrincipalContract("user-a", "user"), set);
+
+        layer.Content.Should().Contain("artifact_id=artifact-a");
+        layer.Content.Should().Contain("revision_id=rev-2");
+        layer.Content.Should().Contain("content_hash=hash-two");
+        layer.Content.Should().Contain("\u0001\u0002\u0003");
+        layer.Diagnostics.Should().BeEmpty();
+    }
+
+    private sealed class FakeContentArtifactQueryPort(
+        ContentArtifactCurrentStateResponse artifact,
+        byte[] content) : IContentArtifactQueryPort
+    {
+        public Task<ContentArtifactListResponse> ListAsync(string scopeId, string requesterPrincipalId, ContentArtifactQueryRequest query, CancellationToken ct = default) =>
+            Task.FromResult(new ContentArtifactListResponse(scopeId, [artifact]));
+
+        public Task<ContentArtifactCurrentStateResponse?> GetAsync(string scopeId, string artifactId, CancellationToken ct = default) =>
+            Task.FromResult<ContentArtifactCurrentStateResponse?>(artifact.ArtifactId == artifactId ? artifact : null);
+
+        public Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(string scopeId, string dedupKey, CancellationToken ct = default) =>
+            Task.FromResult<ContentArtifactCurrentStateResponse?>(null);
+
+        public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) =>
+            Task.FromResult(new ContentArtifactRevisionContentResponse(
+                new ContentArtifactReferenceContract(artifactId, revisionId, "hash-two", "text/plain"), content));
+    }
+}

--- a/test/Aevatar.AI.Tests/ConversationContextAttachmentTests.cs
+++ b/test/Aevatar.AI.Tests/ConversationContextAttachmentTests.cs
@@ -1,4 +1,7 @@
+using System.Text;
 using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.Prompting;
+using Aevatar.AI.Core.Prompting;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -8,72 +11,284 @@ namespace Aevatar.AI.Tests;
 
 public sealed class ConversationContextAttachmentTests
 {
+    // Fix (review round 1, F1):
+    //   Revision selection and degraded prompt-layer outcomes had no acceptance coverage.
+    //   These tests assert prompt content, exact revision reads, placeholders, and diagnostics.
     [Fact]
     public void AttachmentSet_NormalizationRejectsDuplicatesAndRequiresPinnedRevision()
     {
-        var duplicate = new ConversationContextAttachmentSet();
-        duplicate.Attachments.Add(new ConversationContextAttachment
-        {
-            ArtifactId = "artifact-a",
-            RevisionMode = ConversationContextAttachmentRevisionMode.FollowCurrent,
-        });
-        duplicate.Attachments.Add(duplicate.Attachments[0].Clone());
+        var duplicate = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent),
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent));
 
         ConversationContextAttachmentAdmission.TryNormalize(duplicate, out _).Should().BeFalse();
 
-        var missingRevision = new ConversationContextAttachmentSet();
-        missingRevision.Attachments.Add(new ConversationContextAttachment
-        {
-            ArtifactId = "artifact-a",
-            RevisionMode = ConversationContextAttachmentRevisionMode.PinnedRevision,
-        });
+        var missingRevision = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.PinnedRevision));
+
         ConversationContextAttachmentAdmission.TryNormalize(missingRevision, out _).Should().BeFalse();
     }
 
     [Fact]
-    public async Task Materializer_UsesCurrentRevisionAndEmitsIdentityHeader()
+    public async Task Materializer_FollowCurrentAdvancesWhilePinnedRevisionRemainsStableInSystemPrompt()
     {
-        var query = new FakeContentArtifactQueryPort(
-            new ContentArtifactCurrentStateResponse(
-                "artifact-a", "scope-a", null, "text", "Report", "plain", "active", "rev-2", 2, 2,
-                new ContentArtifactPrincipalContract("user-a", "user"), [], [], null, null,
-                [
-                    new ContentArtifactRevisionResponse("rev-1", 1, null, "text/plain", 5, "hash-one", "available", true, false, new ContentArtifactExecutionProvenanceContract("scope-a"), [], DateTimeOffset.UtcNow),
-                    new ContentArtifactRevisionResponse("rev-2", 2, "rev-1", "text/plain", 5, "hash-two", "available", true, false, new ContentArtifactExecutionProvenanceContract("scope-a"), [], DateTimeOffset.UtcNow),
-                ], DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
-            new byte[] { 1, 2, 3 });
-        var set = new ConversationContextAttachmentSet();
-        set.Attachments.Add(new ConversationContextAttachment
-        {
-            ArtifactId = "artifact-a",
-            RevisionMode = ConversationContextAttachmentRevisionMode.FollowCurrent,
-        });
+        var query = new FakeContentArtifactQueryPort(BuildArtifact("rev-1"));
+        var materializer = new ContentArtifactConversationPromptLayerMaterializer(query);
+        var requester = new ContentArtifactPrincipalContract("principal-alpha", "user");
+        var followCurrent = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent));
+        var pinned = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.PinnedRevision, "rev-1"));
 
-        var layer = await new ContentArtifactConversationPromptLayerMaterializer(query)
-            .MaterializeAsync("scope-a", new ContentArtifactPrincipalContract("user-a", "user"), set);
+        var followFirst = await materializer.MaterializeAsync("scope-alpha", requester, followCurrent);
+        var pinnedFirst = await materializer.MaterializeAsync("scope-alpha", requester, pinned);
 
-        layer.Content.Should().Contain("artifact_id=artifact-a");
-        layer.Content.Should().Contain("revision_id=rev-2");
-        layer.Content.Should().Contain("content_hash=hash-two");
-        layer.Content.Should().Contain("\u0001\u0002\u0003");
-        layer.Diagnostics.Should().BeEmpty();
+        query.Artifact = BuildArtifact("rev-2");
+        var followSecond = await materializer.MaterializeAsync("scope-alpha", requester, followCurrent);
+        var pinnedSecond = await materializer.MaterializeAsync("scope-alpha", requester, pinned);
+
+        followFirst.Content.Should().Contain("revision_id=rev-1").And.Contain("content-rev-1");
+        pinnedFirst.Content.Should().Contain("revision_id=rev-1").And.Contain("content-rev-1");
+        followSecond.Content.Should().Contain("revision_id=rev-2").And.Contain("content-rev-2");
+        pinnedSecond.Content.Should().Contain("revision_id=rev-1").And.Contain("content-rev-1");
+        query.ContentRevisionIds.Should().Equal("rev-1", "rev-1", "rev-2", "rev-1");
+
+        var composed = SystemPromptLayerComposer.Compose(
+            new KernelPromptLayer("kernel", new KernelPromptProvenance("kernel")),
+            new BuiltInPromptFloorLayer("floor", new BuiltInPromptFloorProvenance("floor")),
+            global: null,
+            profile: null,
+            selectedSkill: null,
+            runtimeFacts: null,
+            conversation: followSecond);
+        composed.Prompt.Should().Contain("<untrusted-conversation-summary>")
+            .And.Contain("artifact_id=artifact-a")
+            .And.Contain("revision_id=rev-2")
+            .And.Contain("content-rev-2");
+        composed.Conversation.Included.Should().BeTrue();
     }
 
-    private sealed class FakeContentArtifactQueryPort(
-        ContentArtifactCurrentStateResponse artifact,
-        byte[] content) : IContentArtifactQueryPort
+    [Theory]
+    [InlineData("redacted", ConversationContextAttachmentUnavailableReason.Redacted)]
+    [InlineData("tombstoned", ConversationContextAttachmentUnavailableReason.Tombstoned)]
+    [InlineData("over-budget", ConversationContextAttachmentUnavailableReason.OverBudget)]
+    [InlineData("read-model-unavailable", ConversationContextAttachmentUnavailableReason.ReadModelUnavailable)]
+    [InlineData("backing-io", ConversationContextAttachmentUnavailableReason.BackingUnavailable)]
+    [InlineData("typed-backing", ConversationContextAttachmentUnavailableReason.BackingUnavailable)]
+    public async Task Materializer_DegradationAlwaysPairsPlaceholderAndDiagnostic(
+        string failure,
+        ConversationContextAttachmentUnavailableReason expectedReason)
     {
-        public Task<ContentArtifactListResponse> ListAsync(string scopeId, string requesterPrincipalId, ContentArtifactQueryRequest query, CancellationToken ct = default) =>
-            Task.FromResult(new ContentArtifactListResponse(scopeId, [artifact]));
+        var query = BuildFailingQuery(failure);
+        var set = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent));
 
-        public Task<ContentArtifactCurrentStateResponse?> GetAsync(string scopeId, string artifactId, CancellationToken ct = default) =>
-            Task.FromResult<ContentArtifactCurrentStateResponse?>(artifact.ArtifactId == artifactId ? artifact : null);
+        var layer = await new ContentArtifactConversationPromptLayerMaterializer(query)
+            .MaterializeAsync(
+                "scope-alpha",
+                new ContentArtifactPrincipalContract("principal-alpha", "user"),
+                set);
 
-        public Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(string scopeId, string dedupKey, CancellationToken ct = default) =>
+        layer.Content.Should().Contain("[content-artifact-unavailable artifact_id=artifact-a")
+            .And.Contain($"reason={expectedReason}")
+            .And.NotContain("[/content-artifact]");
+        layer.Diagnostics.Should().ContainSingle();
+        layer.Diagnostics[0].Detail.Should().Contain("artifact-a").And.Contain(expectedReason.ToString());
+    }
+
+    [Fact]
+    public async Task MaterializeOrDegradeAsync_WithoutReadPortEmitsOnePairPerSealedAttachment()
+    {
+        var set = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent),
+            Attachment("artifact-b", ConversationContextAttachmentRevisionMode.PinnedRevision, "rev-7"));
+
+        var layer = await ContentArtifactConversationPromptLayerMaterializer.MaterializeOrDegradeAsync(
+            materializer: null,
+            set,
+            "scope-alpha",
+            "principal-alpha");
+
+        layer.Should().NotBeNull();
+        layer!.Content.Should().Contain("artifact_id=artifact-a")
+            .And.Contain("artifact_id=artifact-b")
+            .And.Contain("reason=ReadModelUnavailable");
+        layer.Diagnostics.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData(null, "principal-alpha")]
+    [InlineData("scope-alpha", null)]
+    public async Task MaterializeOrDegradeAsync_WithoutTypedCallerAuthorityDoesNotInventScope(
+        string? scopeId,
+        string? principalId)
+    {
+        var query = new FakeContentArtifactQueryPort(BuildArtifact("rev-1"));
+        var set = AttachmentSet(
+            Attachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent));
+
+        var layer = await ContentArtifactConversationPromptLayerMaterializer.MaterializeOrDegradeAsync(
+            new ContentArtifactConversationPromptLayerMaterializer(query),
+            set,
+            scopeId,
+            principalId);
+
+        layer.Should().NotBeNull();
+        layer!.Content.Should().Contain("reason=AccessDenied");
+        layer.Diagnostics.Should().ContainSingle();
+        query.GetCalls.Should().Be(0);
+    }
+
+    private static FakeContentArtifactQueryPort BuildFailingQuery(string failure)
+    {
+        var lifecycle = failure == "tombstoned"
+            ? ContentArtifactLifecycleStatusNames.Tombstoned
+            : ContentArtifactLifecycleStatusNames.Active;
+        var availability = failure == "redacted"
+            ? ContentArtifactRevisionAvailabilityNames.Redacted
+            : ContentArtifactRevisionAvailabilityNames.Available;
+        var query = new FakeContentArtifactQueryPort(
+            BuildArtifact("rev-2", lifecycle, availability));
+
+        if (failure == "over-budget")
+            query.ContentByRevision["rev-2"] = new byte[ContentArtifactConversationPromptLayerMaterializer.MaximumAttachmentBytes + 1];
+        else if (failure == "read-model-unavailable")
+            query.GetException = new InvalidOperationException("read model unavailable");
+        else if (failure == "backing-io")
+            query.ContentException = new IOException("backing provider unavailable");
+        else if (failure == "typed-backing")
+        {
+            query.ContentException = new ContentArtifactContentUnavailableException(
+                "artifact-a",
+                "rev-2",
+                ContentArtifactContentUnavailableReason.BackingUnavailable);
+        }
+
+        return query;
+    }
+
+    private static ContentArtifactCurrentStateResponse BuildArtifact(
+        string currentRevisionId,
+        string lifecycle = ContentArtifactLifecycleStatusNames.Active,
+        string currentAvailability = ContentArtifactRevisionAvailabilityNames.Available) =>
+        new(
+            "artifact-a",
+            "scope-alpha",
+            null,
+            "text",
+            "Report",
+            "plain",
+            lifecycle,
+            currentRevisionId,
+            2,
+            2,
+            new ContentArtifactPrincipalContract("principal-alpha", "user"),
+            [],
+            [],
+            null,
+            null,
+            [
+                Revision("rev-1", 1, ContentArtifactRevisionAvailabilityNames.Available),
+                Revision("rev-2", 2, currentAvailability),
+            ],
+            DateTimeOffset.Parse("2026-08-25T00:00:00Z"),
+            DateTimeOffset.Parse("2026-08-25T00:01:00Z"));
+
+    private static ContentArtifactRevisionResponse Revision(
+        string revisionId,
+        long revisionNumber,
+        string availability) =>
+        new(
+            revisionId,
+            revisionNumber,
+            revisionNumber == 1 ? null : "rev-1",
+            "text/plain",
+            13,
+            $"hash-{revisionId}",
+            availability,
+            true,
+            false,
+            new ContentArtifactExecutionProvenanceContract("scope-alpha"),
+            [],
+            DateTimeOffset.Parse("2026-08-25T00:00:00Z"));
+
+    private static ConversationContextAttachmentSet AttachmentSet(
+        params ConversationContextAttachment[] attachments)
+    {
+        var set = new ConversationContextAttachmentSet();
+        set.Attachments.Add(attachments);
+        return set;
+    }
+
+    private static ConversationContextAttachment Attachment(
+        string artifactId,
+        ConversationContextAttachmentRevisionMode revisionMode,
+        string pinnedRevisionId = "") =>
+        new()
+        {
+            ArtifactId = artifactId,
+            RevisionMode = revisionMode,
+            PinnedRevisionId = pinnedRevisionId,
+        };
+
+    private sealed class FakeContentArtifactQueryPort(
+        ContentArtifactCurrentStateResponse artifact) : IContentArtifactQueryPort
+    {
+        public ContentArtifactCurrentStateResponse Artifact { get; set; } = artifact;
+        public Exception? GetException { get; set; }
+        public Exception? ContentException { get; set; }
+        public int GetCalls { get; private set; }
+        public List<string> ContentRevisionIds { get; } = [];
+        public Dictionary<string, byte[]> ContentByRevision { get; } = new(StringComparer.Ordinal)
+        {
+            ["rev-1"] = Encoding.UTF8.GetBytes("content-rev-1"),
+            ["rev-2"] = Encoding.UTF8.GetBytes("content-rev-2"),
+        };
+
+        public Task<ContentArtifactListResponse> ListAsync(
+            string scopeId,
+            string requesterPrincipalId,
+            ContentArtifactQueryRequest query,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ContentArtifactListResponse(scopeId, [Artifact]));
+
+        public Task<ContentArtifactCurrentStateResponse?> GetAsync(
+            string scopeId,
+            string artifactId,
+            CancellationToken ct = default)
+        {
+            GetCalls++;
+            return GetException is null
+                ? Task.FromResult<ContentArtifactCurrentStateResponse?>(
+                    Artifact.ArtifactId == artifactId ? Artifact : null)
+                : Task.FromException<ContentArtifactCurrentStateResponse?>(GetException);
+        }
+
+        public Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(
+            string scopeId,
+            string dedupKey,
+            CancellationToken ct = default) =>
             Task.FromResult<ContentArtifactCurrentStateResponse?>(null);
 
-        public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(string scopeId, string artifactId, string revisionId, ContentArtifactPrincipalContract requester, CancellationToken ct = default) =>
-            Task.FromResult(new ContentArtifactRevisionContentResponse(
-                new ContentArtifactReferenceContract(artifactId, revisionId, "hash-two", "text/plain"), content));
+        public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
+            string scopeId,
+            string artifactId,
+            string revisionId,
+            ContentArtifactPrincipalContract requester,
+            CancellationToken ct = default)
+        {
+            ContentRevisionIds.Add(revisionId);
+            if (ContentException is not null)
+                return Task.FromException<ContentArtifactRevisionContentResponse>(ContentException);
+
+            var content = ContentByRevision[revisionId];
+            return Task.FromResult(new ContentArtifactRevisionContentResponse(
+                new ContentArtifactReferenceContract(
+                    artifactId,
+                    revisionId,
+                    $"hash-{revisionId}",
+                    "text/plain"),
+                content));
+        }
     }
 }

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -36,6 +36,7 @@ using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.GAgents.NyxidChat.AgentProfiles;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -66,7 +67,8 @@ public class NyxIdChatGAgentTests
                 "agent_profile",
                 "first_turn",
                 "requested_actor_id",
-                "agent_profile_reference");
+                "agent_profile_reference",
+                "context_attachments");
     }
 
     [Fact]
@@ -276,6 +278,80 @@ public class NyxIdChatGAgentTests
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
         source.ResolveCalls.Should().Be(1);
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    // Fix (review round 1, F1):
+    //   Create admission rejection cases were not proven to stop actor creation.
+    //   The matrix now asserts the typed error and an empty runtime create ledger.
+    [Theory]
+    [InlineData("missing")]
+    [InlineData("unauthorized")]
+    [InlineData("other-content")]
+    [InlineData("over-limit")]
+    [InlineData("pinned-unavailable")]
+    public async Task CreateTargetResolver_ShouldRejectUnavailableContextAttachmentsBeforeCreatingActor(
+        string failure)
+    {
+        var runtime = new RecordingActorRuntime();
+        var artifact = BuildAdmissionArtifact();
+        var query = new AttachmentAdmissionQueryPort(artifact);
+        var command = BuildAttachmentAdmissionCommand(
+            BuildContextAttachment("artifact-a", ConversationContextAttachmentRevisionMode.FollowCurrent));
+
+        switch (failure)
+        {
+            case "missing":
+                query.Artifact = null;
+                break;
+            case "unauthorized":
+                query.Artifact = artifact with
+                {
+                    Owner = new ContentArtifactPrincipalContract("principal-other", "user"),
+                    ReaderPrincipalIds = [],
+                };
+                break;
+            case "other-content":
+                query.Artifact = artifact with { Kind = "other_content" };
+                break;
+            case "over-limit":
+                command.ContextAttachments = BuildContextAttachmentSet(
+                    Enumerable.Range(1, ConversationContextAttachmentAdmission.MaximumAttachments + 1)
+                        .Select(index => BuildContextAttachment(
+                            $"artifact-{index}",
+                            ConversationContextAttachmentRevisionMode.FollowCurrent))
+                        .ToArray());
+                break;
+            case "pinned-unavailable":
+                query.Artifact = artifact with
+                {
+                    Revisions =
+                    [
+                        artifact.Revisions[0] with
+                        {
+                            Availability = ContentArtifactRevisionAvailabilityNames.Redacted,
+                        },
+                    ],
+                };
+                command.ContextAttachments = BuildContextAttachmentSet(
+                    BuildContextAttachment(
+                        "artifact-a",
+                        ConversationContextAttachmentRevisionMode.PinnedRevision,
+                        "rev-1"));
+                break;
+        }
+
+        var resolver = new NyxIdChatConversationCreateCommandTargetResolver(
+            runtime,
+            StaticChatRoutePolicyQueryPort.ForSnapshot(null),
+            NewChatRouteResolver(),
+            new DisabledNyxIdChatAgentProfileResolver(),
+            query);
+
+        var result = await resolver.ResolveAsync(command);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(NyxIdChatLifecycleCommandStartError.AdmissionUnavailable);
         runtime.CreateCalls.Should().BeEmpty();
     }
 
@@ -919,6 +995,102 @@ public class NyxIdChatGAgentTests
         await act.Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*cannot be replaced*");
+    }
+
+    // Fix (review round 1, F1):
+    //   Attachment binding replay lacked bind, idempotent, conflict, and missing-set coverage.
+    //   These event-store tests mirror the established AgentProfileBoundEvent shape.
+    [Fact]
+    public async Task ActivateAsync_ShouldReplayCommittedContextAttachmentBinding()
+    {
+        using var provider = BuildServiceProvider();
+        const string actorId = "conversation-attachment-replay-bind";
+        var attachments = BuildContextAttachmentSet(
+            BuildContextAttachment(
+                "artifact-alpha",
+                ConversationContextAttachmentRevisionMode.FollowCurrent));
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new ConversationContextAttachmentsBoundEvent { Attachments = attachments.Clone() });
+        var agent = CreateConversationAgent(provider, actorId);
+
+        await agent.ActivateAsync();
+
+        ConversationContextAttachmentAdmission.ByteEquivalent(
+            agent.State.ContextAttachments,
+            attachments).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldReplayEquivalentCommittedContextAttachmentBindingIdempotently()
+    {
+        using var provider = BuildServiceProvider();
+        const string actorId = "conversation-attachment-replay-equivalent";
+        var attachments = BuildContextAttachmentSet(
+            BuildContextAttachment(
+                "artifact-alpha",
+                ConversationContextAttachmentRevisionMode.PinnedRevision,
+                "revision-alpha"));
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new ConversationContextAttachmentsBoundEvent { Attachments = attachments.Clone() },
+            new ConversationContextAttachmentsBoundEvent { Attachments = attachments.Clone() });
+        var agent = CreateConversationAgent(provider, actorId);
+
+        await agent.ActivateAsync();
+
+        ConversationContextAttachmentAdmission.ByteEquivalent(
+            agent.State.ContextAttachments,
+            attachments).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldRejectConflictingCommittedContextAttachmentBindingDuringReplay()
+    {
+        using var provider = BuildServiceProvider();
+        const string actorId = "conversation-attachment-replay-conflict";
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new ConversationContextAttachmentsBoundEvent
+            {
+                Attachments = BuildContextAttachmentSet(
+                    BuildContextAttachment(
+                        "artifact-alpha",
+                        ConversationContextAttachmentRevisionMode.FollowCurrent)),
+            },
+            new ConversationContextAttachmentsBoundEvent
+            {
+                Attachments = BuildContextAttachmentSet(
+                    BuildContextAttachment(
+                        "artifact-beta",
+                        ConversationContextAttachmentRevisionMode.FollowCurrent)),
+            });
+        var agent = CreateConversationAgent(provider, actorId);
+
+        var act = () => agent.ActivateAsync();
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot replace*");
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ShouldKeepContextAttachmentsUnboundForMissingCommittedSet()
+    {
+        using var provider = BuildServiceProvider();
+        const string actorId = "conversation-attachment-replay-missing";
+        await AppendCommittedEventsAsync(
+            provider,
+            actorId,
+            new ConversationContextAttachmentsBoundEvent());
+        var agent = CreateConversationAgent(provider, actorId);
+
+        await agent.ActivateAsync();
+
+        agent.State.ContextAttachments.Should().BeNull();
     }
 
     [Fact]
@@ -2825,6 +2997,82 @@ public class NyxIdChatGAgentTests
     private static ChatRouteResolver NewChatRouteResolver() =>
         new(new StaticChatRouteFallbackProvider(string.Empty));
 
+    private static NyxIdChatConversationCreateCommand BuildAttachmentAdmissionCommand(
+        params ConversationContextAttachment[] attachments) =>
+        new()
+        {
+            ScopeId = "scope-alpha",
+            RequestedActorId = "conversation-alpha",
+            ContextAttachments = BuildContextAttachmentSet(attachments),
+            FirstTurn = new NyxIdChatStartTurnCommand
+            {
+                ScopeId = "scope-alpha",
+                ConversationActorId = "conversation-alpha",
+                TurnId = "turn-beta",
+                ToolContext = new AgentToolExecutionContextPayload
+                {
+                    Caller = new AgentToolCallerContextPayload
+                    {
+                        OwnerSubject = "principal-alpha",
+                    },
+                },
+            },
+        };
+
+    private static ConversationContextAttachmentSet BuildContextAttachmentSet(
+        params ConversationContextAttachment[] attachments)
+    {
+        var set = new ConversationContextAttachmentSet();
+        set.Attachments.Add(attachments);
+        return set;
+    }
+
+    private static ConversationContextAttachment BuildContextAttachment(
+        string artifactId,
+        ConversationContextAttachmentRevisionMode revisionMode,
+        string pinnedRevisionId = "") =>
+        new()
+        {
+            ArtifactId = artifactId,
+            RevisionMode = revisionMode,
+            PinnedRevisionId = pinnedRevisionId,
+        };
+
+    private static ContentArtifactCurrentStateResponse BuildAdmissionArtifact() =>
+        new(
+            "artifact-a",
+            "scope-alpha",
+            null,
+            "text",
+            "Admission fixture",
+            "plain",
+            ContentArtifactLifecycleStatusNames.Active,
+            "rev-1",
+            1,
+            1,
+            new ContentArtifactPrincipalContract("principal-alpha", "user"),
+            [],
+            [],
+            null,
+            null,
+            [
+                new ContentArtifactRevisionResponse(
+                    "rev-1",
+                    1,
+                    null,
+                    "text/plain",
+                    7,
+                    "hash-rev-1",
+                    ContentArtifactRevisionAvailabilityNames.Available,
+                    true,
+                    false,
+                    new ContentArtifactExecutionProvenanceContract("scope-alpha"),
+                    [],
+                    DateTimeOffset.Parse("2026-08-25T00:00:00Z")),
+            ],
+            DateTimeOffset.Parse("2026-08-25T00:00:00Z"),
+            DateTimeOffset.Parse("2026-08-25T00:01:00Z"));
+
     private static AgentProfileSnapshot BuildSealedProfile(
         string profileVersion,
         string routeToolSetRef = "") =>
@@ -3166,6 +3414,45 @@ public class NyxIdChatGAgentTests
                 throw DispatchException;
             return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
         }
+    }
+
+    private sealed class AttachmentAdmissionQueryPort(
+        ContentArtifactCurrentStateResponse? artifact) : IContentArtifactQueryPort
+    {
+        public ContentArtifactCurrentStateResponse? Artifact { get; set; } = artifact;
+
+        public Task<ContentArtifactListResponse> ListAsync(
+            string scopeId,
+            string requesterPrincipalId,
+            ContentArtifactQueryRequest query,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ContentArtifactListResponse(
+                scopeId,
+                Artifact is null ? [] : [Artifact]));
+
+        public Task<ContentArtifactCurrentStateResponse?> GetAsync(
+            string scopeId,
+            string artifactId,
+            CancellationToken ct = default) =>
+            Task.FromResult(
+                Artifact is not null &&
+                string.Equals(Artifact.ArtifactId, artifactId, StringComparison.Ordinal)
+                    ? Artifact
+                    : null);
+
+        public Task<ContentArtifactCurrentStateResponse?> GetByDedupKeyAsync(
+            string scopeId,
+            string dedupKey,
+            CancellationToken ct = default) =>
+            Task.FromResult<ContentArtifactCurrentStateResponse?>(null);
+
+        public Task<ContentArtifactRevisionContentResponse> GetRevisionContentAsync(
+            string scopeId,
+            string artifactId,
+            string revisionId,
+            ContentArtifactPrincipalContract requester,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("Create admission must not read artifact content.");
     }
 
     private sealed class RecordingActorRuntime(List<string>? operations = null) : IActorRuntime

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationGAgentTargetActorIdTests.cs
@@ -64,6 +64,32 @@ public sealed class ConversationGAgentTargetActorIdTests
     }
 
     [Fact]
+    public async Task HandleInboundActivityAsync_ShouldCopySealedContextAttachmentsToRunCarriers()
+    {
+        var actorId = ConversationGAgent.BuildActorId("lark:group:oc_attachment_chat");
+        var runner = new DeferredReplyTurnRunner();
+        var dispatcher = new RecordingLlmReplyRunDispatcher();
+        var agent = await CreateAgentAsync(actorId, runner, dispatcher);
+        var attachments = new ConversationContextAttachmentSet();
+        attachments.Attachments.Add(new ConversationContextAttachment
+        {
+            ArtifactId = "artifact-alpha",
+            RevisionMode = ConversationContextAttachmentRevisionMode.PinnedRevision,
+            PinnedRevisionId = "revision-alpha",
+        });
+        agent.State.ContextAttachments = attachments.Clone();
+
+        await agent.HandleInboundActivityAsync(BuildInboundActivity("msg-attachment-1"));
+
+        dispatcher.Requests.Should().ContainSingle();
+        dispatcher.Requests[0].ContextAttachments.ToByteArray()
+            .Should().Equal(attachments.ToByteArray());
+        agent.State.PendingLlmReplyRequests.Should().ContainSingle();
+        agent.State.PendingLlmReplyRequests[0].ContextAttachments.ToByteArray()
+            .Should().Equal(attachments.ToByteArray());
+    }
+
+    [Fact]
     public async Task HandleLlmReplyReadyAsync_WhenProfileDiffersFromConversationPin_ShouldFailClosed()
     {
         var actorId = ConversationGAgent.BuildActorId("lark:group:oc_group_chat_1");

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactEndpointsTests.cs
@@ -128,7 +128,7 @@ public sealed class ContentArtifactEndpointsTests
         var service = new RecordingService(new ContentArtifactContentUnavailableException(
             "artifact-1",
             "revision-1",
-            "redacted"));
+            ContentArtifactContentUnavailableReason.Redacted));
 
         var result = await InvokeAsync(operation, service);
 


### PR DESCRIPTION
## Issue
Closes #3525 — [NyxID Chat] Conversation 级类型化结构化档案附件（typed structured context attachment）

## Implementation summary
See `.implement-loop/runs/implement-issue-3525.md`.

## Stacked-PR position
- Base: `feature/integrate`
- Head: `feat/2026-08-25_issue-3525`
- Auto-loop iteration: implement-loop / milestone Typed Context & Deterministic Computation (v1)

🤖 Generated by codex-implement-loop. Reviewer is a Claude subagent (see PR comments for round-N review reports).
