### PR TITLE
Issue #3541: [ContentArtifact] revision 追加不推进 current 指针，使 FOLLOW_CURRENT 会话附件永久注入首版正文

### DIFF
--- a/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
+++ b/agents/Aevatar.GAgents.ContentArtifacts/ContentArtifactGAgent.cs
@@ -60,7 +60,13 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(command.Revision);
-        EnsureWriter(command.RequestedBy);
+        // Implement (issue #3541):
+        //   Behavior: append may make the new revision current within the same committed event.
+        //   Why this shape: one actor-owned transition prevents a partial append/advance outcome.
+        if (command.AdvanceToCurrent)
+            EnsureReaderWriter(command.RequestedBy);
+        else
+            EnsureWriter(command.RequestedBy);
         EnsureActiveArtifact(command.ArtifactId);
         var dedupKey = ContentArtifactConventions.NormalizeRequired(
             command.Revision.DedupKey,
@@ -88,6 +94,7 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
         {
             Revision = revision,
             AppendedAtUtc = appendedAt,
+            MadeCurrent = command.AdvanceToCurrent,
         });
     }
 
@@ -339,6 +346,8 @@ public sealed class ContentArtifactGAgent : GAgentBase<ContentArtifactState>, IP
         var next = state.Clone();
         var revision = evt.Revision?.Clone() ?? throw new InvalidOperationException("Appended revision is required.");
         next.Revisions.Add(revision.RevisionId, revision);
+        if (evt.MadeCurrent)
+            next.CurrentRevisionId = revision.RevisionId;
         AdvanceVersion(next, evt.AppendedAtUtc);
         return next;
     }

--- a/agents/Aevatar.GAgents.NyxidChat/ContentArtifactConversationPromptLayerMaterializer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ContentArtifactConversationPromptLayerMaterializer.cs
@@ -173,7 +173,12 @@ public sealed class ContentArtifactConversationPromptLayerMaterializer
                     continue;
                 }
 
+                // Implement (issue #3541):
+                //   Behavior: the injected header exposes the exact revision number and artifact update time.
+                //   Why this shape: consumers can audit FOLLOW_CURRENT resolution without inferring freshness.
                 var header = $"[content-artifact artifact_id={artifactId} revision_id={revisionId} " +
+                             $"revision_number={revision.RevisionNumber} " +
+                             $"updated_at_utc={artifact.UpdatedAtUtc.ToUniversalTime():O} " +
                              $"content_hash={PrefixHash(content.Reference.ContentHash)} media_type={content.Reference.MediaType}]\n";
                 var body = Encoding.UTF8.GetString(content.Content);
                 var section = header + body + "\n[/content-artifact]\n";

--- a/docs/canon/content-artifacts.md
+++ b/docs/canon/content-artifacts.md
@@ -81,12 +81,19 @@ later tombstoned or otherwise unavailable, consumers report
 Creation commits revision 1 and makes it current. Append assigns the next
 revision number from the authoritative revision history. Append never changes a
 prior revision's content, hash, provenance, citations, creation time, or
-supersession reason. Advancing the current pointer is a separate command.
+supersession reason. Append leaves the current pointer unchanged by default. An
+append request may set the typed `advanceToCurrent` option; the authority Actor
+then records the new revision and moves the current pointer in one committed
+append event and one concurrency-version increment. There is no observable
+state in which that append committed but its requested pointer movement failed.
+The CAS-protected current-pointer command remains available for advancing to an
+existing revision.
 
 Append carries no expected concurrency version. Its client-supplied revision
 `dedupKey` is the idempotency key: an authorized retry with identical facts is a
-no-op, while the same key with different facts fails closed. The Actor assigns
-the revision number and id from authoritative state.
+no-op, while the same key with different facts fails closed. A duplicate append
+does not re-advance a pointer that moved later. The Actor assigns the revision
+number and id from authoritative state.
 
 Pointer advance, redaction, expiry, and tombstone carry an expected artifact
 concurrency version. The Actor authorizes first, then checks CAS before duplicate
@@ -145,9 +152,10 @@ ownership.
 
 The owner can read, append, advance, redact, expire, and tombstone. Explicit
 readers can read and discover. A writer-only principal has one append-only
-capability: it can append and blindly retry without CAS, but cannot read, list,
-advance, redact, expire, attach to a Run, or tombstone. Advance, redaction, and
-expiry require owner authority or membership in both reader and writer lists.
+capability: it can append with `advanceToCurrent = false` and blindly retry
+without CAS, but cannot read, list, advance, redact, expire, attach to a Run, or
+tombstone. Atomic append-and-advance, explicit advance, redaction, and expiry
+require owner authority or membership in both reader and writer lists.
 Only the owner may tombstone. Redaction and retention expiry clear the content
 location while preserving identity, hash, provenance, citations, and typed
 reason/time facts. Tombstone clears the current pointer and all surviving
@@ -186,6 +194,8 @@ The canonical resource root is `/api/scopes/{scopeId}/content-artifacts`.
 Endpoints create and list artifacts; read artifact metadata, one exact revision,
 the current revision, or verified content; append a revision; advance current;
 redact, expire, or tombstone; and attach exact references to a Service Run.
+Append accepts optional `advanceToCurrent`, defaulting to false, for an atomic
+append-and-pointer-move mutation.
 
 Mutation responses are `202 Accepted` dispatch receipts. Clients observe
 committed state through the current-state query surface and its authoritative

--- a/docs/canon/conversation-context-and-memory.md
+++ b/docs/canon/conversation-context-and-memory.md
@@ -47,6 +47,13 @@ for missing, inactive, unauthorized, unsupported-kind, duplicate/over-limit, or 
 pinned revisions. A turn may degrade to a typed unavailable placeholder when a later verified
 read is redacted, tombstoned, expired, over budget, or temporarily unavailable.
 
+`FOLLOW_CURRENT` resolves only the artifact read model's explicit `CurrentRevisionId` on each
+turn; it never infers the highest revision number or silently retargets to the latest append.
+Writers that intend a new revision to become current use append with `advanceToCurrent = true`
+for one atomic mutation, or the separate CAS-protected pointer command. The injected identity
+header reports the resolved `revision_id`, `revision_number`, artifact `updated_at_utc`, content
+hash, and media type so consumers can audit the exact input.
+
 ## 3. Protobuf 与写侧契约
 
 内部事实、命令、事件和 actor state 全部使用 Protobuf：
@@ -135,4 +142,4 @@ message window、`RoleGAgent` session tracking limit、user-memory 50 条上限�
 5. fixture 是否使用不同的 conversation/session/user identity？
 6. 是否把核心 category/source/recovery/control 语义建模为 Protobuf，而非 generic bag？
 7. 是否意外新增了统一 memory framework 或 LLM provider 对 user-memory lifecycle 的所有权？
-8. 附件是否只经 read model + verified read 注入，且 identity header 标明实际 revision/hash/media type？
+8. 附件是否只经 read model + verified read 注入，FOLLOW_CURRENT 是否只解析显式 current 指针，且 identity header 标明实际 revision number/id、artifact update time、hash 与 media type？

--- a/src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto
+++ b/src/Aevatar.ContentArtifacts.Abstractions/content_artifact_messages.proto
@@ -166,6 +166,7 @@ message AppendContentArtifactRevision {
   ContentArtifactPrincipal requested_by = 3;
   ContentArtifactRevision revision = 4;
   google.protobuf.Timestamp requested_at_utc = 5;
+  bool advance_to_current = 6;
 }
 
 message AdvanceContentArtifactCurrentRevision {
@@ -209,6 +210,7 @@ message ContentArtifactCreatedEvent {
 message ContentArtifactRevisionAppendedEvent {
   ContentArtifactRevision revision = 1;
   google.protobuf.Timestamp appended_at_utc = 2;
+  bool made_current = 3;
 }
 
 message ContentArtifactCurrentRevisionAdvancedEvent {

--- a/src/Aevatar.Studio.Application.Abstractions/Studio/Contracts/ContentArtifactContracts.cs
+++ b/src/Aevatar.Studio.Application.Abstractions/Studio/Contracts/ContentArtifactContracts.cs
@@ -104,7 +104,8 @@ public sealed record CreateContentArtifactRequest(
     IReadOnlyDictionary<string, string>? Labels = null);
 
 public sealed record AppendContentArtifactRevisionRequest(
-    ContentArtifactRevisionWriteRequest Revision);
+    ContentArtifactRevisionWriteRequest Revision,
+    bool AdvanceToCurrent = false);
 
 public sealed record AdvanceContentArtifactCurrentRevisionRequest(
     long ExpectedConcurrencyVersion,

--- a/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/ContentArtifactService.cs
@@ -153,9 +153,17 @@ public sealed class ContentArtifactService : IContentArtifactService
         var current = await _queryPort.GetAsync(normalizedScopeId, normalizedArtifactId, ct);
         if (current != null)
         {
+            // Implement (issue #3541):
+            //   Behavior: append-and-advance requires the same authority as explicit pointer advance.
+            //   Why this shape: the optional atomic path must not widen writer-only permissions.
+            var isOwner = PrincipalEquals(current.Owner, principal);
             var canWrite = PrincipalEquals(current.Owner, principal) ||
                            current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal);
-            if (!string.Equals(current.ScopeId, normalizedScopeId, StringComparison.Ordinal) || !canWrite)
+            var canAdvance = isOwner ||
+                             current.ReaderPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal) &&
+                             current.WriterPrincipalIds.Contains(principal.PrincipalId, StringComparer.Ordinal);
+            var authorized = request.AdvanceToCurrent ? canAdvance : canWrite;
+            if (!string.Equals(current.ScopeId, normalizedScopeId, StringComparison.Ordinal) || !authorized)
                 throw new ContentArtifactNotFoundException(normalizedScopeId, normalizedArtifactId);
         }
         var normalizedRevision = NormalizeRevisionWrite(

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchContentArtifactCommandService.cs
@@ -74,6 +74,7 @@ internal sealed class ActorDispatchContentArtifactCommandService : IContentArtif
                 RequestedBy = ToPrincipal(requester),
                 Revision = ToRevision(artifactId, revisionNumber: 0, request.Revision, now),
                 RequestedAtUtc = now,
+                AdvanceToCurrent = request.AdvanceToCurrent,
             },
             "append",
             0,

--- a/test/Aevatar.AI.Tests/ConversationContextAttachmentTests.cs
+++ b/test/Aevatar.AI.Tests/ConversationContextAttachmentTests.cs
@@ -49,7 +49,10 @@ public sealed class ConversationContextAttachmentTests
 
         followFirst.Content.Should().Contain("revision_id=rev-1").And.Contain("content-rev-1");
         pinnedFirst.Content.Should().Contain("revision_id=rev-1").And.Contain("content-rev-1");
-        followSecond.Content.Should().Contain("revision_id=rev-2").And.Contain("content-rev-2");
+        followSecond.Content.Should().Contain("revision_id=rev-2")
+            .And.Contain("revision_number=2")
+            .And.Contain("updated_at_utc=2026-08-25T00:01:00.0000000+00:00")
+            .And.Contain("content-rev-2");
         pinnedSecond.Content.Should().Contain("revision_id=rev-1").And.Contain("content-rev-1");
         query.ContentRevisionIds.Should().Equal("rev-1", "rev-1", "rev-2", "rev-1");
 

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactCommandServiceTests.cs
@@ -52,7 +52,8 @@ public sealed class ContentArtifactCommandServiceTests
             CreateCommandDispatch(dispatchPort));
         var artifactId = ContentArtifactConventions.BuildArtifactId(ScopeId, "report-dedup");
         var request = new AppendContentArtifactRevisionRequest(
-            RevisionWrite("revision four", "revision-4-dedup", "revision-3"));
+            RevisionWrite("revision four", "revision-4-dedup", "revision-3"),
+            AdvanceToCurrent: true);
 
         var receipt = await service.AppendRevisionAsync(
             ScopeId,
@@ -66,6 +67,7 @@ public sealed class ContentArtifactCommandServiceTests
         command.Revision.RevisionNumber.Should().Be(0);
         command.Revision.RevisionId.Should().BeEmpty();
         command.Revision.ParentRevisionId.Should().Be("revision-3");
+        command.AdvanceToCurrent.Should().BeTrue();
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactGAgentTests.cs
@@ -159,6 +159,59 @@ public sealed class ContentArtifactGAgentTests
             .ContainSingle(item => item.DedupKey == "revision-2-dedup").Subject;
         appended.RevisionNumber.Should().Be(2);
         appended.RevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(ArtifactId, 2));
+        agent.State.CurrentRevisionId.Should().Be(ContentArtifactConventions.BuildRevisionId(ArtifactId, 1));
+    }
+
+    [Fact]
+    public async Task AppendWithAdvance_ShouldAtomicallyMakeNewRevisionCurrentAndRemainRetrySafe()
+    {
+        var eventStore = new InMemoryEventStore();
+        var agent = await CreateAgentAsync(eventStore: eventStore);
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var append = new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            RequestedBy = Principal("editor-1"),
+            Revision = BuildRevision(2, "revision two", "revision-2-dedup", agent.State.CurrentRevisionId),
+            AdvanceToCurrent = true,
+        };
+
+        await agent.HandleAppendRevisionAsync(append);
+
+        var appended = agent.State.Revisions.Values.Should()
+            .ContainSingle(item => item.DedupKey == "revision-2-dedup").Subject;
+        agent.State.CurrentRevisionId.Should().Be(appended.RevisionId);
+        agent.State.ConcurrencyVersion.Should().Be(2);
+
+        var recovered = await CreateAgentAsync(eventStore: eventStore);
+        await recovered.HandleAppendRevisionAsync(append.Clone());
+
+        recovered.State.CurrentRevisionId.Should().Be(appended.RevisionId);
+        recovered.State.ConcurrencyVersion.Should().Be(2);
+        recovered.State.Revisions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task AppendWithAdvance_ShouldRejectWriterOnlyAuthority()
+    {
+        var agent = await CreateAgentAsync();
+        await agent.HandleCreateAsync(BuildCreate("revision one"));
+        var firstRevisionId = agent.State.CurrentRevisionId;
+        var append = new AppendContentArtifactRevision
+        {
+            ArtifactId = ArtifactId,
+            RequestedBy = Principal("writer-1"),
+            Revision = BuildRevision(2, "revision two", "revision-2-dedup", firstRevisionId),
+            AdvanceToCurrent = true,
+        };
+
+        var act = () => agent.HandleAppendRevisionAsync(append);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*not authorized*");
+        agent.State.CurrentRevisionId.Should().Be(firstRevisionId);
+        agent.State.ConcurrencyVersion.Should().Be(1);
+        agent.State.Revisions.Should().ContainSingle();
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ContentArtifacts/ContentArtifactServiceTests.cs
@@ -201,6 +201,36 @@ public sealed class ContentArtifactServiceTests
 
         commandPort.AppendRequest.Should().NotBeNull();
         commandPort.AppendRequest!.Revision.ParentRevisionId.Should().Be("revision-1");
+        commandPort.AppendRequest.AdvanceToCurrent.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AppendRevisionAsync_WithAdvanceShouldRequireReadAndWriteAuthority()
+    {
+        var current = BuildCurrentState() with
+        {
+            ReaderPrincipalIds = ["reader-1", "editor-1"],
+            WriterPrincipalIds = ["writer-1", "editor-1"],
+        };
+        var commandPort = new RecordingCommandPort();
+        var service = CreateService(commandPort: commandPort, queryPort: new RecordingQueryPort(current));
+        var request = new AppendContentArtifactRevisionRequest(
+            RevisionWrite("revision two", "revision-2-dedup", parentRevisionId: "revision-1"),
+            AdvanceToCurrent: true);
+
+        var writerOnly = () => service.AppendRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            request,
+            Principal("writer-1"));
+
+        await writerOnly.Should().ThrowAsync<ContentArtifactNotFoundException>();
+        await service.AppendRevisionAsync(
+            "scope-1",
+            "artifact-1",
+            request,
+            Principal("editor-1"));
+        commandPort.AppendRequest!.AdvanceToCurrent.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
## Issue
Closes #3541 — [ContentArtifact] revision 追加不推进 current 指针，使 FOLLOW_CURRENT 会话附件永久注入首版正文

## Implementation summary
See `.implement-loop/runs/implement-issue-3541.md`.

## Stacked-PR position
- Base: `feature/integrate`
- Head: `feat/2026-08-27_issue-3541`
- Auto-loop iteration: implement-loop / milestone Typed Context & Deterministic Computation (v1) follow-up

🤖 Generated by codex-implement-loop. Reviewer is a Claude subagent (see PR comments for round-N review reports).
